### PR TITLE
ref #518 move compile module

### DIFF
--- a/docs/src/compile/compile_cli.md
+++ b/docs/src/compile/compile_cli.md
@@ -1,0 +1,4 @@
+::: ffmpeg.compile.compile_cli
+    options:
+      show_source: false
+      members_order: source

--- a/docs/src/dag/compile.md
+++ b/docs/src/dag/compile.md
@@ -1,4 +1,0 @@
-::: ffmpeg.dag.compile
-    options:
-      show_source: false
-      members_order: source

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,7 +60,7 @@ nav:
           - audio stream: src/streams/audio_stream.md
           - av stream: src/streams/av_stream.md
       - Compile:
-          - compile: src/compile/compile.md
+          - compile_cli: src/compile/compile_cli.md
           - context: src/compile/context.md
       - DAG:
           - nodes: src/dag/nodes.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,9 +59,10 @@ nav:
           - video stream: src/streams/video_stream.md
           - audio stream: src/streams/audio_stream.md
           - av stream: src/streams/av_stream.md
-      - DAG:
-          - compile: src/dag/compile.md
+      - Compile:
+          - compile: src/compile/compile.md
           - context: src/compile/context.md
+      - DAG:
           - nodes: src/dag/nodes.md
           - schema: src/dag/schema.md
           - utils: src/dag/utils.md

--- a/src/ffmpeg/compile/compile_cli.py
+++ b/src/ffmpeg/compile/compile_cli.py
@@ -9,10 +9,10 @@ handling global options, inputs, complex filtergraphs, and outputs.
 
 from __future__ import annotations
 
-from ..compile.context import DAGContext
-from .nodes import FilterNode, GlobalNode, InputNode, OutputNode
-from .schema import Stream
-from .validate import validate
+from ..dag.nodes import FilterNode, GlobalNode, InputNode, OutputNode
+from ..dag.schema import Stream
+from ..dag.validate import validate
+from .context import DAGContext
 
 
 def compile(stream: Stream, auto_fix: bool = True) -> list[str]:

--- a/src/ffmpeg/dag/global_runnable/runnable.py
+++ b/src/ffmpeg/dag/global_runnable/runnable.py
@@ -111,7 +111,7 @@ class GlobalRunable(GlobalArgs):
             # Result: ['ffmpeg', '-i', 'input.mp4', 'output.mp4']
             ```
         """
-        from ..compile import compile
+        from ...compile.compile_cli import compile
 
         if isinstance(cmd, str):
             cmd = [cmd]


### PR DESCRIPTION
This pull request reorganizes and refactors the `compile` module by moving it out of the `dag` namespace, updating related imports, and adjusting documentation and configuration files accordingly. The changes aim to improve module clarity and navigation structure.

### Module reorganization and refactoring:

* Renamed the file `src/ffmpeg/dag/compile.py` to `src/ffmpeg/compile/compile_cli.py` and updated imports to reflect the new structure. The `DAGContext` import was moved to the local `compile` module, while other imports (`FilterNode`, `GlobalNode`, `InputNode`, `OutputNode`, `Stream`, and `validate`) were updated to reference the `dag` namespace.

### Documentation updates:

* Removed the `::: ffmpeg.dag.compile` section from `docs/src/dag/compile.md`, likely as part of the module reorganization.

### Navigation structure updates:

* Updated `mkdocs.yml` to reflect the new module structure by moving the `compile` entry under a new `Compile` section and adjusting the navigation hierarchy. The `DAG` section now includes only DAG-specific topics such as `nodes`, `schema`, and `utils`.