### PR TITLE
handle bool type

### DIFF
--- a/src/ffmpeg/nodes/nodes.py
+++ b/src/ffmpeg/nodes/nodes.py
@@ -98,6 +98,9 @@ class FilterNode(Node):
 
         commands = []
         for key, value in self.kwargs.items():
+            if isinstance(value, bool):
+                value = str(int(value))
+
             if not isinstance(value, Default):
                 commands += [f"{key}={escape(value)}"]
 

--- a/src/ffmpeg/tests/__snapshots__/test_base/test_compile_bool_option.1.json
+++ b/src/ffmpeg/tests/__snapshots__/test_base/test_compile_bool_option.1.json
@@ -1,0 +1,10 @@
+[
+  "ffmpeg",
+  "-i",
+  "input.mp4",
+  "-filter_complex",
+  "[0]drawtext=text=hello:escape_text=1[s0]",
+  "-map",
+  "[s0]",
+  "output.mp4"
+]

--- a/src/ffmpeg/tests/__snapshots__/test_base/test_compile_bool_option.json
+++ b/src/ffmpeg/tests/__snapshots__/test_base/test_compile_bool_option.json
@@ -1,0 +1,10 @@
+[
+  "ffmpeg",
+  "-i",
+  "input.mp4",
+  "-filter_complex",
+  "[0]drawtext=text=hello:escape_text=0[s0]",
+  "-map",
+  "[s0]",
+  "output.mp4"
+]

--- a/src/ffmpeg/tests/test_base.py
+++ b/src/ffmpeg/tests/test_base.py
@@ -108,3 +108,13 @@ def test_drawtext_escaping(snapshot: SnapshotAssertion) -> None:
         .output(filename="output.mp4")
         .compile()
     )
+
+
+def test_compile_bool_option(snapshot: SnapshotAssertion) -> None:
+    assert snapshot(extension_class=JSONSnapshotExtension) == (
+        input("input.mp4").drawtext(text="hello", escape_text=False).output(filename="output.mp4").compile()
+    )
+
+    assert snapshot(extension_class=JSONSnapshotExtension) == (
+        input("input.mp4").drawtext(text="hello", escape_text=True).output(filename="output.mp4").compile()
+    )


### PR DESCRIPTION
- fix #148 handle different option type's encode
- it looks like only bool needs to be handle now (`True -> 1`, `False -> 0`)