### PR TITLE
fix #655 submit diff

### DIFF
--- a/src/ffmpeg/common/cache/FFMpegFilterManuallyDefined/hstack_vaapi.json
+++ b/src/ffmpeg/common/cache/FFMpegFilterManuallyDefined/hstack_vaapi.json
@@ -1,6 +1,6 @@
 {
   "__class__": "FFMpegFilterManuallyDefined",
-  "formula_typings_input": null,
+  "formula_typings_input": "[StreamType.video] * int(inputs)",
   "formula_typings_output": null,
   "name": "hstack_vaapi",
   "pre": []

--- a/src/ffmpeg/common/cache/FFMpegFilterManuallyDefined/ladspa.json
+++ b/src/ffmpeg/common/cache/FFMpegFilterManuallyDefined/ladspa.json
@@ -1,6 +1,6 @@
 {
   "__class__": "FFMpegFilterManuallyDefined",
-  "formula_typings_input": null,
+  "formula_typings_input": "[StreamType.audio]",
   "formula_typings_output": null,
   "name": "ladspa",
   "pre": []

--- a/src/ffmpeg/common/cache/FFMpegFilterManuallyDefined/lv2.json
+++ b/src/ffmpeg/common/cache/FFMpegFilterManuallyDefined/lv2.json
@@ -1,6 +1,6 @@
 {
   "__class__": "FFMpegFilterManuallyDefined",
-  "formula_typings_input": null,
+  "formula_typings_input": "[StreamType.audio]",
   "formula_typings_output": null,
   "name": "lv2",
   "pre": []

--- a/src/ffmpeg/common/cache/FFMpegFilterManuallyDefined/program_opencl.json
+++ b/src/ffmpeg/common/cache/FFMpegFilterManuallyDefined/program_opencl.json
@@ -1,6 +1,6 @@
 {
   "__class__": "FFMpegFilterManuallyDefined",
-  "formula_typings_input": null,
+  "formula_typings_input": "[StreamType.video] * int(inputs)",
   "formula_typings_output": null,
   "name": "program_opencl",
   "pre": []

--- a/src/ffmpeg/common/cache/FFMpegFilterManuallyDefined/vstack_vaapi.json
+++ b/src/ffmpeg/common/cache/FFMpegFilterManuallyDefined/vstack_vaapi.json
@@ -1,6 +1,6 @@
 {
   "__class__": "FFMpegFilterManuallyDefined",
-  "formula_typings_input": null,
+  "formula_typings_input": "[StreamType.video] * int(inputs)",
   "formula_typings_output": null,
   "name": "vstack_vaapi",
   "pre": []

--- a/src/ffmpeg/common/cache/FFMpegFilterManuallyDefined/xstack_vaapi.json
+++ b/src/ffmpeg/common/cache/FFMpegFilterManuallyDefined/xstack_vaapi.json
@@ -1,6 +1,6 @@
 {
   "__class__": "FFMpegFilterManuallyDefined",
-  "formula_typings_input": null,
+  "formula_typings_input": "[StreamType.video] * int(inputs)",
   "formula_typings_output": null,
   "name": "xstack_vaapi",
   "pre": []

--- a/src/ffmpeg/common/cache/list/filters.json
+++ b/src/ffmpeg/common/cache/list/filters.json
@@ -1287,12 +1287,40 @@
             "help": "inverted sine cardinal function",
             "name": "isinc",
             "value": "18"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "quartic",
+            "name": "quat",
+            "value": "19"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "quartic root",
+            "name": "quatr",
+            "value": "20"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "squared quarter of sine wave",
+            "name": "qsin2",
+            "value": "21"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "squared half of sine wave",
+            "name": "hsin2",
+            "value": "22"
           }
         ],
         "default": "tri",
-        "description": "set fade curve type for 1st stream (from -1 to 18) (default tri)",
+        "description": "set fade curve type for 1st stream (from -1 to 22) (default tri)",
         "flags": "..F.A......",
-        "max": "18",
+        "max": "22",
         "min": "-1",
         "name": "curve1",
         "required": false,
@@ -1447,12 +1475,40 @@
             "help": "inverted sine cardinal function",
             "name": "isinc",
             "value": "18"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "quartic",
+            "name": "quat",
+            "value": "19"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "quartic root",
+            "name": "quatr",
+            "value": "20"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "squared quarter of sine wave",
+            "name": "qsin2",
+            "value": "21"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "squared half of sine wave",
+            "name": "hsin2",
+            "value": "22"
           }
         ],
         "default": "tri",
-        "description": "set fade curve type for 2nd stream (from -1 to 18) (default tri)",
+        "description": "set fade curve type for 2nd stream (from -1 to 22) (default tri)",
         "flags": "..F.A......",
-        "max": "18",
+        "max": "22",
         "min": "-1",
         "name": "curve2",
         "required": false,
@@ -3714,6 +3770,53 @@
       {
         "__class__": "FFMpegFilterOption",
         "alias": [
+          "dftype"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A....T.",
+            "help": "",
+            "name": "bandpass",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A....T.",
+            "help": "",
+            "name": "lowpass",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A....T.",
+            "help": "",
+            "name": "highpass",
+            "value": "2"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A....T.",
+            "help": "",
+            "name": "peak",
+            "value": "3"
+          }
+        ],
+        "default": "bandpass",
+        "description": "set detection filter type (from 0 to 3) (default bandpass)",
+        "flags": "..F.A....T.",
+        "max": "3",
+        "min": "0",
+        "name": "dftype",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
           "tftype"
         ],
         "choices": [
@@ -3818,6 +3921,46 @@
         "max": "1",
         "min": "-1",
         "name": "auto",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "precision"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "set auto processing precision",
+            "name": "auto",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "set single-floating point processing precision",
+            "name": "float",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "set double-floating point processing precision",
+            "name": "double",
+            "value": "2"
+          }
+        ],
+        "default": "auto",
+        "description": "set processing precision (from 0 to 2) (default auto)",
+        "flags": "..F.A......",
+        "max": "2",
+        "min": "0",
+        "name": "precision",
         "required": false,
         "type": {
           "__class__": "FFMpegFilterOptionType",
@@ -4965,12 +5108,40 @@
             "help": "inverted sine cardinal function",
             "name": "isinc",
             "value": "18"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A....T.",
+            "help": "quartic",
+            "name": "quat",
+            "value": "19"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A....T.",
+            "help": "quartic root",
+            "name": "quatr",
+            "value": "20"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A....T.",
+            "help": "squared quarter of sine wave",
+            "name": "qsin2",
+            "value": "21"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A....T.",
+            "help": "squared half of sine wave",
+            "name": "hsin2",
+            "value": "22"
           }
         ],
         "default": "tri",
-        "description": "set fade curve type (from -1 to 18) (default tri)",
+        "description": "set fade curve type (from -1 to 22) (default tri)",
         "flags": "..F.A....T.",
-        "max": "18",
+        "max": "22",
         "min": "-1",
         "name": "curve",
         "required": false,
@@ -5958,6 +6129,353 @@
         }
       }
     ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "audio"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Generate a FIR equalizer coefficients audio stream.",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": true,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "afireqsrc",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "preset",
+          "p"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "",
+            "name": "custom",
+            "value": "-1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "",
+            "name": "flat",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "",
+            "name": "acoustic",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "",
+            "name": "bass",
+            "value": "2"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "",
+            "name": "beats",
+            "value": "3"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "",
+            "name": "classic",
+            "value": "4"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "",
+            "name": "clear",
+            "value": "5"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "",
+            "name": "deep",
+            "value": "bass       6"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "",
+            "name": "dubstep",
+            "value": "7"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "",
+            "name": "electronic",
+            "value": "8"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "",
+            "name": "hardstyle",
+            "value": "9"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "",
+            "name": "hop",
+            "value": "10"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "",
+            "name": "jazz",
+            "value": "11"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "",
+            "name": "metal",
+            "value": "12"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "",
+            "name": "movie",
+            "value": "13"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "",
+            "name": "pop",
+            "value": "14"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "",
+            "name": "b",
+            "value": "15"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "",
+            "name": "rock",
+            "value": "16"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "",
+            "name": "vocal",
+            "value": "booster   17"
+          }
+        ],
+        "default": "flat",
+        "description": "set equalizer preset (from -1 to 17) (default flat)",
+        "flags": "..F.A......",
+        "max": "17",
+        "min": "-1",
+        "name": "preset",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "gains",
+          "g"
+        ],
+        "choices": [],
+        "default": "0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0",
+        "description": "set gain values per band (default \"0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0\")",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "gains",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "bands",
+          "b"
+        ],
+        "choices": [],
+        "default": "25 40 63 100 160 250 400 630 1000 1600 2500 4000 6300 10000 16000 24000",
+        "description": "set central frequency values per band (default \"25 40 63 100 160 250 400 630 1000 1600 2500 4000 6300 10000 16000 24000\")",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "bands",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "taps",
+          "t"
+        ],
+        "choices": [],
+        "default": 4096,
+        "description": "set number of taps (from 16 to 65535) (default 4096)",
+        "flags": "..F.A......",
+        "max": "65535",
+        "min": "16",
+        "name": "taps",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "sample_rate",
+          "r"
+        ],
+        "choices": [],
+        "default": 44100,
+        "description": "set sample rate (from 1 to INT_MAX) (default 44100)",
+        "flags": "..F.A......",
+        "max": "INT_MAX",
+        "min": "1",
+        "name": "sample_rate",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "nb_samples",
+          "n"
+        ],
+        "choices": [],
+        "default": 1024,
+        "description": "set the number of samples per requested frame (from 1 to INT_MAX) (default 1024)",
+        "flags": "..F.A......",
+        "max": "INT_MAX",
+        "min": "1",
+        "name": "nb_samples",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "interp",
+          "i"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "",
+            "name": "linear",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "",
+            "name": "cubic",
+            "value": "1"
+          }
+        ],
+        "default": "linear",
+        "description": "set the interpolation (from 0 to 1) (default linear)",
+        "flags": "..F.A......",
+        "max": "1",
+        "min": "0",
+        "name": "interp",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "phase",
+          "h"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "linear phase",
+            "name": "linear",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "minimum phase",
+            "name": "min",
+            "value": "1"
+          }
+        ],
+        "default": "min",
+        "description": "set the phase (from 0 to 1) (default min)",
+        "flags": "..F.A......",
+        "max": "1",
+        "min": "0",
+        "name": "phase",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#afireqsrc",
+    "stream_typings_input": [],
     "stream_typings_output": [
       {
         "__class__": "FFMpegIOType",
@@ -7226,7 +7744,7 @@
     "is_dynamic_output": false,
     "is_filter_sink": false,
     "is_filter_source": false,
-    "is_support_command": false,
+    "is_support_command": true,
     "is_support_framesync": false,
     "is_support_slice_threading": false,
     "is_support_timeline": false,
@@ -7260,7 +7778,7 @@
         "choices": [],
         "default": 0.9,
         "description": "set video opacity (from 0 to 1) (default 0.9)",
-        "flags": "..FV.......",
+        "flags": "..FV.....T.",
         "max": "1",
         "min": "0",
         "name": "opacity",
@@ -7279,29 +7797,50 @@
         "choices": [
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "full",
-            "value": "0"
+            "value": "full"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "compact",
-            "value": "1"
+            "value": "compact"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "nozero",
+            "value": "nozero"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "noeof",
+            "value": "noeof"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "nodisabled",
+            "value": "nodisabled"
           }
         ],
-        "default": "full",
-        "description": "set mode (from 0 to 1) (default full)",
-        "flags": "..FV.......",
-        "max": "1",
-        "min": "0",
+        "default": "0",
+        "description": "set mode (default 0)",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
         "name": "mode",
         "required": false,
         "type": {
           "__class__": "FFMpegFilterOptionType",
-          "value": "int"
+          "value": "flags"
         }
       },
       {
@@ -7313,120 +7852,141 @@
         "choices": [
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "none",
+            "value": "none"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "all",
+            "value": "all"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "queue",
             "value": "queue"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "frame_count_in",
             "value": "frame_count_in"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "frame_count_out",
             "value": "frame_count_out"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "frame_count_delta",
             "value": "frame_count_delta"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "pts",
             "value": "pts"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "pts_delta",
             "value": "pts_delta"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "time",
             "value": "time"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "time_delta",
             "value": "time_delta"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "timebase",
             "value": "timebase"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "format",
             "value": "format"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "size",
             "value": "size"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "rate",
             "value": "rate"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "eof",
             "value": "eof"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "sample_count_in",
             "value": "sample_count_in"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "sample_count_out",
             "value": "sample_count_out"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "sample_count_delta",
             "value": "sample_count_delta"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "disabled",
+            "value": "disabled"
           }
         ],
-        "default": "queue",
-        "description": "set flags (default queue)",
-        "flags": "..FV.......",
+        "default": "all+queue",
+        "description": "set flags (default all+queue)",
+        "flags": "..FV.....T.",
         "max": null,
         "min": null,
         "name": "flags",
@@ -9220,15 +9780,33 @@
         ],
         "choices": [],
         "default": 0,
-        "description": "set the loop start sample (from 0 to I64_MAX) (default 0)",
+        "description": "set the loop start sample (from -1 to I64_MAX) (default 0)",
         "flags": "..F.A......",
         "max": "I64_MAX",
-        "min": "0",
+        "min": "-1",
         "name": "start",
         "required": false,
         "type": {
           "__class__": "FFMpegFilterOptionType",
           "value": "int64"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "time"
+        ],
+        "choices": [],
+        "default": "INT64_MAX",
+        "description": "set the loop start time (default INT64_MAX)",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "time",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "duration"
         }
       }
     ],
@@ -10812,12 +11390,19 @@
             "help": "noise",
             "name": "n",
             "value": "3"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A....T.",
+            "help": "error",
+            "name": "e",
+            "value": "4"
           }
         ],
         "default": "o",
-        "description": "set output mode (from 0 to 3) (default o)",
+        "description": "set output mode (from 0 to 4) (default o)",
         "flags": "..F.A....T.",
-        "max": "3",
+        "max": "4",
         "min": "0",
         "name": "out_mode",
         "required": false,
@@ -10995,12 +11580,19 @@
             "help": "noise",
             "name": "n",
             "value": "3"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A....T.",
+            "help": "error",
+            "name": "e",
+            "value": "4"
           }
         ],
         "default": "o",
-        "description": "set output mode (from 0 to 3) (default o)",
+        "description": "set output mode (from 0 to 4) (default o)",
         "flags": "..F.A....T.",
-        "max": "3",
+        "max": "4",
         "min": "0",
         "name": "out_mode",
         "required": false,
@@ -11229,6 +11821,24 @@
         "type": {
           "__class__": "FFMpegFilterOptionType",
           "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "density"
+        ],
+        "choices": [],
+        "default": 0.05,
+        "description": "set density (from 0 to 1) (default 0.05)",
+        "flags": "..F.A......",
+        "max": "1",
+        "min": "0",
+        "name": "density",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "double"
         }
       }
     ],
@@ -12219,6 +12829,70 @@
   },
   {
     "__class__": "FFMpegFilter",
+    "description": "Measure Audio Peak Signal-to-Noise Ratio.",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": true,
+    "is_support_timeline": true,
+    "name": "apsnr",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [],
+        "choices": [],
+        "default": null,
+        "description": "timeline editing",
+        "flags": null,
+        "max": null,
+        "min": null,
+        "name": "enable",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#apsnr",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "input0",
+        "type": {
+          "__class__": "StreamType",
+          "value": "audio"
+        }
+      },
+      {
+        "__class__": "FFMpegIOType",
+        "name": "input1",
+        "type": {
+          "__class__": "StreamType",
+          "value": "audio"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "audio"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
     "description": "Audio Psychoacoustic Clipper.",
     "formula_typings_input": null,
     "formula_typings_output": null,
@@ -12870,6 +13544,178 @@
   },
   {
     "__class__": "FFMpegFilter",
+    "description": "Apply Recursive Least Squares algorithm to first audio stream.",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": true,
+    "is_support_framesync": false,
+    "is_support_slice_threading": true,
+    "is_support_timeline": true,
+    "name": "arls",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "order"
+        ],
+        "choices": [],
+        "default": 16,
+        "description": "set the filter order (from 1 to 32767) (default 16)",
+        "flags": "..F.A......",
+        "max": "32767",
+        "min": "1",
+        "name": "order",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "lambda"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "set the filter lambda (from 0 to 1) (default 1)",
+        "flags": "..F.A....T.",
+        "max": "1",
+        "min": "0",
+        "name": "lambda",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "delta"
+        ],
+        "choices": [],
+        "default": 2.0,
+        "description": "set the filter delta (from 0 to 32767) (default 2)",
+        "flags": "..F.A......",
+        "max": "32767",
+        "min": "0",
+        "name": "delta",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "out_mode"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A....T.",
+            "help": "input",
+            "name": "i",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A....T.",
+            "help": "desired",
+            "name": "d",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A....T.",
+            "help": "output",
+            "name": "o",
+            "value": "2"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A....T.",
+            "help": "noise",
+            "name": "n",
+            "value": "3"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A....T.",
+            "help": "error",
+            "name": "e",
+            "value": "4"
+          }
+        ],
+        "default": "o",
+        "description": "set output mode (from 0 to 4) (default o)",
+        "flags": "..F.A....T.",
+        "max": "4",
+        "min": "0",
+        "name": "out_mode",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [],
+        "choices": [],
+        "default": null,
+        "description": "timeline editing",
+        "flags": null,
+        "max": null,
+        "min": null,
+        "name": "enable",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#arls",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "input",
+        "type": {
+          "__class__": "StreamType",
+          "value": "audio"
+        }
+      },
+      {
+        "__class__": "FFMpegIOType",
+        "name": "desired",
+        "type": {
+          "__class__": "StreamType",
+          "value": "audio"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "audio"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
     "description": "Reduce noise from speech using Recurrent Neural Networks.",
     "formula_typings_input": null,
     "formula_typings_output": null,
@@ -12973,10 +13819,27 @@
     "is_filter_source": false,
     "is_support_command": false,
     "is_support_framesync": false,
-    "is_support_slice_threading": false,
-    "is_support_timeline": false,
+    "is_support_slice_threading": true,
+    "is_support_timeline": true,
     "name": "asdr",
-    "options": [],
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [],
+        "choices": [],
+        "default": null,
+        "description": "timeline editing",
+        "flags": null,
+        "max": null,
+        "min": null,
+        "name": "enable",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      }
+    ],
     "pre": [],
     "ref": "https://ffmpeg.org/ffmpeg-filters.html#asdr",
     "stream_typings_input": [
@@ -13232,10 +14095,10 @@
     "is_dynamic_output": false,
     "is_filter_sink": false,
     "is_filter_source": false,
-    "is_support_command": false,
+    "is_support_command": true,
     "is_support_framesync": false,
     "is_support_slice_threading": false,
-    "is_support_timeline": false,
+    "is_support_timeline": true,
     "name": "asetnsamples",
     "options": [
       {
@@ -13247,7 +14110,7 @@
         "choices": [],
         "default": 1024,
         "description": "set the number of per-frame output samples (from 1 to INT_MAX) (default 1024)",
-        "flags": "..F.A......",
+        "flags": "..F.A....T.",
         "max": "INT_MAX",
         "min": "1",
         "name": "nb_out_samples",
@@ -13266,7 +14129,7 @@
         "choices": [],
         "default": true,
         "description": "pad last frame with zeros (default true)",
-        "flags": "..F.A......",
+        "flags": "..F.A....T.",
         "max": null,
         "min": null,
         "name": "pad",
@@ -13274,6 +14137,22 @@
         "type": {
           "__class__": "FFMpegFilterOptionType",
           "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [],
+        "choices": [],
+        "default": null,
+        "description": "timeline editing",
+        "flags": null,
+        "max": null,
+        "min": null,
+        "name": "enable",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
         }
       }
     ],
@@ -13310,7 +14189,7 @@
     "is_dynamic_output": false,
     "is_filter_sink": false,
     "is_filter_source": false,
-    "is_support_command": false,
+    "is_support_command": true,
     "is_support_framesync": false,
     "is_support_slice_threading": false,
     "is_support_timeline": false,
@@ -13324,7 +14203,7 @@
         "choices": [],
         "default": "PTS",
         "description": "Expression determining the frame timestamp (default \"PTS\")",
-        "flags": "..F.A......",
+        "flags": "..F.A....T.",
         "max": null,
         "min": null,
         "name": "expr",
@@ -13753,6 +14632,70 @@
       {
         "__class__": "FFMpegIOType",
         "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "audio"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "audio"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Measure Audio Scale-Invariant Signal-to-Distortion Ratio.",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": true,
+    "is_support_timeline": true,
+    "name": "asisdr",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [],
+        "choices": [],
+        "default": null,
+        "description": "timeline editing",
+        "flags": null,
+        "max": null,
+        "min": null,
+        "name": "enable",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#asisdr",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "input0",
+        "type": {
+          "__class__": "StreamType",
+          "value": "audio"
+        }
+      },
+      {
+        "__class__": "FFMpegIOType",
+        "name": "input1",
         "type": {
           "__class__": "StreamType",
           "value": "audio"
@@ -14404,6 +15347,172 @@
   },
   {
     "__class__": "FFMpegFilter",
+    "description": "Automatic Speech Recognition.",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "asr",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "rate"
+        ],
+        "choices": [],
+        "default": 16000,
+        "description": "set sampling rate (from 0 to INT_MAX) (default 16000)",
+        "flags": "..F.A......",
+        "max": "INT_MAX",
+        "min": "0",
+        "name": "rate",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "hmm"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "set directory containing acoustic model files",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "hmm",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "dict"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "set pronunciation dictionary",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "dict",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "lm"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "set language model file",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "lm",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "lmctl"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "set language model set",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "lmctl",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "lmname"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "set which language model to use",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "lmname",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "logfn"
+        ],
+        "choices": [],
+        "default": "/dev/null",
+        "description": "set output for log messages (default \"/dev/null\")",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "logfn",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#asr",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "audio"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "audio"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
     "description": "Render ASS subtitles onto input video using the libass library.",
     "formula_typings_input": null,
     "formula_typings_output": null,
@@ -14819,10 +15928,17 @@
             "help": "",
             "name": "Zero_crossings_rate",
             "value": "Zero_crossings_rate"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "",
+            "name": "Abs_Peak_count",
+            "value": "Abs_Peak_count"
           }
         ],
-        "default": "all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate",
-        "description": "Select the parameters which are measured per channel (default all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate)",
+        "default": "all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate+Abs_Peak_count",
+        "description": "Select the parameters which are measured per channel (default all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate+Abs_Peak_count)",
         "flags": "..F.A......",
         "max": null,
         "min": null,
@@ -15027,10 +16143,17 @@
             "help": "",
             "name": "Zero_crossings_rate",
             "value": "Zero_crossings_rate"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "",
+            "name": "Abs_Peak_count",
+            "value": "Abs_Peak_count"
           }
         ],
-        "default": "all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate",
-        "description": "Select the parameters which are measured overall (default all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate)",
+        "default": "all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate+Abs_Peak_count",
+        "description": "Select the parameters which are measured overall (default all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate+Abs_Peak_count)",
         "flags": "..F.A......",
         "max": null,
         "min": null,
@@ -17024,6 +18147,194 @@
   },
   {
     "__class__": "FFMpegFilter",
+    "description": "Apply average blur filter",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "avgblur_opencl",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "sizeX"
+        ],
+        "choices": [],
+        "default": 1,
+        "description": "set horizontal size (from 1 to 1024) (default 1)",
+        "flags": "..FV.......",
+        "max": "1024",
+        "min": "1",
+        "name": "sizeX",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "planes"
+        ],
+        "choices": [],
+        "default": 15,
+        "description": "set planes to filter (from 0 to 15) (default 15)",
+        "flags": "..FV.......",
+        "max": "15",
+        "min": "0",
+        "name": "planes",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "sizeY"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "set vertical size (from 0 to 1024) (default 0)",
+        "flags": "..FV.......",
+        "max": "1024",
+        "min": "0",
+        "name": "sizeY",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#avgblur_005fopencl",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Apply avgblur mask to input video",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "avgblur_vulkan",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "sizeX"
+        ],
+        "choices": [],
+        "default": 3,
+        "description": "Set horizontal radius (from 1 to 32) (default 3)",
+        "flags": "..FV.......",
+        "max": "32",
+        "min": "1",
+        "name": "sizeX",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "sizeY"
+        ],
+        "choices": [],
+        "default": 3,
+        "description": "Set vertical radius (from 1 to 32) (default 3)",
+        "flags": "..FV.......",
+        "max": "32",
+        "min": "1",
+        "name": "sizeY",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "planes"
+        ],
+        "choices": [],
+        "default": 15,
+        "description": "Set planes to filter (bitmask) (from 0 to 15) (default 15)",
+        "flags": "..FV.......",
+        "max": "15",
+        "min": "0",
+        "name": "planes",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#avgblur_005fvulkan",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
     "description": "Generate an Audio Video Sync Test.",
     "formula_typings_input": null,
     "formula_typings_output": null,
@@ -17032,7 +18343,7 @@
     "is_dynamic_output": false,
     "is_filter_sink": false,
     "is_filter_source": true,
-    "is_support_command": false,
+    "is_support_command": true,
     "is_support_framesync": false,
     "is_support_slice_threading": false,
     "is_support_timeline": false,
@@ -17104,7 +18415,7 @@
         "choices": [],
         "default": 0.7,
         "description": "set beep amplitude (from 0 to 1) (default 0.7)",
-        "flags": "..F.A......",
+        "flags": "..F.A....T.",
         "max": "1",
         "min": "0",
         "name": "amplitude",
@@ -17142,7 +18453,7 @@
         "choices": [],
         "default": 0,
         "description": "set flash delay (from -30 to 30) (default 0)",
-        "flags": "..FV.......",
+        "flags": "..FV.....T.",
         "max": "30",
         "min": "-30",
         "name": "delay",
@@ -17161,7 +18472,7 @@
         "choices": [],
         "default": false,
         "description": "set delay cycle (default false)",
-        "flags": "..FV.......",
+        "flags": "..FV.....T.",
         "max": null,
         "min": null,
         "name": "cycle",
@@ -17290,7 +18601,7 @@
         ],
         "choices": [],
         "default": 256,
-        "description": "set segment size (from 2 to 131072) (default 256)",
+        "description": "set the segment size (from 2 to 131072) (default 256)",
         "flags": "..F.A......",
         "max": "131072",
         "min": "2",
@@ -17320,12 +18631,19 @@
             "help": "fast algorithm",
             "name": "fast",
             "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "best algorithm",
+            "name": "best",
+            "value": "2"
           }
         ],
-        "default": "slow",
-        "description": "set algorithm (from 0 to 1) (default slow)",
+        "default": "best",
+        "description": "set the algorithm (from 0 to 2) (default best)",
         "flags": "..F.A......",
-        "max": "1",
+        "max": "2",
         "min": "0",
         "name": "algo",
         "required": false,
@@ -17349,6 +18667,65 @@
       {
         "__class__": "FFMpegIOType",
         "name": "axcorrelate1",
+        "type": {
+          "__class__": "StreamType",
+          "value": "audio"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "audio"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Receive commands through ZMQ and broker them to filters.",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "azmq",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "bind_address",
+          "b"
+        ],
+        "choices": [],
+        "default": "tcp://*:5555",
+        "description": "set bind address (default \"tcp://*:5555\")",
+        "flags": "..FVA......",
+        "max": null,
+        "min": null,
+        "name": "bind_address",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#zmq_002c-azmq",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
         "type": {
           "__class__": "StreamType",
           "value": "audio"
@@ -19299,7 +20676,7 @@
       }
     ],
     "pre": [],
-    "ref": "https://ffmpeg.org/ffmpeg-filters.html#blackdetect",
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#blackdetect_002c-blackdetect_005fvulkan",
     "stream_typings_input": [
       {
         "__class__": "FFMpegIOType",
@@ -21318,6 +22695,309 @@
   },
   {
     "__class__": "FFMpegFilter",
+    "description": "Blend two video frames in Vulkan",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": true,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "blend_vulkan",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "c0_mode"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "normal",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "multiply",
+            "value": "13"
+          }
+        ],
+        "default": "normal",
+        "description": "set component #0 blend mode (from 0 to 39) (default normal)",
+        "flags": "..FV.......",
+        "max": "39",
+        "min": "0",
+        "name": "c0_mode",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "c1_mode"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "normal",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "multiply",
+            "value": "13"
+          }
+        ],
+        "default": "normal",
+        "description": "set component #1 blend mode (from 0 to 39) (default normal)",
+        "flags": "..FV.......",
+        "max": "39",
+        "min": "0",
+        "name": "c1_mode",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "c2_mode"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "normal",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "multiply",
+            "value": "13"
+          }
+        ],
+        "default": "normal",
+        "description": "set component #2 blend mode (from 0 to 39) (default normal)",
+        "flags": "..FV.......",
+        "max": "39",
+        "min": "0",
+        "name": "c2_mode",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "c3_mode"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "normal",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "multiply",
+            "value": "13"
+          }
+        ],
+        "default": "normal",
+        "description": "set component #3 blend mode (from 0 to 39) (default normal)",
+        "flags": "..FV.......",
+        "max": "39",
+        "min": "0",
+        "name": "c3_mode",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "all_mode"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "normal",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "multiply",
+            "value": "13"
+          }
+        ],
+        "default": -1,
+        "description": "set blend mode for all components (from -1 to 39) (default -1)",
+        "flags": "..FV.......",
+        "max": "39",
+        "min": "-1",
+        "name": "all_mode",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "c0_opacity"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "set color component #0 opacity (from 0 to 1) (default 1)",
+        "flags": "..FV.......",
+        "max": "1",
+        "min": "0",
+        "name": "c0_opacity",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "double"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "c1_opacity"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "set color component #1 opacity (from 0 to 1) (default 1)",
+        "flags": "..FV.......",
+        "max": "1",
+        "min": "0",
+        "name": "c1_opacity",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "double"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "c2_opacity"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "set color component #2 opacity (from 0 to 1) (default 1)",
+        "flags": "..FV.......",
+        "max": "1",
+        "min": "0",
+        "name": "c2_opacity",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "double"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "c3_opacity"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "set color component #3 opacity (from 0 to 1) (default 1)",
+        "flags": "..FV.......",
+        "max": "1",
+        "min": "0",
+        "name": "c3_opacity",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "double"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "all_opacity"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "set opacity for all color components (from 0 to 1) (default 1)",
+        "flags": "..FV.......",
+        "max": "1",
+        "min": "0",
+        "name": "all_opacity",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "double"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#blend_005fvulkan",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "top",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      },
+      {
+        "__class__": "FFMpegIOType",
+        "name": "bottom",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
     "description": "Blockdetect filter.",
     "formula_typings_input": null,
     "formula_typings_output": null,
@@ -21991,6 +23671,276 @@
   },
   {
     "__class__": "FFMpegFilter",
+    "description": "Apply boxblur filter to input video",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "boxblur_opencl",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "luma_radius",
+          "lr"
+        ],
+        "choices": [],
+        "default": "2",
+        "description": "Radius of the luma blurring box (default \"2\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "luma_radius",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "luma_power",
+          "lp"
+        ],
+        "choices": [],
+        "default": 2,
+        "description": "How many times should the boxblur be applied to luma (from 0 to INT_MAX) (default 2)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "0",
+        "name": "luma_power",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "chroma_radius",
+          "cr"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "Radius of the chroma blurring box",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "chroma_radius",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "chroma_power",
+          "cp"
+        ],
+        "choices": [],
+        "default": -1,
+        "description": "How many times should the boxblur be applied to chroma (from -1 to INT_MAX) (default -1)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "-1",
+        "name": "chroma_power",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "alpha_radius",
+          "ar"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "Radius of the alpha blurring box",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "alpha_radius",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "alpha_power",
+          "ap"
+        ],
+        "choices": [],
+        "default": -1,
+        "description": "How many times should the boxblur be applied to alpha (from -1 to INT_MAX) (default -1)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "-1",
+        "name": "alpha_power",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#boxblur_005fopencl",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Bauer stereo-to-binaural filter.",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "bs2b",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "profile"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "default profile",
+            "name": "default",
+            "value": "2949820"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "Chu Moy circuit",
+            "name": "cmoy",
+            "value": "3932860"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "Jan Meier circuit",
+            "name": "jmeier",
+            "value": "6226570"
+          }
+        ],
+        "default": "default",
+        "description": "Apply a pre-defined crossfeed level (from 0 to INT_MAX) (default default)",
+        "flags": "..F.A......",
+        "max": "INT_MAX",
+        "min": "0",
+        "name": "profile",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "fcut"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "Set cut frequency (in Hz) (from 0 to 2000) (default 0)",
+        "flags": "..F.A......",
+        "max": "2000",
+        "min": "0",
+        "name": "fcut",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "feed"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "Set feed level (in Hz) (from 0 to 150) (default 0)",
+        "flags": "..F.A......",
+        "max": "150",
+        "min": "0",
+        "name": "feed",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#bs2b",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "audio"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "audio"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
     "description": "Buffer video frames, and make them accessible to the filterchain.",
     "formula_typings_input": null,
     "formula_typings_output": null,
@@ -22343,6 +24293,182 @@
   },
   {
     "__class__": "FFMpegFilter",
+    "description": "Deinterlace Vulkan frames via bwdif",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": true,
+    "name": "bwdif_vulkan",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "mode"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "send one frame for each frame",
+            "name": "send_frame",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "send one frame for each field",
+            "name": "send_field",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "send one frame for each frame, but skip spatial interlacing check",
+            "name": "send_frame_nospatial",
+            "value": "2"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "send one frame for each field, but skip spatial interlacing check",
+            "name": "send_field_nospatial",
+            "value": "3"
+          }
+        ],
+        "default": "send_frame",
+        "description": "specify the interlacing mode (from 0 to 3) (default send_frame)",
+        "flags": "..FV.......",
+        "max": "3",
+        "min": "0",
+        "name": "mode",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "parity"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "assume top field first",
+            "name": "tff",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "assume bottom field first",
+            "name": "bff",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "auto detect parity",
+            "name": "auto",
+            "value": "-1"
+          }
+        ],
+        "default": "auto",
+        "description": "specify the assumed picture field parity (from -1 to 1) (default auto)",
+        "flags": "..FV.......",
+        "max": "1",
+        "min": "-1",
+        "name": "parity",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "deint"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "deinterlace all frames",
+            "name": "all",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "only deinterlace frames marked as interlaced",
+            "name": "interlaced",
+            "value": "1"
+          }
+        ],
+        "default": "all",
+        "description": "specify which frames to deinterlace (from 0 to 1) (default all)",
+        "flags": "..FV.......",
+        "max": "1",
+        "min": "0",
+        "name": "deint",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [],
+        "choices": [],
+        "default": null,
+        "description": "timeline editing",
+        "flags": null,
+        "max": null,
+        "min": null,
+        "name": "enable",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#bwdif_005fvulkan",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
     "description": "Contrast Adaptive Sharpen.",
     "formula_typings_input": null,
     "formula_typings_output": null,
@@ -22412,6 +24538,45 @@
     ],
     "pre": [],
     "ref": "https://ffmpeg.org/ffmpeg-filters.html#cas",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Repack CEA-708 closed caption metadata",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "ccrepack",
+    "options": [],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#ccrepack",
     "stream_typings_input": [
       {
         "__class__": "FFMpegIOType",
@@ -22955,6 +25120,82 @@
         "type": {
           "__class__": "StreamType",
           "value": "audio"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Offset chroma of input video (chromatic aberration)",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "chromaber_vulkan",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "dist_x"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "Set horizontal distortion amount (from -10 to 10) (default 0)",
+        "flags": "..FV.......",
+        "max": "10",
+        "min": "-10",
+        "name": "dist_x",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "dist_y"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "Set vertical distortion amount (from -10 to 10) (default 0)",
+        "flags": "..FV.......",
+        "max": "10",
+        "min": "-10",
+        "name": "dist_y",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#chromaber_005fvulkan",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
         }
       }
     ]
@@ -24371,6 +26612,210 @@
     ],
     "pre": [],
     "ref": "https://ffmpeg.org/ffmpeg-filters.html#allrgb_002c-allyuv_002c-color_002c-colorchart_002c-colorspectrum_002c-haldclutsrc_002c-nullsrc_002c-pal75bars_002c-pal100bars_002c-rgbtestsrc_002c-smptebars_002c-smptehdbars_002c-testsrc_002c-testsrc2_002c-yuvtestsrc",
+    "stream_typings_input": [],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Generate a constant color (Vulkan)",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": true,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "color_vulkan",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "color",
+          "c"
+        ],
+        "choices": [],
+        "default": "black",
+        "description": "set color (default \"black\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "color",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "color"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "size",
+          "s"
+        ],
+        "choices": [],
+        "default": "1920x1080",
+        "description": "set video size (default \"1920x1080\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "size",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "image_size"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "rate",
+          "r"
+        ],
+        "choices": [],
+        "default": "60",
+        "description": "set video rate (default \"60\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "rate",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "video_rate"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "duration",
+          "d"
+        ],
+        "choices": [],
+        "default": -1e-06,
+        "description": "set video duration (default -0.000001)",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "duration",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "duration"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "sar"
+        ],
+        "choices": [],
+        "default": "1/1",
+        "description": "set video sample aspect ratio (from 0 to INT_MAX) (default 1/1)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "0",
+        "name": "sar",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "rational"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "format"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "Output video format (software format of hardware frames)",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "format",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "out_range"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Full range",
+            "name": "full",
+            "value": "2"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Limited range",
+            "name": "limited",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Full range",
+            "name": "jpeg",
+            "value": "2"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Limited range",
+            "name": "mpeg",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Limited range",
+            "name": "tv",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Full range",
+            "name": "pc",
+            "value": "2"
+          }
+        ],
+        "default": 0,
+        "description": "Output colour range (from 0 to 2) (default 0) (from 0 to 2) (default 0)",
+        "flags": "..FV.......",
+        "max": "2",
+        "min": "0",
+        "name": "out_range",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#color_005fvulkan",
     "stream_typings_input": [],
     "stream_typings_output": [
       {
@@ -25889,6 +28334,100 @@
     ],
     "pre": [],
     "ref": "https://ffmpeg.org/ffmpeg-filters.html#colorkey",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Turns a certain color into transparency. Operates on RGB colors.",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "colorkey_opencl",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "color"
+        ],
+        "choices": [],
+        "default": "black",
+        "description": "set the colorkey key color (default \"black\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "color",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "color"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "similarity"
+        ],
+        "choices": [],
+        "default": 0.01,
+        "description": "set the colorkey similarity value (from 0.01 to 1) (default 0.01)",
+        "flags": "..FV.......",
+        "max": "1",
+        "min": "0.01",
+        "name": "similarity",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "blend"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "set the colorkey key blend value (from 0 to 1) (default 0)",
+        "flags": "..FV.......",
+        "max": "1",
+        "min": "0",
+        "name": "blend",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#colorkey_005fopencl",
     "stream_typings_input": [
       {
         "__class__": "FFMpegIOType",
@@ -28872,6 +31411,245 @@
     ],
     "pre": [],
     "ref": "https://ffmpeg.org/ffmpeg-filters.html#convolution",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Apply convolution mask to input video",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "convolution_opencl",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "0m",
+          "1m"
+        ],
+        "choices": [],
+        "default": "0 0 0 0 1 0 0 0 0",
+        "description": "set matrix for 2nd plane (default \"0 0 0 0 1 0 0 0 0\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "0m",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "2m"
+        ],
+        "choices": [],
+        "default": "0 0 0 0 1 0 0 0 0",
+        "description": "set matrix for 3rd plane (default \"0 0 0 0 1 0 0 0 0\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "2m",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "3m"
+        ],
+        "choices": [],
+        "default": "0 0 0 0 1 0 0 0 0",
+        "description": "set matrix for 4th plane (default \"0 0 0 0 1 0 0 0 0\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "3m",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "0rdiv"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "set rdiv for 1nd plane (from 0 to INT_MAX) (default 1)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "0",
+        "name": "0rdiv",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "1rdiv"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "set rdiv for 2nd plane (from 0 to INT_MAX) (default 1)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "0",
+        "name": "1rdiv",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "2rdiv"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "set rdiv for 3rd plane (from 0 to INT_MAX) (default 1)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "0",
+        "name": "2rdiv",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "3rdiv"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "set rdiv for 4th plane (from 0 to INT_MAX) (default 1)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "0",
+        "name": "3rdiv",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "0bias"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "set bias for 1st plane (from 0 to INT_MAX) (default 0)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "0",
+        "name": "0bias",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "1bias"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "set bias for 2nd plane (from 0 to INT_MAX) (default 0)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "0",
+        "name": "1bias",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "2bias"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "set bias for 3rd plane (from 0 to INT_MAX) (default 0)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "0",
+        "name": "2bias",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "3bias"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "set bias for 4th plane (from 0 to INT_MAX) (default 0)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "0",
+        "name": "3bias",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#convolution_005fopencl",
     "stream_typings_input": [
       {
         "__class__": "FFMpegIOType",
@@ -32719,17 +35497,9 @@
         "alias": [
           "dnn_backend"
         ],
-        "choices": [
-          {
-            "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
-            "help": "native backend flag",
-            "name": "native",
-            "value": "0"
-          }
-        ],
-        "default": "native",
-        "description": "DNN backend (from 0 to 1) (default native)",
+        "choices": [],
+        "default": 1,
+        "description": "DNN backend (from 0 to 1) (default 1)",
         "flags": "..FV.......",
         "max": "1",
         "min": "0",
@@ -33113,6 +35883,154 @@
     ],
     "pre": [],
     "ref": "https://ffmpeg.org/ffmpeg-filters.html#deshake",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Feature-point based video stabilization filter",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "deshake_opencl",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "tripod"
+        ],
+        "choices": [],
+        "default": false,
+        "description": "simulates a tripod by preventing any camera movement whatsoever from the original frame (default false)",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "tripod",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "debug"
+        ],
+        "choices": [],
+        "default": false,
+        "description": "turn on additional debugging information (default false)",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "debug",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "adaptive_crop"
+        ],
+        "choices": [],
+        "default": true,
+        "description": "attempt to subtly crop borders to reduce mirrored content (default true)",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "adaptive_crop",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "refine_features"
+        ],
+        "choices": [],
+        "default": true,
+        "description": "refine feature point locations at a sub-pixel level (default true)",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "refine_features",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "smooth_strength"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "smoothing strength (0 attempts to adaptively determine optimal strength) (from 0 to 1) (default 0)",
+        "flags": "..FV.......",
+        "max": "1",
+        "min": "0",
+        "name": "smooth_strength",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "smooth_window_multiplier"
+        ],
+        "choices": [],
+        "default": 2.0,
+        "description": "multiplier for number of frames to buffer for motion data (from 0.1 to 10) (default 2)",
+        "flags": "..FV.......",
+        "max": "10",
+        "min": "0.1",
+        "name": "smooth_window_multiplier",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#deshake_005fopencl",
     "stream_typings_input": [
       {
         "__class__": "FFMpegIOType",
@@ -33730,7 +36648,7 @@
   },
   {
     "__class__": "FFMpegFilter",
-    "description": "Displace pixels.",
+    "description": "Apply dilation effect",
     "formula_typings_input": null,
     "formula_typings_output": null,
     "id": null,
@@ -33741,6 +36659,136 @@
     "is_support_command": false,
     "is_support_framesync": false,
     "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "dilation_opencl",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "threshold0"
+        ],
+        "choices": [],
+        "default": 65535.0,
+        "description": "set threshold for 1st plane (from 0 to 65535) (default 65535)",
+        "flags": "..FV.......",
+        "max": "65535",
+        "min": "0",
+        "name": "threshold0",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "threshold1"
+        ],
+        "choices": [],
+        "default": 65535.0,
+        "description": "set threshold for 2nd plane (from 0 to 65535) (default 65535)",
+        "flags": "..FV.......",
+        "max": "65535",
+        "min": "0",
+        "name": "threshold1",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "threshold2"
+        ],
+        "choices": [],
+        "default": 65535.0,
+        "description": "set threshold for 3rd plane (from 0 to 65535) (default 65535)",
+        "flags": "..FV.......",
+        "max": "65535",
+        "min": "0",
+        "name": "threshold2",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "threshold3"
+        ],
+        "choices": [],
+        "default": 65535.0,
+        "description": "set threshold for 4th plane (from 0 to 65535) (default 65535)",
+        "flags": "..FV.......",
+        "max": "65535",
+        "min": "0",
+        "name": "threshold3",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "coordinates"
+        ],
+        "choices": [],
+        "default": 255,
+        "description": "set coordinates (from 0 to 255) (default 255)",
+        "flags": "..FV.......",
+        "max": "255",
+        "min": "0",
+        "name": "coordinates",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#dilation_005fopencl",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Displace pixels.",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": true,
+    "is_support_framesync": false,
+    "is_support_slice_threading": true,
     "is_support_timeline": true,
     "name": "displace",
     "options": [
@@ -33752,28 +36800,28 @@
         "choices": [
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "blank",
             "value": "0"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "smear",
             "value": "1"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "wrap",
             "value": "2"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "mirror",
             "value": "3"
@@ -33781,7 +36829,7 @@
         ],
         "default": "smear",
         "description": "set edge mode (from 0 to 3) (default smear)",
-        "flags": "..FV.......",
+        "flags": "..FV.....T.",
         "max": "3",
         "min": "0",
         "name": "edge",
@@ -34290,17 +37338,9 @@
         "alias": [
           "dnn_backend"
         ],
-        "choices": [
-          {
-            "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
-            "help": "native backend flag",
-            "name": "native",
-            "value": "0"
-          }
-        ],
-        "default": "native",
-        "description": "DNN backend (from INT_MIN to INT_MAX) (default native)",
+        "choices": [],
+        "default": 1,
+        "description": "DNN backend (from INT_MIN to INT_MAX) (default 1)",
         "flags": "..FV.......",
         "max": "INT_MAX",
         "min": "INT_MIN",
@@ -35332,7 +38372,7 @@
         "choices": [],
         "default": null,
         "description": "set text",
-        "flags": "..FV.......",
+        "flags": "..FV.....T.",
         "max": null,
         "min": null,
         "name": "text",
@@ -35368,7 +38408,7 @@
         "choices": [],
         "default": "black",
         "description": "set foreground color (default \"black\")",
-        "flags": "..FV.......",
+        "flags": "..FV.....T.",
         "max": null,
         "min": null,
         "name": "fontcolor",
@@ -35404,7 +38444,7 @@
         "choices": [],
         "default": "white",
         "description": "set box color (default \"white\")",
-        "flags": "..FV.......",
+        "flags": "..FV.....T.",
         "max": null,
         "min": null,
         "name": "boxcolor",
@@ -35422,7 +38462,7 @@
         "choices": [],
         "default": "black",
         "description": "set border color (default \"black\")",
-        "flags": "..FV.......",
+        "flags": "..FV.....T.",
         "max": null,
         "min": null,
         "name": "bordercolor",
@@ -35440,7 +38480,7 @@
         "choices": [],
         "default": "black",
         "description": "set shadow color (default \"black\")",
-        "flags": "..FV.......",
+        "flags": "..FV.....T.",
         "max": null,
         "min": null,
         "name": "shadowcolor",
@@ -35458,7 +38498,7 @@
         "choices": [],
         "default": false,
         "description": "set box (default false)",
-        "flags": "..FV.......",
+        "flags": "..FV.....T.",
         "max": null,
         "min": null,
         "name": "box",
@@ -35474,16 +38514,16 @@
           "boxborderw"
         ],
         "choices": [],
-        "default": 0,
-        "description": "set box border width (from INT_MIN to INT_MAX) (default 0)",
-        "flags": "..FV.......",
-        "max": "INT_MAX",
-        "min": "INT_MIN",
+        "default": "0",
+        "description": "set box borders width (default \"0\")",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
         "name": "boxborderw",
         "required": false,
         "type": {
           "__class__": "FFMpegFilterOptionType",
-          "value": "int"
+          "value": "string"
         }
       },
       {
@@ -35494,7 +38534,7 @@
         "choices": [],
         "default": 0,
         "description": "set line spacing in pixels (from INT_MIN to INT_MAX) (default 0)",
-        "flags": "..FV.......",
+        "flags": "..FV.....T.",
         "max": "INT_MAX",
         "min": "INT_MIN",
         "name": "line_spacing",
@@ -35512,7 +38552,7 @@
         "choices": [],
         "default": null,
         "description": "set font size",
-        "flags": "..FV.......",
+        "flags": "..FV.....T.",
         "max": null,
         "min": null,
         "name": "fontsize",
@@ -35525,12 +38565,115 @@
       {
         "__class__": "FFMpegFilterOption",
         "alias": [
+          "text_align"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "left",
+            "value": "left"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "L",
+            "value": "L"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "right",
+            "value": "right"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "R",
+            "value": "R"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "center",
+            "value": "center"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "C",
+            "value": "C"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "top",
+            "value": "top"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "T",
+            "value": "T"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "bottom",
+            "value": "bottom"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "B",
+            "value": "B"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "middle",
+            "value": "middle"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "M",
+            "value": "M"
+          }
+        ],
+        "default": "0",
+        "description": "set text alignment (default 0)",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "text_align",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "flags"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
           "x"
         ],
         "choices": [],
         "default": "0",
         "description": "set x expression (default \"0\")",
-        "flags": "..FV.......",
+        "flags": "..FV.....T.",
         "max": null,
         "min": null,
         "name": "x",
@@ -35548,7 +38691,7 @@
         "choices": [],
         "default": "0",
         "description": "set y expression (default \"0\")",
-        "flags": "..FV.......",
+        "flags": "..FV.....T.",
         "max": null,
         "min": null,
         "name": "y",
@@ -35561,12 +38704,48 @@
       {
         "__class__": "FFMpegFilterOption",
         "alias": [
+          "boxw"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "set box width (from 0 to INT_MAX) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "INT_MAX",
+        "min": "0",
+        "name": "boxw",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "boxh"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "set box height (from 0 to INT_MAX) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "INT_MAX",
+        "min": "0",
+        "name": "boxh",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
           "shadowx"
         ],
         "choices": [],
         "default": 0,
         "description": "set shadow x offset (from INT_MIN to INT_MAX) (default 0)",
-        "flags": "..FV.......",
+        "flags": "..FV.....T.",
         "max": "INT_MAX",
         "min": "INT_MIN",
         "name": "shadowx",
@@ -35584,7 +38763,7 @@
         "choices": [],
         "default": 0,
         "description": "set shadow y offset (from INT_MIN to INT_MAX) (default 0)",
-        "flags": "..FV.......",
+        "flags": "..FV.....T.",
         "max": "INT_MAX",
         "min": "INT_MIN",
         "name": "shadowy",
@@ -35602,7 +38781,7 @@
         "choices": [],
         "default": 0,
         "description": "set border width (from INT_MIN to INT_MAX) (default 0)",
-        "flags": "..FV.......",
+        "flags": "..FV.....T.",
         "max": "INT_MAX",
         "min": "INT_MIN",
         "name": "borderw",
@@ -35620,7 +38799,7 @@
         "choices": [],
         "default": 4,
         "description": "set tab size (from 0 to INT_MAX) (default 4)",
-        "flags": "..FV.......",
+        "flags": "..FV.....T.",
         "max": "INT_MAX",
         "min": "0",
         "name": "tabsize",
@@ -35709,6 +38888,46 @@
       {
         "__class__": "FFMpegFilterOption",
         "alias": [
+          "y_align"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "y is referred to the top of the first text line",
+            "name": "text",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "y is referred to the baseline of the first line",
+            "name": "baseline",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "y is referred to the font defined line metrics",
+            "name": "font",
+            "value": "2"
+          }
+        ],
+        "default": "text",
+        "description": "set the y alignment (from 0 to 2) (default text)",
+        "flags": "..FV.....T.",
+        "max": "2",
+        "min": "0",
+        "name": "y_align",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
           "timecode"
         ],
         "choices": [],
@@ -35788,7 +39007,7 @@
         "choices": [],
         "default": "1",
         "description": "apply alpha while rendering (default \"1\")",
-        "flags": "..FV.......",
+        "flags": "..FV.....T.",
         "max": null,
         "min": null,
         "name": "alpha",
@@ -36748,6 +39967,114 @@
         "type": {
           "__class__": "FFMpegFilterOptionType",
           "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "integrated"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "integrated loudness (LUFS) (from -DBL_MAX to DBL_MAX) (default 0)",
+        "flags": "..F.A.XR...",
+        "max": "DBL_MAX",
+        "min": "-DBL_MAX",
+        "name": "integrated",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "double"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "range"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "loudness range (LU) (from -DBL_MAX to DBL_MAX) (default 0)",
+        "flags": "..F.A.XR...",
+        "max": "DBL_MAX",
+        "min": "-DBL_MAX",
+        "name": "range",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "double"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "lra_low"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "LRA low (LUFS) (from -DBL_MAX to DBL_MAX) (default 0)",
+        "flags": "..F.A.XR...",
+        "max": "DBL_MAX",
+        "min": "-DBL_MAX",
+        "name": "lra_low",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "double"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "lra_high"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "LRA high (LUFS) (from -DBL_MAX to DBL_MAX) (default 0)",
+        "flags": "..F.A.XR...",
+        "max": "DBL_MAX",
+        "min": "-DBL_MAX",
+        "name": "lra_high",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "double"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "sample_peak"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "sample peak (dBFS) (from -DBL_MAX to DBL_MAX) (default 0)",
+        "flags": "..F.A.XR...",
+        "max": "DBL_MAX",
+        "min": "-DBL_MAX",
+        "name": "sample_peak",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "double"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "true_peak"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "true peak (dBFS) (from -DBL_MAX to DBL_MAX) (default 0)",
+        "flags": "..F.A.XR...",
+        "max": "DBL_MAX",
+        "min": "-DBL_MAX",
+        "name": "true_peak",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "double"
         }
       }
     ],
@@ -37987,6 +41314,136 @@
   },
   {
     "__class__": "FFMpegFilter",
+    "description": "Apply erosion effect",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "erosion_opencl",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "threshold0"
+        ],
+        "choices": [],
+        "default": 65535.0,
+        "description": "set threshold for 1st plane (from 0 to 65535) (default 65535)",
+        "flags": "..FV.......",
+        "max": "65535",
+        "min": "0",
+        "name": "threshold0",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "threshold1"
+        ],
+        "choices": [],
+        "default": 65535.0,
+        "description": "set threshold for 2nd plane (from 0 to 65535) (default 65535)",
+        "flags": "..FV.......",
+        "max": "65535",
+        "min": "0",
+        "name": "threshold1",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "threshold2"
+        ],
+        "choices": [],
+        "default": 65535.0,
+        "description": "set threshold for 3rd plane (from 0 to 65535) (default 65535)",
+        "flags": "..FV.......",
+        "max": "65535",
+        "min": "0",
+        "name": "threshold2",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "threshold3"
+        ],
+        "choices": [],
+        "default": 65535.0,
+        "description": "set threshold for 4th plane (from 0 to 65535) (default 65535)",
+        "flags": "..FV.......",
+        "max": "65535",
+        "min": "0",
+        "name": "threshold3",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "coordinates"
+        ],
+        "choices": [],
+        "default": 255,
+        "description": "set coordinates (from 0 to 255) (default 255)",
+        "flags": "..FV.......",
+        "max": "255",
+        "min": "0",
+        "name": "coordinates",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#erosion_005fopencl",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
     "description": "Apply Edge Slope Tracing deinterlace.",
     "formula_typings_input": null,
     "formula_typings_output": null,
@@ -38149,16 +41606,16 @@
           "ecost"
         ],
         "choices": [],
-        "default": 1.0,
-        "description": "specify the edge cost for edge matching (from 0 to 9) (default 1)",
+        "default": 2,
+        "description": "specify the edge cost for edge matching (from 0 to 50) (default 2)",
         "flags": "..FV.....T.",
-        "max": "9",
+        "max": "50",
         "min": "0",
         "name": "ecost",
         "required": false,
         "type": {
           "__class__": "FFMpegFilterOptionType",
-          "value": "float"
+          "value": "int"
         }
       },
       {
@@ -38167,16 +41624,16 @@
           "mcost"
         ],
         "choices": [],
-        "default": 0.5,
-        "description": "specify the middle cost for edge matching (from 0 to 1) (default 0.5)",
+        "default": 1,
+        "description": "specify the middle cost for edge matching (from 0 to 50) (default 1)",
         "flags": "..FV.....T.",
-        "max": "1",
+        "max": "50",
         "min": "0",
         "name": "mcost",
         "required": false,
         "type": {
           "__class__": "FFMpegFilterOptionType",
-          "value": "float"
+          "value": "int"
         }
       },
       {
@@ -38185,16 +41642,16 @@
           "dcost"
         ],
         "choices": [],
-        "default": 0.5,
-        "description": "specify the distance cost for edge matching (from 0 to 1) (default 0.5)",
+        "default": 1,
+        "description": "specify the distance cost for edge matching (from 0 to 50) (default 1)",
         "flags": "..FV.....T.",
-        "max": "1",
+        "max": "50",
         "min": "0",
         "name": "dcost",
         "required": false,
         "type": {
           "__class__": "FFMpegFilterOptionType",
-          "value": "float"
+          "value": "int"
         }
       },
       {
@@ -41097,6 +44554,168 @@
   },
   {
     "__class__": "FFMpegFilter",
+    "description": "Flip both horizontally and vertically",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "flip_vulkan",
+    "options": [],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#flip_005fvulkan",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Synthesize voice from text using libflite.",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": true,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "flite",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "list_voices"
+        ],
+        "choices": [],
+        "default": false,
+        "description": "list voices and exit (default false)",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "list_voices",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "nb_samples",
+          "n"
+        ],
+        "choices": [],
+        "default": 512,
+        "description": "set number of samples per frame (from 0 to INT_MAX) (default 512)",
+        "flags": "..F.A......",
+        "max": "INT_MAX",
+        "min": "0",
+        "name": "nb_samples",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "text"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "set text to speak",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "text",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "textfile"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "set filename of the text to speak",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "textfile",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "v",
+          "voice"
+        ],
+        "choices": [],
+        "default": "kal",
+        "description": "set voice (default \"kal\")",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "v",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#flite",
+    "stream_typings_input": [],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "audio"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
     "description": "Fill area with same color with another color.",
     "formula_typings_input": null,
     "formula_typings_output": null,
@@ -42506,6 +46125,136 @@
   },
   {
     "__class__": "FFMpegFilter",
+    "description": "Gaussian Blur in Vulkan",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "gblur_vulkan",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "sigma"
+        ],
+        "choices": [],
+        "default": 0.5,
+        "description": "Set sigma (from 0.01 to 1024) (default 0.5)",
+        "flags": "..FV.......",
+        "max": "1024",
+        "min": "0.01",
+        "name": "sigma",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "sigmaV"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "Set vertical sigma (from 0 to 1024) (default 0)",
+        "flags": "..FV.......",
+        "max": "1024",
+        "min": "0",
+        "name": "sigmaV",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "planes"
+        ],
+        "choices": [],
+        "default": 15,
+        "description": "Set planes to filter (from 0 to 15) (default 15)",
+        "flags": "..FV.......",
+        "max": "15",
+        "min": "0",
+        "name": "planes",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "size"
+        ],
+        "choices": [],
+        "default": 19,
+        "description": "Set kernel size (from 1 to 127) (default 19)",
+        "flags": "..FV.......",
+        "max": "127",
+        "min": "1",
+        "name": "size",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "sizeV"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "Set vertical kernel size (from 0 to 127) (default 0)",
+        "flags": "..FV.......",
+        "max": "127",
+        "min": "0",
+        "name": "sizeV",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#gblur_005fvulkan",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
     "description": "Apply generic equation to each pixel.",
     "formula_typings_input": null,
     "formula_typings_output": null,
@@ -43250,7 +46999,7 @@
     "is_dynamic_output": false,
     "is_filter_sink": false,
     "is_filter_source": false,
-    "is_support_command": false,
+    "is_support_command": true,
     "is_support_framesync": false,
     "is_support_slice_threading": false,
     "is_support_timeline": false,
@@ -43284,7 +47033,7 @@
         "choices": [],
         "default": 0.9,
         "description": "set video opacity (from 0 to 1) (default 0.9)",
-        "flags": "..FV.......",
+        "flags": "..FV.....T.",
         "max": "1",
         "min": "0",
         "name": "opacity",
@@ -43303,29 +47052,50 @@
         "choices": [
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "full",
-            "value": "0"
+            "value": "full"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "compact",
-            "value": "1"
+            "value": "compact"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "nozero",
+            "value": "nozero"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "noeof",
+            "value": "noeof"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "nodisabled",
+            "value": "nodisabled"
           }
         ],
-        "default": "full",
-        "description": "set mode (from 0 to 1) (default full)",
-        "flags": "..FV.......",
-        "max": "1",
-        "min": "0",
+        "default": "0",
+        "description": "set mode (default 0)",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
         "name": "mode",
         "required": false,
         "type": {
           "__class__": "FFMpegFilterOptionType",
-          "value": "int"
+          "value": "flags"
         }
       },
       {
@@ -43337,120 +47107,141 @@
         "choices": [
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "none",
+            "value": "none"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "all",
+            "value": "all"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "queue",
             "value": "queue"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "frame_count_in",
             "value": "frame_count_in"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "frame_count_out",
             "value": "frame_count_out"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "frame_count_delta",
             "value": "frame_count_delta"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "pts",
             "value": "pts"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "pts_delta",
             "value": "pts_delta"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "time",
             "value": "time"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "time_delta",
             "value": "time_delta"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "timebase",
             "value": "timebase"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "format",
             "value": "format"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "size",
             "value": "size"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "rate",
             "value": "rate"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "eof",
             "value": "eof"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "sample_count_in",
             "value": "sample_count_in"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "sample_count_out",
             "value": "sample_count_out"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
+            "flags": "..FV.....T.",
             "help": "",
             "name": "sample_count_delta",
             "value": "sample_count_delta"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "disabled",
+            "value": "disabled"
           }
         ],
-        "default": "queue",
-        "description": "set flags (default queue)",
-        "flags": "..FV.......",
+        "default": "all+queue",
+        "description": "set flags (default all+queue)",
+        "flags": "..FV.....T.",
         "max": null,
         "min": null,
         "name": "flags",
@@ -44932,6 +48723,45 @@
     ],
     "pre": [],
     "ref": "https://ffmpeg.org/ffmpeg-filters.html#hflip",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Horizontally flip the input video in Vulkan",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "hflip_vulkan",
+    "options": [],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#hflip_005fvulkan",
     "stream_typings_input": [
       {
         "__class__": "FFMpegIOType",
@@ -46811,6 +50641,91 @@
   },
   {
     "__class__": "FFMpegFilter",
+    "description": "\"VA-API\" hstack",
+    "formula_typings_input": "[StreamType.video] * int(inputs)",
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": true,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "hstack_vaapi",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "inputs"
+        ],
+        "choices": [],
+        "default": 2,
+        "description": "Set number of inputs (from 2 to 65535) (default 2)",
+        "flags": "..FV.......",
+        "max": "65535",
+        "min": "2",
+        "name": "inputs",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "shortest"
+        ],
+        "choices": [],
+        "default": false,
+        "description": "Force termination when the shortest input terminates (default false)",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "shortest",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "height"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "Set output height (0 to use the height of input 0) (from 0 to 65535) (default 0)",
+        "flags": "..FV.......",
+        "max": "65535",
+        "min": "0",
+        "name": "height",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#hstack_005fvaapi",
+    "stream_typings_input": [],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
     "description": "Turns a certain HSV range into gray.",
     "formula_typings_input": null,
     "formula_typings_output": null,
@@ -47696,6 +51611,64 @@
     ],
     "pre": [],
     "ref": "https://ffmpeg.org/ffmpeg-filters.html#hwupload",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Upload a system memory frame to a CUDA device.",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "hwupload_cuda",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "device"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "Number of the device to use (from 0 to INT_MAX) (default 0)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "0",
+        "name": "device",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#hwupload_005fcuda",
     "stream_typings_input": [
       {
         "__class__": "FFMpegIOType",
@@ -49169,6 +53142,170 @@
   },
   {
     "__class__": "FFMpegFilter",
+    "description": "Apply LADSPA effect.",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": true,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": true,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "ladspa",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "file",
+          "f"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "set library name or full path",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "file",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "plugin",
+          "p"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "set plugin name",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "plugin",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "controls",
+          "c"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "set plugin options",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "controls",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "sample_rate",
+          "s"
+        ],
+        "choices": [],
+        "default": 44100,
+        "description": "set sample rate (from 1 to INT_MAX) (default 44100)",
+        "flags": "..F.A......",
+        "max": "INT_MAX",
+        "min": "1",
+        "name": "sample_rate",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "nb_samples",
+          "n"
+        ],
+        "choices": [],
+        "default": 1024,
+        "description": "set the number of samples per requested frame (from 1 to INT_MAX) (default 1024)",
+        "flags": "..F.A......",
+        "max": "INT_MAX",
+        "min": "1",
+        "name": "nb_samples",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "duration",
+          "d"
+        ],
+        "choices": [],
+        "default": -1e-06,
+        "description": "set audio duration (default -0.000001)",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "duration",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "duration"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "latency",
+          "l"
+        ],
+        "choices": [],
+        "default": false,
+        "description": "enable latency compensation (default false)",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "latency",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#ladspa",
+    "stream_typings_input": [],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "audio"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
     "description": "Slowly update darker pixels.",
     "formula_typings_input": null,
     "formula_typings_output": null,
@@ -49483,6 +53620,2084 @@
         }
       }
     ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Apply various GPU filters from libplacebo",
+    "formula_typings_input": "[StreamType.video] * int(inputs)",
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": true,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": true,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "libplacebo",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "inputs"
+        ],
+        "choices": [],
+        "default": 1,
+        "description": "Number of inputs (from 1 to INT_MAX) (default 1)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "1",
+        "name": "inputs",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "w"
+        ],
+        "choices": [],
+        "default": "iw",
+        "description": "Output video frame width (default \"iw\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "w",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "h"
+        ],
+        "choices": [],
+        "default": "ih",
+        "description": "Output video frame height (default \"ih\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "h",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "fps"
+        ],
+        "choices": [],
+        "default": "none",
+        "description": "Output video frame rate (default \"none\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "fps",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "crop_x"
+        ],
+        "choices": [],
+        "default": "(iw-cw",
+        "description": "Input video crop x (default \"(iw-cw)/2\")",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "crop_x",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "crop_y"
+        ],
+        "choices": [],
+        "default": "(ih-ch",
+        "description": "Input video crop y (default \"(ih-ch)/2\")",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "crop_y",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "crop_w"
+        ],
+        "choices": [],
+        "default": "iw",
+        "description": "Input video crop w (default \"iw\")",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "crop_w",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "crop_h"
+        ],
+        "choices": [],
+        "default": "ih",
+        "description": "Input video crop h (default \"ih\")",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "crop_h",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "pos_x"
+        ],
+        "choices": [],
+        "default": "(ow-pw",
+        "description": "Output video placement x (default \"(ow-pw)/2\")",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "pos_x",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "pos_y"
+        ],
+        "choices": [],
+        "default": "(oh-ph",
+        "description": "Output video placement y (default \"(oh-ph)/2\")",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "pos_y",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "pos_w"
+        ],
+        "choices": [],
+        "default": "ow",
+        "description": "Output video placement w (default \"ow\")",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "pos_w",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "pos_h"
+        ],
+        "choices": [],
+        "default": "oh",
+        "description": "Output video placement h (default \"oh\")",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "pos_h",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "format"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "Output video format",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "format",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "force_original_aspect_ratio"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "disable",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "decrease",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "increase",
+            "value": "2"
+          }
+        ],
+        "default": "disable",
+        "description": "decrease or increase w/h if necessary to keep the original AR (from 0 to 2) (default disable)",
+        "flags": "..FV.......",
+        "max": "2",
+        "min": "0",
+        "name": "force_original_aspect_ratio",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "force_divisible_by"
+        ],
+        "choices": [],
+        "default": 1,
+        "description": "enforce that the output resolution is divisible by a defined integer when force_original_aspect_ratio is used (from 1 to 256) (default 1)",
+        "flags": "..FV.......",
+        "max": "256",
+        "min": "1",
+        "name": "force_divisible_by",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "normalize_sar"
+        ],
+        "choices": [],
+        "default": false,
+        "description": "force SAR normalization to 1:1 by adjusting pos_x/y/w/h (default false)",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "normalize_sar",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "pad_crop_ratio"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "ratio between padding and cropping when normalizing SAR (0=pad, 1=crop) (from 0 to 1) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "1",
+        "min": "0",
+        "name": "pad_crop_ratio",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "fillcolor"
+        ],
+        "choices": [],
+        "default": "black",
+        "description": "Background fill color (default \"black\")",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "fillcolor",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "corner_rounding"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "Corner rounding radius (from 0 to 1) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "1",
+        "min": "0",
+        "name": "corner_rounding",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "extra_opts"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "Pass extra libplacebo-specific options using a :-separated list of key=value pairs",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "extra_opts",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "dictionary"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "colorspace"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "keep the same colorspace",
+            "name": "auto",
+            "value": "-1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "gbr",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "bt709",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "unknown",
+            "value": "2"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "bt470bg",
+            "value": "5"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "smpte170m",
+            "value": "6"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "smpte240m",
+            "value": "7"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "ycgco",
+            "value": "8"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "bt2020nc",
+            "value": "9"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "bt2020c",
+            "value": "10"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "ictcp",
+            "value": "14"
+          }
+        ],
+        "default": "auto",
+        "description": "select colorspace (from -1 to 14) (default auto)",
+        "flags": "..FV.....T.",
+        "max": "14",
+        "min": "-1",
+        "name": "colorspace",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "range"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "keep the same color range",
+            "name": "auto",
+            "value": "-1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "unspecified",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "unknown",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "limited",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "tv",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "mpeg",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "full",
+            "value": "2"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "pc",
+            "value": "2"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "jpeg",
+            "value": "2"
+          }
+        ],
+        "default": "auto",
+        "description": "select color range (from -1 to 2) (default auto)",
+        "flags": "..FV.....T.",
+        "max": "2",
+        "min": "-1",
+        "name": "range",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "color_primaries"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "keep the same color primaries",
+            "name": "auto",
+            "value": "-1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "bt709",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "unknown",
+            "value": "2"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "bt470m",
+            "value": "4"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "bt470bg",
+            "value": "5"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "smpte170m",
+            "value": "6"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "smpte240m",
+            "value": "7"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "film",
+            "value": "8"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "bt2020",
+            "value": "9"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "smpte428",
+            "value": "10"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "smpte431",
+            "value": "11"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "smpte432",
+            "value": "12"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "p22",
+            "value": "22"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "ebu3213",
+            "value": "22"
+          }
+        ],
+        "default": "auto",
+        "description": "select color primaries (from -1 to 22) (default auto)",
+        "flags": "..FV.....T.",
+        "max": "22",
+        "min": "-1",
+        "name": "color_primaries",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "color_trc"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "keep the same color transfer",
+            "name": "auto",
+            "value": "-1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "bt709",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "unknown",
+            "value": "2"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "bt470m",
+            "value": "4"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "bt470bg",
+            "value": "5"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "smpte170m",
+            "value": "6"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "smpte240m",
+            "value": "7"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "linear",
+            "value": "8"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "4",
+            "value": "11"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "bt1361e",
+            "value": "12"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "1",
+            "value": "13"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "10",
+            "value": "14"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "12",
+            "value": "15"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "smpte2084",
+            "value": "16"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "b67",
+            "value": "18"
+          }
+        ],
+        "default": "auto",
+        "description": "select color transfer (from -1 to 18) (default auto)",
+        "flags": "..FV.....T.",
+        "max": "18",
+        "min": "-1",
+        "name": "color_trc",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "upscaler"
+        ],
+        "choices": [],
+        "default": "spline36",
+        "description": "Upscaler function (default \"spline36\")",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "upscaler",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "downscaler"
+        ],
+        "choices": [],
+        "default": "mitchell",
+        "description": "Downscaler function (default \"mitchell\")",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "downscaler",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "frame_mixer"
+        ],
+        "choices": [],
+        "default": "none",
+        "description": "Frame mixing function (default \"none\")",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "frame_mixer",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "lut_entries"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "Number of scaler LUT entries (from 0 to 256) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "256",
+        "min": "0",
+        "name": "lut_entries",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "antiringing"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "Antiringing strength (for non-EWA filters) (from 0 to 1) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "1",
+        "min": "0",
+        "name": "antiringing",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "sigmoid"
+        ],
+        "choices": [],
+        "default": true,
+        "description": "Enable sigmoid upscaling (default true)",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "sigmoid",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "apply_filmgrain"
+        ],
+        "choices": [],
+        "default": true,
+        "description": "Apply film grain metadata (default true)",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "apply_filmgrain",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "apply_dolbyvision"
+        ],
+        "choices": [],
+        "default": true,
+        "description": "Apply Dolby Vision metadata (default true)",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "apply_dolbyvision",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "deband"
+        ],
+        "choices": [],
+        "default": false,
+        "description": "Enable debanding (default false)",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "deband",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "deband_iterations"
+        ],
+        "choices": [],
+        "default": 1,
+        "description": "Deband iterations (from 0 to 16) (default 1)",
+        "flags": "..FV.....T.",
+        "max": "16",
+        "min": "0",
+        "name": "deband_iterations",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "deband_threshold"
+        ],
+        "choices": [],
+        "default": 4.0,
+        "description": "Deband threshold (from 0 to 1024) (default 4)",
+        "flags": "..FV.....T.",
+        "max": "1024",
+        "min": "0",
+        "name": "deband_threshold",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "deband_radius"
+        ],
+        "choices": [],
+        "default": 16.0,
+        "description": "Deband radius (from 0 to 1024) (default 16)",
+        "flags": "..FV.....T.",
+        "max": "1024",
+        "min": "0",
+        "name": "deband_radius",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "deband_grain"
+        ],
+        "choices": [],
+        "default": 6.0,
+        "description": "Deband grain (from 0 to 1024) (default 6)",
+        "flags": "..FV.....T.",
+        "max": "1024",
+        "min": "0",
+        "name": "deband_grain",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "brightness"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "Brightness boost (from -1 to 1) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "1",
+        "min": "-1",
+        "name": "brightness",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "contrast"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "Contrast gain (from 0 to 16) (default 1)",
+        "flags": "..FV.....T.",
+        "max": "16",
+        "min": "0",
+        "name": "contrast",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "saturation"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "Saturation gain (from 0 to 16) (default 1)",
+        "flags": "..FV.....T.",
+        "max": "16",
+        "min": "0",
+        "name": "saturation",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "hue"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "Hue shift (from -3.14159 to 3.14159) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "3.14159",
+        "min": "-3.14159",
+        "name": "hue",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "gamma"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "Gamma adjustment (from 0 to 16) (default 1)",
+        "flags": "..FV.....T.",
+        "max": "16",
+        "min": "0",
+        "name": "gamma",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "peak_detect"
+        ],
+        "choices": [],
+        "default": true,
+        "description": "Enable dynamic peak detection for HDR tone-mapping (default true)",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "peak_detect",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "smoothing_period"
+        ],
+        "choices": [],
+        "default": 100.0,
+        "description": "Peak detection smoothing period (from 0 to 1000) (default 100)",
+        "flags": "..FV.....T.",
+        "max": "1000",
+        "min": "0",
+        "name": "smoothing_period",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "minimum_peak"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "Peak detection minimum peak (from 0 to 100) (default 1)",
+        "flags": "..FV.....T.",
+        "max": "100",
+        "min": "0",
+        "name": "minimum_peak",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "scene_threshold_low"
+        ],
+        "choices": [],
+        "default": 5.5,
+        "description": "Scene change low threshold (from -1 to 100) (default 5.5)",
+        "flags": "..FV.....T.",
+        "max": "100",
+        "min": "-1",
+        "name": "scene_threshold_low",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "scene_threshold_high"
+        ],
+        "choices": [],
+        "default": 10.0,
+        "description": "Scene change high threshold (from -1 to 100) (default 10)",
+        "flags": "..FV.....T.",
+        "max": "100",
+        "min": "-1",
+        "name": "scene_threshold_high",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "percentile"
+        ],
+        "choices": [],
+        "default": 99.995,
+        "description": "Peak detection percentile (from 0 to 100) (default 99.995)",
+        "flags": "..FV.....T.",
+        "max": "100",
+        "min": "0",
+        "name": "percentile",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "gamut_mode"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Hard-clip (RGB per-channel)",
+            "name": "clip",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Colorimetric soft clipping",
+            "name": "perceptual",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Relative colorimetric clipping",
+            "name": "relative",
+            "value": "2"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Saturation mapping (RGB -> RGB)",
+            "name": "saturation",
+            "value": "3"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Absolute colorimetric clipping",
+            "name": "absolute",
+            "value": "4"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Colorimetrically desaturate colors towards white",
+            "name": "desaturate",
+            "value": "5"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Colorimetric clip with bias towards darkening image to fit gamut",
+            "name": "darken",
+            "value": "6"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Highlight out-of-gamut colors",
+            "name": "warn",
+            "value": "7"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Linearly reduce chromaticity to fit gamut",
+            "name": "linear",
+            "value": "8"
+          }
+        ],
+        "default": "perceptual",
+        "description": "Gamut-mapping mode (from 0 to 8) (default perceptual)",
+        "flags": "..FV.....T.",
+        "max": "8",
+        "min": "0",
+        "name": "gamut_mode",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "tonemapping"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Automatic selection",
+            "name": "auto",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "No tone mapping (clip",
+            "name": "clip",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "SMPTE ST 2094-40",
+            "name": "40",
+            "value": "2"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "SMPTE ST 2094-10",
+            "name": "10",
+            "value": "3"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "ITU-R BT.2390 EETF",
+            "name": "2390",
+            "value": "4"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "ITU-R BT.2446 Method A",
+            "name": "2446a",
+            "value": "5"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Single-pivot polynomial spline",
+            "name": "spline",
+            "value": "6"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Reinhard",
+            "name": "reinhard",
+            "value": "7"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Mobius",
+            "name": "mobius",
+            "value": "8"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Filmic tone-mapping (Hable)",
+            "name": "hable",
+            "value": "9"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Gamma function with knee",
+            "name": "gamma",
+            "value": "10"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Perceptually linear stretch",
+            "name": "linear",
+            "value": "11"
+          }
+        ],
+        "default": "auto",
+        "description": "Tone-mapping algorithm (from 0 to 11) (default auto)",
+        "flags": "..FV.....T.",
+        "max": "11",
+        "min": "0",
+        "name": "tonemapping",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "tonemapping_param"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "Tunable parameter for some tone-mapping functions (from 0 to 100) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "100",
+        "min": "0",
+        "name": "tonemapping_param",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "inverse_tonemapping"
+        ],
+        "choices": [],
+        "default": false,
+        "description": "Inverse tone mapping (range expansion) (default false)",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "inverse_tonemapping",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "tonemapping_lut_size"
+        ],
+        "choices": [],
+        "default": 256,
+        "description": "Tone-mapping LUT size (from 2 to 1024) (default 256)",
+        "flags": "..FV.....T.",
+        "max": "1024",
+        "min": "2",
+        "name": "tonemapping_lut_size",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "contrast_recovery"
+        ],
+        "choices": [],
+        "default": 0.3,
+        "description": "HDR contrast recovery strength (from 0 to 3) (default 0.3)",
+        "flags": "..FV.....T.",
+        "max": "3",
+        "min": "0",
+        "name": "contrast_recovery",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "contrast_smoothness"
+        ],
+        "choices": [],
+        "default": 3.5,
+        "description": "HDR contrast recovery smoothness (from 1 to 32) (default 3.5)",
+        "flags": "..FV.....T.",
+        "max": "32",
+        "min": "1",
+        "name": "contrast_smoothness",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "desaturation_strength"
+        ],
+        "choices": [],
+        "default": -1.0,
+        "description": "Desaturation strength (from -1 to 1) (default -1)",
+        "flags": "..FV.....TP",
+        "max": "1",
+        "min": "-1",
+        "name": "desaturation_strength",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "desaturation_exponent"
+        ],
+        "choices": [],
+        "default": -1.0,
+        "description": "Desaturation exponent (from -1 to 10) (default -1)",
+        "flags": "..FV.....TP",
+        "max": "10",
+        "min": "-1",
+        "name": "desaturation_exponent",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "gamut_warning"
+        ],
+        "choices": [],
+        "default": false,
+        "description": "Highlight out-of-gamut colors (default false)",
+        "flags": "..FV.....TP",
+        "max": null,
+        "min": null,
+        "name": "gamut_warning",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "gamut_clipping"
+        ],
+        "choices": [],
+        "default": false,
+        "description": "Enable desaturating colorimetric gamut clipping (default false)",
+        "flags": "..FV.....TP",
+        "max": null,
+        "min": null,
+        "name": "gamut_clipping",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "intent"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Perceptual",
+            "name": "perceptual",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Relative colorimetric",
+            "name": "relative",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Absolute colorimetric",
+            "name": "absolute",
+            "value": "3"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Saturation mapping",
+            "name": "saturation",
+            "value": "2"
+          }
+        ],
+        "default": "perceptual",
+        "description": "Rendering intent (from 0 to 3) (default perceptual)",
+        "flags": "..FV.....TP",
+        "max": "3",
+        "min": "0",
+        "name": "intent",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "tonemapping_mode"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Automatic selection",
+            "name": "auto",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Per-channel (RGB)",
+            "name": "rgb",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Maximum component",
+            "name": "max",
+            "value": "2"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Hybrid of Luma/RGB",
+            "name": "hybrid",
+            "value": "3"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Luminance",
+            "name": "luma",
+            "value": "4"
+          }
+        ],
+        "default": "auto",
+        "description": "Tone-mapping mode (from 0 to 4) (default auto)",
+        "flags": "..FV.....TP",
+        "max": "4",
+        "min": "0",
+        "name": "tonemapping_mode",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "tonemapping_crosstalk"
+        ],
+        "choices": [],
+        "default": 0.04,
+        "description": "Crosstalk factor for tone-mapping (from 0 to 0.3) (default 0.04)",
+        "flags": "..FV.....TP",
+        "max": "0.3",
+        "min": "0",
+        "name": "tonemapping_crosstalk",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "overshoot"
+        ],
+        "choices": [],
+        "default": 0.05,
+        "description": "Tone-mapping overshoot margin (from 0 to 1) (default 0.05)",
+        "flags": "..FV.....TP",
+        "max": "1",
+        "min": "0",
+        "name": "overshoot",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "hybrid_mix"
+        ],
+        "choices": [],
+        "default": 0.2,
+        "description": "Tone-mapping hybrid LMS mixing coefficient (from 0 to 1) (default 0.2)",
+        "flags": "..FV.....T.",
+        "max": "1",
+        "min": "0",
+        "name": "hybrid_mix",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "dithering"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Disable dithering",
+            "name": "none",
+            "value": "-1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Blue noise",
+            "name": "blue",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Ordered LUT",
+            "name": "ordered",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Fixed function ordered",
+            "name": "ordered_fixed",
+            "value": "2"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "White noise",
+            "name": "white",
+            "value": "3"
+          }
+        ],
+        "default": "blue",
+        "description": "Dither method to use (from -1 to 3) (default blue)",
+        "flags": "..FV.....T.",
+        "max": "3",
+        "min": "-1",
+        "name": "dithering",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "dither_lut_size"
+        ],
+        "choices": [],
+        "default": 6,
+        "description": "Dithering LUT size (from 1 to 8) (default 6)",
+        "flags": "..FV.......",
+        "max": "8",
+        "min": "1",
+        "name": "dither_lut_size",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "dither_temporal"
+        ],
+        "choices": [],
+        "default": false,
+        "description": "Enable temporal dithering (default false)",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "dither_temporal",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "cones"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "L cone",
+            "name": "l",
+            "value": "l"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "M cone",
+            "name": "m",
+            "value": "m"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "S cone",
+            "name": "s",
+            "value": "s"
+          }
+        ],
+        "default": "0",
+        "description": "Colorblindness adaptation model (default 0)",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "cones",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "flags"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "cone-strength"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "Colorblindness adaptation strength (from 0 to 10) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "10",
+        "min": "0",
+        "name": "cone-strength",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "custom_shader_path"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "Path to custom user shader (mpv .hook format)",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "custom_shader_path",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "custom_shader_bin"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "Custom user shader as binary (mpv .hook format)",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "custom_shader_bin",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "binary"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "skip_aa"
+        ],
+        "choices": [],
+        "default": false,
+        "description": "Skip anti-aliasing (default false)",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "skip_aa",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "polar_cutoff"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "Polar LUT cutoff (from 0 to 1) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "1",
+        "min": "0",
+        "name": "polar_cutoff",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "disable_linear"
+        ],
+        "choices": [],
+        "default": false,
+        "description": "Disable linear scaling (default false)",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "disable_linear",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "disable_builtin"
+        ],
+        "choices": [],
+        "default": false,
+        "description": "Disable built-in scalers (default false)",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "disable_builtin",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "force_icc_lut"
+        ],
+        "choices": [],
+        "default": false,
+        "description": "Deprecated, does nothing (default false)",
+        "flags": "..FV.....TP",
+        "max": null,
+        "min": null,
+        "name": "force_icc_lut",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "force_dither"
+        ],
+        "choices": [],
+        "default": false,
+        "description": "Force dithering (default false)",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "force_dither",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "disable_fbos"
+        ],
+        "choices": [],
+        "default": false,
+        "description": "Force-disable FBOs (default false)",
+        "flags": "..FV.....T.",
+        "max": null,
+        "min": null,
+        "name": "disable_fbos",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      }
+    ],
+    "pre": {
+      "inputs": "len(streams)"
+    },
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#libplacebo",
+    "stream_typings_input": [],
     "stream_typings_output": [
       {
         "__class__": "FFMpegIOType",
@@ -50016,15 +56231,33 @@
         ],
         "choices": [],
         "default": 0,
-        "description": "set the loop start frame (from 0 to I64_MAX) (default 0)",
+        "description": "set the loop start frame (from -1 to I64_MAX) (default 0)",
         "flags": "..FV.......",
         "max": "I64_MAX",
-        "min": "0",
+        "min": "-1",
         "name": "start",
         "required": false,
         "type": {
           "__class__": "FFMpegFilterOptionType",
           "value": "int64"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "time"
+        ],
+        "choices": [],
+        "default": "INT64_MAX",
+        "description": "set the loop start time (default INT64_MAX)",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "time",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "duration"
         }
       }
     ],
@@ -52498,6 +58731,132 @@
   },
   {
     "__class__": "FFMpegFilter",
+    "description": "Apply LV2 effect.",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": true,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": true,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "lv2",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "plugin",
+          "p"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "set plugin uri",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "plugin",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "controls",
+          "c"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "set plugin options",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "controls",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "sample_rate",
+          "s"
+        ],
+        "choices": [],
+        "default": 44100,
+        "description": "set sample rate (from 1 to INT_MAX) (default 44100)",
+        "flags": "..F.A......",
+        "max": "INT_MAX",
+        "min": "1",
+        "name": "sample_rate",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "nb_samples",
+          "n"
+        ],
+        "choices": [],
+        "default": 1024,
+        "description": "set the number of samples per requested frame (from 1 to INT_MAX) (default 1024)",
+        "flags": "..F.A......",
+        "max": "INT_MAX",
+        "min": "1",
+        "name": "nb_samples",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "duration",
+          "d"
+        ],
+        "choices": [],
+        "default": -1e-06,
+        "description": "set audio duration (default -0.000001)",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "duration",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "duration"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#lv2",
+    "stream_typings_input": [],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "audio"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
     "description": "Render a Mandelbrot fractal.",
     "formula_typings_input": null,
     "formula_typings_output": null,
@@ -53493,6 +59852,144 @@
     ],
     "pre": [],
     "ref": "https://ffmpeg.org/ffmpeg-filters.html#maskfun",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Apply motion compensating deinterlacing.",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "mcdeint",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "mode"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "fast",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "medium",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "slow",
+            "value": "2"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "extra_slow",
+            "value": "3"
+          }
+        ],
+        "default": "fast",
+        "description": "set mode (from 0 to 3) (default fast)",
+        "flags": "..FV.......",
+        "max": "3",
+        "min": "0",
+        "name": "mode",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "parity"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "assume top field first",
+            "name": "tff",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "assume bottom field first",
+            "name": "bff",
+            "value": "1"
+          }
+        ],
+        "default": "bff",
+        "description": "set the assumed picture field parity (from -1 to 1) (default bff)",
+        "flags": "..FV.......",
+        "max": "1",
+        "min": "-1",
+        "name": "parity",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "qp"
+        ],
+        "choices": [],
+        "default": 1,
+        "description": "set qp (from INT_MIN to INT_MAX) (default 1)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "INT_MIN",
+        "name": "qp",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#mcdeint",
     "stream_typings_input": [
       {
         "__class__": "FFMpegIOType",
@@ -55071,7 +61568,7 @@
     "is_filter_source": false,
     "is_support_command": true,
     "is_support_framesync": true,
-    "is_support_slice_threading": false,
+    "is_support_slice_threading": true,
     "is_support_timeline": true,
     "name": "morpho",
     "options": [
@@ -55567,6 +62064,24 @@
         "max": "INT_MAX",
         "min": "INT_MIN",
         "name": "max",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "keep"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "set the number of similar consecutive frames to be kept before starting to drop similar frames (from 0 to INT_MAX) (default 0)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "0",
+        "name": "keep",
         "required": false,
         "type": {
           "__class__": "FFMpegFilterOptionType",
@@ -56394,6 +62909,392 @@
     ],
     "pre": [],
     "ref": "https://ffmpeg.org/ffmpeg-filters.html#nlmeans",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Non-local means denoiser through OpenCL",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "nlmeans_opencl",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "s"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "denoising strength (from 1 to 30) (default 1)",
+        "flags": "..FV.......",
+        "max": "30",
+        "min": "1",
+        "name": "s",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "double"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "p"
+        ],
+        "choices": [],
+        "default": 7,
+        "description": "patch size (from 0 to 99) (default 7)",
+        "flags": "..FV.......",
+        "max": "99",
+        "min": "0",
+        "name": "p",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "pc"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "patch size for chroma planes (from 0 to 99) (default 0)",
+        "flags": "..FV.......",
+        "max": "99",
+        "min": "0",
+        "name": "pc",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "r"
+        ],
+        "choices": [],
+        "default": 15,
+        "description": "research window (from 0 to 99) (default 15)",
+        "flags": "..FV.......",
+        "max": "99",
+        "min": "0",
+        "name": "r",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "rc"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "research window for chroma planes (from 0 to 99) (default 0)",
+        "flags": "..FV.......",
+        "max": "99",
+        "min": "0",
+        "name": "rc",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#nlmeans_005fopencl",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Non-local means denoiser (Vulkan)",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "nlmeans_vulkan",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "s"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "denoising strength for all components (from 1 to 100) (default 1)",
+        "flags": "..FV.......",
+        "max": "100",
+        "min": "1",
+        "name": "s",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "double"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "p"
+        ],
+        "choices": [],
+        "default": 7,
+        "description": "patch size for all components (from 0 to 99) (default 7)",
+        "flags": "..FV.......",
+        "max": "99",
+        "min": "0",
+        "name": "p",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "r"
+        ],
+        "choices": [],
+        "default": 15,
+        "description": "research window radius (from 0 to 99) (default 15)",
+        "flags": "..FV.......",
+        "max": "99",
+        "min": "0",
+        "name": "r",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "t"
+        ],
+        "choices": [],
+        "default": 36,
+        "description": "parallelism (from 1 to 168) (default 36)",
+        "flags": "..FV.......",
+        "max": "168",
+        "min": "1",
+        "name": "t",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "s1"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "denoising strength for component 1 (from 1 to 100) (default 1)",
+        "flags": "..FV.......",
+        "max": "100",
+        "min": "1",
+        "name": "s1",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "double"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "s2"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "denoising strength for component 2 (from 1 to 100) (default 1)",
+        "flags": "..FV.......",
+        "max": "100",
+        "min": "1",
+        "name": "s2",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "double"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "s3"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "denoising strength for component 3 (from 1 to 100) (default 1)",
+        "flags": "..FV.......",
+        "max": "100",
+        "min": "1",
+        "name": "s3",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "double"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "s4"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "denoising strength for component 4 (from 1 to 100) (default 1)",
+        "flags": "..FV.......",
+        "max": "100",
+        "min": "1",
+        "name": "s4",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "double"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "p1"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "patch size for component 1 (from 0 to 99) (default 0)",
+        "flags": "..FV.......",
+        "max": "99",
+        "min": "0",
+        "name": "p1",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "p2"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "patch size for component 2 (from 0 to 99) (default 0)",
+        "flags": "..FV.......",
+        "max": "99",
+        "min": "0",
+        "name": "p2",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "p3"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "patch size for component 3 (from 0 to 99) (default 0)",
+        "flags": "..FV.......",
+        "max": "99",
+        "min": "0",
+        "name": "p3",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "p4"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "patch size for component 4 (from 0 to 99) (default 0)",
+        "flags": "..FV.......",
+        "max": "99",
+        "min": "0",
+        "name": "p4",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#nlmeans_005fvulkan",
     "stream_typings_input": [
       {
         "__class__": "FFMpegIOType",
@@ -57719,6 +64620,129 @@
   },
   {
     "__class__": "FFMpegFilter",
+    "description": "Generate video using an OpenCL program",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": true,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "openclsrc",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "source"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "OpenCL program source file",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "source",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "kernel"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "Kernel name in program",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "kernel",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "size",
+          "s"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "Video size",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "size",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "image_size"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "format"
+        ],
+        "choices": [],
+        "default": "none",
+        "description": "Video format (default none)",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "format",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "pix_fmt"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "rate",
+          "r"
+        ],
+        "choices": [],
+        "default": "25",
+        "description": "Video frame rate (default \"25\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "rate",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "video_rate"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#openclsrc",
+    "stream_typings_input": [],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
     "description": "2D Video Oscilloscope.",
     "formula_typings_input": null,
     "formula_typings_output": null,
@@ -58216,28 +65240,35 @@
             "__class__": "FFMpegFilterOptionChoice",
             "flags": "..FV.......",
             "help": "",
-            "name": "rgb",
+            "name": "yuv444p10",
             "value": "5"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
             "flags": "..FV.......",
             "help": "",
-            "name": "gbrp",
+            "name": "rgb",
             "value": "6"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
             "flags": "..FV.......",
             "help": "",
-            "name": "auto",
+            "name": "gbrp",
             "value": "7"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "auto",
+            "value": "8"
           }
         ],
         "default": "yuv420",
-        "description": "set output format (from 0 to 7) (default yuv420)",
+        "description": "set output format (from 0 to 8) (default yuv420)",
         "flags": "..FV.......",
-        "max": "7",
+        "max": "8",
         "min": "0",
         "name": "format",
         "required": false,
@@ -58349,6 +65380,442 @@
     ],
     "pre": [],
     "ref": "https://ffmpeg.org/ffmpeg-filters.html#overlay",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "main",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      },
+      {
+        "__class__": "FFMpegIOType",
+        "name": "overlay",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Overlay one video on top of another",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "overlay_opencl",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "x"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "Overlay x position (from 0 to INT_MAX) (default 0)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "0",
+        "name": "x",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "y"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "Overlay y position (from 0 to INT_MAX) (default 0)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "0",
+        "name": "y",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#overlay_005fopencl",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "main",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      },
+      {
+        "__class__": "FFMpegIOType",
+        "name": "overlay",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Overlay one video on top of another",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": true,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "overlay_vaapi",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "x"
+        ],
+        "choices": [],
+        "default": "0",
+        "description": "Overlay x position (default \"0\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "x",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "y"
+        ],
+        "choices": [],
+        "default": "0",
+        "description": "Overlay y position (default \"0\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "y",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "w"
+        ],
+        "choices": [],
+        "default": "overlay_iw",
+        "description": "Overlay width (default \"overlay_iw\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "w",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "h"
+        ],
+        "choices": [],
+        "default": "overlay_ih*w/overlay_iw",
+        "description": "Overlay height (default \"overlay_ih*w/overlay_iw\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "h",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "alpha"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "Overlay global alpha (from 0 to 1) (default 1)",
+        "flags": "..FV.......",
+        "max": "1",
+        "min": "0",
+        "name": "alpha",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "eof_action"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Repeat the previous frame.",
+            "name": "repeat",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "End both streams.",
+            "name": "endall",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Pass through the main input.",
+            "name": "pass",
+            "value": "2"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Repeat the previous frame.",
+            "name": "repeat",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "End both streams.",
+            "name": "endall",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Pass through the main input.",
+            "name": "pass",
+            "value": "2"
+          }
+        ],
+        "default": "repeat",
+        "description": "Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)",
+        "flags": "..FV.......",
+        "max": "2",
+        "min": "0",
+        "name": "eof_action",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "shortest"
+        ],
+        "choices": [],
+        "default": false,
+        "description": "force termination when the shortest input terminates (default false)",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "shortest",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "repeatlast"
+        ],
+        "choices": [],
+        "default": true,
+        "description": "repeat overlay of the last overlay frame (default true)",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "repeatlast",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "ts_sync_mode"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Frame from secondary input with the nearest lower or equal timestamp to the primary input frame",
+            "name": "default",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Frame from secondary input with the absolute nearest timestamp to the primary input frame",
+            "name": "nearest",
+            "value": "1"
+          }
+        ],
+        "default": "default",
+        "description": "How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)",
+        "flags": "..FV.......",
+        "max": "1",
+        "min": "0",
+        "name": "ts_sync_mode",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#overlay_005fvaapi",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "main",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      },
+      {
+        "__class__": "FFMpegIOType",
+        "name": "overlay",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Overlay a source on top of another",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "overlay_vulkan",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "x"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "Set horizontal offset (from 0 to INT_MAX) (default 0)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "0",
+        "name": "x",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "y"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "Set vertical offset (from 0 to INT_MAX) (default 0)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "0",
+        "name": "y",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#overlay_005fvulkan",
     "stream_typings_input": [
       {
         "__class__": "FFMpegIOType",
@@ -58652,6 +66119,156 @@
     ],
     "pre": [],
     "ref": "https://ffmpeg.org/ffmpeg-filters.html#pad",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Pad the input video.",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "pad_opencl",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "width",
+          "w"
+        ],
+        "choices": [],
+        "default": "iw",
+        "description": "set the pad area width (default \"iw\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "width",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "height",
+          "h"
+        ],
+        "choices": [],
+        "default": "ih",
+        "description": "set the pad area height (default \"ih\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "height",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "x"
+        ],
+        "choices": [],
+        "default": "0",
+        "description": "set the x offset for the input image position (default \"0\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "x",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "y"
+        ],
+        "choices": [],
+        "default": "0",
+        "description": "set the y offset for the input image position (default \"0\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "y",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "color"
+        ],
+        "choices": [],
+        "default": "black",
+        "description": "set the color of the padded area border (default \"black\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "color",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "color"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "aspect"
+        ],
+        "choices": [],
+        "default": "0/1",
+        "description": "pad to fit an aspect instead of a resolution (from 0 to 32767) (default 0/1)",
+        "flags": "..FV.......",
+        "max": "32767",
+        "min": "0",
+        "name": "aspect",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "rational"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#pad_005fopencl",
     "stream_typings_input": [
       {
         "__class__": "FFMpegIOType",
@@ -60354,80 +67971,6 @@
   },
   {
     "__class__": "FFMpegFilter",
-    "description": "Filter video using libpostproc.",
-    "formula_typings_input": null,
-    "formula_typings_output": null,
-    "id": null,
-    "is_dynamic_input": false,
-    "is_dynamic_output": false,
-    "is_filter_sink": false,
-    "is_filter_source": false,
-    "is_support_command": true,
-    "is_support_framesync": false,
-    "is_support_slice_threading": false,
-    "is_support_timeline": true,
-    "name": "pp",
-    "options": [
-      {
-        "__class__": "FFMpegFilterOption",
-        "alias": [
-          "subfilters"
-        ],
-        "choices": [],
-        "default": "de",
-        "description": "set postprocess subfilters (default \"de\")",
-        "flags": "..FV.......",
-        "max": null,
-        "min": null,
-        "name": "subfilters",
-        "required": false,
-        "type": {
-          "__class__": "FFMpegFilterOptionType",
-          "value": "string"
-        }
-      },
-      {
-        "__class__": "FFMpegFilterOption",
-        "alias": [],
-        "choices": [],
-        "default": null,
-        "description": "timeline editing",
-        "flags": null,
-        "max": null,
-        "min": null,
-        "name": "enable",
-        "required": false,
-        "type": {
-          "__class__": "FFMpegFilterOptionType",
-          "value": "string"
-        }
-      }
-    ],
-    "pre": [],
-    "ref": "https://ffmpeg.org/ffmpeg-filters.html#pp",
-    "stream_typings_input": [
-      {
-        "__class__": "FFMpegIOType",
-        "name": "default",
-        "type": {
-          "__class__": "StreamType",
-          "value": "video"
-        }
-      }
-    ],
-    "stream_typings_output": [
-      {
-        "__class__": "FFMpegIOType",
-        "name": "default",
-        "type": {
-          "__class__": "StreamType",
-          "value": "video"
-        }
-      }
-    ]
-  },
-  {
-    "__class__": "FFMpegFilter",
     "description": "Apply Postprocessing 7 filter.",
     "formula_typings_input": null,
     "formula_typings_output": null,
@@ -60735,6 +68278,313 @@
   },
   {
     "__class__": "FFMpegFilter",
+    "description": "Apply prewitt operator",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "prewitt_opencl",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "planes"
+        ],
+        "choices": [],
+        "default": 15,
+        "description": "set planes to filter (from 0 to 15) (default 15)",
+        "flags": "..FV.......",
+        "max": "15",
+        "min": "0",
+        "name": "planes",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "scale"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "set scale (from 0 to 65535) (default 1)",
+        "flags": "..FV.......",
+        "max": "65535",
+        "min": "0",
+        "name": "scale",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "delta"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "set delta (from -65535 to 65535) (default 0)",
+        "flags": "..FV.......",
+        "max": "65535",
+        "min": "-65535",
+        "name": "delta",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#prewitt_005fopencl",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Filter video using an OpenCL program",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": true,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": true,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "program_opencl",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "source"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "OpenCL program source file",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "source",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "kernel"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "Kernel name in program",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "kernel",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "inputs"
+        ],
+        "choices": [],
+        "default": 1,
+        "description": "Number of inputs (from 1 to INT_MAX) (default 1)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "1",
+        "name": "inputs",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "size",
+          "s"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "Video size",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "size",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "image_size"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "eof_action"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Repeat the previous frame.",
+            "name": "repeat",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "End both streams.",
+            "name": "endall",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Pass through the main input.",
+            "name": "pass",
+            "value": "2"
+          }
+        ],
+        "default": "repeat",
+        "description": "Action to take when encountering EOF from secondary input  (from 0 to 2) (default repeat)",
+        "flags": "..FV.......",
+        "max": "2",
+        "min": "0",
+        "name": "eof_action",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "shortest"
+        ],
+        "choices": [],
+        "default": false,
+        "description": "force termination when the shortest input terminates (default false)",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "shortest",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "repeatlast"
+        ],
+        "choices": [],
+        "default": true,
+        "description": "extend last frame of secondary streams beyond EOF (default true)",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "repeatlast",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "ts_sync_mode"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Frame from secondary input with the nearest lower or equal timestamp to the primary input frame",
+            "name": "default",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "Frame from secondary input with the absolute nearest timestamp to the primary input frame",
+            "name": "nearest",
+            "value": "1"
+          }
+        ],
+        "default": "default",
+        "description": "How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)",
+        "flags": "..FV.......",
+        "max": "1",
+        "min": "0",
+        "name": "ts_sync_mode",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#program_005fopencl",
+    "stream_typings_input": [],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
     "description": "Make pseudocolored video frames.",
     "formula_typings_input": null,
     "formula_typings_output": null,
@@ -60958,12 +68808,54 @@
             "help": "",
             "name": "spectral",
             "value": "14"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "cool",
+            "value": "15"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "heat",
+            "value": "16"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "fiery",
+            "value": "17"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "blues",
+            "value": "18"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "green",
+            "value": "19"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.....T.",
+            "help": "",
+            "name": "helix",
+            "value": "20"
           }
         ],
         "default": "none",
-        "description": "set preset (from -1 to 14) (default none)",
+        "description": "set preset (from -1 to 20) (default none)",
         "flags": "..FV.....T.",
-        "max": "14",
+        "max": "20",
         "min": "-1",
         "name": "preset",
         "required": false,
@@ -62003,6 +69895,113 @@
   },
   {
     "__class__": "FFMpegFilter",
+    "description": "Remap pixels using OpenCL.",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "remap_opencl",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "interp"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "near",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "linear",
+            "value": "1"
+          }
+        ],
+        "default": "linear",
+        "description": "set interpolation method (from 0 to 1) (default linear)",
+        "flags": "..FV.......",
+        "max": "1",
+        "min": "0",
+        "name": "interp",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "fill"
+        ],
+        "choices": [],
+        "default": "black",
+        "description": "set the color of the unmapped pixels (default \"black\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "fill",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "color"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#remap_005fopencl",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "source",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      },
+      {
+        "__class__": "FFMpegIOType",
+        "name": "xmap",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      },
+      {
+        "__class__": "FFMpegIOType",
+        "name": "ymap",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
     "description": "Remove grain.",
     "formula_typings_input": null,
     "formula_typings_output": null,
@@ -62258,7 +70257,44 @@
     "is_support_slice_threading": false,
     "is_support_timeline": false,
     "name": "replaygain",
-    "options": [],
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "track_gain"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "track gain (dB) (from -FLT_MAX to FLT_MAX) (default 0)",
+        "flags": "..F.A.XR...",
+        "max": "FLT_MAX",
+        "min": "-FLT_MAX",
+        "name": "track_gain",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "track_peak"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "track peak (from -FLT_MAX to FLT_MAX) (default 0)",
+        "flags": "..F.A.XR...",
+        "max": "FLT_MAX",
+        "min": "-FLT_MAX",
+        "name": "track_peak",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      }
+    ],
     "pre": [],
     "ref": "https://ffmpeg.org/ffmpeg-filters.html#replaygain",
     "stream_typings_input": [
@@ -62791,6 +70827,100 @@
   },
   {
     "__class__": "FFMpegFilter",
+    "description": "Apply roberts operator",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "roberts_opencl",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "planes"
+        ],
+        "choices": [],
+        "default": 15,
+        "description": "set planes to filter (from 0 to 15) (default 15)",
+        "flags": "..FV.......",
+        "max": "15",
+        "min": "0",
+        "name": "planes",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "scale"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "set scale (from 0 to 65535) (default 1)",
+        "flags": "..FV.......",
+        "max": "65535",
+        "min": "0",
+        "name": "scale",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "delta"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "set delta (from -65535 to 65535) (default 0)",
+        "flags": "..FV.......",
+        "max": "65535",
+        "min": "-65535",
+        "name": "delta",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#roberts_005fopencl",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
     "description": "Rotate the input image.",
     "formula_typings_input": null,
     "formula_typings_output": null,
@@ -63221,14 +71351,14 @@
             "flags": "..F.A......",
             "help": "",
             "name": "quality",
-            "value": "0"
+            "value": "33554432"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
             "flags": "..F.A......",
             "help": "",
             "name": "speed",
-            "value": "33554432"
+            "value": "0"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
@@ -63238,8 +71368,8 @@
             "value": "67108864"
           }
         ],
-        "default": "quality",
-        "description": "set pitch quality (from 0 to INT_MAX) (default quality)",
+        "default": "speed",
+        "description": "set pitch quality (from 0 to INT_MAX) (default speed)",
         "flags": "..F.A......",
         "max": "INT_MAX",
         "min": "0",
@@ -65660,7 +73790,7 @@
     "is_dynamic_output": false,
     "is_filter_sink": false,
     "is_filter_source": false,
-    "is_support_command": false,
+    "is_support_command": true,
     "is_support_framesync": false,
     "is_support_slice_threading": false,
     "is_support_timeline": false,
@@ -65674,7 +73804,7 @@
         "choices": [],
         "default": "PTS",
         "description": "Expression determining the frame timestamp (default \"PTS\")",
-        "flags": "..FV.......",
+        "flags": "..FV.....T.",
         "max": null,
         "min": null,
         "name": "expr",
@@ -66749,7 +74879,7 @@
             "__class__": "FFMpegFilterOptionChoice",
             "flags": "..FV.......",
             "help": "logarithmic",
-            "name": "log2",
+            "name": "log",
             "value": "1"
           },
           {
@@ -66772,14 +74902,89 @@
             "help": "erbs",
             "name": "erbs",
             "value": "4"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "sqrt",
+            "name": "sqrt",
+            "value": "5"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "cbrt",
+            "name": "cbrt",
+            "value": "6"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "qdrt",
+            "name": "qdrt",
+            "value": "7"
           }
         ],
         "default": "linear",
-        "description": "set frequency scale (from 0 to 4) (default linear)",
+        "description": "set frequency scale (from 0 to 7) (default linear)",
+        "flags": "..FV.......",
+        "max": "7",
+        "min": "0",
+        "name": "scale",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "iscale"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "linear",
+            "name": "linear",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "logarithmic",
+            "name": "log",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "sqrt",
+            "name": "sqrt",
+            "value": "2"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "cbrt",
+            "name": "cbrt",
+            "value": "3"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "qdrt",
+            "name": "qdrt",
+            "value": "4"
+          }
+        ],
+        "default": "log",
+        "description": "set intensity scale (from 0 to 4) (default log)",
         "flags": "..FV.......",
         "max": "4",
         "min": "0",
-        "name": "scale",
+        "name": "iscale",
         "required": false,
         "type": {
           "__class__": "FFMpegFilterOptionType",
@@ -66793,9 +74998,9 @@
         ],
         "choices": [],
         "default": 20.0,
-        "description": "set minimum frequency (from 1 to 2000) (default 20)",
+        "description": "set minimum frequency (from 1 to 192000) (default 20)",
         "flags": "..FV.......",
-        "max": "2000",
+        "max": "192000",
         "min": "1",
         "name": "min",
         "required": false,
@@ -66811,11 +75016,47 @@
         ],
         "choices": [],
         "default": 20000.0,
-        "description": "set maximum frequency (from 0 to 192000) (default 20000)",
+        "description": "set maximum frequency (from 1 to 192000) (default 20000)",
         "flags": "..FV.......",
         "max": "192000",
-        "min": "0",
+        "min": "1",
         "name": "max",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "imin"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "set minimum intensity (from 0 to 1) (default 0)",
+        "flags": "..FV.......",
+        "max": "1",
+        "min": "0",
+        "name": "imin",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "imax"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "set maximum intensity (from 0 to 1) (default 1)",
+        "flags": "..FV.......",
+        "max": "1",
+        "min": "0",
+        "name": "imax",
         "required": false,
         "type": {
           "__class__": "FFMpegFilterOptionType",
@@ -66847,9 +75088,9 @@
         ],
         "choices": [],
         "default": 1.0,
-        "description": "set frequency deviation (from 0 to 10) (default 1)",
+        "description": "set frequency deviation (from 0 to 100) (default 1)",
         "flags": "..FV.......",
-        "max": "10",
+        "max": "100",
         "min": "0",
         "name": "deviation",
         "required": false,
@@ -67015,6 +75256,42 @@
         "type": {
           "__class__": "FFMpegFilterOptionType",
           "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "bar"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "set bar ratio (from 0 to 1) (default 0)",
+        "flags": "..FV.......",
+        "max": "1",
+        "min": "0",
+        "name": "bar",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "rotation"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "set color rotation (from -1 to 1) (default 0)",
+        "flags": "..FV.......",
+        "max": "1",
+        "min": "-1",
+        "name": "rotation",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
         }
       }
     ],
@@ -69915,8 +78192,8 @@
           "n"
         ],
         "choices": [],
-        "default": 0,
-        "description": "set how many samples to show in the same point (from 0 to INT_MAX) (default 0)",
+        "default": "0/1",
+        "description": "set how many samples to show in the same point (from 0 to INT_MAX) (default 0/1)",
         "flags": "..FV.......",
         "max": "INT_MAX",
         "min": "0",
@@ -69924,7 +78201,7 @@
         "required": false,
         "type": {
           "__class__": "FFMpegFilterOptionType",
-          "value": "int"
+          "value": "rational"
         }
       },
       {
@@ -72189,10 +80466,10 @@
     "is_dynamic_output": false,
     "is_filter_sink": false,
     "is_filter_source": false,
-    "is_support_command": false,
+    "is_support_command": true,
     "is_support_framesync": false,
     "is_support_slice_threading": false,
-    "is_support_timeline": false,
+    "is_support_timeline": true,
     "name": "silenceremove",
     "options": [
       {
@@ -72239,7 +80516,7 @@
         "choices": [],
         "default": 0.0,
         "description": "set threshold for start silence detection (from 0 to DBL_MAX) (default 0)",
-        "flags": "..F.A......",
+        "flags": "..F.A....T.",
         "max": "DBL_MAX",
         "min": "0",
         "name": "start_threshold",
@@ -72275,14 +80552,14 @@
         "choices": [
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..F.A......",
+            "flags": "..F.A....T.",
             "help": "",
             "name": "any",
             "value": "0"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..F.A......",
+            "flags": "..F.A....T.",
             "help": "",
             "name": "all",
             "value": "1"
@@ -72290,7 +80567,7 @@
         ],
         "default": "any",
         "description": "set which channel will trigger trimming from start (from 0 to 1) (default any)",
-        "flags": "..F.A......",
+        "flags": "..F.A....T.",
         "max": "1",
         "min": "0",
         "name": "start_mode",
@@ -72325,7 +80602,7 @@
         ],
         "choices": [],
         "default": 0.0,
-        "description": "set stop duration of non-silence part (default 0)",
+        "description": "set stop duration of silence part (default 0)",
         "flags": "..F.A......",
         "max": null,
         "min": null,
@@ -72344,7 +80621,7 @@
         "choices": [],
         "default": 0.0,
         "description": "set threshold for stop silence detection (from 0 to DBL_MAX) (default 0)",
-        "flags": "..F.A......",
+        "flags": "..F.A....T.",
         "max": "DBL_MAX",
         "min": "0",
         "name": "stop_threshold",
@@ -72380,22 +80657,22 @@
         "choices": [
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..F.A......",
+            "flags": "..F.A....T.",
             "help": "",
             "name": "any",
             "value": "0"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..F.A......",
+            "flags": "..F.A....T.",
             "help": "",
             "name": "all",
             "value": "1"
           }
         ],
-        "default": "any",
-        "description": "set which channel will trigger trimming from end (from 0 to 1) (default any)",
-        "flags": "..F.A......",
+        "default": "all",
+        "description": "set which channel will trigger trimming from end (from 0 to 1) (default all)",
+        "flags": "..F.A....T.",
         "max": "1",
         "min": "0",
         "name": "stop_mode",
@@ -72414,22 +80691,50 @@
           {
             "__class__": "FFMpegFilterOptionChoice",
             "flags": "..F.A......",
-            "help": "use absolute values of samples",
-            "name": "peak",
+            "help": "use mean absolute values of samples",
+            "name": "avg",
             "value": "0"
           },
           {
             "__class__": "FFMpegFilterOptionChoice",
             "flags": "..F.A......",
-            "help": "use squared values of samples",
+            "help": "use root mean squared values of samples",
             "name": "rms",
             "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "use max absolute values of samples",
+            "name": "peak",
+            "value": "2"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "use median of absolute values of samples",
+            "name": "median",
+            "value": "3"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "use absolute of max peak to min peak difference",
+            "name": "ptp",
+            "value": "4"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "use standard deviation from values of samples",
+            "name": "dev",
+            "value": "5"
           }
         ],
         "default": "rms",
-        "description": "set how silence is detected (from 0 to 1) (default rms)",
+        "description": "set how silence is detected (from 0 to 5) (default rms)",
         "flags": "..F.A......",
-        "max": "1",
+        "max": "5",
         "min": "0",
         "name": "detection",
         "required": false,
@@ -72454,6 +80759,55 @@
         "type": {
           "__class__": "FFMpegFilterOptionType",
           "value": "duration"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "timestamp"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "full timestamps rewrite, keep only the start time",
+            "name": "write",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "non-dropped frames are left with same timestamp",
+            "name": "copy",
+            "value": "1"
+          }
+        ],
+        "default": "write",
+        "description": "set how every output frame timestamp is processed (from 0 to 1) (default write)",
+        "flags": "..F.A......",
+        "max": "1",
+        "min": "0",
+        "name": "timestamp",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [],
+        "choices": [],
+        "default": null,
+        "description": "timeline editing",
+        "flags": null,
+        "max": null,
+        "min": null,
+        "name": "enable",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
         }
       }
     ],
@@ -73370,6 +81724,407 @@
   },
   {
     "__class__": "FFMpegFilter",
+    "description": "Apply sobel operator",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "sobel_opencl",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "planes"
+        ],
+        "choices": [],
+        "default": 15,
+        "description": "set planes to filter (from 0 to 15) (default 15)",
+        "flags": "..FV.......",
+        "max": "15",
+        "min": "0",
+        "name": "planes",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "scale"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "set scale (from 0 to 65535) (default 1)",
+        "flags": "..FV.......",
+        "max": "65535",
+        "min": "0",
+        "name": "scale",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "delta"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "set delta (from -65535 to 65535) (default 0)",
+        "flags": "..FV.......",
+        "max": "65535",
+        "min": "-65535",
+        "name": "delta",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#sobel_005fopencl",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "SOFAlizer (Spatially Oriented Format for Acoustics).",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": true,
+    "is_support_timeline": false,
+    "name": "sofalizer",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "sofa"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "sofa filename",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "sofa",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "gain"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "set gain in dB (from -20 to 40) (default 0)",
+        "flags": "..F.A......",
+        "max": "40",
+        "min": "-20",
+        "name": "gain",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "rotation"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "set rotation (from -360 to 360) (default 0)",
+        "flags": "..F.A......",
+        "max": "360",
+        "min": "-360",
+        "name": "rotation",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "elevation"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "set elevation (from -90 to 90) (default 0)",
+        "flags": "..F.A......",
+        "max": "90",
+        "min": "-90",
+        "name": "elevation",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "radius"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "set radius (from 0 to 5) (default 1)",
+        "flags": "..F.A......",
+        "max": "5",
+        "min": "0",
+        "name": "radius",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "type"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "time domain",
+            "name": "time",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..F.A......",
+            "help": "frequency domain",
+            "name": "freq",
+            "value": "1"
+          }
+        ],
+        "default": "freq",
+        "description": "set processing (from 0 to 1) (default freq)",
+        "flags": "..F.A......",
+        "max": "1",
+        "min": "0",
+        "name": "type",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "speakers"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "set speaker custom positions",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "speakers",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "lfegain"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "set lfe gain (from -20 to 40) (default 0)",
+        "flags": "..F.A......",
+        "max": "40",
+        "min": "-20",
+        "name": "lfegain",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "framesize"
+        ],
+        "choices": [],
+        "default": 1024,
+        "description": "set frame size (from 1024 to 96000) (default 1024)",
+        "flags": "..F.A......",
+        "max": "96000",
+        "min": "1024",
+        "name": "framesize",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "normalize"
+        ],
+        "choices": [],
+        "default": true,
+        "description": "normalize IRs (default true)",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "normalize",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "interpolate"
+        ],
+        "choices": [],
+        "default": false,
+        "description": "interpolate IRs from neighbors (default false)",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "interpolate",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "minphase"
+        ],
+        "choices": [],
+        "default": false,
+        "description": "minphase IRs (default false)",
+        "flags": "..F.A......",
+        "max": null,
+        "min": null,
+        "name": "minphase",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "anglestep"
+        ],
+        "choices": [],
+        "default": 0.5,
+        "description": "set neighbor search angle step (from 0.01 to 10) (default 0.5)",
+        "flags": "..F.A......",
+        "max": "10",
+        "min": "0.01",
+        "name": "anglestep",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "radstep"
+        ],
+        "choices": [],
+        "default": 0.01,
+        "description": "set neighbor search radius step (from 0.01 to 1) (default 0.01)",
+        "flags": "..F.A......",
+        "max": "1",
+        "min": "0.01",
+        "name": "radstep",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#sofalizer",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "audio"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "audio"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
     "description": "Convert input spectrum videos to audio output.",
     "formula_typings_input": null,
     "formula_typings_output": null,
@@ -74215,17 +82970,9 @@
         "alias": [
           "dnn_backend"
         ],
-        "choices": [
-          {
-            "__class__": "FFMpegFilterOptionChoice",
-            "flags": "..FV.......",
-            "help": "native backend flag",
-            "name": "native",
-            "value": "0"
-          }
-        ],
-        "default": "native",
-        "description": "DNN backend used for model execution (from 0 to 1) (default native)",
+        "choices": [],
+        "default": 1,
+        "description": "DNN backend used for model execution (from 0 to 1) (default 1)",
         "flags": "..FV.......",
         "max": "1",
         "min": "0",
@@ -75855,6 +84602,24 @@
         "type": {
           "__class__": "FFMpegFilterOptionType",
           "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "wrap_unicode"
+        ],
+        "choices": [],
+        "default": "auto",
+        "description": "break lines according to the Unicode Line Breaking Algorithm (default auto)",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "wrap_unicode",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
         }
       }
     ],
@@ -81553,6 +90318,469 @@
   },
   {
     "__class__": "FFMpegFilter",
+    "description": "Perform HDR to SDR conversion with tonemapping.",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "tonemap_opencl",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "tonemap"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "none",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "linear",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "gamma",
+            "value": "2"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "clip",
+            "value": "3"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "reinhard",
+            "value": "4"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "hable",
+            "value": "5"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "mobius",
+            "value": "6"
+          }
+        ],
+        "default": "none",
+        "description": "tonemap algorithm selection (from 0 to 6) (default none)",
+        "flags": "..FV.......",
+        "max": "6",
+        "min": "0",
+        "name": "tonemap",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "transfer",
+          "t"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "bt709",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "bt2020",
+            "value": "14"
+          }
+        ],
+        "default": "bt709",
+        "description": "set transfer characteristic (from -1 to INT_MAX) (default bt709)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "-1",
+        "name": "transfer",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "matrix",
+          "m"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "bt709",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "bt2020",
+            "value": "9"
+          }
+        ],
+        "default": -1,
+        "description": "set colorspace matrix (from -1 to INT_MAX) (default -1)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "-1",
+        "name": "matrix",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "primaries",
+          "p"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "bt709",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "bt2020",
+            "value": "9"
+          }
+        ],
+        "default": -1,
+        "description": "set color primaries (from -1 to INT_MAX) (default -1)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "-1",
+        "name": "primaries",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "range",
+          "r"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "tv",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "pc",
+            "value": "2"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "limited",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "",
+            "name": "full",
+            "value": "2"
+          }
+        ],
+        "default": -1,
+        "description": "set color range (from -1 to INT_MAX) (default -1)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "-1",
+        "name": "range",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "format"
+        ],
+        "choices": [],
+        "default": "none",
+        "description": "output pixel format (default none)",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "format",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "pix_fmt"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "peak"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "signal peak override (from 0 to DBL_MAX) (default 0)",
+        "flags": "..FV.......",
+        "max": "DBL_MAX",
+        "min": "0",
+        "name": "peak",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "double"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "param"
+        ],
+        "choices": [],
+        "default": NaN,
+        "description": "tonemap parameter (from DBL_MIN to DBL_MAX) (default nan)",
+        "flags": "..FV.......",
+        "max": "DBL_MAX",
+        "min": "DBL_MIN",
+        "name": "param",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "double"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "desat"
+        ],
+        "choices": [],
+        "default": 0.5,
+        "description": "desaturation parameter (from 0 to DBL_MAX) (default 0.5)",
+        "flags": "..FV.......",
+        "max": "DBL_MAX",
+        "min": "0",
+        "name": "desat",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "double"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "threshold"
+        ],
+        "choices": [],
+        "default": 0.2,
+        "description": "scene detection threshold (from 0 to DBL_MAX) (default 0.2)",
+        "flags": "..FV.......",
+        "max": "DBL_MAX",
+        "min": "0",
+        "name": "threshold",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "double"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#tonemap_005fopencl",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "VAAPI VPP for tone-mapping",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "tonemap_vaapi",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "format"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "Output pixel format set",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "format",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "matrix",
+          "m"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "Output color matrix coefficient set",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "matrix",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "primaries",
+          "p"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "Output color primaries set",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "primaries",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "transfer",
+          "t"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "Output color transfer characteristics set",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "transfer",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#tonemap_005fvaapi",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
     "description": "Temporarily pad video frames.",
     "formula_typings_input": null,
     "formula_typings_output": null,
@@ -81853,6 +91081,133 @@
     ],
     "pre": [],
     "ref": "https://ffmpeg.org/ffmpeg-filters.html#transpose",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Transpose Vulkan Filter",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "transpose_vulkan",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "dir"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "rotate counter-clockwise with vertical flip",
+            "name": "cclock_flip",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "rotate clockwise",
+            "name": "clock",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "rotate counter-clockwise",
+            "name": "cclock",
+            "value": "2"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "rotate clockwise with vertical flip",
+            "name": "clock_flip",
+            "value": "3"
+          }
+        ],
+        "default": "cclock_flip",
+        "description": "set transpose direction (from 0 to 7) (default cclock_flip)",
+        "flags": "..FV.......",
+        "max": "7",
+        "min": "0",
+        "name": "dir",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "passthrough"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "always apply transposition",
+            "name": "none",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "preserve portrait geometry",
+            "name": "portrait",
+            "value": "2"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "preserve landscape geometry",
+            "name": "landscape",
+            "value": "1"
+          }
+        ],
+        "default": "none",
+        "description": "do not apply transposition if the input matches the specified geometry (from 0 to INT_MAX) (default none)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "0",
+        "name": "passthrough",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#transpose_005fvulkan",
     "stream_typings_input": [
       {
         "__class__": "FFMpegIOType",
@@ -82834,6 +92189,160 @@
   },
   {
     "__class__": "FFMpegFilter",
+    "description": "Apply unsharp mask to input video",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "unsharp_opencl",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "luma_msize_x",
+          "lx"
+        ],
+        "choices": [],
+        "default": 5.0,
+        "description": "Set luma mask horizontal diameter (pixels) (from 1 to 23) (default 5)",
+        "flags": "..FV.......",
+        "max": "23",
+        "min": "1",
+        "name": "luma_msize_x",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "luma_msize_y",
+          "ly"
+        ],
+        "choices": [],
+        "default": 5.0,
+        "description": "Set luma mask vertical diameter (pixels) (from 1 to 23) (default 5)",
+        "flags": "..FV.......",
+        "max": "23",
+        "min": "1",
+        "name": "luma_msize_y",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "luma_amount",
+          "la"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "Set luma amount (multiplier) (from -10 to 10) (default 1)",
+        "flags": "..FV.......",
+        "max": "10",
+        "min": "-10",
+        "name": "luma_amount",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "chroma_msize_x",
+          "cx"
+        ],
+        "choices": [],
+        "default": 5.0,
+        "description": "Set chroma mask horizontal diameter (pixels after subsampling) (from 1 to 23) (default 5)",
+        "flags": "..FV.......",
+        "max": "23",
+        "min": "1",
+        "name": "chroma_msize_x",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "chroma_msize_y",
+          "cy"
+        ],
+        "choices": [],
+        "default": 5.0,
+        "description": "Set chroma mask vertical diameter (pixels after subsampling) (from 1 to 23) (default 5)",
+        "flags": "..FV.......",
+        "max": "23",
+        "min": "1",
+        "name": "chroma_msize_y",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "chroma_amount",
+          "ca"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "Set chroma amount (multiplier) (from -10 to 10) (default 0)",
+        "flags": "..FV.......",
+        "max": "10",
+        "min": "-10",
+        "name": "chroma_amount",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "float"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#unsharp_005fopencl",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
     "description": "Untile a frame into a sequence of frames.",
     "formula_typings_input": null,
     "formula_typings_output": null,
@@ -82869,6 +92378,134 @@
     ],
     "pre": [],
     "ref": "https://ffmpeg.org/ffmpeg-filters.html#untile",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Apply Ultra Simple / Slow Post-processing filter.",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": true,
+    "is_support_timeline": true,
+    "name": "uspp",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "quality"
+        ],
+        "choices": [],
+        "default": 3,
+        "description": "set quality (from 0 to 8) (default 3)",
+        "flags": "..FV.......",
+        "max": "8",
+        "min": "0",
+        "name": "quality",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "qp"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "force a constant quantizer parameter (from 0 to 63) (default 0)",
+        "flags": "..FV.......",
+        "max": "63",
+        "min": "0",
+        "name": "qp",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "use_bframe_qp"
+        ],
+        "choices": [],
+        "default": false,
+        "description": "use B-frames' QP (default false)",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "use_bframe_qp",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "codec"
+        ],
+        "choices": [],
+        "default": "snow",
+        "description": "Codec name (default \"snow\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "codec",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [],
+        "choices": [],
+        "default": null,
+        "description": "timeline editing",
+        "flags": null,
+        "max": null,
+        "min": null,
+        "name": "enable",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#uspp",
     "stream_typings_input": [
       {
         "__class__": "FFMpegIOType",
@@ -85078,6 +94715,45 @@
   },
   {
     "__class__": "FFMpegFilter",
+    "description": "Vertically flip the input video in Vulkan",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "vflip_vulkan",
+    "options": [],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#vflip_005fvulkan",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
     "description": "Variable frame rate detect filter.",
     "formula_typings_input": null,
     "formula_typings_output": null,
@@ -86807,6 +96483,91 @@
   },
   {
     "__class__": "FFMpegFilter",
+    "description": "\"VA-API\" vstack",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": true,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "vstack_vaapi",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "inputs"
+        ],
+        "choices": [],
+        "default": 2,
+        "description": "Set number of inputs (from 2 to 65535) (default 2)",
+        "flags": "..FV.......",
+        "max": "65535",
+        "min": "2",
+        "name": "inputs",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "shortest"
+        ],
+        "choices": [],
+        "default": false,
+        "description": "Force termination when the shortest input terminates (default false)",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "shortest",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "width"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "Set output width (0 to use the width of input 0) (from 0 to 65535) (default 0)",
+        "flags": "..FV.......",
+        "max": "65535",
+        "min": "0",
+        "name": "width",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#vstack_005fvaapi",
+    "stream_typings_input": [],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
     "description": "Apply Martin Weston three field deinterlace.",
     "formula_typings_input": null,
     "formula_typings_output": null,
@@ -87499,6 +97260,39 @@
         "max": "1",
         "min": "0",
         "name": "fitmode",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "input"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "try to select from all available formats",
+            "name": "all",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "pick first available format",
+            "name": "first",
+            "value": "1"
+          }
+        ],
+        "default": "first",
+        "description": "set input formats selection (from 0 to 1) (default first)",
+        "flags": "..FV.......",
+        "max": "1",
+        "min": "0",
+        "name": "input",
         "required": false,
         "type": {
           "__class__": "FFMpegFilterOptionType",
@@ -88248,12 +98042,96 @@
             "help": "slow fade transition",
             "name": "fadeslow",
             "value": "45"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "hl wind transition",
+            "name": "hlwind",
+            "value": "46"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "hr wind transition",
+            "name": "hrwind",
+            "value": "47"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "vu wind transition",
+            "name": "vuwind",
+            "value": "48"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "vd wind transition",
+            "name": "vdwind",
+            "value": "49"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "cover left transition",
+            "name": "coverleft",
+            "value": "50"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "cover right transition",
+            "name": "coverright",
+            "value": "51"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "cover up transition",
+            "name": "coverup",
+            "value": "52"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "cover down transition",
+            "name": "coverdown",
+            "value": "53"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "reveal left transition",
+            "name": "revealleft",
+            "value": "54"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "reveal right transition",
+            "name": "revealright",
+            "value": "55"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "reveal up transition",
+            "name": "revealup",
+            "value": "56"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "reveal down transition",
+            "name": "revealdown",
+            "value": "57"
           }
         ],
         "default": "fade",
-        "description": "set cross fade transition (from -1 to 45) (default fade)",
+        "description": "set cross fade transition (from -1 to 57) (default fade)",
         "flags": "..FV.......",
-        "max": "45",
+        "max": "57",
         "min": "-1",
         "name": "transition",
         "required": false,
@@ -88319,6 +98197,215 @@
     ],
     "pre": [],
     "ref": "https://ffmpeg.org/ffmpeg-filters.html#xfade",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "main",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      },
+      {
+        "__class__": "FFMpegIOType",
+        "name": "xfade",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Cross fade one video with another video.",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "xfade_opencl",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "transition"
+        ],
+        "choices": [
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "custom transition",
+            "name": "custom",
+            "value": "0"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "fade transition",
+            "name": "fade",
+            "value": "1"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "wipe left transition",
+            "name": "wipeleft",
+            "value": "2"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "wipe right transition",
+            "name": "wiperight",
+            "value": "3"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "wipe up transition",
+            "name": "wipeup",
+            "value": "4"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "wipe down transition",
+            "name": "wipedown",
+            "value": "5"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "slide left transition",
+            "name": "slideleft",
+            "value": "6"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "slide right transition",
+            "name": "slideright",
+            "value": "7"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "slide up transition",
+            "name": "slideup",
+            "value": "8"
+          },
+          {
+            "__class__": "FFMpegFilterOptionChoice",
+            "flags": "..FV.......",
+            "help": "slide down transition",
+            "name": "slidedown",
+            "value": "9"
+          }
+        ],
+        "default": "fade",
+        "description": "set cross fade transition (from 0 to 9) (default fade)",
+        "flags": "..FV.......",
+        "max": "9",
+        "min": "0",
+        "name": "transition",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "source"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "set OpenCL program source file for custom transition",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "source",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "kernel"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "set kernel name in program file for custom transition",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "kernel",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "duration"
+        ],
+        "choices": [],
+        "default": 1.0,
+        "description": "set cross fade duration (default 1)",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "duration",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "duration"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "offset"
+        ],
+        "choices": [],
+        "default": 0.0,
+        "description": "set cross fade start relative to first input stream (default 0)",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "offset",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "duration"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#xfade_005fopencl",
     "stream_typings_input": [
       {
         "__class__": "FFMpegIOType",
@@ -88671,6 +98758,145 @@
       "inputs": "len(streams)"
     },
     "ref": "https://ffmpeg.org/ffmpeg-filters.html#xstack",
+    "stream_typings_input": [],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "\"VA-API\" xstack",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": true,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "xstack_vaapi",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "inputs"
+        ],
+        "choices": [],
+        "default": 2,
+        "description": "Set number of inputs (from 2 to 65535) (default 2)",
+        "flags": "..FV.......",
+        "max": "65535",
+        "min": "2",
+        "name": "inputs",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "shortest"
+        ],
+        "choices": [],
+        "default": false,
+        "description": "Force termination when the shortest input terminates (default false)",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "shortest",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "boolean"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "layout"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "Set custom layout",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "layout",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "grid"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "set fixed size grid layout",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "grid",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "image_size"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "grid_tile_size"
+        ],
+        "choices": [],
+        "default": null,
+        "description": "set tile size in grid layout",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "grid_tile_size",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "image_size"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "fill"
+        ],
+        "choices": [],
+        "default": "none",
+        "description": "Set the color for unused pixels (default \"none\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "fill",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#xstack_005fvaapi",
     "stream_typings_input": [],
     "stream_typings_output": [
       {
@@ -89066,6 +99292,459 @@
     ],
     "pre": [],
     "ref": "https://ffmpeg.org/ffmpeg-filters.html#allrgb_002c-allyuv_002c-color_002c-colorchart_002c-colorspectrum_002c-haldclutsrc_002c-nullsrc_002c-pal75bars_002c-pal100bars_002c-rgbtestsrc_002c-smptebars_002c-smptehdbars_002c-testsrc_002c-testsrc2_002c-yuvtestsrc",
+    "stream_typings_input": [],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Receive commands through ZMQ and broker them to filters.",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": false,
+    "is_support_command": false,
+    "is_support_framesync": false,
+    "is_support_slice_threading": false,
+    "is_support_timeline": false,
+    "name": "zmq",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "bind_address",
+          "b"
+        ],
+        "choices": [],
+        "default": "tcp://*:5555",
+        "description": "set bind address (default \"tcp://*:5555\")",
+        "flags": "..FVA......",
+        "max": null,
+        "min": null,
+        "name": "bind_address",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "string"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#zmq_002c-azmq",
+    "stream_typings_input": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ],
+    "stream_typings_output": [
+      {
+        "__class__": "FFMpegIOType",
+        "name": "default",
+        "type": {
+          "__class__": "StreamType",
+          "value": "video"
+        }
+      }
+    ]
+  },
+  {
+    "__class__": "FFMpegFilter",
+    "description": "Generate zone-plate.",
+    "formula_typings_input": null,
+    "formula_typings_output": null,
+    "id": null,
+    "is_dynamic_input": false,
+    "is_dynamic_output": false,
+    "is_filter_sink": false,
+    "is_filter_source": true,
+    "is_support_command": true,
+    "is_support_framesync": false,
+    "is_support_slice_threading": true,
+    "is_support_timeline": false,
+    "name": "zoneplate",
+    "options": [
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "size",
+          "s"
+        ],
+        "choices": [],
+        "default": "320x240",
+        "description": "set video size (default \"320x240\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "size",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "image_size"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "rate",
+          "r"
+        ],
+        "choices": [],
+        "default": "25",
+        "description": "set video rate (default \"25\")",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "rate",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "video_rate"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "duration",
+          "d"
+        ],
+        "choices": [],
+        "default": -1e-06,
+        "description": "set video duration (default -0.000001)",
+        "flags": "..FV.......",
+        "max": null,
+        "min": null,
+        "name": "duration",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "duration"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "sar"
+        ],
+        "choices": [],
+        "default": "1/1",
+        "description": "set video sample aspect ratio (from 0 to INT_MAX) (default 1/1)",
+        "flags": "..FV.......",
+        "max": "INT_MAX",
+        "min": "0",
+        "name": "sar",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "rational"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "precision"
+        ],
+        "choices": [],
+        "default": 10,
+        "description": "set LUT precision (from 4 to 16) (default 10)",
+        "flags": "..FV.......",
+        "max": "16",
+        "min": "4",
+        "name": "precision",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "xo"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "set X-axis offset (from INT_MIN to INT_MAX) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "INT_MAX",
+        "min": "INT_MIN",
+        "name": "xo",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "yo"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "set Y-axis offset (from INT_MIN to INT_MAX) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "INT_MAX",
+        "min": "INT_MIN",
+        "name": "yo",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "to"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "set T-axis offset (from INT_MIN to INT_MAX) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "INT_MAX",
+        "min": "INT_MIN",
+        "name": "to",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "k0"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "set 0-order phase (from INT_MIN to INT_MAX) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "INT_MAX",
+        "min": "INT_MIN",
+        "name": "k0",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "kx"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "set 1-order X-axis phase (from INT_MIN to INT_MAX) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "INT_MAX",
+        "min": "INT_MIN",
+        "name": "kx",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "ky"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "set 1-order Y-axis phase (from INT_MIN to INT_MAX) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "INT_MAX",
+        "min": "INT_MIN",
+        "name": "ky",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "kt"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "set 1-order T-axis phase (from INT_MIN to INT_MAX) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "INT_MAX",
+        "min": "INT_MIN",
+        "name": "kt",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "kxt"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "set X-axis*T-axis product phase (from INT_MIN to INT_MAX) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "INT_MAX",
+        "min": "INT_MIN",
+        "name": "kxt",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "kyt"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "set Y-axis*T-axis product phase (from INT_MIN to INT_MAX) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "INT_MAX",
+        "min": "INT_MIN",
+        "name": "kyt",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "kxy"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "set X-axis*Y-axis product phase (from INT_MIN to INT_MAX) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "INT_MAX",
+        "min": "INT_MIN",
+        "name": "kxy",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "kx2"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "set 2-order X-axis phase (from INT_MIN to INT_MAX) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "INT_MAX",
+        "min": "INT_MIN",
+        "name": "kx2",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "ky2"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "set 2-order Y-axis phase (from INT_MIN to INT_MAX) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "INT_MAX",
+        "min": "INT_MIN",
+        "name": "ky2",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "kt2"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "set 2-order T-axis phase (from INT_MIN to INT_MAX) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "INT_MAX",
+        "min": "INT_MIN",
+        "name": "kt2",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "ku"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "set 0-order U-color phase (from INT_MIN to INT_MAX) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "INT_MAX",
+        "min": "INT_MIN",
+        "name": "ku",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      },
+      {
+        "__class__": "FFMpegFilterOption",
+        "alias": [
+          "kv"
+        ],
+        "choices": [],
+        "default": 0,
+        "description": "set 0-order V-color phase (from INT_MIN to INT_MAX) (default 0)",
+        "flags": "..FV.....T.",
+        "max": "INT_MAX",
+        "min": "INT_MIN",
+        "name": "kv",
+        "required": false,
+        "type": {
+          "__class__": "FFMpegFilterOptionType",
+          "value": "int"
+        }
+      }
+    ],
+    "pre": [],
+    "ref": "https://ffmpeg.org/ffmpeg-filters.html#zoneplate",
     "stream_typings_input": [],
     "stream_typings_output": [
       {

--- a/src/ffmpeg/common/cache/list/filters.json
+++ b/src/ffmpeg/common/cache/list/filters.json
@@ -53143,7 +53143,7 @@
   {
     "__class__": "FFMpegFilter",
     "description": "Apply LADSPA effect.",
-    "formula_typings_input": null,
+    "formula_typings_input": "[StreamType.audio]",
     "formula_typings_output": null,
     "id": null,
     "is_dynamic_input": true,
@@ -58732,7 +58732,7 @@
   {
     "__class__": "FFMpegFilter",
     "description": "Apply LV2 effect.",
-    "formula_typings_input": null,
+    "formula_typings_input": "[StreamType.audio]",
     "formula_typings_output": null,
     "id": null,
     "is_dynamic_input": true,
@@ -68373,7 +68373,7 @@
   {
     "__class__": "FFMpegFilter",
     "description": "Filter video using an OpenCL program",
-    "formula_typings_input": null,
+    "formula_typings_input": "[StreamType.video] * int(inputs)",
     "formula_typings_output": null,
     "id": null,
     "is_dynamic_input": true,
@@ -96484,7 +96484,7 @@
   {
     "__class__": "FFMpegFilter",
     "description": "\"VA-API\" vstack",
-    "formula_typings_input": null,
+    "formula_typings_input": "[StreamType.video] * int(inputs)",
     "formula_typings_output": null,
     "id": null,
     "is_dynamic_input": true,
@@ -98773,7 +98773,7 @@
   {
     "__class__": "FFMpegFilter",
     "description": "\"VA-API\" xstack",
-    "formula_typings_input": null,
+    "formula_typings_input": "[StreamType.video] * int(inputs)",
     "formula_typings_output": null,
     "id": null,
     "is_dynamic_input": true,

--- a/src/ffmpeg/filters.py
+++ b/src/ffmpeg/filters.py
@@ -10,8 +10,10 @@ from .schema import Auto, Default
 from .streams.audio import AudioStream
 from .streams.video import VideoStream
 from .types import (
+    Binary,
     Boolean,
     Color,
+    Dictionary,
     Double,
     Duration,
     Flags,
@@ -53,6 +55,10 @@ def acrossfade(
         "losi",
         "sinc",
         "isinc",
+        "quat",
+        "quatr",
+        "qsin2",
+        "hsin2",
     ]
     | Default = Default("tri"),
     curve2: Int
@@ -77,6 +83,10 @@ def acrossfade(
         "losi",
         "sinc",
         "isinc",
+        "quat",
+        "quatr",
+        "qsin2",
+        "hsin2",
     ]
     | Default = Default("tri"),
     extra_options: dict[str, Any] = None,
@@ -89,8 +99,8 @@ def acrossfade(
         nb_samples: set number of samples for cross fade duration (from 1 to 2.14748e+08) (default 44100)
         duration: set cross fade duration (default 0)
         overlap: overlap 1st stream end with 2nd stream start (default true)
-        curve1: set fade curve type for 1st stream (from -1 to 18) (default tri)
-        curve2: set fade curve type for 2nd stream (from -1 to 18) (default tri)
+        curve1: set fade curve type for 1st stream (from -1 to 22) (default tri)
+        curve2: set fade curve type for 2nd stream (from -1 to 22) (default tri)
 
     Returns:
         default: the audio stream
@@ -326,7 +336,7 @@ def anlmf(
     mu: Float = Default(0.75),
     eps: Float = Default(1.0),
     leakage: Float = Default(0.0),
-    out_mode: Int | Literal["i", "d", "o", "n"] | Default = Default("o"),
+    out_mode: Int | Literal["i", "d", "o", "n", "e"] | Default = Default("o"),
     enable: String = Default(None),
     extra_options: dict[str, Any] = None,
 ) -> AudioStream:
@@ -339,7 +349,7 @@ def anlmf(
         mu: set the filter mu (from 0 to 2) (default 0.75)
         eps: set the filter eps (from 0 to 1) (default 1)
         leakage: set the filter leakage (from 0 to 1) (default 0)
-        out_mode: set output mode (from 0 to 3) (default o)
+        out_mode: set output mode (from 0 to 4) (default o)
         enable: timeline editing
 
     Returns:
@@ -376,7 +386,7 @@ def anlms(
     mu: Float = Default(0.75),
     eps: Float = Default(1.0),
     leakage: Float = Default(0.0),
-    out_mode: Int | Literal["i", "d", "o", "n"] | Default = Default("o"),
+    out_mode: Int | Literal["i", "d", "o", "n", "e"] | Default = Default("o"),
     enable: String = Default(None),
     extra_options: dict[str, Any] = None,
 ) -> AudioStream:
@@ -389,7 +399,7 @@ def anlms(
         mu: set the filter mu (from 0 to 2) (default 0.75)
         eps: set the filter eps (from 0 to 1) (default 1)
         leakage: set the filter leakage (from 0 to 1) (default 0)
-        out_mode: set output mode (from 0 to 3) (default o)
+        out_mode: set output mode (from 0 to 4) (default o)
         enable: timeline editing
 
     Returns:
@@ -418,14 +428,101 @@ def anlms(
     return filter_node.audio(0)
 
 
+def apsnr(
+    _input0: AudioStream,
+    _input1: AudioStream,
+    *,
+    enable: String = Default(None),
+    extra_options: dict[str, Any] = None,
+) -> AudioStream:
+    """
+
+    Measure Audio Peak Signal-to-Noise Ratio.
+
+    Args:
+        enable: timeline editing
+
+    Returns:
+        default: the audio stream
+
+    References:
+        [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#apsnr)
+
+    """
+    filter_node = filter_node_factory(
+        FFMpegFilterDef(
+            name="apsnr", typings_input=("audio", "audio"), typings_output=("audio",)
+        ),
+        _input0,
+        _input1,
+        **{
+            "enable": enable,
+        }
+        | (extra_options or {}),
+    )
+    return filter_node.audio(0)
+
+
+def arls(
+    _input: AudioStream,
+    _desired: AudioStream,
+    *,
+    order: Int = Default(16),
+    _lambda: Float = Default(1.0),
+    delta: Float = Default(2.0),
+    out_mode: Int | Literal["i", "d", "o", "n", "e"] | Default = Default("o"),
+    enable: String = Default(None),
+    extra_options: dict[str, Any] = None,
+) -> AudioStream:
+    """
+
+    Apply Recursive Least Squares algorithm to first audio stream.
+
+    Args:
+        order: set the filter order (from 1 to 32767) (default 16)
+        _lambda: set the filter lambda (from 0 to 1) (default 1)
+        delta: set the filter delta (from 0 to 32767) (default 2)
+        out_mode: set output mode (from 0 to 4) (default o)
+        enable: timeline editing
+
+    Returns:
+        default: the audio stream
+
+    References:
+        [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#arls)
+
+    """
+    filter_node = filter_node_factory(
+        FFMpegFilterDef(
+            name="arls", typings_input=("audio", "audio"), typings_output=("audio",)
+        ),
+        _input,
+        _desired,
+        **{
+            "order": order,
+            "lambda": _lambda,
+            "delta": delta,
+            "out_mode": out_mode,
+            "enable": enable,
+        }
+        | (extra_options or {}),
+    )
+    return filter_node.audio(0)
+
+
 def asdr(
     _input0: AudioStream,
     _input1: AudioStream,
+    *,
+    enable: String = Default(None),
     extra_options: dict[str, Any] = None,
 ) -> AudioStream:
     """
 
     Measure Audio Signal-to-Distortion Ratio.
+
+    Args:
+        enable: timeline editing
 
     Returns:
         default: the audio stream
@@ -440,7 +537,45 @@ def asdr(
         ),
         _input0,
         _input1,
-        **{} | (extra_options or {}),
+        **{
+            "enable": enable,
+        }
+        | (extra_options or {}),
+    )
+    return filter_node.audio(0)
+
+
+def asisdr(
+    _input0: AudioStream,
+    _input1: AudioStream,
+    *,
+    enable: String = Default(None),
+    extra_options: dict[str, Any] = None,
+) -> AudioStream:
+    """
+
+    Measure Audio Scale-Invariant Signal-to-Distortion Ratio.
+
+    Args:
+        enable: timeline editing
+
+    Returns:
+        default: the audio stream
+
+    References:
+        [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asisdr)
+
+    """
+    filter_node = filter_node_factory(
+        FFMpegFilterDef(
+            name="asisdr", typings_input=("audio", "audio"), typings_output=("audio",)
+        ),
+        _input0,
+        _input1,
+        **{
+            "enable": enable,
+        }
+        | (extra_options or {}),
     )
     return filter_node.audio(0)
 
@@ -489,7 +624,7 @@ def axcorrelate(
     _axcorrelate1: AudioStream,
     *,
     size: Int = Default(256),
-    algo: Int | Literal["slow", "fast"] | Default = Default("slow"),
+    algo: Int | Literal["slow", "fast", "best"] | Default = Default("best"),
     extra_options: dict[str, Any] = None,
 ) -> AudioStream:
     """
@@ -497,8 +632,8 @@ def axcorrelate(
     Cross-correlate two audio streams.
 
     Args:
-        size: set segment size (from 2 to 131072) (default 256)
-        algo: set algorithm (from 0 to 1) (default slow)
+        size: set the segment size (from 2 to 131072) (default 256)
+        algo: set the algorithm (from 0 to 2) (default best)
 
     Returns:
         default: the audio stream
@@ -835,6 +970,70 @@ def blend(
             "repeatlast": repeatlast,
             "ts_sync_mode": ts_sync_mode,
             "enable": enable,
+        }
+        | (extra_options or {}),
+    )
+    return filter_node.video(0)
+
+
+def blend_vulkan(
+    _top: VideoStream,
+    _bottom: VideoStream,
+    *,
+    c0_mode: Int | Literal["normal", "multiply"] | Default = Default("normal"),
+    c1_mode: Int | Literal["normal", "multiply"] | Default = Default("normal"),
+    c2_mode: Int | Literal["normal", "multiply"] | Default = Default("normal"),
+    c3_mode: Int | Literal["normal", "multiply"] | Default = Default("normal"),
+    all_mode: Int | Literal["normal", "multiply"] | Default = Default(-1),
+    c0_opacity: Double = Default(1.0),
+    c1_opacity: Double = Default(1.0),
+    c2_opacity: Double = Default(1.0),
+    c3_opacity: Double = Default(1.0),
+    all_opacity: Double = Default(1.0),
+    extra_options: dict[str, Any] = None,
+) -> VideoStream:
+    """
+
+    Blend two video frames in Vulkan
+
+    Args:
+        c0_mode: set component #0 blend mode (from 0 to 39) (default normal)
+        c1_mode: set component #1 blend mode (from 0 to 39) (default normal)
+        c2_mode: set component #2 blend mode (from 0 to 39) (default normal)
+        c3_mode: set component #3 blend mode (from 0 to 39) (default normal)
+        all_mode: set blend mode for all components (from -1 to 39) (default -1)
+        c0_opacity: set color component #0 opacity (from 0 to 1) (default 1)
+        c1_opacity: set color component #1 opacity (from 0 to 1) (default 1)
+        c2_opacity: set color component #2 opacity (from 0 to 1) (default 1)
+        c3_opacity: set color component #3 opacity (from 0 to 1) (default 1)
+        all_opacity: set opacity for all color components (from 0 to 1) (default 1)
+
+    Returns:
+        default: the video stream
+
+    References:
+        [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blend_005fvulkan)
+
+    """
+    filter_node = filter_node_factory(
+        FFMpegFilterDef(
+            name="blend_vulkan",
+            typings_input=("video", "video"),
+            typings_output=("video",),
+        ),
+        _top,
+        _bottom,
+        **{
+            "c0_mode": c0_mode,
+            "c1_mode": c1_mode,
+            "c2_mode": c2_mode,
+            "c3_mode": c3_mode,
+            "all_mode": all_mode,
+            "c0_opacity": c0_opacity,
+            "c1_opacity": c1_opacity,
+            "c2_opacity": c2_opacity,
+            "c3_opacity": c3_opacity,
+            "all_opacity": all_opacity,
         }
         | (extra_options or {}),
     )
@@ -1661,6 +1860,46 @@ def hstack(
     return filter_node.video(0)
 
 
+def hstack_vaapi(
+    *streams: VideoStream,
+    inputs: Int = Default(2),
+    shortest: Boolean = Default(False),
+    height: Int = Default(0),
+    extra_options: dict[str, Any] = None,
+) -> VideoStream:
+    """
+
+    "VA-API" hstack
+
+    Args:
+        inputs: Set number of inputs (from 2 to 65535) (default 2)
+        shortest: Force termination when the shortest input terminates (default false)
+        height: Set output height (0 to use the height of input 0) (from 0 to 65535) (default 0)
+
+    Returns:
+        default: the video stream
+
+    References:
+        [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hstack_005fvaapi)
+
+    """
+    filter_node = filter_node_factory(
+        FFMpegFilterDef(
+            name="hstack_vaapi",
+            typings_input="[StreamType.video] * int(inputs)",
+            typings_output=("video",),
+        ),
+        *streams,
+        **{
+            "inputs": inputs,
+            "shortest": shortest,
+            "height": height,
+        }
+        | (extra_options or {}),
+    )
+    return filter_node.video(0)
+
+
 def hysteresis(
     _base: VideoStream,
     _alt: VideoStream,
@@ -1842,6 +2081,409 @@ def join(
     return filter_node.audio(0)
 
 
+def ladspa(
+    *streams: AudioStream,
+    file: String = Default(None),
+    plugin: String = Default(None),
+    controls: String = Default(None),
+    sample_rate: Int = Default(44100),
+    nb_samples: Int = Default(1024),
+    duration: Duration = Default(-1e-06),
+    latency: Boolean = Default(False),
+    extra_options: dict[str, Any] = None,
+) -> AudioStream:
+    """
+
+    Apply LADSPA effect.
+
+    Args:
+        file: set library name or full path
+        plugin: set plugin name
+        controls: set plugin options
+        sample_rate: set sample rate (from 1 to INT_MAX) (default 44100)
+        nb_samples: set the number of samples per requested frame (from 1 to INT_MAX) (default 1024)
+        duration: set audio duration (default -0.000001)
+        latency: enable latency compensation (default false)
+
+    Returns:
+        default: the audio stream
+
+    References:
+        [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ladspa)
+
+    """
+    filter_node = filter_node_factory(
+        FFMpegFilterDef(
+            name="ladspa", typings_input="[StreamType.audio]", typings_output=("audio",)
+        ),
+        *streams,
+        **{
+            "file": file,
+            "plugin": plugin,
+            "controls": controls,
+            "sample_rate": sample_rate,
+            "nb_samples": nb_samples,
+            "duration": duration,
+            "latency": latency,
+        }
+        | (extra_options or {}),
+    )
+    return filter_node.audio(0)
+
+
+def libplacebo(
+    *streams: VideoStream,
+    inputs: Int = Auto("len(streams)"),
+    w: String = Default("iw"),
+    h: String = Default("ih"),
+    fps: String = Default("none"),
+    crop_x: String = Default("(iw-cw"),
+    crop_y: String = Default("(ih-ch"),
+    crop_w: String = Default("iw"),
+    crop_h: String = Default("ih"),
+    pos_x: String = Default("(ow-pw"),
+    pos_y: String = Default("(oh-ph"),
+    pos_w: String = Default("ow"),
+    pos_h: String = Default("oh"),
+    format: String = Default(None),
+    force_original_aspect_ratio: Int
+    | Literal["disable", "decrease", "increase"]
+    | Default = Default("disable"),
+    force_divisible_by: Int = Default(1),
+    normalize_sar: Boolean = Default(False),
+    pad_crop_ratio: Float = Default(0.0),
+    fillcolor: String = Default("black"),
+    corner_rounding: Float = Default(0.0),
+    extra_opts: Dictionary = Default(None),
+    colorspace: Int
+    | Literal[
+        "auto",
+        "gbr",
+        "bt709",
+        "unknown",
+        "bt470bg",
+        "smpte170m",
+        "smpte240m",
+        "ycgco",
+        "bt2020nc",
+        "bt2020c",
+        "ictcp",
+    ]
+    | Default = Default("auto"),
+    range: Int
+    | Literal[
+        "auto", "unspecified", "unknown", "limited", "tv", "mpeg", "full", "pc", "jpeg"
+    ]
+    | Default = Default("auto"),
+    color_primaries: Int
+    | Literal[
+        "auto",
+        "bt709",
+        "unknown",
+        "bt470m",
+        "bt470bg",
+        "smpte170m",
+        "smpte240m",
+        "film",
+        "bt2020",
+        "smpte428",
+        "smpte431",
+        "smpte432",
+        "p22",
+        "ebu3213",
+    ]
+    | Default = Default("auto"),
+    color_trc: Int
+    | Literal[
+        "auto",
+        "bt709",
+        "unknown",
+        "bt470m",
+        "bt470bg",
+        "smpte170m",
+        "smpte240m",
+        "linear",
+        "4",
+        "bt1361e",
+        "1",
+        "10",
+        "12",
+        "smpte2084",
+        "b67",
+    ]
+    | Default = Default("auto"),
+    upscaler: String = Default("spline36"),
+    downscaler: String = Default("mitchell"),
+    frame_mixer: String = Default("none"),
+    lut_entries: Int = Default(0),
+    antiringing: Float = Default(0.0),
+    sigmoid: Boolean = Default(True),
+    apply_filmgrain: Boolean = Default(True),
+    apply_dolbyvision: Boolean = Default(True),
+    deband: Boolean = Default(False),
+    deband_iterations: Int = Default(1),
+    deband_threshold: Float = Default(4.0),
+    deband_radius: Float = Default(16.0),
+    deband_grain: Float = Default(6.0),
+    brightness: Float = Default(0.0),
+    contrast: Float = Default(1.0),
+    saturation: Float = Default(1.0),
+    hue: Float = Default(0.0),
+    gamma: Float = Default(1.0),
+    peak_detect: Boolean = Default(True),
+    smoothing_period: Float = Default(100.0),
+    minimum_peak: Float = Default(1.0),
+    scene_threshold_low: Float = Default(5.5),
+    scene_threshold_high: Float = Default(10.0),
+    percentile: Float = Default(99.995),
+    gamut_mode: Int
+    | Literal[
+        "clip",
+        "perceptual",
+        "relative",
+        "saturation",
+        "absolute",
+        "desaturate",
+        "darken",
+        "warn",
+        "linear",
+    ]
+    | Default = Default("perceptual"),
+    tonemapping: Int
+    | Literal[
+        "auto",
+        "clip",
+        "40",
+        "10",
+        "2390",
+        "2446a",
+        "spline",
+        "reinhard",
+        "mobius",
+        "hable",
+        "gamma",
+        "linear",
+    ]
+    | Default = Default("auto"),
+    tonemapping_param: Float = Default(0.0),
+    inverse_tonemapping: Boolean = Default(False),
+    tonemapping_lut_size: Int = Default(256),
+    contrast_recovery: Float = Default(0.3),
+    contrast_smoothness: Float = Default(3.5),
+    desaturation_strength: Float = Default(-1.0),
+    desaturation_exponent: Float = Default(-1.0),
+    gamut_warning: Boolean = Default(False),
+    gamut_clipping: Boolean = Default(False),
+    intent: Int
+    | Literal["perceptual", "relative", "absolute", "saturation"]
+    | Default = Default("perceptual"),
+    tonemapping_mode: Int
+    | Literal["auto", "rgb", "max", "hybrid", "luma"]
+    | Default = Default("auto"),
+    tonemapping_crosstalk: Float = Default(0.04),
+    overshoot: Float = Default(0.05),
+    hybrid_mix: Float = Default(0.2),
+    dithering: Int
+    | Literal["none", "blue", "ordered", "ordered_fixed", "white"]
+    | Default = Default("blue"),
+    dither_lut_size: Int = Default(6),
+    dither_temporal: Boolean = Default(False),
+    cones: Flags | Literal["l", "m", "s"] | Default = Default("0"),
+    cone_strength: Float = Default(0.0),
+    custom_shader_path: String = Default(None),
+    custom_shader_bin: Binary = Default(None),
+    skip_aa: Boolean = Default(False),
+    polar_cutoff: Float = Default(0.0),
+    disable_linear: Boolean = Default(False),
+    disable_builtin: Boolean = Default(False),
+    force_icc_lut: Boolean = Default(False),
+    force_dither: Boolean = Default(False),
+    disable_fbos: Boolean = Default(False),
+    extra_options: dict[str, Any] = None,
+) -> VideoStream:
+    """
+
+    Apply various GPU filters from libplacebo
+
+    Args:
+        inputs: Number of inputs (from 1 to INT_MAX) (default 1)
+        w: Output video frame width (default "iw")
+        h: Output video frame height (default "ih")
+        fps: Output video frame rate (default "none")
+        crop_x: Input video crop x (default "(iw-cw)/2")
+        crop_y: Input video crop y (default "(ih-ch)/2")
+        crop_w: Input video crop w (default "iw")
+        crop_h: Input video crop h (default "ih")
+        pos_x: Output video placement x (default "(ow-pw)/2")
+        pos_y: Output video placement y (default "(oh-ph)/2")
+        pos_w: Output video placement w (default "ow")
+        pos_h: Output video placement h (default "oh")
+        format: Output video format
+        force_original_aspect_ratio: decrease or increase w/h if necessary to keep the original AR (from 0 to 2) (default disable)
+        force_divisible_by: enforce that the output resolution is divisible by a defined integer when force_original_aspect_ratio is used (from 1 to 256) (default 1)
+        normalize_sar: force SAR normalization to 1:1 by adjusting pos_x/y/w/h (default false)
+        pad_crop_ratio: ratio between padding and cropping when normalizing SAR (0=pad, 1=crop) (from 0 to 1) (default 0)
+        fillcolor: Background fill color (default "black")
+        corner_rounding: Corner rounding radius (from 0 to 1) (default 0)
+        extra_opts: Pass extra libplacebo-specific options using a :-separated list of key=value pairs
+        colorspace: select colorspace (from -1 to 14) (default auto)
+        range: select color range (from -1 to 2) (default auto)
+        color_primaries: select color primaries (from -1 to 22) (default auto)
+        color_trc: select color transfer (from -1 to 18) (default auto)
+        upscaler: Upscaler function (default "spline36")
+        downscaler: Downscaler function (default "mitchell")
+        frame_mixer: Frame mixing function (default "none")
+        lut_entries: Number of scaler LUT entries (from 0 to 256) (default 0)
+        antiringing: Antiringing strength (for non-EWA filters) (from 0 to 1) (default 0)
+        sigmoid: Enable sigmoid upscaling (default true)
+        apply_filmgrain: Apply film grain metadata (default true)
+        apply_dolbyvision: Apply Dolby Vision metadata (default true)
+        deband: Enable debanding (default false)
+        deband_iterations: Deband iterations (from 0 to 16) (default 1)
+        deband_threshold: Deband threshold (from 0 to 1024) (default 4)
+        deband_radius: Deband radius (from 0 to 1024) (default 16)
+        deband_grain: Deband grain (from 0 to 1024) (default 6)
+        brightness: Brightness boost (from -1 to 1) (default 0)
+        contrast: Contrast gain (from 0 to 16) (default 1)
+        saturation: Saturation gain (from 0 to 16) (default 1)
+        hue: Hue shift (from -3.14159 to 3.14159) (default 0)
+        gamma: Gamma adjustment (from 0 to 16) (default 1)
+        peak_detect: Enable dynamic peak detection for HDR tone-mapping (default true)
+        smoothing_period: Peak detection smoothing period (from 0 to 1000) (default 100)
+        minimum_peak: Peak detection minimum peak (from 0 to 100) (default 1)
+        scene_threshold_low: Scene change low threshold (from -1 to 100) (default 5.5)
+        scene_threshold_high: Scene change high threshold (from -1 to 100) (default 10)
+        percentile: Peak detection percentile (from 0 to 100) (default 99.995)
+        gamut_mode: Gamut-mapping mode (from 0 to 8) (default perceptual)
+        tonemapping: Tone-mapping algorithm (from 0 to 11) (default auto)
+        tonemapping_param: Tunable parameter for some tone-mapping functions (from 0 to 100) (default 0)
+        inverse_tonemapping: Inverse tone mapping (range expansion) (default false)
+        tonemapping_lut_size: Tone-mapping LUT size (from 2 to 1024) (default 256)
+        contrast_recovery: HDR contrast recovery strength (from 0 to 3) (default 0.3)
+        contrast_smoothness: HDR contrast recovery smoothness (from 1 to 32) (default 3.5)
+        desaturation_strength: Desaturation strength (from -1 to 1) (default -1)
+        desaturation_exponent: Desaturation exponent (from -1 to 10) (default -1)
+        gamut_warning: Highlight out-of-gamut colors (default false)
+        gamut_clipping: Enable desaturating colorimetric gamut clipping (default false)
+        intent: Rendering intent (from 0 to 3) (default perceptual)
+        tonemapping_mode: Tone-mapping mode (from 0 to 4) (default auto)
+        tonemapping_crosstalk: Crosstalk factor for tone-mapping (from 0 to 0.3) (default 0.04)
+        overshoot: Tone-mapping overshoot margin (from 0 to 1) (default 0.05)
+        hybrid_mix: Tone-mapping hybrid LMS mixing coefficient (from 0 to 1) (default 0.2)
+        dithering: Dither method to use (from -1 to 3) (default blue)
+        dither_lut_size: Dithering LUT size (from 1 to 8) (default 6)
+        dither_temporal: Enable temporal dithering (default false)
+        cones: Colorblindness adaptation model (default 0)
+        cone_strength: Colorblindness adaptation strength (from 0 to 10) (default 0)
+        custom_shader_path: Path to custom user shader (mpv .hook format)
+        custom_shader_bin: Custom user shader as binary (mpv .hook format)
+        skip_aa: Skip anti-aliasing (default false)
+        polar_cutoff: Polar LUT cutoff (from 0 to 1) (default 0)
+        disable_linear: Disable linear scaling (default false)
+        disable_builtin: Disable built-in scalers (default false)
+        force_icc_lut: Deprecated, does nothing (default false)
+        force_dither: Force dithering (default false)
+        disable_fbos: Force-disable FBOs (default false)
+
+    Returns:
+        default: the video stream
+
+    References:
+        [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#libplacebo)
+
+    """
+    filter_node = filter_node_factory(
+        FFMpegFilterDef(
+            name="libplacebo",
+            typings_input="[StreamType.video] * int(inputs)",
+            typings_output=("video",),
+        ),
+        *streams,
+        **{
+            "inputs": inputs,
+            "w": w,
+            "h": h,
+            "fps": fps,
+            "crop_x": crop_x,
+            "crop_y": crop_y,
+            "crop_w": crop_w,
+            "crop_h": crop_h,
+            "pos_x": pos_x,
+            "pos_y": pos_y,
+            "pos_w": pos_w,
+            "pos_h": pos_h,
+            "format": format,
+            "force_original_aspect_ratio": force_original_aspect_ratio,
+            "force_divisible_by": force_divisible_by,
+            "normalize_sar": normalize_sar,
+            "pad_crop_ratio": pad_crop_ratio,
+            "fillcolor": fillcolor,
+            "corner_rounding": corner_rounding,
+            "extra_opts": extra_opts,
+            "colorspace": colorspace,
+            "range": range,
+            "color_primaries": color_primaries,
+            "color_trc": color_trc,
+            "upscaler": upscaler,
+            "downscaler": downscaler,
+            "frame_mixer": frame_mixer,
+            "lut_entries": lut_entries,
+            "antiringing": antiringing,
+            "sigmoid": sigmoid,
+            "apply_filmgrain": apply_filmgrain,
+            "apply_dolbyvision": apply_dolbyvision,
+            "deband": deband,
+            "deband_iterations": deband_iterations,
+            "deband_threshold": deband_threshold,
+            "deband_radius": deband_radius,
+            "deband_grain": deband_grain,
+            "brightness": brightness,
+            "contrast": contrast,
+            "saturation": saturation,
+            "hue": hue,
+            "gamma": gamma,
+            "peak_detect": peak_detect,
+            "smoothing_period": smoothing_period,
+            "minimum_peak": minimum_peak,
+            "scene_threshold_low": scene_threshold_low,
+            "scene_threshold_high": scene_threshold_high,
+            "percentile": percentile,
+            "gamut_mode": gamut_mode,
+            "tonemapping": tonemapping,
+            "tonemapping_param": tonemapping_param,
+            "inverse_tonemapping": inverse_tonemapping,
+            "tonemapping_lut_size": tonemapping_lut_size,
+            "contrast_recovery": contrast_recovery,
+            "contrast_smoothness": contrast_smoothness,
+            "desaturation_strength": desaturation_strength,
+            "desaturation_exponent": desaturation_exponent,
+            "gamut_warning": gamut_warning,
+            "gamut_clipping": gamut_clipping,
+            "intent": intent,
+            "tonemapping_mode": tonemapping_mode,
+            "tonemapping_crosstalk": tonemapping_crosstalk,
+            "overshoot": overshoot,
+            "hybrid_mix": hybrid_mix,
+            "dithering": dithering,
+            "dither_lut_size": dither_lut_size,
+            "dither_temporal": dither_temporal,
+            "cones": cones,
+            "cone-strength": cone_strength,
+            "custom_shader_path": custom_shader_path,
+            "custom_shader_bin": custom_shader_bin,
+            "skip_aa": skip_aa,
+            "polar_cutoff": polar_cutoff,
+            "disable_linear": disable_linear,
+            "disable_builtin": disable_builtin,
+            "force_icc_lut": force_icc_lut,
+            "force_dither": force_dither,
+            "disable_fbos": disable_fbos,
+        }
+        | (extra_options or {}),
+    )
+    return filter_node.video(0)
+
+
 def limitdiff(
     *streams: VideoStream,
     threshold: Float = Default(0.00392157),
@@ -1948,6 +2590,50 @@ def lut2(
         | (extra_options or {}),
     )
     return filter_node.video(0)
+
+
+def lv2(
+    *streams: AudioStream,
+    plugin: String = Default(None),
+    controls: String = Default(None),
+    sample_rate: Int = Default(44100),
+    nb_samples: Int = Default(1024),
+    duration: Duration = Default(-1e-06),
+    extra_options: dict[str, Any] = None,
+) -> AudioStream:
+    """
+
+    Apply LV2 effect.
+
+    Args:
+        plugin: set plugin uri
+        controls: set plugin options
+        sample_rate: set sample rate (from 1 to INT_MAX) (default 44100)
+        nb_samples: set the number of samples per requested frame (from 1 to INT_MAX) (default 1024)
+        duration: set audio duration (default -0.000001)
+
+    Returns:
+        default: the audio stream
+
+    References:
+        [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lv2)
+
+    """
+    filter_node = filter_node_factory(
+        FFMpegFilterDef(
+            name="lv2", typings_input="[StreamType.audio]", typings_output=("audio",)
+        ),
+        *streams,
+        **{
+            "plugin": plugin,
+            "controls": controls,
+            "sample_rate": sample_rate,
+            "nb_samples": nb_samples,
+            "duration": duration,
+        }
+        | (extra_options or {}),
+    )
+    return filter_node.audio(0)
 
 
 def maskedclamp(
@@ -2484,7 +3170,15 @@ def overlay(
     shortest: Boolean = Default(False),
     format: Int
     | Literal[
-        "yuv420", "yuv420p10", "yuv422", "yuv422p10", "yuv444", "rgb", "gbrp", "auto"
+        "yuv420",
+        "yuv420p10",
+        "yuv422",
+        "yuv422p10",
+        "yuv444",
+        "yuv444p10",
+        "rgb",
+        "gbrp",
+        "auto",
     ]
     | Default = Default("yuv420"),
     repeatlast: Boolean = Default(True),
@@ -2503,7 +3197,7 @@ def overlay(
         eof_action: Action to take when encountering EOF from secondary input (from 0 to 2) (default repeat)
         eval: specify when to evaluate expressions (from 0 to 1) (default frame)
         shortest: force termination when the shortest input terminates (default false)
-        format: set output format (from 0 to 7) (default yuv420)
+        format: set output format (from 0 to 8) (default yuv420)
         repeatlast: repeat overlay of the last overlay frame (default true)
         alpha: alpha format (from 0 to 1) (default straight)
         ts_sync_mode: How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
@@ -2533,6 +3227,149 @@ def overlay(
             "alpha": alpha,
             "ts_sync_mode": ts_sync_mode,
             "enable": enable,
+        }
+        | (extra_options or {}),
+    )
+    return filter_node.video(0)
+
+
+def overlay_opencl(
+    _main: VideoStream,
+    _overlay: VideoStream,
+    *,
+    x: Int = Default(0),
+    y: Int = Default(0),
+    extra_options: dict[str, Any] = None,
+) -> VideoStream:
+    """
+
+    Overlay one video on top of another
+
+    Args:
+        x: Overlay x position (from 0 to INT_MAX) (default 0)
+        y: Overlay y position (from 0 to INT_MAX) (default 0)
+
+    Returns:
+        default: the video stream
+
+    References:
+        [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay_005fopencl)
+
+    """
+    filter_node = filter_node_factory(
+        FFMpegFilterDef(
+            name="overlay_opencl",
+            typings_input=("video", "video"),
+            typings_output=("video",),
+        ),
+        _main,
+        _overlay,
+        **{
+            "x": x,
+            "y": y,
+        }
+        | (extra_options or {}),
+    )
+    return filter_node.video(0)
+
+
+def overlay_vaapi(
+    _main: VideoStream,
+    _overlay: VideoStream,
+    *,
+    x: String = Default("0"),
+    y: String = Default("0"),
+    w: String = Default("overlay_iw"),
+    h: String = Default("overlay_ih*w/overlay_iw"),
+    alpha: Float = Default(1.0),
+    eof_action: Int
+    | Literal["repeat", "endall", "pass", "repeat", "endall", "pass"]
+    | Default = Default("repeat"),
+    shortest: Boolean = Default(False),
+    repeatlast: Boolean = Default(True),
+    ts_sync_mode: Int | Literal["default", "nearest"] | Default = Default("default"),
+    extra_options: dict[str, Any] = None,
+) -> VideoStream:
+    """
+
+    Overlay one video on top of another
+
+    Args:
+        x: Overlay x position (default "0")
+        y: Overlay y position (default "0")
+        w: Overlay width (default "overlay_iw")
+        h: Overlay height (default "overlay_ih*w/overlay_iw")
+        alpha: Overlay global alpha (from 0 to 1) (default 1)
+        eof_action: Action to take when encountering EOF from secondary input (from 0 to 2) (default repeat)
+        shortest: force termination when the shortest input terminates (default false)
+        repeatlast: repeat overlay of the last overlay frame (default true)
+        ts_sync_mode: How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
+
+    Returns:
+        default: the video stream
+
+    References:
+        [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay_005fvaapi)
+
+    """
+    filter_node = filter_node_factory(
+        FFMpegFilterDef(
+            name="overlay_vaapi",
+            typings_input=("video", "video"),
+            typings_output=("video",),
+        ),
+        _main,
+        _overlay,
+        **{
+            "x": x,
+            "y": y,
+            "w": w,
+            "h": h,
+            "alpha": alpha,
+            "eof_action": eof_action,
+            "shortest": shortest,
+            "repeatlast": repeatlast,
+            "ts_sync_mode": ts_sync_mode,
+        }
+        | (extra_options or {}),
+    )
+    return filter_node.video(0)
+
+
+def overlay_vulkan(
+    _main: VideoStream,
+    _overlay: VideoStream,
+    *,
+    x: Int = Default(0),
+    y: Int = Default(0),
+    extra_options: dict[str, Any] = None,
+) -> VideoStream:
+    """
+
+    Overlay a source on top of another
+
+    Args:
+        x: Set horizontal offset (from 0 to INT_MAX) (default 0)
+        y: Set vertical offset (from 0 to INT_MAX) (default 0)
+
+    Returns:
+        default: the video stream
+
+    References:
+        [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay_005fvulkan)
+
+    """
+    filter_node = filter_node_factory(
+        FFMpegFilterDef(
+            name="overlay_vulkan",
+            typings_input=("video", "video"),
+            typings_output=("video",),
+        ),
+        _main,
+        _overlay,
+        **{
+            "x": x,
+            "y": y,
         }
         | (extra_options or {}),
     )
@@ -2642,6 +3479,61 @@ def premultiply(
     return filter_node.video(0)
 
 
+def program_opencl(
+    *streams: VideoStream,
+    source: String = Default(None),
+    kernel: String = Default(None),
+    inputs: Int = Default(1),
+    size: Image_size = Default(None),
+    eof_action: Int | Literal["repeat", "endall", "pass"] | Default = Default("repeat"),
+    shortest: Boolean = Default(False),
+    repeatlast: Boolean = Default(True),
+    ts_sync_mode: Int | Literal["default", "nearest"] | Default = Default("default"),
+    extra_options: dict[str, Any] = None,
+) -> VideoStream:
+    """
+
+    Filter video using an OpenCL program
+
+    Args:
+        source: OpenCL program source file
+        kernel: Kernel name in program
+        inputs: Number of inputs (from 1 to INT_MAX) (default 1)
+        size: Video size
+        eof_action: Action to take when encountering EOF from secondary input (from 0 to 2) (default repeat)
+        shortest: force termination when the shortest input terminates (default false)
+        repeatlast: extend last frame of secondary streams beyond EOF (default true)
+        ts_sync_mode: How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
+
+    Returns:
+        default: the video stream
+
+    References:
+        [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#program_005fopencl)
+
+    """
+    filter_node = filter_node_factory(
+        FFMpegFilterDef(
+            name="program_opencl",
+            typings_input="[StreamType.video] * int(inputs)",
+            typings_output=("video",),
+        ),
+        *streams,
+        **{
+            "source": source,
+            "kernel": kernel,
+            "inputs": inputs,
+            "size": size,
+            "eof_action": eof_action,
+            "shortest": shortest,
+            "repeatlast": repeatlast,
+            "ts_sync_mode": ts_sync_mode,
+        }
+        | (extra_options or {}),
+    )
+    return filter_node.video(0)
+
+
 def psnr(
     _main: VideoStream,
     _reference: VideoStream,
@@ -2733,6 +3625,48 @@ def remap(
         _ymap,
         **{
             "format": format,
+            "fill": fill,
+        }
+        | (extra_options or {}),
+    )
+    return filter_node.video(0)
+
+
+def remap_opencl(
+    _source: VideoStream,
+    _xmap: VideoStream,
+    _ymap: VideoStream,
+    *,
+    interp: Int | Literal["near", "linear"] | Default = Default("linear"),
+    fill: Color = Default("black"),
+    extra_options: dict[str, Any] = None,
+) -> VideoStream:
+    """
+
+    Remap pixels using OpenCL.
+
+    Args:
+        interp: set interpolation method (from 0 to 1) (default linear)
+        fill: set the color of the unmapped pixels (default "black")
+
+    Returns:
+        default: the video stream
+
+    References:
+        [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#remap_005fopencl)
+
+    """
+    filter_node = filter_node_factory(
+        FFMpegFilterDef(
+            name="remap_opencl",
+            typings_input=("video", "video", "video"),
+            typings_output=("video",),
+        ),
+        _source,
+        _xmap,
+        _ymap,
+        **{
+            "interp": interp,
             "fill": fill,
         }
         | (extra_options or {}),
@@ -3338,6 +4272,46 @@ def vstack(
     return filter_node.video(0)
 
 
+def vstack_vaapi(
+    *streams: VideoStream,
+    inputs: Int = Default(2),
+    shortest: Boolean = Default(False),
+    width: Int = Default(0),
+    extra_options: dict[str, Any] = None,
+) -> VideoStream:
+    """
+
+    "VA-API" vstack
+
+    Args:
+        inputs: Set number of inputs (from 2 to 65535) (default 2)
+        shortest: Force termination when the shortest input terminates (default false)
+        width: Set output width (0 to use the width of input 0) (from 0 to 65535) (default 0)
+
+    Returns:
+        default: the video stream
+
+    References:
+        [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vstack_005fvaapi)
+
+    """
+    filter_node = filter_node_factory(
+        FFMpegFilterDef(
+            name="vstack_vaapi",
+            typings_input="[StreamType.video] * int(inputs)",
+            typings_output=("video",),
+        ),
+        *streams,
+        **{
+            "inputs": inputs,
+            "shortest": shortest,
+            "width": width,
+        }
+        | (extra_options or {}),
+    )
+    return filter_node.video(0)
+
+
 def xcorrelate(
     _primary: VideoStream,
     _secondary: VideoStream,
@@ -3446,6 +4420,18 @@ def xfade(
         "zoomin",
         "fadefast",
         "fadeslow",
+        "hlwind",
+        "hrwind",
+        "vuwind",
+        "vdwind",
+        "coverleft",
+        "coverright",
+        "coverup",
+        "coverdown",
+        "revealleft",
+        "revealright",
+        "revealup",
+        "revealdown",
     ]
     | Default = Default("fade"),
     duration: Duration = Default(1.0),
@@ -3458,7 +4444,7 @@ def xfade(
     Cross fade one video with another video.
 
     Args:
-        transition: set cross fade transition (from -1 to 45) (default fade)
+        transition: set cross fade transition (from -1 to 57) (default fade)
         duration: set cross fade duration (default 1)
         offset: set cross fade start relative to first input stream (default 0)
         expr: set expression for custom transition
@@ -3481,6 +4467,68 @@ def xfade(
             "duration": duration,
             "offset": offset,
             "expr": expr,
+        }
+        | (extra_options or {}),
+    )
+    return filter_node.video(0)
+
+
+def xfade_opencl(
+    _main: VideoStream,
+    _xfade: VideoStream,
+    *,
+    transition: Int
+    | Literal[
+        "custom",
+        "fade",
+        "wipeleft",
+        "wiperight",
+        "wipeup",
+        "wipedown",
+        "slideleft",
+        "slideright",
+        "slideup",
+        "slidedown",
+    ]
+    | Default = Default("fade"),
+    source: String = Default(None),
+    kernel: String = Default(None),
+    duration: Duration = Default(1.0),
+    offset: Duration = Default(0.0),
+    extra_options: dict[str, Any] = None,
+) -> VideoStream:
+    """
+
+    Cross fade one video with another video.
+
+    Args:
+        transition: set cross fade transition (from 0 to 9) (default fade)
+        source: set OpenCL program source file for custom transition
+        kernel: set kernel name in program file for custom transition
+        duration: set cross fade duration (default 1)
+        offset: set cross fade start relative to first input stream (default 0)
+
+    Returns:
+        default: the video stream
+
+    References:
+        [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xfade_005fopencl)
+
+    """
+    filter_node = filter_node_factory(
+        FFMpegFilterDef(
+            name="xfade_opencl",
+            typings_input=("video", "video"),
+            typings_output=("video",),
+        ),
+        _main,
+        _xfade,
+        **{
+            "transition": transition,
+            "source": source,
+            "kernel": kernel,
+            "duration": duration,
+            "offset": offset,
         }
         | (extra_options or {}),
     )
@@ -3581,6 +4629,55 @@ def xstack(
             "layout": layout,
             "grid": grid,
             "shortest": shortest,
+            "fill": fill,
+        }
+        | (extra_options or {}),
+    )
+    return filter_node.video(0)
+
+
+def xstack_vaapi(
+    *streams: VideoStream,
+    inputs: Int = Default(2),
+    shortest: Boolean = Default(False),
+    layout: String = Default(None),
+    grid: Image_size = Default(None),
+    grid_tile_size: Image_size = Default(None),
+    fill: String = Default("none"),
+    extra_options: dict[str, Any] = None,
+) -> VideoStream:
+    """
+
+    "VA-API" xstack
+
+    Args:
+        inputs: Set number of inputs (from 2 to 65535) (default 2)
+        shortest: Force termination when the shortest input terminates (default false)
+        layout: Set custom layout
+        grid: set fixed size grid layout
+        grid_tile_size: set tile size in grid layout
+        fill: Set the color for unused pixels (default "none")
+
+    Returns:
+        default: the video stream
+
+    References:
+        [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xstack_005fvaapi)
+
+    """
+    filter_node = filter_node_factory(
+        FFMpegFilterDef(
+            name="xstack_vaapi",
+            typings_input="[StreamType.video] * int(inputs)",
+            typings_output=("video",),
+        ),
+        *streams,
+        **{
+            "inputs": inputs,
+            "shortest": shortest,
+            "layout": layout,
+            "grid": grid,
+            "grid_tile_size": grid_tile_size,
             "fill": fill,
         }
         | (extra_options or {}),

--- a/src/ffmpeg/filters.py
+++ b/src/ffmpeg/filters.py
@@ -1,4 +1,6 @@
 # NOTE: this file is auto-generated, do not modify
+
+
 from typing import Any, Literal
 
 from .common.schema import FFMpegFilterDef
@@ -51,10 +53,6 @@ def acrossfade(
         "losi",
         "sinc",
         "isinc",
-        "quat",
-        "quatr",
-        "qsin2",
-        "hsin2",
     ]
     | Default = Default("tri"),
     curve2: Int
@@ -79,10 +77,6 @@ def acrossfade(
         "losi",
         "sinc",
         "isinc",
-        "quat",
-        "quatr",
-        "qsin2",
-        "hsin2",
     ]
     | Default = Default("tri"),
     extra_options: dict[str, Any] = None,
@@ -95,8 +89,8 @@ def acrossfade(
         nb_samples: set number of samples for cross fade duration (from 1 to 2.14748e+08) (default 44100)
         duration: set cross fade duration (default 0)
         overlap: overlap 1st stream end with 2nd stream start (default true)
-        curve1: set fade curve type for 1st stream (from -1 to 22) (default tri)
-        curve2: set fade curve type for 2nd stream (from -1 to 22) (default tri)
+        curve1: set fade curve type for 1st stream (from -1 to 18) (default tri)
+        curve2: set fade curve type for 2nd stream (from -1 to 18) (default tri)
 
     Returns:
         default: the audio stream
@@ -332,7 +326,7 @@ def anlmf(
     mu: Float = Default(0.75),
     eps: Float = Default(1.0),
     leakage: Float = Default(0.0),
-    out_mode: Int | Literal["i", "d", "o", "n", "e"] | Default = Default("o"),
+    out_mode: Int | Literal["i", "d", "o", "n"] | Default = Default("o"),
     enable: String = Default(None),
     extra_options: dict[str, Any] = None,
 ) -> AudioStream:
@@ -345,7 +339,7 @@ def anlmf(
         mu: set the filter mu (from 0 to 2) (default 0.75)
         eps: set the filter eps (from 0 to 1) (default 1)
         leakage: set the filter leakage (from 0 to 1) (default 0)
-        out_mode: set output mode (from 0 to 4) (default o)
+        out_mode: set output mode (from 0 to 3) (default o)
         enable: timeline editing
 
     Returns:
@@ -382,7 +376,7 @@ def anlms(
     mu: Float = Default(0.75),
     eps: Float = Default(1.0),
     leakage: Float = Default(0.0),
-    out_mode: Int | Literal["i", "d", "o", "n", "e"] | Default = Default("o"),
+    out_mode: Int | Literal["i", "d", "o", "n"] | Default = Default("o"),
     enable: String = Default(None),
     extra_options: dict[str, Any] = None,
 ) -> AudioStream:
@@ -395,7 +389,7 @@ def anlms(
         mu: set the filter mu (from 0 to 2) (default 0.75)
         eps: set the filter eps (from 0 to 1) (default 1)
         leakage: set the filter leakage (from 0 to 1) (default 0)
-        out_mode: set output mode (from 0 to 4) (default o)
+        out_mode: set output mode (from 0 to 3) (default o)
         enable: timeline editing
 
     Returns:
@@ -424,101 +418,14 @@ def anlms(
     return filter_node.audio(0)
 
 
-def apsnr(
-    _input0: AudioStream,
-    _input1: AudioStream,
-    *,
-    enable: String = Default(None),
-    extra_options: dict[str, Any] = None,
-) -> AudioStream:
-    """
-
-    Measure Audio Peak Signal-to-Noise Ratio.
-
-    Args:
-        enable: timeline editing
-
-    Returns:
-        default: the audio stream
-
-    References:
-        [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#apsnr)
-
-    """
-    filter_node = filter_node_factory(
-        FFMpegFilterDef(
-            name="apsnr", typings_input=("audio", "audio"), typings_output=("audio",)
-        ),
-        _input0,
-        _input1,
-        **{
-            "enable": enable,
-        }
-        | (extra_options or {}),
-    )
-    return filter_node.audio(0)
-
-
-def arls(
-    _input: AudioStream,
-    _desired: AudioStream,
-    *,
-    order: Int = Default(16),
-    _lambda: Float = Default(1.0),
-    delta: Float = Default(2.0),
-    out_mode: Int | Literal["i", "d", "o", "n", "e"] | Default = Default("o"),
-    enable: String = Default(None),
-    extra_options: dict[str, Any] = None,
-) -> AudioStream:
-    """
-
-    Apply Recursive Least Squares algorithm to first audio stream.
-
-    Args:
-        order: set the filter order (from 1 to 32767) (default 16)
-        _lambda: set the filter lambda (from 0 to 1) (default 1)
-        delta: set the filter delta (from 0 to 32767) (default 2)
-        out_mode: set output mode (from 0 to 4) (default o)
-        enable: timeline editing
-
-    Returns:
-        default: the audio stream
-
-    References:
-        [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#arls)
-
-    """
-    filter_node = filter_node_factory(
-        FFMpegFilterDef(
-            name="arls", typings_input=("audio", "audio"), typings_output=("audio",)
-        ),
-        _input,
-        _desired,
-        **{
-            "order": order,
-            "lambda": _lambda,
-            "delta": delta,
-            "out_mode": out_mode,
-            "enable": enable,
-        }
-        | (extra_options or {}),
-    )
-    return filter_node.audio(0)
-
-
 def asdr(
     _input0: AudioStream,
     _input1: AudioStream,
-    *,
-    enable: String = Default(None),
     extra_options: dict[str, Any] = None,
 ) -> AudioStream:
     """
 
     Measure Audio Signal-to-Distortion Ratio.
-
-    Args:
-        enable: timeline editing
 
     Returns:
         default: the audio stream
@@ -533,45 +440,7 @@ def asdr(
         ),
         _input0,
         _input1,
-        **{
-            "enable": enable,
-        }
-        | (extra_options or {}),
-    )
-    return filter_node.audio(0)
-
-
-def asisdr(
-    _input0: AudioStream,
-    _input1: AudioStream,
-    *,
-    enable: String = Default(None),
-    extra_options: dict[str, Any] = None,
-) -> AudioStream:
-    """
-
-    Measure Audio Scale-Invariant Signal-to-Distortion Ratio.
-
-    Args:
-        enable: timeline editing
-
-    Returns:
-        default: the audio stream
-
-    References:
-        [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asisdr)
-
-    """
-    filter_node = filter_node_factory(
-        FFMpegFilterDef(
-            name="asisdr", typings_input=("audio", "audio"), typings_output=("audio",)
-        ),
-        _input0,
-        _input1,
-        **{
-            "enable": enable,
-        }
-        | (extra_options or {}),
+        **{} | (extra_options or {}),
     )
     return filter_node.audio(0)
 
@@ -620,7 +489,7 @@ def axcorrelate(
     _axcorrelate1: AudioStream,
     *,
     size: Int = Default(256),
-    algo: Int | Literal["slow", "fast", "best"] | Default = Default("best"),
+    algo: Int | Literal["slow", "fast"] | Default = Default("slow"),
     extra_options: dict[str, Any] = None,
 ) -> AudioStream:
     """
@@ -628,8 +497,8 @@ def axcorrelate(
     Cross-correlate two audio streams.
 
     Args:
-        size: set the segment size (from 2 to 131072) (default 256)
-        algo: set the algorithm (from 0 to 2) (default best)
+        size: set segment size (from 2 to 131072) (default 256)
+        algo: set algorithm (from 0 to 1) (default slow)
 
     Returns:
         default: the audio stream
@@ -1973,71 +1842,6 @@ def join(
     return filter_node.audio(0)
 
 
-def libvmaf(
-    _main: VideoStream,
-    _reference: VideoStream,
-    *,
-    log_path: String = Default(None),
-    log_fmt: String = Default("xml"),
-    pool: String = Default(None),
-    n_threads: Int = Default(0),
-    n_subsample: Int = Default(1),
-    model: String = Default("version=vmaf_v0.6.1"),
-    feature: String = Default(None),
-    eof_action: Int | Literal["repeat", "endall", "pass"] | Default = Default("repeat"),
-    shortest: Boolean = Default(False),
-    repeatlast: Boolean = Default(True),
-    ts_sync_mode: Int | Literal["default", "nearest"] | Default = Default("default"),
-    extra_options: dict[str, Any] = None,
-) -> VideoStream:
-    """
-
-    Calculate the VMAF between two video streams.
-
-    Args:
-        log_path: Set the file path to be used to write log.
-        log_fmt: Set the format of the log (csv, json, xml, or sub). (default "xml")
-        pool: Set the pool method to be used for computing vmaf.
-        n_threads: Set number of threads to be used when computing vmaf. (from 0 to UINT32_MAX) (default 0)
-        n_subsample: Set interval for frame subsampling used when computing vmaf. (from 1 to UINT32_MAX) (default 1)
-        model: Set the model to be used for computing vmaf. (default "version=vmaf_v0.6.1")
-        feature: Set the feature to be used for computing vmaf.
-        eof_action: Action to take when encountering EOF from secondary input (from 0 to 2) (default repeat)
-        shortest: force termination when the shortest input terminates (default false)
-        repeatlast: extend last frame of secondary streams beyond EOF (default true)
-        ts_sync_mode: How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
-
-    Returns:
-        default: the video stream
-
-    References:
-        [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#libvmaf)
-
-    """
-    filter_node = filter_node_factory(
-        FFMpegFilterDef(
-            name="libvmaf", typings_input=("video", "video"), typings_output=("video",)
-        ),
-        _main,
-        _reference,
-        **{
-            "log_path": log_path,
-            "log_fmt": log_fmt,
-            "pool": pool,
-            "n_threads": n_threads,
-            "n_subsample": n_subsample,
-            "model": model,
-            "feature": feature,
-            "eof_action": eof_action,
-            "shortest": shortest,
-            "repeatlast": repeatlast,
-            "ts_sync_mode": ts_sync_mode,
-        }
-        | (extra_options or {}),
-    )
-    return filter_node.video(0)
-
-
 def limitdiff(
     *streams: VideoStream,
     threshold: Float = Default(0.00392157),
@@ -2680,15 +2484,7 @@ def overlay(
     shortest: Boolean = Default(False),
     format: Int
     | Literal[
-        "yuv420",
-        "yuv420p10",
-        "yuv422",
-        "yuv422p10",
-        "yuv444",
-        "yuv444p10",
-        "rgb",
-        "gbrp",
-        "auto",
+        "yuv420", "yuv420p10", "yuv422", "yuv422p10", "yuv444", "rgb", "gbrp", "auto"
     ]
     | Default = Default("yuv420"),
     repeatlast: Boolean = Default(True),
@@ -2707,7 +2503,7 @@ def overlay(
         eof_action: Action to take when encountering EOF from secondary input (from 0 to 2) (default repeat)
         eval: specify when to evaluate expressions (from 0 to 1) (default frame)
         shortest: force termination when the shortest input terminates (default false)
-        format: set output format (from 0 to 8) (default yuv420)
+        format: set output format (from 0 to 7) (default yuv420)
         repeatlast: repeat overlay of the last overlay frame (default true)
         alpha: alpha format (from 0 to 1) (default straight)
         ts_sync_mode: How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
@@ -3650,18 +3446,6 @@ def xfade(
         "zoomin",
         "fadefast",
         "fadeslow",
-        "hlwind",
-        "hrwind",
-        "vuwind",
-        "vdwind",
-        "coverleft",
-        "coverright",
-        "coverup",
-        "coverdown",
-        "revealleft",
-        "revealright",
-        "revealup",
-        "revealdown",
     ]
     | Default = Default("fade"),
     duration: Duration = Default(1.0),
@@ -3674,7 +3458,7 @@ def xfade(
     Cross fade one video with another video.
 
     Args:
-        transition: set cross fade transition (from -1 to 57) (default fade)
+        transition: set cross fade transition (from -1 to 45) (default fade)
         duration: set cross fade duration (default 1)
         offset: set cross fade start relative to first input stream (default 0)
         expr: set expression for custom transition

--- a/src/ffmpeg/sources.py
+++ b/src/ffmpeg/sources.py
@@ -1,4 +1,5 @@
 # NOTE: this file is auto-generated, do not modify
+
 from typing import Any, Literal
 
 from .common.schema import FFMpegFilterDef

--- a/src/ffmpeg/streams/audio.py
+++ b/src/ffmpeg/streams/audio.py
@@ -19,7 +19,6 @@ from ..types import (
     Image_size,
     Int,
     Int64,
-    Rational,
     String,
     Video_rate,
 )
@@ -310,10 +309,6 @@ class AudioStream(FilterableStream):
             "losi",
             "sinc",
             "isinc",
-            "quat",
-            "quatr",
-            "qsin2",
-            "hsin2",
         ]
         | Default = Default("tri"),
         curve2: Int
@@ -338,10 +333,6 @@ class AudioStream(FilterableStream):
             "losi",
             "sinc",
             "isinc",
-            "quat",
-            "quatr",
-            "qsin2",
-            "hsin2",
         ]
         | Default = Default("tri"),
         extra_options: dict[str, Any] = None,
@@ -354,8 +345,8 @@ class AudioStream(FilterableStream):
             nb_samples: set number of samples for cross fade duration (from 1 to 2.14748e+08) (default 44100)
             duration: set cross fade duration (default 0)
             overlap: overlap 1st stream end with 2nd stream start (default true)
-            curve1: set fade curve type for 1st stream (from -1 to 22) (default tri)
-            curve2: set fade curve type for 2nd stream (from -1 to 22) (default tri)
+            curve1: set fade curve type for 1st stream (from -1 to 18) (default tri)
+            curve2: set fade curve type for 2nd stream (from -1 to 18) (default tri)
 
         Returns:
             default: the audio stream
@@ -918,15 +909,11 @@ class AudioStream(FilterableStream):
         makeup: Double = Default(0.0),
         range: Double = Default(50.0),
         mode: Int | Literal["listen", "cut", "boost"] | Default = Default("cut"),
-        dftype: Int
-        | Literal["bandpass", "lowpass", "highpass", "peak"]
-        | Default = Default("bandpass"),
         tftype: Int | Literal["bell", "lowshelf", "highshelf"] | Default = Default(
             "bell"
         ),
         direction: Int | Literal["downward", "upward"] | Default = Default("downward"),
         auto: Int | Literal["disabled", "off", "on"] | Default = Default("disabled"),
-        precision: Int | Literal["auto", "float", "double"] | Default = Default("auto"),
         enable: String = Default(None),
         extra_options: dict[str, Any] = None,
     ) -> AudioStream:
@@ -946,11 +933,9 @@ class AudioStream(FilterableStream):
             makeup: set makeup gain (from 0 to 100) (default 0)
             range: set max gain (from 1 to 200) (default 50)
             mode: set mode (from -1 to 1) (default cut)
-            dftype: set detection filter type (from 0 to 3) (default bandpass)
             tftype: set target filter type (from 0 to 2) (default bell)
             direction: set direction (from 0 to 1) (default downward)
             auto: set auto threshold (from -1 to 1) (default disabled)
-            precision: set processing precision (from 0 to 2) (default auto)
             enable: timeline editing
 
         Returns:
@@ -979,11 +964,9 @@ class AudioStream(FilterableStream):
                 "makeup": makeup,
                 "range": range,
                 "mode": mode,
-                "dftype": dftype,
                 "tftype": tftype,
                 "direction": direction,
                 "auto": auto,
-                "precision": precision,
                 "enable": enable,
             }
             | (extra_options or {}),
@@ -1243,10 +1226,6 @@ class AudioStream(FilterableStream):
             "losi",
             "sinc",
             "isinc",
-            "quat",
-            "quatr",
-            "qsin2",
-            "hsin2",
         ]
         | Default = Default("tri"),
         silence: Double = Default(0.0),
@@ -1264,7 +1243,7 @@ class AudioStream(FilterableStream):
             nb_samples: set number of samples for fade duration (from 1 to I64_MAX) (default 44100)
             start_time: set time to start fading (default 0)
             duration: set fade duration (default 0)
-            curve: set fade curve type (from -1 to 22) (default tri)
+            curve: set fade curve type (from -1 to 18) (default tri)
             silence: set the silence gain (from 0 to 1) (default 0)
             unity: set the unity gain (from 0 to 1) (default 1)
             enable: timeline editing
@@ -1660,13 +1639,9 @@ class AudioStream(FilterableStream):
         *,
         size: Image_size = Default("hd720"),
         opacity: Float = Default(0.9),
-        mode: Flags
-        | Literal["full", "compact", "nozero", "noeof", "nodisabled"]
-        | Default = Default("0"),
+        mode: Int | Literal["full", "compact"] | Default = Default("full"),
         flags: Flags
         | Literal[
-            "none",
-            "all",
             "queue",
             "frame_count_in",
             "frame_count_out",
@@ -1683,9 +1658,8 @@ class AudioStream(FilterableStream):
             "sample_count_in",
             "sample_count_out",
             "sample_count_delta",
-            "disabled",
         ]
-        | Default = Default("all+queue"),
+        | Default = Default("queue"),
         rate: Video_rate = Default("25"),
         extra_options: dict[str, Any] = None,
     ) -> VideoStream:
@@ -1696,8 +1670,8 @@ class AudioStream(FilterableStream):
         Args:
             size: set monitor size (default "hd720")
             opacity: set video opacity (from 0 to 1) (default 0.9)
-            mode: set mode (default 0)
-            flags: set flags (default all+queue)
+            mode: set mode (from 0 to 1) (default full)
+            flags: set flags (default queue)
             rate: set video rate (default "25")
 
         Returns:
@@ -2055,7 +2029,6 @@ class AudioStream(FilterableStream):
         loop: Int = Default(0),
         size: Int64 = Default(0),
         start: Int64 = Default(0),
-        time: Duration = Default("INT64_MAX"),
         extra_options: dict[str, Any] = None,
     ) -> AudioStream:
         """
@@ -2065,8 +2038,7 @@ class AudioStream(FilterableStream):
         Args:
             loop: number of loops (from -1 to INT_MAX) (default 0)
             size: max number of samples to loop (from 0 to INT_MAX) (default 0)
-            start: set the loop start sample (from -1 to I64_MAX) (default 0)
-            time: set the loop start time (default INT64_MAX)
+            start: set the loop start sample (from 0 to I64_MAX) (default 0)
 
         Returns:
             default: the audio stream
@@ -2084,7 +2056,6 @@ class AudioStream(FilterableStream):
                 "loop": loop,
                 "size": size,
                 "start": start,
-                "time": time,
             }
             | (extra_options or {}),
         )
@@ -2288,7 +2259,7 @@ class AudioStream(FilterableStream):
         mu: Float = Default(0.75),
         eps: Float = Default(1.0),
         leakage: Float = Default(0.0),
-        out_mode: Int | Literal["i", "d", "o", "n", "e"] | Default = Default("o"),
+        out_mode: Int | Literal["i", "d", "o", "n"] | Default = Default("o"),
         enable: String = Default(None),
         extra_options: dict[str, Any] = None,
     ) -> AudioStream:
@@ -2301,7 +2272,7 @@ class AudioStream(FilterableStream):
             mu: set the filter mu (from 0 to 2) (default 0.75)
             eps: set the filter eps (from 0 to 1) (default 1)
             leakage: set the filter leakage (from 0 to 1) (default 0)
-            out_mode: set output mode (from 0 to 4) (default o)
+            out_mode: set output mode (from 0 to 3) (default o)
             enable: timeline editing
 
         Returns:
@@ -2339,7 +2310,7 @@ class AudioStream(FilterableStream):
         mu: Float = Default(0.75),
         eps: Float = Default(1.0),
         leakage: Float = Default(0.0),
-        out_mode: Int | Literal["i", "d", "o", "n", "e"] | Default = Default("o"),
+        out_mode: Int | Literal["i", "d", "o", "n"] | Default = Default("o"),
         enable: String = Default(None),
         extra_options: dict[str, Any] = None,
     ) -> AudioStream:
@@ -2352,7 +2323,7 @@ class AudioStream(FilterableStream):
             mu: set the filter mu (from 0 to 2) (default 0.75)
             eps: set the filter eps (from 0 to 1) (default 1)
             leakage: set the filter leakage (from 0 to 1) (default 0)
-            out_mode: set output mode (from 0 to 4) (default o)
+            out_mode: set output mode (from 0 to 3) (default o)
             enable: timeline editing
 
         Returns:
@@ -2649,42 +2620,6 @@ class AudioStream(FilterableStream):
         )
         return filter_node.audio(0)
 
-    def apsnr(
-        self,
-        _input1: AudioStream,
-        *,
-        enable: String = Default(None),
-        extra_options: dict[str, Any] = None,
-    ) -> AudioStream:
-        """
-
-        Measure Audio Peak Signal-to-Noise Ratio.
-
-        Args:
-            enable: timeline editing
-
-        Returns:
-            default: the audio stream
-
-        References:
-            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#apsnr)
-
-        """
-        filter_node = filter_node_factory(
-            FFMpegFilterDef(
-                name="apsnr",
-                typings_input=("audio", "audio"),
-                typings_output=("audio",),
-            ),
-            self,
-            _input1,
-            **{
-                "enable": enable,
-            }
-            | (extra_options or {}),
-        )
-        return filter_node.audio(0)
-
     def apsyclip(
         self,
         *,
@@ -2893,52 +2828,6 @@ class AudioStream(FilterableStream):
         )
         return filter_node.audio(0)
 
-    def arls(
-        self,
-        _desired: AudioStream,
-        *,
-        order: Int = Default(16),
-        _lambda: Float = Default(1.0),
-        delta: Float = Default(2.0),
-        out_mode: Int | Literal["i", "d", "o", "n", "e"] | Default = Default("o"),
-        enable: String = Default(None),
-        extra_options: dict[str, Any] = None,
-    ) -> AudioStream:
-        """
-
-        Apply Recursive Least Squares algorithm to first audio stream.
-
-        Args:
-            order: set the filter order (from 1 to 32767) (default 16)
-            _lambda: set the filter lambda (from 0 to 1) (default 1)
-            delta: set the filter delta (from 0 to 32767) (default 2)
-            out_mode: set output mode (from 0 to 4) (default o)
-            enable: timeline editing
-
-        Returns:
-            default: the audio stream
-
-        References:
-            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#arls)
-
-        """
-        filter_node = filter_node_factory(
-            FFMpegFilterDef(
-                name="arls", typings_input=("audio", "audio"), typings_output=("audio",)
-            ),
-            self,
-            _desired,
-            **{
-                "order": order,
-                "lambda": _lambda,
-                "delta": delta,
-                "out_mode": out_mode,
-                "enable": enable,
-            }
-            | (extra_options or {}),
-        )
-        return filter_node.audio(0)
-
     def arnndn(
         self,
         *,
@@ -2980,16 +2869,11 @@ class AudioStream(FilterableStream):
     def asdr(
         self,
         _input1: AudioStream,
-        *,
-        enable: String = Default(None),
         extra_options: dict[str, Any] = None,
     ) -> AudioStream:
         """
 
         Measure Audio Signal-to-Distortion Ratio.
-
-        Args:
-            enable: timeline editing
 
         Returns:
             default: the audio stream
@@ -3004,10 +2888,7 @@ class AudioStream(FilterableStream):
             ),
             self,
             _input1,
-            **{
-                "enable": enable,
-            }
-            | (extra_options or {}),
+            **{} | (extra_options or {}),
         )
         return filter_node.audio(0)
 
@@ -3129,7 +3010,6 @@ class AudioStream(FilterableStream):
         *,
         nb_out_samples: Int = Default(1024),
         pad: Boolean = Default(True),
-        enable: String = Default(None),
         extra_options: dict[str, Any] = None,
     ) -> AudioStream:
         """
@@ -3139,7 +3019,6 @@ class AudioStream(FilterableStream):
         Args:
             nb_out_samples: set the number of per-frame output samples (from 1 to INT_MAX) (default 1024)
             pad: pad last frame with zeros (default true)
-            enable: timeline editing
 
         Returns:
             default: the audio stream
@@ -3156,7 +3035,6 @@ class AudioStream(FilterableStream):
             **{
                 "nb_out_samples": nb_out_samples,
                 "pad": pad,
-                "enable": enable,
             }
             | (extra_options or {}),
         )
@@ -3338,42 +3216,6 @@ class AudioStream(FilterableStream):
             **{
                 "mode": mode,
                 "type": type,
-                "enable": enable,
-            }
-            | (extra_options or {}),
-        )
-        return filter_node.audio(0)
-
-    def asisdr(
-        self,
-        _input1: AudioStream,
-        *,
-        enable: String = Default(None),
-        extra_options: dict[str, Any] = None,
-    ) -> AudioStream:
-        """
-
-        Measure Audio Scale-Invariant Signal-to-Distortion Ratio.
-
-        Args:
-            enable: timeline editing
-
-        Returns:
-            default: the audio stream
-
-        References:
-            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asisdr)
-
-        """
-        filter_node = filter_node_factory(
-            FFMpegFilterDef(
-                name="asisdr",
-                typings_input=("audio", "audio"),
-                typings_output=("audio",),
-            ),
-            self,
-            _input1,
-            **{
                 "enable": enable,
             }
             | (extra_options or {}),
@@ -3590,10 +3432,9 @@ class AudioStream(FilterableStream):
             "RMS_trough",
             "Zero_crossings",
             "Zero_crossings_rate",
-            "Abs_Peak_count",
         ]
         | Default = Default(
-            "all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate+Abs_Peak_count"
+            "all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate"
         ),
         measure_overall: Flags
         | Literal[
@@ -3624,10 +3465,9 @@ class AudioStream(FilterableStream):
             "RMS_trough",
             "Zero_crossings",
             "Zero_crossings_rate",
-            "Abs_Peak_count",
         ]
         | Default = Default(
-            "all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate+Abs_Peak_count"
+            "all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate"
         ),
         extra_options: dict[str, Any] = None,
     ) -> AudioStream:
@@ -3639,8 +3479,8 @@ class AudioStream(FilterableStream):
             length: set the window length (from 0 to 10) (default 0.05)
             metadata: inject metadata in the filtergraph (default false)
             reset: Set the number of frames over which cumulative stats are calculated before being reset (from 0 to INT_MAX) (default 0)
-            measure_perchannel: Select the parameters which are measured per channel (default all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate+Abs_Peak_count)
-            measure_overall: Select the parameters which are measured overall (default all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate+Abs_Peak_count)
+            measure_perchannel: Select the parameters which are measured per channel (default all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate)
+            measure_overall: Select the parameters which are measured overall (default all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate)
 
         Returns:
             default: the audio stream
@@ -4107,7 +3947,7 @@ class AudioStream(FilterableStream):
         _axcorrelate1: AudioStream,
         *,
         size: Int = Default(256),
-        algo: Int | Literal["slow", "fast", "best"] | Default = Default("best"),
+        algo: Int | Literal["slow", "fast"] | Default = Default("slow"),
         extra_options: dict[str, Any] = None,
     ) -> AudioStream:
         """
@@ -4115,8 +3955,8 @@ class AudioStream(FilterableStream):
         Cross-correlate two audio streams.
 
         Args:
-            size: set the segment size (from 2 to 131072) (default 256)
-            algo: set the algorithm (from 0 to 2) (default best)
+            size: set segment size (from 2 to 131072) (default 256)
+            algo: set algorithm (from 0 to 1) (default slow)
 
         Returns:
             default: the audio stream
@@ -4136,38 +3976,6 @@ class AudioStream(FilterableStream):
             **{
                 "size": size,
                 "algo": algo,
-            }
-            | (extra_options or {}),
-        )
-        return filter_node.audio(0)
-
-    def azmq(
-        self,
-        *,
-        bind_address: String = Default("tcp://*:5555"),
-        extra_options: dict[str, Any] = None,
-    ) -> AudioStream:
-        """
-
-        Receive commands through ZMQ and broker them to filters.
-
-        Args:
-            bind_address: set bind address (default "tcp://*:5555")
-
-        Returns:
-            default: the audio stream
-
-        References:
-            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#zmq_002c-azmq)
-
-        """
-        filter_node = filter_node_factory(
-            FFMpegFilterDef(
-                name="azmq", typings_input=("audio",), typings_output=("audio",)
-            ),
-            self,
-            **{
-                "bind_address": bind_address,
             }
             | (extra_options or {}),
         )
@@ -5012,12 +4820,6 @@ class AudioStream(FilterableStream):
         scale: Int | Literal["absolute", "LUFS", "relative", "LU"] | Default = Default(
             "absolute"
         ),
-        integrated: Double = Default(0.0),
-        range: Double = Default(0.0),
-        lra_low: Double = Default(0.0),
-        lra_high: Double = Default(0.0),
-        sample_peak: Double = Default(0.0),
-        true_peak: Double = Default(0.0),
         extra_options: dict[str, Any] = None,
     ) -> FilterNode:
         """
@@ -5036,12 +4838,6 @@ class AudioStream(FilterableStream):
             target: set a specific target level in LUFS (-23 to 0) (from -23 to 0) (default -23)
             gauge: set gauge display type (from 0 to 1) (default momentary)
             scale: sets display method for the stats (from 0 to 1) (default absolute)
-            integrated: integrated loudness (LUFS) (from -DBL_MAX to DBL_MAX) (default 0)
-            range: loudness range (LU) (from -DBL_MAX to DBL_MAX) (default 0)
-            lra_low: LRA low (LUFS) (from -DBL_MAX to DBL_MAX) (default 0)
-            lra_high: LRA high (LUFS) (from -DBL_MAX to DBL_MAX) (default 0)
-            sample_peak: sample peak (dBFS) (from -DBL_MAX to DBL_MAX) (default 0)
-            true_peak: true peak (dBFS) (from -DBL_MAX to DBL_MAX) (default 0)
 
         Returns:
             filter_node: the filter node
@@ -5070,12 +4866,6 @@ class AudioStream(FilterableStream):
                 "target": target,
                 "gauge": gauge,
                 "scale": scale,
-                "integrated": integrated,
-                "range": range,
-                "lra_low": lra_low,
-                "lra_high": lra_high,
-                "sample_peak": sample_peak,
-                "true_peak": true_peak,
             }
             | (extra_options or {}),
         )
@@ -5847,18 +5637,11 @@ class AudioStream(FilterableStream):
 
     def replaygain(
         self,
-        *,
-        track_gain: Float = Default(0.0),
-        track_peak: Float = Default(0.0),
         extra_options: dict[str, Any] = None,
     ) -> AudioStream:
         """
 
         ReplayGain scanner.
-
-        Args:
-            track_gain: track gain (dB) (from -FLT_MAX to FLT_MAX) (default 0)
-            track_peak: track peak (from -FLT_MAX to FLT_MAX) (default 0)
 
         Returns:
             default: the audio stream
@@ -5872,11 +5655,7 @@ class AudioStream(FilterableStream):
                 name="replaygain", typings_input=("audio",), typings_output=("audio",)
             ),
             self,
-            **{
-                "track_gain": track_gain,
-                "track_peak": track_peak,
-            }
-            | (extra_options or {}),
+            **{} | (extra_options or {}),
         )
         return filter_node.audio(0)
 
@@ -5898,7 +5677,7 @@ class AudioStream(FilterableStream):
         smoothing: Int | Literal["off", "on"] | Default = Default("off"),
         formant: Int | Literal["shifted", "preserved"] | Default = Default("shifted"),
         pitchq: Int | Literal["quality", "speed", "consistency"] | Default = Default(
-            "speed"
+            "quality"
         ),
         channels: Int | Literal["apart", "together"] | Default = Default("apart"),
         extra_options: dict[str, Any] = None,
@@ -5916,7 +5695,7 @@ class AudioStream(FilterableStream):
             window: set window (from 0 to INT_MAX) (default standard)
             smoothing: set smoothing (from 0 to INT_MAX) (default off)
             formant: set formant (from 0 to INT_MAX) (default shifted)
-            pitchq: set pitch quality (from 0 to INT_MAX) (default speed)
+            pitchq: set pitch quality (from 0 to INT_MAX) (default quality)
             channels: set channels (from 0 to INT_MAX) (default apart)
 
         Returns:
@@ -6070,15 +5849,10 @@ class AudioStream(FilterableStream):
         size: Image_size = Default("640x512"),
         rate: String = Default("25"),
         scale: Int
-        | Literal["linear", "log", "bark", "mel", "erbs", "sqrt", "cbrt", "qdrt"]
+        | Literal["linear", "log2", "bark", "mel", "erbs"]
         | Default = Default("linear"),
-        iscale: Int
-        | Literal["linear", "log", "sqrt", "cbrt", "qdrt"]
-        | Default = Default("log"),
         min: Float = Default(20.0),
         max: Float = Default(20000.0),
-        imin: Float = Default(0.0),
-        imax: Float = Default(1.0),
         logb: Float = Default(0.0001),
         deviation: Float = Default(1.0),
         pps: Int = Default(64),
@@ -6089,8 +5863,6 @@ class AudioStream(FilterableStream):
             "replace"
         ),
         direction: Int | Literal["lr", "rl", "ud", "du"] | Default = Default("lr"),
-        bar: Float = Default(0.0),
-        rotation: Float = Default(0.0),
         extra_options: dict[str, Any] = None,
     ) -> VideoStream:
         """
@@ -6100,20 +5872,15 @@ class AudioStream(FilterableStream):
         Args:
             size: set video size (default "640x512")
             rate: set video rate (default "25")
-            scale: set frequency scale (from 0 to 7) (default linear)
-            iscale: set intensity scale (from 0 to 4) (default log)
-            min: set minimum frequency (from 1 to 192000) (default 20)
-            max: set maximum frequency (from 1 to 192000) (default 20000)
-            imin: set minimum intensity (from 0 to 1) (default 0)
-            imax: set maximum intensity (from 0 to 1) (default 1)
+            scale: set frequency scale (from 0 to 4) (default linear)
+            min: set minimum frequency (from 1 to 2000) (default 20)
+            max: set maximum frequency (from 0 to 192000) (default 20000)
             logb: set logarithmic basis (from 0 to 1) (default 0.0001)
-            deviation: set frequency deviation (from 0 to 100) (default 1)
+            deviation: set frequency deviation (from 0 to 10) (default 1)
             pps: set pixels per second (from 1 to 1024) (default 64)
             mode: set output mode (from 0 to 4) (default magnitude)
             slide: set slide mode (from 0 to 2) (default replace)
             direction: set direction mode (from 0 to 3) (default lr)
-            bar: set bar ratio (from 0 to 1) (default 0)
-            rotation: set color rotation (from -1 to 1) (default 0)
 
         Returns:
             default: the video stream
@@ -6131,19 +5898,14 @@ class AudioStream(FilterableStream):
                 "size": size,
                 "rate": rate,
                 "scale": scale,
-                "iscale": iscale,
                 "min": min,
                 "max": max,
-                "imin": imin,
-                "imax": imax,
                 "logb": logb,
                 "deviation": deviation,
                 "pps": pps,
                 "mode": mode,
                 "slide": slide,
                 "direction": direction,
-                "bar": bar,
-                "rotation": rotation,
             }
             | (extra_options or {}),
         )
@@ -6662,7 +6424,7 @@ class AudioStream(FilterableStream):
         mode: Int | Literal["point", "line", "p2p", "cline"] | Default = Default(
             "point"
         ),
-        n: Rational = Default("0/1"),
+        n: Int = Default(0),
         rate: Video_rate = Default("25"),
         split_channels: Boolean = Default(False),
         colors: String = Default(
@@ -6679,7 +6441,7 @@ class AudioStream(FilterableStream):
         Args:
             size: set video size (default "600x240")
             mode: select display mode (from 0 to 3) (default point)
-            n: set how many samples to show in the same point (from 0 to INT_MAX) (default 0/1)
+            n: set how many samples to show in the same point (from 0 to INT_MAX) (default 0)
             rate: set video rate (default "25")
             split_channels: draw channels separately (default false)
             colors: set channels colors (default "red|green|blue|yellow|orange|lime|pink|magenta|brown")
@@ -6954,13 +6716,9 @@ class AudioStream(FilterableStream):
         stop_duration: Duration = Default(0.0),
         stop_threshold: Double = Default(0.0),
         stop_silence: Duration = Default(0.0),
-        stop_mode: Int | Literal["any", "all"] | Default = Default("all"),
-        detection: Int
-        | Literal["avg", "rms", "peak", "median", "ptp", "dev"]
-        | Default = Default("rms"),
+        stop_mode: Int | Literal["any", "all"] | Default = Default("any"),
+        detection: Int | Literal["peak", "rms"] | Default = Default("rms"),
         window: Duration = Default(0.02),
-        timestamp: Int | Literal["write", "copy"] | Default = Default("write"),
-        enable: String = Default(None),
         extra_options: dict[str, Any] = None,
     ) -> AudioStream:
         """
@@ -6974,14 +6732,12 @@ class AudioStream(FilterableStream):
             start_silence: set start duration of silence part to keep (default 0)
             start_mode: set which channel will trigger trimming from start (from 0 to 1) (default any)
             stop_periods: set periods of silence parts to skip from end (from -9000 to 9000) (default 0)
-            stop_duration: set stop duration of silence part (default 0)
+            stop_duration: set stop duration of non-silence part (default 0)
             stop_threshold: set threshold for stop silence detection (from 0 to DBL_MAX) (default 0)
             stop_silence: set stop duration of silence part to keep (default 0)
-            stop_mode: set which channel will trigger trimming from end (from 0 to 1) (default all)
-            detection: set how silence is detected (from 0 to 5) (default rms)
+            stop_mode: set which channel will trigger trimming from end (from 0 to 1) (default any)
+            detection: set how silence is detected (from 0 to 1) (default rms)
             window: set duration of window for silence detection (default 0.02)
-            timestamp: set how every output frame timestamp is processed (from 0 to 1) (default write)
-            enable: timeline editing
 
         Returns:
             default: the audio stream
@@ -7010,8 +6766,6 @@ class AudioStream(FilterableStream):
                 "stop_mode": stop_mode,
                 "detection": detection,
                 "window": window,
-                "timestamp": timestamp,
-                "enable": enable,
             }
             | (extra_options or {}),
         )

--- a/src/ffmpeg/streams/video.py
+++ b/src/ffmpeg/streams/video.py
@@ -1160,30 +1160,6 @@ class VideoStream(FilterableStream):
         )
         return filter_node.video(0)
 
-    def ccrepack(
-        self,
-        extra_options: dict[str, Any] = None,
-    ) -> VideoStream:
-        """
-
-        Repack CEA-708 closed caption metadata
-
-        Returns:
-            default: the video stream
-
-        References:
-            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ccrepack)
-
-        """
-        filter_node = filter_node_factory(
-            FFMpegFilterDef(
-                name="ccrepack", typings_input=("video",), typings_output=("video",)
-            ),
-            self,
-            **{} | (extra_options or {}),
-        )
-        return filter_node.video(0)
-
     def chromahold(
         self,
         *,
@@ -2508,47 +2484,6 @@ class VideoStream(FilterableStream):
         )
         return filter_node.video(0)
 
-    def coreimage(
-        self,
-        *,
-        list_filters: Boolean = Default(False),
-        list_generators: Boolean = Default(False),
-        filter: String = Default(None),
-        output_rect: String = Default(None),
-        extra_options: dict[str, Any] = None,
-    ) -> VideoStream:
-        """
-
-        Video filtering using CoreImage API.
-
-        Args:
-            list_filters: list available filters (default false)
-            list_generators: list available generators (default false)
-            filter: names and options of filters to apply
-            output_rect: output rectangle within output image
-
-        Returns:
-            default: the video stream
-
-        References:
-            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#coreimage)
-
-        """
-        filter_node = filter_node_factory(
-            FFMpegFilterDef(
-                name="coreimage", typings_input=("video",), typings_output=("video",)
-            ),
-            self,
-            **{
-                "list_filters": list_filters,
-                "list_generators": list_generators,
-                "filter": filter,
-                "output_rect": output_rect,
-            }
-            | (extra_options or {}),
-        )
-        return filter_node.video(0)
-
     def corr(
         self,
         _reference: VideoStream,
@@ -3378,7 +3313,7 @@ class VideoStream(FilterableStream):
         self,
         *,
         filter_type: Int | Literal["derain", "dehaze"] | Default = Default("derain"),
-        dnn_backend: Int = Default(1),
+        dnn_backend: Int | Literal["native"] | Default = Default("native"),
         model: String = Default(None),
         input: String = Default("x"),
         output: String = Default("y"),
@@ -3391,7 +3326,7 @@ class VideoStream(FilterableStream):
 
         Args:
             filter_type: filter type(derain/dehaze) (from 0 to 1) (default derain)
-            dnn_backend: DNN backend (from 0 to 1) (default 1)
+            dnn_backend: DNN backend (from 0 to 1) (default native)
             model: path to model file
             input: input name of the model (default "x")
             output: output name of the model (default "y")
@@ -3677,7 +3612,7 @@ class VideoStream(FilterableStream):
     def dnn_classify(
         self,
         *,
-        dnn_backend: Int | Literal["openvino"] | Default = Default("openvino"),
+        dnn_backend: Int = Default(2),
         model: String = Default(None),
         input: String = Default(None),
         output: String = Default(None),
@@ -3694,7 +3629,7 @@ class VideoStream(FilterableStream):
         Apply DNN classify filter to the input.
 
         Args:
-            dnn_backend: DNN backend (from INT_MIN to INT_MAX) (default openvino)
+            dnn_backend: DNN backend (from INT_MIN to INT_MAX) (default 2)
             model: path to model file
             input: input name of the model
             output: output name of the model
@@ -3736,7 +3671,7 @@ class VideoStream(FilterableStream):
     def dnn_detect(
         self,
         *,
-        dnn_backend: Int | Literal["openvino"] | Default = Default("openvino"),
+        dnn_backend: Int = Default(2),
         model: String = Default(None),
         input: String = Default(None),
         output: String = Default(None),
@@ -3752,7 +3687,7 @@ class VideoStream(FilterableStream):
         Apply DNN detect filter to the input.
 
         Args:
-            dnn_backend: DNN backend (from INT_MIN to INT_MAX) (default openvino)
+            dnn_backend: DNN backend (from INT_MIN to INT_MAX) (default 2)
             model: path to model file
             input: input name of the model
             output: output name of the model
@@ -3792,7 +3727,7 @@ class VideoStream(FilterableStream):
     def dnn_processing(
         self,
         *,
-        dnn_backend: Int | Literal["openvino"] | Default = Default(1),
+        dnn_backend: Int | Literal["native"] | Default = Default("native"),
         model: String = Default(None),
         input: String = Default(None),
         output: String = Default(None),
@@ -3806,7 +3741,7 @@ class VideoStream(FilterableStream):
         Apply DNN processing filter to the input.
 
         Args:
-            dnn_backend: DNN backend (from INT_MIN to INT_MAX) (default 1)
+            dnn_backend: DNN backend (from INT_MIN to INT_MAX) (default native)
             model: path to model file
             input: input name of the model
             output: output name of the model
@@ -4072,29 +4007,11 @@ class VideoStream(FilterableStream):
         bordercolor: Color = Default("black"),
         shadowcolor: Color = Default("black"),
         box: Boolean = Default(False),
-        boxborderw: String = Default("0"),
+        boxborderw: Int = Default(0),
         line_spacing: Int = Default(0),
         fontsize: String = Default(None),
-        text_align: Flags
-        | Literal[
-            "left",
-            "L",
-            "right",
-            "R",
-            "center",
-            "C",
-            "top",
-            "T",
-            "bottom",
-            "B",
-            "middle",
-            "M",
-        ]
-        | Default = Default("0"),
         x: String = Default("0"),
         y: String = Default("0"),
-        boxw: Int = Default(0),
-        boxh: Int = Default(0),
         shadowx: Int = Default(0),
         shadowy: Int = Default(0),
         borderw: Int = Default(0),
@@ -4104,7 +4021,6 @@ class VideoStream(FilterableStream):
         expansion: Int | Literal["none", "normal", "strftime"] | Default = Default(
             "normal"
         ),
-        y_align: Int | Literal["text", "baseline", "font"] | Default = Default("text"),
         timecode: String = Default(None),
         tc24hmax: Boolean = Default(False),
         timecode_rate: Rational = Default("0/1"),
@@ -4113,6 +4029,7 @@ class VideoStream(FilterableStream):
         fix_bounds: Boolean = Default(False),
         start_number: Int = Default(0),
         text_source: String = Default(None),
+        text_shaping: Boolean = Default(True),
         ft_load_flags: Flags
         | Literal[
             "default",
@@ -4149,14 +4066,11 @@ class VideoStream(FilterableStream):
             bordercolor: set border color (default "black")
             shadowcolor: set shadow color (default "black")
             box: set box (default false)
-            boxborderw: set box borders width (default "0")
+            boxborderw: set box border width (from INT_MIN to INT_MAX) (default 0)
             line_spacing: set line spacing in pixels (from INT_MIN to INT_MAX) (default 0)
             fontsize: set font size
-            text_align: set text alignment (default 0)
             x: set x expression (default "0")
             y: set y expression (default "0")
-            boxw: set box width (from 0 to INT_MAX) (default 0)
-            boxh: set box height (from 0 to INT_MAX) (default 0)
             shadowx: set shadow x offset (from INT_MIN to INT_MAX) (default 0)
             shadowy: set shadow y offset (from INT_MIN to INT_MAX) (default 0)
             borderw: set border width (from INT_MIN to INT_MAX) (default 0)
@@ -4164,7 +4078,6 @@ class VideoStream(FilterableStream):
             basetime: set base time (from I64_MIN to I64_MAX) (default I64_MIN)
             font: Font name (default "Sans")
             expansion: set the expansion mode (from 0 to 2) (default normal)
-            y_align: set the y alignment (from 0 to 2) (default text)
             timecode: set initial timecode
             tc24hmax: set 24 hours max (timecode only) (default false)
             timecode_rate: set rate (timecode only) (from 0 to INT_MAX) (default 0/1)
@@ -4173,6 +4086,7 @@ class VideoStream(FilterableStream):
             fix_bounds: check and fix text coords to avoid clipping (default false)
             start_number: start frame number for n/frame_num variable (from 0 to INT_MAX) (default 0)
             text_source: the source of text
+            text_shaping: attempt to shape text before drawing (default true)
             ft_load_flags: set font loading flags for libfreetype (default 0)
             enable: timeline editing
 
@@ -4201,11 +4115,8 @@ class VideoStream(FilterableStream):
                 "boxborderw": boxborderw,
                 "line_spacing": line_spacing,
                 "fontsize": fontsize,
-                "text_align": text_align,
                 "x": x,
                 "y": y,
-                "boxw": boxw,
-                "boxh": boxh,
                 "shadowx": shadowx,
                 "shadowy": shadowy,
                 "borderw": borderw,
@@ -4213,7 +4124,6 @@ class VideoStream(FilterableStream):
                 "basetime": basetime,
                 "font": font,
                 "expansion": expansion,
-                "y_align": y_align,
                 "timecode": timecode,
                 "tc24hmax": tc24hmax,
                 "timecode_rate": timecode_rate,
@@ -4222,6 +4132,7 @@ class VideoStream(FilterableStream):
                 "fix_bounds": fix_bounds,
                 "start_number": start_number,
                 "text_source": text_source,
+                "text_shaping": text_shaping,
                 "ft_load_flags": ft_load_flags,
                 "enable": enable,
             }
@@ -4500,9 +4411,9 @@ class VideoStream(FilterableStream):
         deint: Int | Literal["all", "interlaced"] | Default = Default("all"),
         rslope: Int = Default(1),
         redge: Int = Default(2),
-        ecost: Int = Default(2),
-        mcost: Int = Default(1),
-        dcost: Int = Default(1),
+        ecost: Float = Default(1.0),
+        mcost: Float = Default(0.5),
+        dcost: Float = Default(0.5),
         interp: Int | Literal["2p", "4p", "6p"] | Default = Default("4p"),
         enable: String = Default(None),
         extra_options: dict[str, Any] = None,
@@ -4517,9 +4428,9 @@ class VideoStream(FilterableStream):
             deint: specify which frames to deinterlace (from 0 to 1) (default all)
             rslope: specify the search radius for edge slope tracing (from 1 to 15) (default 1)
             redge: specify the search radius for best edge matching (from 0 to 15) (default 2)
-            ecost: specify the edge cost for edge matching (from 0 to 50) (default 2)
-            mcost: specify the middle cost for edge matching (from 0 to 50) (default 1)
-            dcost: specify the distance cost for edge matching (from 0 to 50) (default 1)
+            ecost: specify the edge cost for edge matching (from 0 to 9) (default 1)
+            mcost: specify the middle cost for edge matching (from 0 to 1) (default 0.5)
+            dcost: specify the distance cost for edge matching (from 0 to 1) (default 0.5)
             interp: specify the type of interpolation (from 0 to 2) (default 4p)
             enable: timeline editing
 
@@ -5623,13 +5534,9 @@ class VideoStream(FilterableStream):
         *,
         size: Image_size = Default("hd720"),
         opacity: Float = Default(0.9),
-        mode: Flags
-        | Literal["full", "compact", "nozero", "noeof", "nodisabled"]
-        | Default = Default("0"),
+        mode: Int | Literal["full", "compact"] | Default = Default("full"),
         flags: Flags
         | Literal[
-            "none",
-            "all",
             "queue",
             "frame_count_in",
             "frame_count_out",
@@ -5646,9 +5553,8 @@ class VideoStream(FilterableStream):
             "sample_count_in",
             "sample_count_out",
             "sample_count_delta",
-            "disabled",
         ]
-        | Default = Default("all+queue"),
+        | Default = Default("queue"),
         rate: Video_rate = Default("25"),
         extra_options: dict[str, Any] = None,
     ) -> VideoStream:
@@ -5659,8 +5565,8 @@ class VideoStream(FilterableStream):
         Args:
             size: set monitor size (default "hd720")
             opacity: set video opacity (from 0 to 1) (default 0.9)
-            mode: set mode (default 0)
-            flags: set flags (default all+queue)
+            mode: set mode (from 0 to 1) (default full)
+            flags: set flags (default queue)
             rate: set video rate (default "25")
 
         Returns:
@@ -6612,7 +6518,7 @@ class VideoStream(FilterableStream):
             default: the video stream
 
         References:
-            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#interlace)
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#interlace_002c-interlace_005fvulkan)
 
         """
         filter_node = filter_node_factory(
@@ -6835,76 +6741,6 @@ class VideoStream(FilterableStream):
         )
         return filter_node.video(0)
 
-    def libvmaf(
-        self,
-        _reference: VideoStream,
-        *,
-        log_path: String = Default(None),
-        log_fmt: String = Default("xml"),
-        pool: String = Default(None),
-        n_threads: Int = Default(0),
-        n_subsample: Int = Default(1),
-        model: String = Default("version=vmaf_v0.6.1"),
-        feature: String = Default(None),
-        eof_action: Int | Literal["repeat", "endall", "pass"] | Default = Default(
-            "repeat"
-        ),
-        shortest: Boolean = Default(False),
-        repeatlast: Boolean = Default(True),
-        ts_sync_mode: Int | Literal["default", "nearest"] | Default = Default(
-            "default"
-        ),
-        extra_options: dict[str, Any] = None,
-    ) -> VideoStream:
-        """
-
-        Calculate the VMAF between two video streams.
-
-        Args:
-            log_path: Set the file path to be used to write log.
-            log_fmt: Set the format of the log (csv, json, xml, or sub). (default "xml")
-            pool: Set the pool method to be used for computing vmaf.
-            n_threads: Set number of threads to be used when computing vmaf. (from 0 to UINT32_MAX) (default 0)
-            n_subsample: Set interval for frame subsampling used when computing vmaf. (from 1 to UINT32_MAX) (default 1)
-            model: Set the model to be used for computing vmaf. (default "version=vmaf_v0.6.1")
-            feature: Set the feature to be used for computing vmaf.
-            eof_action: Action to take when encountering EOF from secondary input (from 0 to 2) (default repeat)
-            shortest: force termination when the shortest input terminates (default false)
-            repeatlast: extend last frame of secondary streams beyond EOF (default true)
-            ts_sync_mode: How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
-
-        Returns:
-            default: the video stream
-
-        References:
-            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#libvmaf)
-
-        """
-        filter_node = filter_node_factory(
-            FFMpegFilterDef(
-                name="libvmaf",
-                typings_input=("video", "video"),
-                typings_output=("video",),
-            ),
-            self,
-            _reference,
-            **{
-                "log_path": log_path,
-                "log_fmt": log_fmt,
-                "pool": pool,
-                "n_threads": n_threads,
-                "n_subsample": n_subsample,
-                "model": model,
-                "feature": feature,
-                "eof_action": eof_action,
-                "shortest": shortest,
-                "repeatlast": repeatlast,
-                "ts_sync_mode": ts_sync_mode,
-            }
-            | (extra_options or {}),
-        )
-        return filter_node.video(0)
-
     def limiter(
         self,
         *,
@@ -6952,7 +6788,6 @@ class VideoStream(FilterableStream):
         loop: Int = Default(0),
         size: Int64 = Default(0),
         start: Int64 = Default(0),
-        time: Duration = Default("INT64_MAX"),
         extra_options: dict[str, Any] = None,
     ) -> VideoStream:
         """
@@ -6962,8 +6797,7 @@ class VideoStream(FilterableStream):
         Args:
             loop: number of loops (from -1 to INT_MAX) (default 0)
             size: max number of frames to loop (from 0 to 32767) (default 0)
-            start: set the loop start frame (from -1 to I64_MAX) (default 0)
-            time: set the loop start time (default INT64_MAX)
+            start: set the loop start frame (from 0 to I64_MAX) (default 0)
 
         Returns:
             default: the video stream
@@ -6981,7 +6815,6 @@ class VideoStream(FilterableStream):
                 "loop": loop,
                 "size": size,
                 "start": start,
-                "time": time,
             }
             | (extra_options or {}),
         )
@@ -7633,46 +7466,6 @@ class VideoStream(FilterableStream):
         )
         return filter_node.video(0)
 
-    def mcdeint(
-        self,
-        *,
-        mode: Int | Literal["fast", "medium", "slow", "extra_slow"] | Default = Default(
-            "fast"
-        ),
-        parity: Int | Literal["tff", "bff"] | Default = Default("bff"),
-        qp: Int = Default(1),
-        extra_options: dict[str, Any] = None,
-    ) -> VideoStream:
-        """
-
-        Apply motion compensating deinterlacing.
-
-        Args:
-            mode: set mode (from 0 to 3) (default fast)
-            parity: set the assumed picture field parity (from -1 to 1) (default bff)
-            qp: set qp (from INT_MIN to INT_MAX) (default 1)
-
-        Returns:
-            default: the video stream
-
-        References:
-            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mcdeint)
-
-        """
-        filter_node = filter_node_factory(
-            FFMpegFilterDef(
-                name="mcdeint", typings_input=("video",), typings_output=("video",)
-            ),
-            self,
-            **{
-                "mode": mode,
-                "parity": parity,
-                "qp": qp,
-            }
-            | (extra_options or {}),
-        )
-        return filter_node.video(0)
-
     def median(
         self,
         *,
@@ -8027,7 +7820,6 @@ class VideoStream(FilterableStream):
         self,
         *,
         max: Int = Default(0),
-        keep: Int = Default(0),
         hi: Int = Default(768),
         lo: Int = Default(320),
         frac: Float = Default(0.33),
@@ -8039,7 +7831,6 @@ class VideoStream(FilterableStream):
 
         Args:
             max: set the maximum number of consecutive dropped frames (positive), or the minimum interval between dropped frames (negative) (from INT_MIN to INT_MAX) (default 0)
-            keep: set the number of similar consecutive frames to be kept before starting to drop similar frames (from 0 to INT_MAX) (default 0)
             hi: set high dropping threshold (from INT_MIN to INT_MAX) (default 768)
             lo: set low dropping threshold (from INT_MIN to INT_MAX) (default 320)
             frac: set fraction dropping threshold (from 0 to 1) (default 0.33)
@@ -8058,7 +7849,6 @@ class VideoStream(FilterableStream):
             self,
             **{
                 "max": max,
-                "keep": keep,
                 "hi": hi,
                 "lo": lo,
                 "frac": frac,
@@ -8494,49 +8284,6 @@ class VideoStream(FilterableStream):
         )
         return filter_node.video(0)
 
-    def ocr(
-        self,
-        *,
-        datapath: String = Default(None),
-        language: String = Default("eng"),
-        whitelist: String = Default(
-            "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.:;,-+_!?\"'[]{}("
-        ),
-        blacklist: String = Default(""),
-        extra_options: dict[str, Any] = None,
-    ) -> VideoStream:
-        """
-
-        Optical Character Recognition.
-
-        Args:
-            datapath: set datapath
-            language: set language (default "eng")
-            whitelist: set character whitelist (default "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.:;,-+_!?"'[]{}()|/\\=*&%$#@!~ ")
-            blacklist: set character blacklist (default "")
-
-        Returns:
-            default: the video stream
-
-        References:
-            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ocr)
-
-        """
-        filter_node = filter_node_factory(
-            FFMpegFilterDef(
-                name="ocr", typings_input=("video",), typings_output=("video",)
-            ),
-            self,
-            **{
-                "datapath": datapath,
-                "language": language,
-                "whitelist": whitelist,
-                "blacklist": blacklist,
-            }
-            | (extra_options or {}),
-        )
-        return filter_node.video(0)
-
     def oscilloscope(
         self,
         *,
@@ -8626,7 +8373,6 @@ class VideoStream(FilterableStream):
             "yuv422",
             "yuv422p10",
             "yuv444",
-            "yuv444p10",
             "rgb",
             "gbrp",
             "auto",
@@ -8652,7 +8398,7 @@ class VideoStream(FilterableStream):
             eof_action: Action to take when encountering EOF from secondary input (from 0 to 2) (default repeat)
             eval: specify when to evaluate expressions (from 0 to 1) (default frame)
             shortest: force termination when the shortest input terminates (default false)
-            format: set output format (from 0 to 8) (default yuv420)
+            format: set output format (from 0 to 7) (default yuv420)
             repeatlast: repeat overlay of the last overlay frame (default true)
             alpha: alpha format (from 0 to 1) (default straight)
             ts_sync_mode: How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
@@ -9329,12 +9075,6 @@ class VideoStream(FilterableStream):
             "preferred",
             "total",
             "spectral",
-            "cool",
-            "heat",
-            "fiery",
-            "blues",
-            "green",
-            "helix",
         ]
         | Default = Default("none"),
         opacity: Float = Default(1.0),
@@ -9351,7 +9091,7 @@ class VideoStream(FilterableStream):
             c2: set component #2 expression (default "val")
             c3: set component #3 expression (default "val")
             index: set component as base (from 0 to 3) (default 0)
-            preset: set preset (from -1 to 20) (default none)
+            preset: set preset (from -1 to 14) (default none)
             opacity: set pseudocolor opacity (from 0 to 1) (default 1)
             enable: timeline editing
 
@@ -10131,50 +9871,6 @@ class VideoStream(FilterableStream):
                 "param0": param0,
                 "param1": param1,
                 "eval": eval,
-            }
-            | (extra_options or {}),
-        )
-        return filter_node.video(0)
-
-    def scale_vt(
-        self,
-        *,
-        w: String = Default("iw"),
-        h: String = Default("ih"),
-        color_matrix: String = Default(None),
-        color_primaries: String = Default(None),
-        color_transfer: String = Default(None),
-        extra_options: dict[str, Any] = None,
-    ) -> VideoStream:
-        """
-
-        Scale Videotoolbox frames
-
-        Args:
-            w: Output video width (default "iw")
-            h: Output video height (default "ih")
-            color_matrix: Output colour matrix coefficient set
-            color_primaries: Output colour primaries
-            color_transfer: Output colour transfer characteristics
-
-        Returns:
-            default: the video stream
-
-        References:
-            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#scale_005fvt)
-
-        """
-        filter_node = filter_node_factory(
-            FFMpegFilterDef(
-                name="scale_vt", typings_input=("video",), typings_output=("video",)
-            ),
-            self,
-            **{
-                "w": w,
-                "h": h,
-                "color_matrix": color_matrix,
-                "color_primaries": color_primaries,
-                "color_transfer": color_transfer,
             }
             | (extra_options or {}),
         )
@@ -11463,7 +11159,7 @@ class VideoStream(FilterableStream):
     def sr(
         self,
         *,
-        dnn_backend: Int = Default(1),
+        dnn_backend: Int | Literal["native"] | Default = Default("native"),
         scale_factor: Int = Default(2),
         model: String = Default(None),
         input: String = Default("x"),
@@ -11475,7 +11171,7 @@ class VideoStream(FilterableStream):
         Apply DNN-based image super resolution to the input.
 
         Args:
-            dnn_backend: DNN backend used for model execution (from 0 to 1) (default 1)
+            dnn_backend: DNN backend used for model execution (from 0 to 1) (default native)
             scale_factor: scale factor for SRCNN model (from 2 to 4) (default 2)
             model: path to model file specifying network architecture and its parameters
             input: input name of the model (default "x")
@@ -11663,7 +11359,6 @@ class VideoStream(FilterableStream):
         charenc: String = Default(None),
         stream_index: Int = Default(-1),
         force_style: String = Default(None),
-        wrap_unicode: Boolean = Default("auto"),
         extra_options: dict[str, Any] = None,
     ) -> VideoStream:
         """
@@ -11678,7 +11373,6 @@ class VideoStream(FilterableStream):
             charenc: set input character encoding
             stream_index: set stream index (from -1 to INT_MAX) (default -1)
             force_style: force subtitle style
-            wrap_unicode: break lines according to the Unicode Line Breaking Algorithm (default auto)
 
         Returns:
             default: the video stream
@@ -11700,7 +11394,6 @@ class VideoStream(FilterableStream):
                 "charenc": charenc,
                 "stream_index": stream_index,
                 "force_style": force_style,
-                "wrap_unicode": wrap_unicode,
             }
             | (extra_options or {}),
         )
@@ -12688,47 +12381,6 @@ class VideoStream(FilterableStream):
         )
         return filter_node.video(0)
 
-    def transpose_vt(
-        self,
-        *,
-        dir: Int
-        | Literal[
-            "cclock_flip", "clock", "cclock", "clock_flip", "reversal", "hflip", "vflip"
-        ]
-        | Default = Default("cclock_flip"),
-        passthrough: Int | Literal["none", "portrait", "landscape"] | Default = Default(
-            "none"
-        ),
-        extra_options: dict[str, Any] = None,
-    ) -> VideoStream:
-        """
-
-        Transpose Videotoolbox frames
-
-        Args:
-            dir: set transpose direction (from 0 to 6) (default cclock_flip)
-            passthrough: do not apply transposition if the input matches the specified geometry (from 0 to INT_MAX) (default none)
-
-        Returns:
-            default: the video stream
-
-        References:
-            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#transpose_005fvt)
-
-        """
-        filter_node = filter_node_factory(
-            FFMpegFilterDef(
-                name="transpose_vt", typings_input=("video",), typings_output=("video",)
-            ),
-            self,
-            **{
-                "dir": dir,
-                "passthrough": passthrough,
-            }
-            | (extra_options or {}),
-        )
-        return filter_node.video(0)
-
     def trim(
         self,
         *,
@@ -12865,50 +12517,6 @@ class VideoStream(FilterableStream):
             self,
             **{
                 "layout": layout,
-            }
-            | (extra_options or {}),
-        )
-        return filter_node.video(0)
-
-    def uspp(
-        self,
-        *,
-        quality: Int = Default(3),
-        qp: Int = Default(0),
-        use_bframe_qp: Boolean = Default(False),
-        codec: String = Default("snow"),
-        enable: String = Default(None),
-        extra_options: dict[str, Any] = None,
-    ) -> VideoStream:
-        """
-
-        Apply Ultra Simple / Slow Post-processing filter.
-
-        Args:
-            quality: set quality (from 0 to 8) (default 3)
-            qp: force a constant quantizer parameter (from 0 to 63) (default 0)
-            use_bframe_qp: use B-frames' QP (default false)
-            codec: Codec name (default "snow")
-            enable: timeline editing
-
-        Returns:
-            default: the video stream
-
-        References:
-            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#uspp)
-
-        """
-        filter_node = filter_node_factory(
-            FFMpegFilterDef(
-                name="uspp", typings_input=("video",), typings_output=("video",)
-            ),
-            self,
-            **{
-                "quality": quality,
-                "qp": qp,
-                "use_bframe_qp": use_bframe_qp,
-                "codec": codec,
-                "enable": enable,
             }
             | (extra_options or {}),
         )
@@ -13445,7 +13053,6 @@ class VideoStream(FilterableStream):
         mincontrast: Double = Default(0.25),
         show: Int = Default(0),
         tripod: Int = Default(0),
-        fileformat: Int | Literal["ascii", "binary"] | Default = Default("binary"),
         extra_options: dict[str, Any] = None,
     ) -> VideoStream:
         """
@@ -13460,7 +13067,6 @@ class VideoStream(FilterableStream):
             mincontrast: below this contrast a field is discarded (0-1) (from 0 to 1) (default 0.25)
             show: 0: draw nothing; 1,2: show fields and transforms (from 0 to 2) (default 0)
             tripod: virtual tripod mode (if >0): motion is compared to a reference reference frame (frame # is the value) (from 0 to INT_MAX) (default 0)
-            fileformat: transforms data file format (from 1 to 2) (default binary)
 
         Returns:
             default: the video stream
@@ -13484,7 +13090,6 @@ class VideoStream(FilterableStream):
                 "mincontrast": mincontrast,
                 "show": show,
                 "tripod": tripod,
-                "fileformat": fileformat,
             }
             | (extra_options or {}),
         )
@@ -13774,7 +13379,6 @@ class VideoStream(FilterableStream):
         tint0: Float = Default(0.0),
         tint1: Float = Default(0.0),
         fitmode: Int | Literal["none", "size"] | Default = Default("none"),
-        input: Int | Literal["all", "first"] | Default = Default("first"),
         extra_options: dict[str, Any] = None,
     ) -> VideoStream:
         """
@@ -13797,7 +13401,6 @@ class VideoStream(FilterableStream):
             tint0: set 1st tint (from -1 to 1) (default 0)
             tint1: set 2nd tint (from -1 to 1) (default 0)
             fitmode: set fit mode (from 0 to 1) (default none)
-            input: set input formats selection (from 0 to 1) (default first)
 
         Returns:
             default: the video stream
@@ -13827,7 +13430,6 @@ class VideoStream(FilterableStream):
                 "tint0": tint0,
                 "tint1": tint1,
                 "fitmode": fitmode,
-                "input": input,
             }
             | (extra_options or {}),
         )
@@ -14010,18 +13612,6 @@ class VideoStream(FilterableStream):
             "zoomin",
             "fadefast",
             "fadeslow",
-            "hlwind",
-            "hrwind",
-            "vuwind",
-            "vdwind",
-            "coverleft",
-            "coverright",
-            "coverup",
-            "coverdown",
-            "revealleft",
-            "revealright",
-            "revealup",
-            "revealdown",
         ]
         | Default = Default("fade"),
         duration: Duration = Default(1.0),
@@ -14034,7 +13624,7 @@ class VideoStream(FilterableStream):
         Cross fade one video with another video.
 
         Args:
-            transition: set cross fade transition (from -1 to 57) (default fade)
+            transition: set cross fade transition (from -1 to 45) (default fade)
             duration: set cross fade duration (default 1)
             offset: set cross fade start relative to first input stream (default 0)
             expr: set expression for custom transition
@@ -14145,38 +13735,6 @@ class VideoStream(FilterableStream):
                 "planes": planes,
                 "sigma": sigma,
                 "enable": enable,
-            }
-            | (extra_options or {}),
-        )
-        return filter_node.video(0)
-
-    def zmq(
-        self,
-        *,
-        bind_address: String = Default("tcp://*:5555"),
-        extra_options: dict[str, Any] = None,
-    ) -> VideoStream:
-        """
-
-        Receive commands through ZMQ and broker them to filters.
-
-        Args:
-            bind_address: set bind address (default "tcp://*:5555")
-
-        Returns:
-            default: the video stream
-
-        References:
-            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#zmq_002c-azmq)
-
-        """
-        filter_node = filter_node_factory(
-            FFMpegFilterDef(
-                name="zmq", typings_input=("video",), typings_output=("video",)
-            ),
-            self,
-            **{
-                "bind_address": bind_address,
             }
             | (extra_options or {}),
         )

--- a/src/ffmpeg/streams/video.py
+++ b/src/ffmpeg/streams/video.py
@@ -19,6 +19,7 @@ from ..types import (
     Image_size,
     Int,
     Int64,
+    Pix_fmt,
     Rational,
     String,
     Video_rate,
@@ -358,6 +359,86 @@ class VideoStream(FilterableStream):
         )
         return filter_node.video(0)
 
+    def avgblur_opencl(
+        self,
+        *,
+        sizeX: Int = Default(1),
+        planes: Int = Default(15),
+        sizeY: Int = Default(0),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Apply average blur filter
+
+        Args:
+            sizeX: set horizontal size (from 1 to 1024) (default 1)
+            planes: set planes to filter (from 0 to 15) (default 15)
+            sizeY: set vertical size (from 0 to 1024) (default 0)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#avgblur_005fopencl)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="avgblur_opencl",
+                typings_input=("video",),
+                typings_output=("video",),
+            ),
+            self,
+            **{
+                "sizeX": sizeX,
+                "planes": planes,
+                "sizeY": sizeY,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
+    def avgblur_vulkan(
+        self,
+        *,
+        sizeX: Int = Default(3),
+        sizeY: Int = Default(3),
+        planes: Int = Default(15),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Apply avgblur mask to input video
+
+        Args:
+            sizeX: Set horizontal radius (from 1 to 32) (default 3)
+            sizeY: Set vertical radius (from 1 to 32) (default 3)
+            planes: Set planes to filter (bitmask) (from 0 to 15) (default 15)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#avgblur_005fvulkan)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="avgblur_vulkan",
+                typings_input=("video",),
+                typings_output=("video",),
+            ),
+            self,
+            **{
+                "sizeX": sizeX,
+                "sizeY": sizeY,
+                "planes": planes,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
     def backgroundkey(
         self,
         *,
@@ -570,7 +651,7 @@ class VideoStream(FilterableStream):
             default: the video stream
 
         References:
-            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blackdetect)
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blackdetect_002c-blackdetect_005fvulkan)
 
         """
         filter_node = filter_node_factory(
@@ -944,6 +1025,69 @@ class VideoStream(FilterableStream):
         )
         return filter_node.video(0)
 
+    def blend_vulkan(
+        self,
+        _bottom: VideoStream,
+        *,
+        c0_mode: Int | Literal["normal", "multiply"] | Default = Default("normal"),
+        c1_mode: Int | Literal["normal", "multiply"] | Default = Default("normal"),
+        c2_mode: Int | Literal["normal", "multiply"] | Default = Default("normal"),
+        c3_mode: Int | Literal["normal", "multiply"] | Default = Default("normal"),
+        all_mode: Int | Literal["normal", "multiply"] | Default = Default(-1),
+        c0_opacity: Double = Default(1.0),
+        c1_opacity: Double = Default(1.0),
+        c2_opacity: Double = Default(1.0),
+        c3_opacity: Double = Default(1.0),
+        all_opacity: Double = Default(1.0),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Blend two video frames in Vulkan
+
+        Args:
+            c0_mode: set component #0 blend mode (from 0 to 39) (default normal)
+            c1_mode: set component #1 blend mode (from 0 to 39) (default normal)
+            c2_mode: set component #2 blend mode (from 0 to 39) (default normal)
+            c3_mode: set component #3 blend mode (from 0 to 39) (default normal)
+            all_mode: set blend mode for all components (from -1 to 39) (default -1)
+            c0_opacity: set color component #0 opacity (from 0 to 1) (default 1)
+            c1_opacity: set color component #1 opacity (from 0 to 1) (default 1)
+            c2_opacity: set color component #2 opacity (from 0 to 1) (default 1)
+            c3_opacity: set color component #3 opacity (from 0 to 1) (default 1)
+            all_opacity: set opacity for all color components (from 0 to 1) (default 1)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blend_005fvulkan)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="blend_vulkan",
+                typings_input=("video", "video"),
+                typings_output=("video",),
+            ),
+            self,
+            _bottom,
+            **{
+                "c0_mode": c0_mode,
+                "c1_mode": c1_mode,
+                "c2_mode": c2_mode,
+                "c3_mode": c3_mode,
+                "all_mode": all_mode,
+                "c0_opacity": c0_opacity,
+                "c1_opacity": c1_opacity,
+                "c2_opacity": c2_opacity,
+                "c3_opacity": c3_opacity,
+                "all_opacity": all_opacity,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
     def blockdetect(
         self,
         *,
@@ -1079,6 +1223,55 @@ class VideoStream(FilterableStream):
         )
         return filter_node.video(0)
 
+    def boxblur_opencl(
+        self,
+        *,
+        luma_radius: String = Default("2"),
+        luma_power: Int = Default(2),
+        chroma_radius: String = Default(None),
+        chroma_power: Int = Default(-1),
+        alpha_radius: String = Default(None),
+        alpha_power: Int = Default(-1),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Apply boxblur filter to input video
+
+        Args:
+            luma_radius: Radius of the luma blurring box (default "2")
+            luma_power: How many times should the boxblur be applied to luma (from 0 to INT_MAX) (default 2)
+            chroma_radius: Radius of the chroma blurring box
+            chroma_power: How many times should the boxblur be applied to chroma (from -1 to INT_MAX) (default -1)
+            alpha_radius: Radius of the alpha blurring box
+            alpha_power: How many times should the boxblur be applied to alpha (from -1 to INT_MAX) (default -1)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#boxblur_005fopencl)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="boxblur_opencl",
+                typings_input=("video",),
+                typings_output=("video",),
+            ),
+            self,
+            **{
+                "luma_radius": luma_radius,
+                "luma_power": luma_power,
+                "chroma_radius": chroma_radius,
+                "chroma_power": chroma_power,
+                "alpha_radius": alpha_radius,
+                "alpha_power": alpha_power,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
     def bwdif(
         self,
         *,
@@ -1110,6 +1303,51 @@ class VideoStream(FilterableStream):
         filter_node = filter_node_factory(
             FFMpegFilterDef(
                 name="bwdif", typings_input=("video",), typings_output=("video",)
+            ),
+            self,
+            **{
+                "mode": mode,
+                "parity": parity,
+                "deint": deint,
+                "enable": enable,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
+    def bwdif_vulkan(
+        self,
+        *,
+        mode: Int
+        | Literal[
+            "send_frame", "send_field", "send_frame_nospatial", "send_field_nospatial"
+        ]
+        | Default = Default("send_frame"),
+        parity: Int | Literal["tff", "bff", "auto"] | Default = Default("auto"),
+        deint: Int | Literal["all", "interlaced"] | Default = Default("all"),
+        enable: String = Default(None),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Deinterlace Vulkan frames via bwdif
+
+        Args:
+            mode: specify the interlacing mode (from 0 to 3) (default send_frame)
+            parity: specify the assumed picture field parity (from -1 to 1) (default auto)
+            deint: specify which frames to deinterlace (from 0 to 1) (default all)
+            enable: timeline editing
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bwdif_005fvulkan)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="bwdif_vulkan", typings_input=("video",), typings_output=("video",)
             ),
             self,
             **{
@@ -1155,6 +1393,67 @@ class VideoStream(FilterableStream):
                 "strength": strength,
                 "planes": planes,
                 "enable": enable,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
+    def ccrepack(
+        self,
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Repack CEA-708 closed caption metadata
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ccrepack)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="ccrepack", typings_input=("video",), typings_output=("video",)
+            ),
+            self,
+            **{} | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
+    def chromaber_vulkan(
+        self,
+        *,
+        dist_x: Float = Default(0.0),
+        dist_y: Float = Default(0.0),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Offset chroma of input video (chromatic aberration)
+
+        Args:
+            dist_x: Set horizontal distortion amount (from -10 to 10) (default 0)
+            dist_y: Set vertical distortion amount (from -10 to 10) (default 0)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#chromaber_005fvulkan)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="chromaber_vulkan",
+                typings_input=("video",),
+                typings_output=("video",),
+            ),
+            self,
+            **{
+                "dist_x": dist_x,
+                "dist_y": dist_y,
             }
             | (extra_options or {}),
         )
@@ -1881,6 +2180,46 @@ class VideoStream(FilterableStream):
         )
         return filter_node.video(0)
 
+    def colorkey_opencl(
+        self,
+        *,
+        color: Color = Default("black"),
+        similarity: Float = Default(0.01),
+        blend: Float = Default(0.0),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Turns a certain color into transparency. Operates on RGB colors.
+
+        Args:
+            color: set the colorkey key color (default "black")
+            similarity: set the colorkey similarity value (from 0.01 to 1) (default 0.01)
+            blend: set the colorkey key blend value (from 0 to 1) (default 0)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorkey_005fopencl)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="colorkey_opencl",
+                typings_input=("video",),
+                typings_output=("video",),
+            ),
+            self,
+            **{
+                "color": color,
+                "similarity": similarity,
+                "blend": blend,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
     def colorlevels(
         self,
         *,
@@ -2394,6 +2733,70 @@ class VideoStream(FilterableStream):
                 "2mode": _2mode,
                 "3mode": _3mode,
                 "enable": enable,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
+    def convolution_opencl(
+        self,
+        *,
+        _0m: String = Default("0 0 0 0 1 0 0 0 0"),
+        _2m: String = Default("0 0 0 0 1 0 0 0 0"),
+        _3m: String = Default("0 0 0 0 1 0 0 0 0"),
+        _0rdiv: Float = Default(1.0),
+        _1rdiv: Float = Default(1.0),
+        _2rdiv: Float = Default(1.0),
+        _3rdiv: Float = Default(1.0),
+        _0bias: Float = Default(0.0),
+        _1bias: Float = Default(0.0),
+        _2bias: Float = Default(0.0),
+        _3bias: Float = Default(0.0),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Apply convolution mask to input video
+
+        Args:
+            _0m: set matrix for 2nd plane (default "0 0 0 0 1 0 0 0 0")
+            _2m: set matrix for 3rd plane (default "0 0 0 0 1 0 0 0 0")
+            _3m: set matrix for 4th plane (default "0 0 0 0 1 0 0 0 0")
+            _0rdiv: set rdiv for 1nd plane (from 0 to INT_MAX) (default 1)
+            _1rdiv: set rdiv for 2nd plane (from 0 to INT_MAX) (default 1)
+            _2rdiv: set rdiv for 3rd plane (from 0 to INT_MAX) (default 1)
+            _3rdiv: set rdiv for 4th plane (from 0 to INT_MAX) (default 1)
+            _0bias: set bias for 1st plane (from 0 to INT_MAX) (default 0)
+            _1bias: set bias for 2nd plane (from 0 to INT_MAX) (default 0)
+            _2bias: set bias for 3rd plane (from 0 to INT_MAX) (default 0)
+            _3bias: set bias for 4th plane (from 0 to INT_MAX) (default 0)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#convolution_005fopencl)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="convolution_opencl",
+                typings_input=("video",),
+                typings_output=("video",),
+            ),
+            self,
+            **{
+                "0m": _0m,
+                "2m": _2m,
+                "3m": _3m,
+                "0rdiv": _0rdiv,
+                "1rdiv": _1rdiv,
+                "2rdiv": _2rdiv,
+                "3rdiv": _3rdiv,
+                "0bias": _0bias,
+                "1bias": _1bias,
+                "2bias": _2bias,
+                "3bias": _3bias,
             }
             | (extra_options or {}),
         )
@@ -3313,7 +3716,7 @@ class VideoStream(FilterableStream):
         self,
         *,
         filter_type: Int | Literal["derain", "dehaze"] | Default = Default("derain"),
-        dnn_backend: Int | Literal["native"] | Default = Default("native"),
+        dnn_backend: Int = Default(1),
         model: String = Default(None),
         input: String = Default("x"),
         output: String = Default("y"),
@@ -3326,7 +3729,7 @@ class VideoStream(FilterableStream):
 
         Args:
             filter_type: filter type(derain/dehaze) (from 0 to 1) (default derain)
-            dnn_backend: DNN backend (from 0 to 1) (default native)
+            dnn_backend: DNN backend (from 0 to 1) (default 1)
             model: path to model file
             input: input name of the model (default "x")
             output: output name of the model (default "y")
@@ -3418,6 +3821,55 @@ class VideoStream(FilterableStream):
                 "search": search,
                 "filename": filename,
                 "opencl": opencl,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
+    def deshake_opencl(
+        self,
+        *,
+        tripod: Boolean = Default(False),
+        debug: Boolean = Default(False),
+        adaptive_crop: Boolean = Default(True),
+        refine_features: Boolean = Default(True),
+        smooth_strength: Float = Default(0.0),
+        smooth_window_multiplier: Float = Default(2.0),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Feature-point based video stabilization filter
+
+        Args:
+            tripod: simulates a tripod by preventing any camera movement whatsoever from the original frame (default false)
+            debug: turn on additional debugging information (default false)
+            adaptive_crop: attempt to subtly crop borders to reduce mirrored content (default true)
+            refine_features: refine feature point locations at a sub-pixel level (default true)
+            smooth_strength: smoothing strength (0 attempts to adaptively determine optimal strength) (from 0 to 1) (default 0)
+            smooth_window_multiplier: multiplier for number of frames to buffer for motion data (from 0.1 to 10) (default 2)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deshake_005fopencl)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="deshake_opencl",
+                typings_input=("video",),
+                typings_output=("video",),
+            ),
+            self,
+            **{
+                "tripod": tripod,
+                "debug": debug,
+                "adaptive_crop": adaptive_crop,
+                "refine_features": refine_features,
+                "smooth_strength": smooth_strength,
+                "smooth_window_multiplier": smooth_window_multiplier,
             }
             | (extra_options or {}),
         )
@@ -3561,6 +4013,52 @@ class VideoStream(FilterableStream):
                 "threshold2": threshold2,
                 "threshold3": threshold3,
                 "enable": enable,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
+    def dilation_opencl(
+        self,
+        *,
+        threshold0: Float = Default(65535.0),
+        threshold1: Float = Default(65535.0),
+        threshold2: Float = Default(65535.0),
+        threshold3: Float = Default(65535.0),
+        coordinates: Int = Default(255),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Apply dilation effect
+
+        Args:
+            threshold0: set threshold for 1st plane (from 0 to 65535) (default 65535)
+            threshold1: set threshold for 2nd plane (from 0 to 65535) (default 65535)
+            threshold2: set threshold for 3rd plane (from 0 to 65535) (default 65535)
+            threshold3: set threshold for 4th plane (from 0 to 65535) (default 65535)
+            coordinates: set coordinates (from 0 to 255) (default 255)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dilation_005fopencl)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="dilation_opencl",
+                typings_input=("video",),
+                typings_output=("video",),
+            ),
+            self,
+            **{
+                "threshold0": threshold0,
+                "threshold1": threshold1,
+                "threshold2": threshold2,
+                "threshold3": threshold3,
+                "coordinates": coordinates,
             }
             | (extra_options or {}),
         )
@@ -3727,7 +4225,7 @@ class VideoStream(FilterableStream):
     def dnn_processing(
         self,
         *,
-        dnn_backend: Int | Literal["native"] | Default = Default("native"),
+        dnn_backend: Int = Default(1),
         model: String = Default(None),
         input: String = Default(None),
         output: String = Default(None),
@@ -3741,7 +4239,7 @@ class VideoStream(FilterableStream):
         Apply DNN processing filter to the input.
 
         Args:
-            dnn_backend: DNN backend (from INT_MIN to INT_MAX) (default native)
+            dnn_backend: DNN backend (from INT_MIN to INT_MAX) (default 1)
             model: path to model file
             input: input name of the model
             output: output name of the model
@@ -4007,11 +4505,29 @@ class VideoStream(FilterableStream):
         bordercolor: Color = Default("black"),
         shadowcolor: Color = Default("black"),
         box: Boolean = Default(False),
-        boxborderw: Int = Default(0),
+        boxborderw: String = Default("0"),
         line_spacing: Int = Default(0),
         fontsize: String = Default(None),
+        text_align: Flags
+        | Literal[
+            "left",
+            "L",
+            "right",
+            "R",
+            "center",
+            "C",
+            "top",
+            "T",
+            "bottom",
+            "B",
+            "middle",
+            "M",
+        ]
+        | Default = Default("0"),
         x: String = Default("0"),
         y: String = Default("0"),
+        boxw: Int = Default(0),
+        boxh: Int = Default(0),
         shadowx: Int = Default(0),
         shadowy: Int = Default(0),
         borderw: Int = Default(0),
@@ -4021,6 +4537,7 @@ class VideoStream(FilterableStream):
         expansion: Int | Literal["none", "normal", "strftime"] | Default = Default(
             "normal"
         ),
+        y_align: Int | Literal["text", "baseline", "font"] | Default = Default("text"),
         timecode: String = Default(None),
         tc24hmax: Boolean = Default(False),
         timecode_rate: Rational = Default("0/1"),
@@ -4066,11 +4583,14 @@ class VideoStream(FilterableStream):
             bordercolor: set border color (default "black")
             shadowcolor: set shadow color (default "black")
             box: set box (default false)
-            boxborderw: set box border width (from INT_MIN to INT_MAX) (default 0)
+            boxborderw: set box borders width (default "0")
             line_spacing: set line spacing in pixels (from INT_MIN to INT_MAX) (default 0)
             fontsize: set font size
+            text_align: set text alignment (default 0)
             x: set x expression (default "0")
             y: set y expression (default "0")
+            boxw: set box width (from 0 to INT_MAX) (default 0)
+            boxh: set box height (from 0 to INT_MAX) (default 0)
             shadowx: set shadow x offset (from INT_MIN to INT_MAX) (default 0)
             shadowy: set shadow y offset (from INT_MIN to INT_MAX) (default 0)
             borderw: set border width (from INT_MIN to INT_MAX) (default 0)
@@ -4078,6 +4598,7 @@ class VideoStream(FilterableStream):
             basetime: set base time (from I64_MIN to I64_MAX) (default I64_MIN)
             font: Font name (default "Sans")
             expansion: set the expansion mode (from 0 to 2) (default normal)
+            y_align: set the y alignment (from 0 to 2) (default text)
             timecode: set initial timecode
             tc24hmax: set 24 hours max (timecode only) (default false)
             timecode_rate: set rate (timecode only) (from 0 to INT_MAX) (default 0/1)
@@ -4115,8 +4636,11 @@ class VideoStream(FilterableStream):
                 "boxborderw": boxborderw,
                 "line_spacing": line_spacing,
                 "fontsize": fontsize,
+                "text_align": text_align,
                 "x": x,
                 "y": y,
+                "boxw": boxw,
+                "boxh": boxh,
                 "shadowx": shadowx,
                 "shadowy": shadowy,
                 "borderw": borderw,
@@ -4124,6 +4648,7 @@ class VideoStream(FilterableStream):
                 "basetime": basetime,
                 "font": font,
                 "expansion": expansion,
+                "y_align": y_align,
                 "timecode": timecode,
                 "tc24hmax": tc24hmax,
                 "timecode_rate": timecode_rate,
@@ -4403,6 +4928,52 @@ class VideoStream(FilterableStream):
         )
         return filter_node.video(0)
 
+    def erosion_opencl(
+        self,
+        *,
+        threshold0: Float = Default(65535.0),
+        threshold1: Float = Default(65535.0),
+        threshold2: Float = Default(65535.0),
+        threshold3: Float = Default(65535.0),
+        coordinates: Int = Default(255),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Apply erosion effect
+
+        Args:
+            threshold0: set threshold for 1st plane (from 0 to 65535) (default 65535)
+            threshold1: set threshold for 2nd plane (from 0 to 65535) (default 65535)
+            threshold2: set threshold for 3rd plane (from 0 to 65535) (default 65535)
+            threshold3: set threshold for 4th plane (from 0 to 65535) (default 65535)
+            coordinates: set coordinates (from 0 to 255) (default 255)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#erosion_005fopencl)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="erosion_opencl",
+                typings_input=("video",),
+                typings_output=("video",),
+            ),
+            self,
+            **{
+                "threshold0": threshold0,
+                "threshold1": threshold1,
+                "threshold2": threshold2,
+                "threshold3": threshold3,
+                "coordinates": coordinates,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
     def estdif(
         self,
         *,
@@ -4411,9 +4982,9 @@ class VideoStream(FilterableStream):
         deint: Int | Literal["all", "interlaced"] | Default = Default("all"),
         rslope: Int = Default(1),
         redge: Int = Default(2),
-        ecost: Float = Default(1.0),
-        mcost: Float = Default(0.5),
-        dcost: Float = Default(0.5),
+        ecost: Int = Default(2),
+        mcost: Int = Default(1),
+        dcost: Int = Default(1),
         interp: Int | Literal["2p", "4p", "6p"] | Default = Default("4p"),
         enable: String = Default(None),
         extra_options: dict[str, Any] = None,
@@ -4428,9 +4999,9 @@ class VideoStream(FilterableStream):
             deint: specify which frames to deinterlace (from 0 to 1) (default all)
             rslope: specify the search radius for edge slope tracing (from 1 to 15) (default 1)
             redge: specify the search radius for best edge matching (from 0 to 15) (default 2)
-            ecost: specify the edge cost for edge matching (from 0 to 9) (default 1)
-            mcost: specify the middle cost for edge matching (from 0 to 1) (default 0.5)
-            dcost: specify the distance cost for edge matching (from 0 to 1) (default 0.5)
+            ecost: specify the edge cost for edge matching (from 0 to 50) (default 2)
+            mcost: specify the middle cost for edge matching (from 0 to 50) (default 1)
+            dcost: specify the distance cost for edge matching (from 0 to 50) (default 1)
             interp: specify the type of interpolation (from 0 to 2) (default 4p)
             enable: timeline editing
 
@@ -4974,6 +5545,30 @@ class VideoStream(FilterableStream):
         )
         return filter_node.video(0)
 
+    def flip_vulkan(
+        self,
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Flip both horizontally and vertically
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#flip_005fvulkan)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="flip_vulkan", typings_input=("video",), typings_output=("video",)
+            ),
+            self,
+            **{} | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
     def floodfill(
         self,
         *,
@@ -5433,6 +6028,50 @@ class VideoStream(FilterableStream):
         )
         return filter_node.video(0)
 
+    def gblur_vulkan(
+        self,
+        *,
+        sigma: Float = Default(0.5),
+        sigmaV: Float = Default(0.0),
+        planes: Int = Default(15),
+        size: Int = Default(19),
+        sizeV: Int = Default(0),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Gaussian Blur in Vulkan
+
+        Args:
+            sigma: Set sigma (from 0.01 to 1024) (default 0.5)
+            sigmaV: Set vertical sigma (from 0 to 1024) (default 0)
+            planes: Set planes to filter (from 0 to 15) (default 15)
+            size: Set kernel size (from 1 to 127) (default 19)
+            sizeV: Set vertical kernel size (from 0 to 127) (default 0)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#gblur_005fvulkan)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="gblur_vulkan", typings_input=("video",), typings_output=("video",)
+            ),
+            self,
+            **{
+                "sigma": sigma,
+                "sigmaV": sigmaV,
+                "planes": planes,
+                "size": size,
+                "sizeV": sizeV,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
     def geq(
         self,
         *,
@@ -5534,9 +6173,13 @@ class VideoStream(FilterableStream):
         *,
         size: Image_size = Default("hd720"),
         opacity: Float = Default(0.9),
-        mode: Int | Literal["full", "compact"] | Default = Default("full"),
+        mode: Flags
+        | Literal["full", "compact", "nozero", "noeof", "nodisabled"]
+        | Default = Default("0"),
         flags: Flags
         | Literal[
+            "none",
+            "all",
             "queue",
             "frame_count_in",
             "frame_count_out",
@@ -5553,8 +6196,9 @@ class VideoStream(FilterableStream):
             "sample_count_in",
             "sample_count_out",
             "sample_count_delta",
+            "disabled",
         ]
-        | Default = Default("queue"),
+        | Default = Default("all+queue"),
         rate: Video_rate = Default("25"),
         extra_options: dict[str, Any] = None,
     ) -> VideoStream:
@@ -5565,8 +6209,8 @@ class VideoStream(FilterableStream):
         Args:
             size: set monitor size (default "hd720")
             opacity: set video opacity (from 0 to 1) (default 0.9)
-            mode: set mode (from 0 to 1) (default full)
-            flags: set flags (default queue)
+            mode: set mode (default 0)
+            flags: set flags (default all+queue)
             rate: set video rate (default "25")
 
         Returns:
@@ -5754,6 +6398,30 @@ class VideoStream(FilterableStream):
                 "enable": enable,
             }
             | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
+    def hflip_vulkan(
+        self,
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Horizontally flip the input video in Vulkan
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hflip_005fvulkan)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="hflip_vulkan", typings_input=("video",), typings_output=("video",)
+            ),
+            self,
+            **{} | (extra_options or {}),
         )
         return filter_node.video(0)
 
@@ -6238,6 +6906,40 @@ class VideoStream(FilterableStream):
             self,
             **{
                 "derive_device": derive_device,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
+    def hwupload_cuda(
+        self,
+        *,
+        device: Int = Default(0),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Upload a system memory frame to a CUDA device.
+
+        Args:
+            device: Number of the device to use (from 0 to INT_MAX) (default 0)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hwupload_005fcuda)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="hwupload_cuda",
+                typings_input=("video",),
+                typings_output=("video",),
+            ),
+            self,
+            **{
+                "device": device,
             }
             | (extra_options or {}),
         )
@@ -6788,6 +7490,7 @@ class VideoStream(FilterableStream):
         loop: Int = Default(0),
         size: Int64 = Default(0),
         start: Int64 = Default(0),
+        time: Duration = Default("INT64_MAX"),
         extra_options: dict[str, Any] = None,
     ) -> VideoStream:
         """
@@ -6797,7 +7500,8 @@ class VideoStream(FilterableStream):
         Args:
             loop: number of loops (from -1 to INT_MAX) (default 0)
             size: max number of frames to loop (from 0 to 32767) (default 0)
-            start: set the loop start frame (from 0 to I64_MAX) (default 0)
+            start: set the loop start frame (from -1 to I64_MAX) (default 0)
+            time: set the loop start time (default INT64_MAX)
 
         Returns:
             default: the video stream
@@ -6815,6 +7519,7 @@ class VideoStream(FilterableStream):
                 "loop": loop,
                 "size": size,
                 "start": start,
+                "time": time,
             }
             | (extra_options or {}),
         )
@@ -7466,6 +8171,46 @@ class VideoStream(FilterableStream):
         )
         return filter_node.video(0)
 
+    def mcdeint(
+        self,
+        *,
+        mode: Int | Literal["fast", "medium", "slow", "extra_slow"] | Default = Default(
+            "fast"
+        ),
+        parity: Int | Literal["tff", "bff"] | Default = Default("bff"),
+        qp: Int = Default(1),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Apply motion compensating deinterlacing.
+
+        Args:
+            mode: set mode (from 0 to 3) (default fast)
+            parity: set the assumed picture field parity (from -1 to 1) (default bff)
+            qp: set qp (from INT_MIN to INT_MAX) (default 1)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mcdeint)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="mcdeint", typings_input=("video",), typings_output=("video",)
+            ),
+            self,
+            **{
+                "mode": mode,
+                "parity": parity,
+                "qp": qp,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
     def median(
         self,
         *,
@@ -7820,6 +8565,7 @@ class VideoStream(FilterableStream):
         self,
         *,
         max: Int = Default(0),
+        keep: Int = Default(0),
         hi: Int = Default(768),
         lo: Int = Default(320),
         frac: Float = Default(0.33),
@@ -7831,6 +8577,7 @@ class VideoStream(FilterableStream):
 
         Args:
             max: set the maximum number of consecutive dropped frames (positive), or the minimum interval between dropped frames (negative) (from INT_MIN to INT_MAX) (default 0)
+            keep: set the number of similar consecutive frames to be kept before starting to drop similar frames (from 0 to INT_MAX) (default 0)
             hi: set high dropping threshold (from INT_MIN to INT_MAX) (default 768)
             lo: set low dropping threshold (from INT_MIN to INT_MAX) (default 320)
             frac: set fraction dropping threshold (from 0 to 1) (default 0.33)
@@ -7849,6 +8596,7 @@ class VideoStream(FilterableStream):
             self,
             **{
                 "max": max,
+                "keep": keep,
                 "hi": hi,
                 "lo": lo,
                 "frac": frac,
@@ -8034,6 +8782,119 @@ class VideoStream(FilterableStream):
                 "r": r,
                 "rc": rc,
                 "enable": enable,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
+    def nlmeans_opencl(
+        self,
+        *,
+        s: Double = Default(1.0),
+        p: Int = Default(7),
+        pc: Int = Default(0),
+        r: Int = Default(15),
+        rc: Int = Default(0),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Non-local means denoiser through OpenCL
+
+        Args:
+            s: denoising strength (from 1 to 30) (default 1)
+            p: patch size (from 0 to 99) (default 7)
+            pc: patch size for chroma planes (from 0 to 99) (default 0)
+            r: research window (from 0 to 99) (default 15)
+            rc: research window for chroma planes (from 0 to 99) (default 0)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#nlmeans_005fopencl)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="nlmeans_opencl",
+                typings_input=("video",),
+                typings_output=("video",),
+            ),
+            self,
+            **{
+                "s": s,
+                "p": p,
+                "pc": pc,
+                "r": r,
+                "rc": rc,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
+    def nlmeans_vulkan(
+        self,
+        *,
+        s: Double = Default(1.0),
+        p: Int = Default(7),
+        r: Int = Default(15),
+        t: Int = Default(36),
+        s1: Double = Default(1.0),
+        s2: Double = Default(1.0),
+        s3: Double = Default(1.0),
+        s4: Double = Default(1.0),
+        p1: Int = Default(0),
+        p2: Int = Default(0),
+        p3: Int = Default(0),
+        p4: Int = Default(0),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Non-local means denoiser (Vulkan)
+
+        Args:
+            s: denoising strength for all components (from 1 to 100) (default 1)
+            p: patch size for all components (from 0 to 99) (default 7)
+            r: research window radius (from 0 to 99) (default 15)
+            t: parallelism (from 1 to 168) (default 36)
+            s1: denoising strength for component 1 (from 1 to 100) (default 1)
+            s2: denoising strength for component 2 (from 1 to 100) (default 1)
+            s3: denoising strength for component 3 (from 1 to 100) (default 1)
+            s4: denoising strength for component 4 (from 1 to 100) (default 1)
+            p1: patch size for component 1 (from 0 to 99) (default 0)
+            p2: patch size for component 2 (from 0 to 99) (default 0)
+            p3: patch size for component 3 (from 0 to 99) (default 0)
+            p4: patch size for component 4 (from 0 to 99) (default 0)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#nlmeans_005fvulkan)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="nlmeans_vulkan",
+                typings_input=("video",),
+                typings_output=("video",),
+            ),
+            self,
+            **{
+                "s": s,
+                "p": p,
+                "r": r,
+                "t": t,
+                "s1": s1,
+                "s2": s2,
+                "s3": s3,
+                "s4": s4,
+                "p1": p1,
+                "p2": p2,
+                "p3": p3,
+                "p4": p4,
             }
             | (extra_options or {}),
         )
@@ -8373,6 +9234,7 @@ class VideoStream(FilterableStream):
             "yuv422",
             "yuv422p10",
             "yuv444",
+            "yuv444p10",
             "rgb",
             "gbrp",
             "auto",
@@ -8398,7 +9260,7 @@ class VideoStream(FilterableStream):
             eof_action: Action to take when encountering EOF from secondary input (from 0 to 2) (default repeat)
             eval: specify when to evaluate expressions (from 0 to 1) (default frame)
             shortest: force termination when the shortest input terminates (default false)
-            format: set output format (from 0 to 7) (default yuv420)
+            format: set output format (from 0 to 8) (default yuv420)
             repeatlast: repeat overlay of the last overlay frame (default true)
             alpha: alpha format (from 0 to 1) (default straight)
             ts_sync_mode: How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
@@ -8430,6 +9292,148 @@ class VideoStream(FilterableStream):
                 "alpha": alpha,
                 "ts_sync_mode": ts_sync_mode,
                 "enable": enable,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
+    def overlay_opencl(
+        self,
+        _overlay: VideoStream,
+        *,
+        x: Int = Default(0),
+        y: Int = Default(0),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Overlay one video on top of another
+
+        Args:
+            x: Overlay x position (from 0 to INT_MAX) (default 0)
+            y: Overlay y position (from 0 to INT_MAX) (default 0)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay_005fopencl)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="overlay_opencl",
+                typings_input=("video", "video"),
+                typings_output=("video",),
+            ),
+            self,
+            _overlay,
+            **{
+                "x": x,
+                "y": y,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
+    def overlay_vaapi(
+        self,
+        _overlay: VideoStream,
+        *,
+        x: String = Default("0"),
+        y: String = Default("0"),
+        w: String = Default("overlay_iw"),
+        h: String = Default("overlay_ih*w/overlay_iw"),
+        alpha: Float = Default(1.0),
+        eof_action: Int
+        | Literal["repeat", "endall", "pass", "repeat", "endall", "pass"]
+        | Default = Default("repeat"),
+        shortest: Boolean = Default(False),
+        repeatlast: Boolean = Default(True),
+        ts_sync_mode: Int | Literal["default", "nearest"] | Default = Default(
+            "default"
+        ),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Overlay one video on top of another
+
+        Args:
+            x: Overlay x position (default "0")
+            y: Overlay y position (default "0")
+            w: Overlay width (default "overlay_iw")
+            h: Overlay height (default "overlay_ih*w/overlay_iw")
+            alpha: Overlay global alpha (from 0 to 1) (default 1)
+            eof_action: Action to take when encountering EOF from secondary input (from 0 to 2) (default repeat)
+            shortest: force termination when the shortest input terminates (default false)
+            repeatlast: repeat overlay of the last overlay frame (default true)
+            ts_sync_mode: How strictly to sync streams based on secondary input timestamps (from 0 to 1) (default default)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay_005fvaapi)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="overlay_vaapi",
+                typings_input=("video", "video"),
+                typings_output=("video",),
+            ),
+            self,
+            _overlay,
+            **{
+                "x": x,
+                "y": y,
+                "w": w,
+                "h": h,
+                "alpha": alpha,
+                "eof_action": eof_action,
+                "shortest": shortest,
+                "repeatlast": repeatlast,
+                "ts_sync_mode": ts_sync_mode,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
+    def overlay_vulkan(
+        self,
+        _overlay: VideoStream,
+        *,
+        x: Int = Default(0),
+        y: Int = Default(0),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Overlay a source on top of another
+
+        Args:
+            x: Set horizontal offset (from 0 to INT_MAX) (default 0)
+            y: Set vertical offset (from 0 to INT_MAX) (default 0)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay_005fvulkan)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="overlay_vulkan",
+                typings_input=("video", "video"),
+                typings_output=("video",),
+            ),
+            self,
+            _overlay,
+            **{
+                "x": x,
+                "y": y,
             }
             | (extra_options or {}),
         )
@@ -8520,6 +9524,53 @@ class VideoStream(FilterableStream):
                 "y": y,
                 "color": color,
                 "eval": eval,
+                "aspect": aspect,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
+    def pad_opencl(
+        self,
+        *,
+        width: String = Default("iw"),
+        height: String = Default("ih"),
+        x: String = Default("0"),
+        y: String = Default("0"),
+        color: Color = Default("black"),
+        aspect: Rational = Default("0/1"),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Pad the input video.
+
+        Args:
+            width: set the pad area width (default "iw")
+            height: set the pad area height (default "ih")
+            x: set the x offset for the input image position (default "0")
+            y: set the y offset for the input image position (default "0")
+            color: set the color of the padded area border (default "black")
+            aspect: pad to fit an aspect instead of a resolution (from 0 to 32767) (default 0/1)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pad_005fopencl)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="pad_opencl", typings_input=("video",), typings_output=("video",)
+            ),
+            self,
+            **{
+                "width": width,
+                "height": height,
+                "x": x,
+                "y": y,
+                "color": color,
                 "aspect": aspect,
             }
             | (extra_options or {}),
@@ -8935,41 +9986,6 @@ class VideoStream(FilterableStream):
         )
         return filter_node.video(0)
 
-    def pp(
-        self,
-        *,
-        subfilters: String = Default("de"),
-        enable: String = Default(None),
-        extra_options: dict[str, Any] = None,
-    ) -> VideoStream:
-        """
-
-        Filter video using libpostproc.
-
-        Args:
-            subfilters: set postprocess subfilters (default "de")
-            enable: timeline editing
-
-        Returns:
-            default: the video stream
-
-        References:
-            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pp)
-
-        """
-        filter_node = filter_node_factory(
-            FFMpegFilterDef(
-                name="pp", typings_input=("video",), typings_output=("video",)
-            ),
-            self,
-            **{
-                "subfilters": subfilters,
-                "enable": enable,
-            }
-            | (extra_options or {}),
-        )
-        return filter_node.video(0)
-
     def pp7(
         self,
         *,
@@ -9049,6 +10065,46 @@ class VideoStream(FilterableStream):
         )
         return filter_node.video(0)
 
+    def prewitt_opencl(
+        self,
+        *,
+        planes: Int = Default(15),
+        scale: Float = Default(1.0),
+        delta: Float = Default(0.0),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Apply prewitt operator
+
+        Args:
+            planes: set planes to filter (from 0 to 15) (default 15)
+            scale: set scale (from 0 to 65535) (default 1)
+            delta: set delta (from -65535 to 65535) (default 0)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#prewitt_005fopencl)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="prewitt_opencl",
+                typings_input=("video",),
+                typings_output=("video",),
+            ),
+            self,
+            **{
+                "planes": planes,
+                "scale": scale,
+                "delta": delta,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
     def pseudocolor(
         self,
         *,
@@ -9075,6 +10131,12 @@ class VideoStream(FilterableStream):
             "preferred",
             "total",
             "spectral",
+            "cool",
+            "heat",
+            "fiery",
+            "blues",
+            "green",
+            "helix",
         ]
         | Default = Default("none"),
         opacity: Float = Default(1.0),
@@ -9091,7 +10153,7 @@ class VideoStream(FilterableStream):
             c2: set component #2 expression (default "val")
             c3: set component #3 expression (default "val")
             index: set component as base (from 0 to 3) (default 0)
-            preset: set preset (from -1 to 14) (default none)
+            preset: set preset (from -1 to 20) (default none)
             opacity: set pseudocolor opacity (from 0 to 1) (default 1)
             enable: timeline editing
 
@@ -9458,6 +10520,47 @@ class VideoStream(FilterableStream):
         )
         return filter_node.video(0)
 
+    def remap_opencl(
+        self,
+        _xmap: VideoStream,
+        _ymap: VideoStream,
+        *,
+        interp: Int | Literal["near", "linear"] | Default = Default("linear"),
+        fill: Color = Default("black"),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Remap pixels using OpenCL.
+
+        Args:
+            interp: set interpolation method (from 0 to 1) (default linear)
+            fill: set the color of the unmapped pixels (default "black")
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#remap_005fopencl)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="remap_opencl",
+                typings_input=("video", "video", "video"),
+                typings_output=("video",),
+            ),
+            self,
+            _xmap,
+            _ymap,
+            **{
+                "interp": interp,
+                "fill": fill,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
     def removegrain(
         self,
         *,
@@ -9680,6 +10783,46 @@ class VideoStream(FilterableStream):
                 "scale": scale,
                 "delta": delta,
                 "enable": enable,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
+    def roberts_opencl(
+        self,
+        *,
+        planes: Int = Default(15),
+        scale: Float = Default(1.0),
+        delta: Float = Default(0.0),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Apply roberts operator
+
+        Args:
+            planes: set planes to filter (from 0 to 15) (default 15)
+            scale: set scale (from 0 to 65535) (default 1)
+            delta: set delta (from -65535 to 65535) (default 0)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#roberts_005fopencl)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="roberts_opencl",
+                typings_input=("video",),
+                typings_output=("video",),
+            ),
+            self,
+            **{
+                "planes": planes,
+                "scale": scale,
+                "delta": delta,
             }
             | (extra_options or {}),
         )
@@ -10993,6 +12136,44 @@ class VideoStream(FilterableStream):
         )
         return filter_node.video(0)
 
+    def sobel_opencl(
+        self,
+        *,
+        planes: Int = Default(15),
+        scale: Float = Default(1.0),
+        delta: Float = Default(0.0),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Apply sobel operator
+
+        Args:
+            planes: set planes to filter (from 0 to 15) (default 15)
+            scale: set scale (from 0 to 65535) (default 1)
+            delta: set delta (from -65535 to 65535) (default 0)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sobel_005fopencl)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="sobel_opencl", typings_input=("video",), typings_output=("video",)
+            ),
+            self,
+            **{
+                "planes": planes,
+                "scale": scale,
+                "delta": delta,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
     def spectrumsynth(
         self,
         _phase: VideoStream,
@@ -11159,7 +12340,7 @@ class VideoStream(FilterableStream):
     def sr(
         self,
         *,
-        dnn_backend: Int | Literal["native"] | Default = Default("native"),
+        dnn_backend: Int = Default(1),
         scale_factor: Int = Default(2),
         model: String = Default(None),
         input: String = Default("x"),
@@ -11171,7 +12352,7 @@ class VideoStream(FilterableStream):
         Apply DNN-based image super resolution to the input.
 
         Args:
-            dnn_backend: DNN backend used for model execution (from 0 to 1) (default native)
+            dnn_backend: DNN backend used for model execution (from 0 to 1) (default 1)
             scale_factor: scale factor for SRCNN model (from 2 to 4) (default 2)
             model: path to model file specifying network architecture and its parameters
             input: input name of the model (default "x")
@@ -11359,6 +12540,7 @@ class VideoStream(FilterableStream):
         charenc: String = Default(None),
         stream_index: Int = Default(-1),
         force_style: String = Default(None),
+        wrap_unicode: Boolean = Default("auto"),
         extra_options: dict[str, Any] = None,
     ) -> VideoStream:
         """
@@ -11373,6 +12555,7 @@ class VideoStream(FilterableStream):
             charenc: set input character encoding
             stream_index: set stream index (from -1 to INT_MAX) (default -1)
             force_style: force subtitle style
+            wrap_unicode: break lines according to the Unicode Line Breaking Algorithm (default auto)
 
         Returns:
             default: the video stream
@@ -11394,6 +12577,7 @@ class VideoStream(FilterableStream):
                 "charenc": charenc,
                 "stream_index": stream_index,
                 "force_style": force_style,
+                "wrap_unicode": wrap_unicode,
             }
             | (extra_options or {}),
         )
@@ -12292,6 +13476,112 @@ class VideoStream(FilterableStream):
         )
         return filter_node.video(0)
 
+    def tonemap_opencl(
+        self,
+        *,
+        tonemap: Int
+        | Literal["none", "linear", "gamma", "clip", "reinhard", "hable", "mobius"]
+        | Default = Default("none"),
+        transfer: Int | Literal["bt709", "bt2020"] | Default = Default("bt709"),
+        matrix: Int | Literal["bt709", "bt2020"] | Default = Default(-1),
+        primaries: Int | Literal["bt709", "bt2020"] | Default = Default(-1),
+        range: Int | Literal["tv", "pc", "limited", "full"] | Default = Default(-1),
+        format: Pix_fmt = Default("none"),
+        peak: Double = Default(0.0),
+        param: Double = Default("nan"),
+        desat: Double = Default(0.5),
+        threshold: Double = Default(0.2),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Perform HDR to SDR conversion with tonemapping.
+
+        Args:
+            tonemap: tonemap algorithm selection (from 0 to 6) (default none)
+            transfer: set transfer characteristic (from -1 to INT_MAX) (default bt709)
+            matrix: set colorspace matrix (from -1 to INT_MAX) (default -1)
+            primaries: set color primaries (from -1 to INT_MAX) (default -1)
+            range: set color range (from -1 to INT_MAX) (default -1)
+            format: output pixel format (default none)
+            peak: signal peak override (from 0 to DBL_MAX) (default 0)
+            param: tonemap parameter (from DBL_MIN to DBL_MAX) (default nan)
+            desat: desaturation parameter (from 0 to DBL_MAX) (default 0.5)
+            threshold: scene detection threshold (from 0 to DBL_MAX) (default 0.2)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tonemap_005fopencl)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="tonemap_opencl",
+                typings_input=("video",),
+                typings_output=("video",),
+            ),
+            self,
+            **{
+                "tonemap": tonemap,
+                "transfer": transfer,
+                "matrix": matrix,
+                "primaries": primaries,
+                "range": range,
+                "format": format,
+                "peak": peak,
+                "param": param,
+                "desat": desat,
+                "threshold": threshold,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
+    def tonemap_vaapi(
+        self,
+        *,
+        format: String = Default(None),
+        matrix: String = Default(None),
+        primaries: String = Default(None),
+        transfer: String = Default(None),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        VAAPI VPP for tone-mapping
+
+        Args:
+            format: Output pixel format set
+            matrix: Output color matrix coefficient set
+            primaries: Output color primaries set
+            transfer: Output color transfer characteristics set
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tonemap_005fvaapi)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="tonemap_vaapi",
+                typings_input=("video",),
+                typings_output=("video",),
+            ),
+            self,
+            **{
+                "format": format,
+                "matrix": matrix,
+                "primaries": primaries,
+                "transfer": transfer,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
     def tpad(
         self,
         *,
@@ -12371,6 +13661,47 @@ class VideoStream(FilterableStream):
         filter_node = filter_node_factory(
             FFMpegFilterDef(
                 name="transpose", typings_input=("video",), typings_output=("video",)
+            ),
+            self,
+            **{
+                "dir": dir,
+                "passthrough": passthrough,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
+    def transpose_vulkan(
+        self,
+        *,
+        dir: Int
+        | Literal["cclock_flip", "clock", "cclock", "clock_flip"]
+        | Default = Default("cclock_flip"),
+        passthrough: Int | Literal["none", "portrait", "landscape"] | Default = Default(
+            "none"
+        ),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Transpose Vulkan Filter
+
+        Args:
+            dir: set transpose direction (from 0 to 7) (default cclock_flip)
+            passthrough: do not apply transposition if the input matches the specified geometry (from 0 to INT_MAX) (default none)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#transpose_005fvulkan)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="transpose_vulkan",
+                typings_input=("video",),
+                typings_output=("video",),
             ),
             self,
             **{
@@ -12490,6 +13821,55 @@ class VideoStream(FilterableStream):
         )
         return filter_node.video(0)
 
+    def unsharp_opencl(
+        self,
+        *,
+        luma_msize_x: Float = Default(5.0),
+        luma_msize_y: Float = Default(5.0),
+        luma_amount: Float = Default(1.0),
+        chroma_msize_x: Float = Default(5.0),
+        chroma_msize_y: Float = Default(5.0),
+        chroma_amount: Float = Default(0.0),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Apply unsharp mask to input video
+
+        Args:
+            luma_msize_x: Set luma mask horizontal diameter (pixels) (from 1 to 23) (default 5)
+            luma_msize_y: Set luma mask vertical diameter (pixels) (from 1 to 23) (default 5)
+            luma_amount: Set luma amount (multiplier) (from -10 to 10) (default 1)
+            chroma_msize_x: Set chroma mask horizontal diameter (pixels after subsampling) (from 1 to 23) (default 5)
+            chroma_msize_y: Set chroma mask vertical diameter (pixels after subsampling) (from 1 to 23) (default 5)
+            chroma_amount: Set chroma amount (multiplier) (from -10 to 10) (default 0)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#unsharp_005fopencl)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="unsharp_opencl",
+                typings_input=("video",),
+                typings_output=("video",),
+            ),
+            self,
+            **{
+                "luma_msize_x": luma_msize_x,
+                "luma_msize_y": luma_msize_y,
+                "luma_amount": luma_amount,
+                "chroma_msize_x": chroma_msize_x,
+                "chroma_msize_y": chroma_msize_y,
+                "chroma_amount": chroma_amount,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
     def untile(
         self,
         *,
@@ -12517,6 +13897,50 @@ class VideoStream(FilterableStream):
             self,
             **{
                 "layout": layout,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
+    def uspp(
+        self,
+        *,
+        quality: Int = Default(3),
+        qp: Int = Default(0),
+        use_bframe_qp: Boolean = Default(False),
+        codec: String = Default("snow"),
+        enable: String = Default(None),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Apply Ultra Simple / Slow Post-processing filter.
+
+        Args:
+            quality: set quality (from 0 to 8) (default 3)
+            qp: force a constant quantizer parameter (from 0 to 63) (default 0)
+            use_bframe_qp: use B-frames' QP (default false)
+            codec: Codec name (default "snow")
+            enable: timeline editing
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#uspp)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="uspp", typings_input=("video",), typings_output=("video",)
+            ),
+            self,
+            **{
+                "quality": quality,
+                "qp": qp,
+                "use_bframe_qp": use_bframe_qp,
+                "codec": codec,
+                "enable": enable,
             }
             | (extra_options or {}),
         )
@@ -12963,6 +14387,30 @@ class VideoStream(FilterableStream):
         )
         return filter_node.video(0)
 
+    def vflip_vulkan(
+        self,
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Vertically flip the input video in Vulkan
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vflip_005fvulkan)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="vflip_vulkan", typings_input=("video",), typings_output=("video",)
+            ),
+            self,
+            **{} | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
     def vfrdet(
         self,
         extra_options: dict[str, Any] = None,
@@ -13379,6 +14827,7 @@ class VideoStream(FilterableStream):
         tint0: Float = Default(0.0),
         tint1: Float = Default(0.0),
         fitmode: Int | Literal["none", "size"] | Default = Default("none"),
+        input: Int | Literal["all", "first"] | Default = Default("first"),
         extra_options: dict[str, Any] = None,
     ) -> VideoStream:
         """
@@ -13401,6 +14850,7 @@ class VideoStream(FilterableStream):
             tint0: set 1st tint (from -1 to 1) (default 0)
             tint1: set 2nd tint (from -1 to 1) (default 0)
             fitmode: set fit mode (from 0 to 1) (default none)
+            input: set input formats selection (from 0 to 1) (default first)
 
         Returns:
             default: the video stream
@@ -13430,6 +14880,7 @@ class VideoStream(FilterableStream):
                 "tint0": tint0,
                 "tint1": tint1,
                 "fitmode": fitmode,
+                "input": input,
             }
             | (extra_options or {}),
         )
@@ -13612,6 +15063,18 @@ class VideoStream(FilterableStream):
             "zoomin",
             "fadefast",
             "fadeslow",
+            "hlwind",
+            "hrwind",
+            "vuwind",
+            "vdwind",
+            "coverleft",
+            "coverright",
+            "coverup",
+            "coverdown",
+            "revealleft",
+            "revealright",
+            "revealup",
+            "revealdown",
         ]
         | Default = Default("fade"),
         duration: Duration = Default(1.0),
@@ -13624,7 +15087,7 @@ class VideoStream(FilterableStream):
         Cross fade one video with another video.
 
         Args:
-            transition: set cross fade transition (from -1 to 45) (default fade)
+            transition: set cross fade transition (from -1 to 57) (default fade)
             duration: set cross fade duration (default 1)
             offset: set cross fade start relative to first input stream (default 0)
             expr: set expression for custom transition
@@ -13649,6 +15112,67 @@ class VideoStream(FilterableStream):
                 "duration": duration,
                 "offset": offset,
                 "expr": expr,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
+    def xfade_opencl(
+        self,
+        _xfade: VideoStream,
+        *,
+        transition: Int
+        | Literal[
+            "custom",
+            "fade",
+            "wipeleft",
+            "wiperight",
+            "wipeup",
+            "wipedown",
+            "slideleft",
+            "slideright",
+            "slideup",
+            "slidedown",
+        ]
+        | Default = Default("fade"),
+        source: String = Default(None),
+        kernel: String = Default(None),
+        duration: Duration = Default(1.0),
+        offset: Duration = Default(0.0),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Cross fade one video with another video.
+
+        Args:
+            transition: set cross fade transition (from 0 to 9) (default fade)
+            source: set OpenCL program source file for custom transition
+            kernel: set kernel name in program file for custom transition
+            duration: set cross fade duration (default 1)
+            offset: set cross fade start relative to first input stream (default 0)
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xfade_005fopencl)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="xfade_opencl",
+                typings_input=("video", "video"),
+                typings_output=("video",),
+            ),
+            self,
+            _xfade,
+            **{
+                "transition": transition,
+                "source": source,
+                "kernel": kernel,
+                "duration": duration,
+                "offset": offset,
             }
             | (extra_options or {}),
         )
@@ -13735,6 +15259,38 @@ class VideoStream(FilterableStream):
                 "planes": planes,
                 "sigma": sigma,
                 "enable": enable,
+            }
+            | (extra_options or {}),
+        )
+        return filter_node.video(0)
+
+    def zmq(
+        self,
+        *,
+        bind_address: String = Default("tcp://*:5555"),
+        extra_options: dict[str, Any] = None,
+    ) -> VideoStream:
+        """
+
+        Receive commands through ZMQ and broker them to filters.
+
+        Args:
+            bind_address: set bind address (default "tcp://*:5555")
+
+        Returns:
+            default: the video stream
+
+        References:
+            [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#zmq_002c-azmq)
+
+        """
+        filter_node = filter_node_factory(
+            FFMpegFilterDef(
+                name="zmq", typings_input=("video",), typings_output=("video",)
+            ),
+            self,
+            **{
+                "bind_address": bind_address,
             }
             | (extra_options or {}),
         )

--- a/src/scripts/code_gen/gen.py
+++ b/src/scripts/code_gen/gen.py
@@ -260,15 +260,12 @@ def render(
     """
     outpath.mkdir(exist_ok=True)
     output = []
+
     for template_file in template_folder.glob("**/*.py.jinja"):
         template_path = template_file.relative_to(template_folder)
 
         template = env.get_template(str(template_path))
-        try:
-            code = template.render(filters=filters, options=options)
-        except Exception as e:
-            print(f"Failed to render {template_path}: {e}")
-            continue
+        code = template.render(filters=filters, options=options)
 
         opath = outpath / str(template_path).replace(".jinja", "")
         opath.parent.mkdir(parents=True, exist_ok=True)

--- a/src/scripts/code_gen/gen.py
+++ b/src/scripts/code_gen/gen.py
@@ -264,7 +264,11 @@ def render(
         template_path = template_file.relative_to(template_folder)
 
         template = env.get_template(str(template_path))
-        code = template.render(filters=filters, options=options)
+        try:
+            code = template.render(filters=filters, options=options)
+        except Exception as e:
+            print(f"Failed to render {template_path}: {e}")
+            continue
 
         opath = outpath / str(template_path).replace(".jinja", "")
         opath.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
- fix #655

This pull request introduces updates to FFmpeg filter definitions for improved type annotations and adds new audio processing methods. The changes enhance the functionality and maintainability of the codebase by defining input types for existing filters and implementing new audio filters with detailed documentation.

### Updates to FFmpeg filter definitions:
* Added explicit `formula_typings_input` for the following filters to specify input stream types:
  - `hstack_vaapi`, `program_opencl`, `vstack_vaapi`, and `xstack_vaapi`: Defined as `[StreamType.video] * int(inputs)` for handling multiple video streams. [[1]](diffhunk://#diff-7f9f80e14fcedceeb5454c6fb8bfe5c038eb4fa771c162522cce55abb9a6014dL3-R3) [[2]](diffhunk://#diff-9cad806aff0fa46b87f3c274b17250be24f6f223e19da9c9bdbb5690f7639a08L3-R3) [[3]](diffhunk://#diff-c50ad1278539a4a0dad9e5f3130130294de7b3fff7b3ed38e5796b4f853c5fa3L3-R3) [[4]](diffhunk://#diff-414e214f1d9894e6c5747ad0c04edcad395d49ab9a85baf86d459f3b2bdf9ba8L3-R3)
  - `ladspa` and `lv2`: Defined as `[StreamType.audio]` for audio stream processing. [[1]](diffhunk://#diff-33f0d9c1d6976c0358a1a04394a4a0be2e5f94afc85d8d3991584226b0c08b57L3-R3) [[2]](diffhunk://#diff-ab258b386dc8ab220dcc5d689a3848b140273035a5dcc69fbef783cbeff91313L3-R3)

### New audio processing methods:
* Added `asr` method for automatic speech recognition with configurable parameters such as `rate`, `hmm`, `dict`, and `lm` for language model settings.
* Added `bs2b` method for Bauer stereo-to-binaural audio processing with options like `profile`, `fcut`, and `feed` to customize the filter behavior.
* Added `sofalizer` method for spatial audio processing using SOFA files, supporting parameters like `sofa`, `gain`, `rotation`, and `radius` for 3D sound customization.

### Minor codebase improvement:
* Added a blank line in the `render` function in `gen.py` for improved readability.