### PR TITLE
copy parse-help schema to IR layer

### DIFF
--- a/src/scripts/code_gen/cli.py
+++ b/src/scripts/code_gen/cli.py
@@ -12,8 +12,8 @@ from ..manual.cli import load_config
 from ..parse_c.cli import parse_ffmpeg_options
 from ..parse_docs.cli import extract_docs
 from ..parse_help.cli import all_codecs, all_filters, all_formats
-from ..parse_help.schema import FFMpegCodec, FFMpegFormat
 from .gen import render
+from .schema import FFMpegAVOption, FFMpegCodec, FFMpegFormat, FFMpegOptionChoice
 
 app = typer.Typer()
 
@@ -52,12 +52,11 @@ def gen_option_info() -> list[FFMpegOption]:
     return options
 
 
-def load_filters(outpath: Path, rebuild: bool) -> list[FFMpegFilter]:
+def load_filters(rebuild: bool) -> list[FFMpegFilter]:
     """
     Load filters from the output path
 
     Args:
-        outpath: The output path
         rebuild: Whether to use the cache
 
     Returns:
@@ -108,12 +107,38 @@ def load_codecs(rebuild: bool) -> list[FFMpegCodec]:
         except Exception as e:
             logging.error(f"Failed to load codecs from cache: {e}")
 
-    codecs = all_codecs()
+    codecs = [
+        FFMpegCodec(
+            name=k.name,
+            flags=k.flags,
+            description=k.description,
+            options=tuple(
+                FFMpegAVOption(
+                    section=i.section,
+                    name=i.name,
+                    type=i.type,
+                    flags=i.flags,
+                    help=i.help,
+                    min=i.min,
+                    max=i.max,
+                    default=i.default,
+                    choices=tuple(
+                        FFMpegOptionChoice(
+                            name=i.name, help=i.help, flags=i.flags, value=i.value
+                        )
+                        for i in i.choices
+                    ),
+                )
+                for i in k.options
+            ),
+        )
+        for k in all_codecs()
+    ]
     save(codecs, "codecs")
     return codecs
 
 
-def load_muxers(rebuild: bool) -> list[FFMpegFormat]:
+def load_formats(rebuild: bool) -> list[FFMpegFormat]:
     """
     Load muxers from the output path
 
@@ -130,7 +155,33 @@ def load_muxers(rebuild: bool) -> list[FFMpegFormat]:
         except Exception as e:
             logging.error(f"Failed to load muxers from cache: {e}")
 
-    formats = all_formats()
+    formats = [
+        FFMpegFormat(
+            name=k.name,
+            flags=k.flags,
+            description=k.description,
+            options=tuple(
+                FFMpegAVOption(
+                    section=i.section,
+                    name=i.name,
+                    type=i.type,
+                    flags=i.flags,
+                    help=i.help,
+                    min=i.min,
+                    max=i.max,
+                    default=i.default,
+                    choices=tuple(
+                        FFMpegOptionChoice(
+                            name=i.name, help=i.help, flags=i.flags, value=i.value
+                        )
+                        for i in i.choices
+                    ),
+                )
+                for i in k.options
+            ),
+        )
+        for k in all_formats()
+    ]
     save(formats, "formats")
     return formats
 
@@ -147,10 +198,10 @@ def generate(outpath: Path | None = None, rebuild: bool = False) -> None:
     if not outpath:
         outpath = Path(__file__).parent.parent.parent / "ffmpeg"
 
-    ffmpeg_filters = load_filters(outpath, rebuild)
+    ffmpeg_filters = load_filters(rebuild)
     ffmpeg_options = gen_option_info()
     ffmpeg_codecs = load_codecs(rebuild)
-    ffmpeg_muxers = load_muxers(rebuild)
+    ffmpeg_muxers = load_formats(rebuild)
 
     render(
         filters=ffmpeg_filters,

--- a/src/scripts/code_gen/cli.py
+++ b/src/scripts/code_gen/cli.py
@@ -124,9 +124,12 @@ def load_codecs(rebuild: bool) -> list[FFMpegCodec]:
                     default=i.default,
                     choices=tuple(
                         FFMpegOptionChoice(
-                            name=i.name, help=i.help, flags=i.flags, value=i.value
+                            name=choice.name,
+                            help=choice.help,
+                            flags=choice.flags,
+                            value=choice.value,
                         )
-                        for i in i.choices
+                        for choice in i.choices
                     ),
                 )
                 for i in k.options
@@ -172,9 +175,12 @@ def load_formats(rebuild: bool) -> list[FFMpegFormat]:
                     default=i.default,
                     choices=tuple(
                         FFMpegOptionChoice(
-                            name=i.name, help=i.help, flags=i.flags, value=i.value
+                            name=choice.name,
+                            help=choice.help,
+                            flags=choice.flags,
+                            value=choice.value,
                         )
-                        for i in i.choices
+                        for choice in i.choices
                     ),
                 )
                 for i in k.options

--- a/src/scripts/code_gen/schema.py
+++ b/src/scripts/code_gen/schema.py
@@ -2,9 +2,11 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Literal
 
+from ffmpeg.common.serialize import Serializable
+
 
 @dataclass(frozen=True, kw_only=True)
-class FFMpegOptionChoice:
+class FFMpegOptionChoice(Serializable):
     name: str
     help: str
     flags: str
@@ -12,7 +14,7 @@ class FFMpegOptionChoice:
 
 
 @dataclass(frozen=True, kw_only=True)
-class FFMpegAVOption:
+class FFMpegAVOption(Serializable):
     section: str
     name: str
     type: str
@@ -97,7 +99,7 @@ class FFMpegAVOption:
 
 
 @dataclass(frozen=True, kw_only=True)
-class FFMpegCodec:
+class FFMpegCodec(Serializable):
     name: str
     flags: str
     description: str
@@ -144,7 +146,7 @@ class FFMpegDecoder(FFMpegCodec):
 
 
 @dataclass(frozen=True, kw_only=True)
-class FFMpegFormat:
+class FFMpegFormat(Serializable):
     name: str
     flags: str
     description: str

--- a/src/scripts/code_gen/schema.py
+++ b/src/scripts/code_gen/schema.py
@@ -105,7 +105,7 @@ class FFMpegCodec(Serializable):
     description: str
     options: tuple[FFMpegAVOption, ...] = ()
 
-    def filterd_options(self) -> Iterable[FFMpegAVOption]:
+    def filtered_options(self) -> Iterable[FFMpegAVOption]:
         # NOTE: the nvenv_hevc has alias for some options, so we need to filter them out
         passed = set()
         for option in self.options:

--- a/src/scripts/code_gen/templates/codecs/decoders.py.jinja
+++ b/src/scripts/code_gen/templates/codecs/decoders.py.jinja
@@ -5,7 +5,7 @@ from ..utils.frozendict import FrozenDict, merge
 {% for codec in codecs %}
 {% if codec.is_decoder %}
 def {{codec.name | option_name_safe }}(
-    {% for option in codec.filterd_options() %}
+    {% for option in codec.filtered_options() %}
     {{option.name| option_name_safe}}: {{option.code_gen_type}} = None,
     {% endfor %}
 ) -> FFMpegDecoderOption:
@@ -13,7 +13,7 @@ def {{codec.name | option_name_safe }}(
     {{codec.description}}
     {% if codec.options | length > 0 %}
     Args:
-    {%- for option in codec.filterd_options() %}
+    {%- for option in codec.filtered_options() %}
         {{option.name | option_name_safe}}: {{option.help}}
     {%- endfor %}
     {%- endif %}
@@ -22,7 +22,7 @@ def {{codec.name | option_name_safe }}(
         the set codec options
     """
     return FFMpegDecoderOption(kwargs=merge({
-        {% for option in codec.filterd_options() %}
+        {% for option in codec.filtered_options() %}
         "{{ option.name}}": {{ option.name | option_name_safe }},
         {% endfor %}
     }))

--- a/src/scripts/code_gen/templates/codecs/encoders.py.jinja
+++ b/src/scripts/code_gen/templates/codecs/encoders.py.jinja
@@ -5,7 +5,7 @@ from ..utils.frozendict import FrozenDict, merge
 {% for codec in codecs %}
 {% if codec.is_encoder %}
 def {{codec.name | option_name_safe }}(
-    {% for option in codec.filterd_options() %}
+    {% for option in codec.filtered_options() %}
     {{option.name| option_name_safe}}: {{option.code_gen_type}} = None,
     {% endfor %}
 ) -> FFMpegEncoderOption:
@@ -13,7 +13,7 @@ def {{codec.name | option_name_safe }}(
     {{codec.description}}
     {% if codec.options | length > 0 %}
     Args:
-    {%- for option in codec.filterd_options() %}
+    {%- for option in codec.filtered_options() %}
         {{option.name | option_name_safe}}: {{option.help}}
     {%- endfor %}
     {%- endif %}
@@ -22,7 +22,7 @@ def {{codec.name | option_name_safe }}(
         the set codec options
     """
     return FFMpegEncoderOption(kwargs=merge({
-        {% for option in codec.filterd_options() %}
+        {% for option in codec.filtered_options() %}
         "{{ option.name}}": {{ option.name | option_name_safe }},
         {% endfor %}
     }))

--- a/src/scripts/parse_help/schema.py
+++ b/src/scripts/parse_help/schema.py
@@ -103,7 +103,7 @@ class FFMpegCodec:
     description: str
     options: tuple[FFMpegAVOption, ...] = ()
 
-    def filterd_options(self) -> Iterable[FFMpegAVOption]:
+    def filtered_options(self) -> Iterable[FFMpegAVOption]:
         # NOTE: the nvenv_hevc has alias for some options, so we need to filter them out
         passed = set()
         for option in self.options:


### PR DESCRIPTION
This pull request refactors the code generation module for FFmpeg by introducing a new schema definition in `src/scripts/code_gen/schema.py` and updating related functions to use the new schema. The changes improve type safety, modularity, and clarity in handling FFmpeg options, codecs, and formats.

### Schema Refactoring:
* Introduced new schema classes (`FFMpegOptionChoice`, `FFMpegAVOption`, `FFMpegCodec`, `FFMpegFormat`, and their subtypes) in `src/scripts/code_gen/schema.py` to encapsulate FFmpeg entities with better type definitions and serialization support.
* Removed `Serializable` inheritance from schema classes in `src/scripts/parse_help/schema.py` to align them with the new schema definitions. [[1]](diffhunk://#diff-f79f5493fe7f5aa3189e95a5d72766877d16f452d1404a121b4d9d53ad743e69L5-R15) [[2]](diffhunk://#diff-f79f5493fe7f5aa3189e95a5d72766877d16f452d1404a121b4d9d53ad743e69L102-R100) [[3]](diffhunk://#diff-f79f5493fe7f5aa3189e95a5d72766877d16f452d1404a121b4d9d53ad743e69L149-R147)

### Function Updates:
* Updated `load_codecs` and `load_formats` functions in `src/scripts/code_gen/cli.py` to use the new schema for constructing codec and format objects, ensuring consistency and adding support for option choices. [[1]](diffhunk://#diff-562ff301c898f99282617a6b2016ee14c9240c06eaca74d83b7a452b3304a8c9L111-R141) [[2]](diffhunk://#diff-562ff301c898f99282617a6b2016ee14c9240c06eaca74d83b7a452b3304a8c9L133-R184)
* Renamed `load_muxers` to `load_formats` for clarity and consistency with FFmpeg terminology.

### Code Simplification:
* Removed the `outpath` parameter from `load_filters` and `load_formats` functions in `src/scripts/code_gen/cli.py`, as it was unused. [[1]](diffhunk://#diff-562ff301c898f99282617a6b2016ee14c9240c06eaca74d83b7a452b3304a8c9L55-L60) [[2]](diffhunk://#diff-562ff301c898f99282617a6b2016ee14c9240c06eaca74d83b7a452b3304a8c9L150-R204)