### PR TITLE
fix #144 escaping

### DIFF
--- a/src/ffmpeg/nodes/nodes.py
+++ b/src/ffmpeg/nodes/nodes.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Sequence
 from pydantic import model_validator
 
 from ..schema import Default, StreamType
+from ..utils.escaping import escape
 from .base import Node, Stream, _DAGContext, empty_dag_context
 
 if TYPE_CHECKING:
@@ -97,10 +98,10 @@ class FilterNode(Node):
         commands = []
         for key, value in self.kwargs.items():
             if not isinstance(value, Default):
-                commands += [f"{key}={value}"]
+                commands += [f"{key}={escape(value)}"]
 
         if commands:
-            return [incoming_labels] + [f"{self.name}="] + [":".join(commands)] + [outgoing_labels]
+            return [incoming_labels] + [f"{self.name}="] + [escape(":".join(commands), "\\'[],;")] + [outgoing_labels]
         return [incoming_labels] + [f"{self.name}"] + [outgoing_labels]
 
 

--- a/src/ffmpeg/tests/__snapshots__/test_base/test_drawtext_escaping.json
+++ b/src/ffmpeg/tests/__snapshots__/test_base/test_drawtext_escaping.json
@@ -1,0 +1,10 @@
+[
+  "ffmpeg",
+  "-i",
+  "input.mp4",
+  "-filter_complex",
+  "[0]drawtext=fontfile=/path/to/font.ttf:text=this is a \\\\\\'string\\\\\\'\\\\: may contain one\\, or more\\, special characters[s0]",
+  "-map",
+  "[s0]",
+  "output.mp4"
+]

--- a/src/ffmpeg/tests/test_base.py
+++ b/src/ffmpeg/tests/test_base.py
@@ -95,3 +95,16 @@ def test_mono_to_stereo_with_offsets_and_video(snapshot: SnapshotAssertion) -> N
         .overwrite_output()
         .compile()
     )
+
+
+def test_drawtext_escaping(snapshot: SnapshotAssertion) -> None:
+    # ["ffmpeg", "-i", "input.mp4", "-filter_complex", "[0]drawtext=text='this is a \\'string\\'': may contain one, or more, special characters':fontfile=/path/to/font.ttf[s0]", "-map", "[s0]", "output.mp4"]
+    assert snapshot(extension_class=JSONSnapshotExtension) == (
+        input("input.mp4")
+        .drawtext(
+            text="this is a 'string': may contain one, or more, special characters",
+            fontfile="/path/to/font.ttf",
+        )
+        .output(filename="output.mp4")
+        .compile()
+    )

--- a/src/ffmpeg/utils/escaping.py
+++ b/src/ffmpeg/utils/escaping.py
@@ -1,0 +1,12 @@
+def escape(text: str | int | tuple[int, int], chars: str = "\\'=:") -> str:
+    """Helper function to escape uncomfortable characters."""
+    text = str(text)
+    _chars = list(set(chars))
+    if "\\" in _chars:
+        _chars.remove("\\")
+        _chars.insert(0, "\\")
+
+    for ch in _chars:
+        text = text.replace(ch, "\\" + ch)
+
+    return text

--- a/src/ffmpeg/utils/tests/__snapshots__/test_escaping.ambr
+++ b/src/ffmpeg/utils/tests/__snapshots__/test_escaping.ambr
@@ -1,0 +1,7 @@
+# serializer version: 1
+# name: test_escaping[this is a 'string': may contain one, or more, special characters]
+  "this is a \\'string\\': may contain one\\, or more\\, special characters"
+# ---
+# name: test_escaping[this is a string[0]]
+  'this is a string\\[0\\]'
+# ---

--- a/src/ffmpeg/utils/tests/test_escaping.py
+++ b/src/ffmpeg/utils/tests/test_escaping.py
@@ -1,0 +1,11 @@
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from ..escaping import escape
+
+
+@pytest.mark.parametrize(
+    "text", ["this is a 'string': may contain one, or more, special characters", "this is a string[0]"]
+)
+def test_escaping(snapshot: SnapshotAssertion, text: str) -> None:
+    assert snapshot == escape(text, "\\'[],;")


### PR DESCRIPTION
- fix #144 handle escaping 
- the escaping rule is introduced here https://ffmpeg.org/ffmpeg-filters.html#Notes-on-filtergraph-escaping
- the implementation is from ffmpeg-python 