### PR TITLE
Fix #587 auto map omit

### DIFF
--- a/src/ffmpeg/compile/compile_cli.py
+++ b/src/ffmpeg/compile/compile_cli.py
@@ -152,6 +152,15 @@ def parse_output(
             stream = parse_stream_selector(map_option, in_streams)
             inputs.append(stream)
 
+        if not inputs:
+            # NOTE: if there is no inputs, and there is only one input node
+            if len([k for k in in_streams if isinstance(in_streams[k], AVStream)]) == 1:
+                inputs = [
+                    in_streams[k]
+                    for k in in_streams
+                    if isinstance(in_streams[k], AVStream)
+                ]
+
         assert inputs, f"No inputs found for output {filename}"
         export.append(output(*inputs, filename=filename, extra_options=options))
         buffer = []

--- a/src/ffmpeg/compile/compile_cli.py
+++ b/src/ffmpeg/compile/compile_cli.py
@@ -676,6 +676,22 @@ def get_args_output_node(node: OutputNode, context: DAGContext) -> list[str]:
     if context:
         for input in node.inputs:
             if isinstance(input.node, InputNode):
+                # NOTE: specially rules,
+                # if there is only one input node,
+                # only one output node,
+                # the output node has only one input,
+                # and the stream selector is not specified,
+                # then the map can be ignore.
+                if (
+                    input.index is None
+                    and isinstance(input, AVStream)
+                    and len([k for k in context.all_nodes if isinstance(k, InputNode)])
+                    == 1
+                    and len([k for k in context.all_nodes if isinstance(k, OutputNode)])
+                    == 1
+                    and len(node.inputs) == 1
+                ):
+                    continue
                 commands += ["-map", get_stream_label(input, context)]
             else:
                 commands += ["-map", f"[{get_stream_label(input, context)}]"]

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_compile_cli[simple-global-args][compile-cli].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_compile_cli[simple-global-args][compile-cli].json
@@ -2,7 +2,5 @@
   "-hide_banner",
   "-i",
   "input1.mp4",
-  "-map",
-  "0",
   "tmp.mp4"
 ]

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_compile[simple-global-args][parse-compile].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_compile[simple-global-args][parse-compile].json
@@ -1,4 +1,0 @@
-[
-  "ffmpeg -hide_banner -i input1.mp4 -map 0 tmp.mp4",
-  "ffmpeg -hide_banner -i input1.mp4 -map 0 tmp.mp4"
-]

--- a/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_compile[simple-global-args][parse-compile].json
+++ b/src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_compile[simple-global-args][parse-compile].json
@@ -1,0 +1,4 @@
+[
+  "ffmpeg -hide_banner -i input1.mp4 tmp.mp4",
+  "ffmpeg -hide_banner -i input1.mp4 tmp.mp4"
+]

--- a/src/ffmpeg/dag/io/tests/__snapshots__/test_input/test_input.json
+++ b/src/ffmpeg/dag/io/tests/__snapshots__/test_input/test_input.json
@@ -10,7 +10,5 @@
   "-nodisplay_vflip",
   "-i",
   "input.mp4",
-  "-map",
-  "0",
   "output.mp4"
 ]

--- a/src/ffmpeg/dag/io/tests/__snapshots__/test_input/test_input_with_filter.json
+++ b/src/ffmpeg/dag/io/tests/__snapshots__/test_input/test_input_with_filter.json
@@ -6,7 +6,5 @@
   "10",
   "-i",
   "anullsrc",
-  "-map",
-  "0",
   "output.mp4"
 ]

--- a/src/ffmpeg/dag/io/tests/__snapshots__/test_output/test_output.json
+++ b/src/ffmpeg/dag/io/tests/__snapshots__/test_output/test_output.json
@@ -2,8 +2,6 @@
   "ffmpeg",
   "-i",
   "input.mp4",
-  "-map",
-  "0",
   "-c",
   "copy",
   "-shortest",

--- a/src/ffmpeg/dag/tests/__snapshots__/test_nodes.ambr
+++ b/src/ffmpeg/dag/tests/__snapshots__/test_nodes.ambr
@@ -101,8 +101,6 @@
     '-nostdin',
     '-i',
     'tmp1.mp4',
-    '-map',
-    '0',
     'output.mp4',
   ])
 # ---

--- a/src/ffmpeg/tests/__snapshots__/test_base/test_assemble_video_from_sequence_of_frames.json
+++ b/src/ffmpeg/tests/__snapshots__/test_base/test_assemble_video_from_sequence_of_frames.json
@@ -6,7 +6,5 @@
   "glob",
   "-i",
   "/path/to/jpegs/*.jpg",
-  "-map",
-  "0",
   "movie.mp4"
 ]

--- a/src/ffmpeg/tests/__snapshots__/test_base/test_concat_dumuxer.json
+++ b/src/ffmpeg/tests/__snapshots__/test_base/test_concat_dumuxer.json
@@ -8,7 +8,5 @@
   "file,http,https,tcp,tls",
   "-i",
   "files.txt",
-  "-map",
-  "0",
   "output.mp4"
 ]

--- a/src/ffmpeg/tests/__snapshots__/test_base/test_output_node.json
+++ b/src/ffmpeg/tests/__snapshots__/test_base/test_output_node.json
@@ -2,8 +2,6 @@
   "ffmpeg",
   "-i",
   "input1",
-  "-map",
-  "0",
   "-str",
   "x",
   "-int",


### PR DESCRIPTION
- fix #587 
- fix #469 

rules: https://github.com/livingbio/typed-ffmpeg/issues/587#issuecomment-2916072578

This pull request introduces changes to simplify the handling of stream mapping in FFmpeg commands when specific conditions are met. It removes the `-map` option in scenarios where it can be inferred automatically, reducing complexity in generated commands and snapshots. The changes span logic updates in `compile_cli.py` and adjustments to test snapshots.

### Logic updates for stream mapping:

* [`src/ffmpeg/compile/compile_cli.py`](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192R155-R163): Added logic to handle cases where there is only one input node, one output node, and no explicit stream selector, allowing the `-map` option to be omitted automatically. [[1]](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192R155-R163) [[2]](diffhunk://#diff-7f65757acce50345851832b42ea78ce09960f4c92856405061a7189c67851192R688-R703)

### Updates to test snapshots:

* Removed `-map` option from various test snapshots where the new logic applies, including:
  - `test_compile_cli[simple-global-args][compile-cli].json` ([src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_compile_cli[simple-global-args][compile-cli].jsonL5-L6](diffhunk://#diff-e9b2b9077064e34875ac68dfba2c5f2f155322eb2a3bbb965b68848da942da8bL5-L6))
  - `test_parse_compile[simple-global-args][parse-compile].json` ([src/ffmpeg/compile/tests/__snapshots__/test_compile_cli/test_parse_compile[simple-global-args][parse-compile].jsonL2-R3](diffhunk://#diff-b926e3b63adf6ff4120eecf4608a0df4ba1a7417fec5d89c05055da754634ecaL2-R3))
  - `test_input.json`
  - `test_input_with_filter.json`
  - `test_output.json`
  - `test_nodes.ambr`
  - `test_assemble_video_from_sequence_of_frames.json`
  - `test_concat_dumuxer.json`
  - `test_output_node.json`