### PR TITLE
refactor ffmpeg option

### DIFF
--- a/src/ffmpeg/codecs/schema.py
+++ b/src/ffmpeg/codecs/schema.py
@@ -1,17 +1,11 @@
 from dataclasses import dataclass
 
-from ..common.serialize import Serializable
-from ..utils.frozendict import FrozenDict
+from ..schema import FFMpegOptionGroup
 
 
 @dataclass(frozen=True, kw_only=True)
-class FFMpegCodecOption(Serializable):
-    kwargs: FrozenDict[str, str | int | float | bool] = FrozenDict({})
+class FFMpegEncoderOption(FFMpegOptionGroup): ...
 
 
 @dataclass(frozen=True, kw_only=True)
-class FFMpegEncoderOption(FFMpegCodecOption): ...
-
-
-@dataclass(frozen=True, kw_only=True)
-class FFMpegDecoderOption(FFMpegCodecOption): ...
+class FFMpegDecoderOption(FFMpegOptionGroup): ...

--- a/src/ffmpeg/formats/schema.py
+++ b/src/ffmpeg/formats/schema.py
@@ -1,17 +1,11 @@
 from dataclasses import dataclass
 
-from ..common.serialize import Serializable
-from ..utils.frozendict import FrozenDict
+from ..schema import FFMpegOptionGroup
 
 
 @dataclass(frozen=True, kw_only=True)
-class FFMpegFormatOption(Serializable):
-    kwargs: FrozenDict[str, str | int | float | bool] = FrozenDict({})
+class FFMpegMuxerOption(FFMpegOptionGroup): ...
 
 
 @dataclass(frozen=True, kw_only=True)
-class FFMpegMuxerOption(FFMpegFormatOption): ...
-
-
-@dataclass(frozen=True, kw_only=True)
-class FFMpegDemuxerOption(FFMpegFormatOption): ...
+class FFMpegDemuxerOption(FFMpegOptionGroup): ...

--- a/src/ffmpeg/schema.py
+++ b/src/ffmpeg/schema.py
@@ -7,7 +7,11 @@ These components form the foundation of the type annotation system that
 enables static type checking in the FFmpeg filter graph.
 """
 
+from dataclasses import dataclass
+
 from .common.schema import StreamType
+from .common.serialize import Serializable
+from .utils.frozendict import FrozenDict
 
 
 class Default(str):
@@ -48,8 +52,20 @@ class Auto(Default):
     """
 
 
+@dataclass(frozen=True, kw_only=True)
+class FFMpegOptionGroup(Serializable):
+    """
+    Represents a group of FFmpeg options.
+
+    This class is used to group options together, such as a codec or format.
+    """
+
+    kwargs: FrozenDict[str, str | int | float | bool] = FrozenDict({})
+
+
 __all__ = [
     "Auto",
     "Default",
     "StreamType",
+    "FFMpegOptionGroup",
 ]


### PR DESCRIPTION
This pull request refactors the FFmpeg schema by introducing a new base class, `FFMpegOptionGroup`, to consolidate shared functionality across codec and format option classes. The changes simplify the codebase and improve maintainability by reducing redundancy.

### Refactoring FFmpeg option classes:

* **Introduction of `FFMpegOptionGroup`**: Added a new base class `FFMpegOptionGroup` in `src/ffmpeg/schema.py` to represent a group of FFmpeg options. This class includes shared attributes and functionality for codec and format options. (`[src/ffmpeg/schema.pyR55-R70](diffhunk://#diff-5200ac8aabfe20f55deac686618b7de693c3d0a0e3261ea15f3c187ead97c1a4R55-R70)`)
* **Refactored codec option classes**: Updated `FFMpegEncoderOption` and `FFMpegDecoderOption` in `src/ffmpeg/codecs/schema.py` to inherit from `FFMpegOptionGroup`, replacing their previous inheritance from `Serializable`. (`[src/ffmpeg/codecs/schema.pyL3-R11](diffhunk://#diff-bd3cf27a92864b75094482170c8ccad31f20306915e273d43e7d59ad752a9252L3-R11)`)
* **Refactored format option classes**: Updated `FFMpegMuxerOption` and `FFMpegDemuxerOption` in `src/ffmpeg/formats/schema.py` to inherit from `FFMpegOptionGroup`, replacing their previous inheritance from `Serializable`. (`[src/ffmpeg/formats/schema.pyL3-R11](diffhunk://#diff-5d731a69daceead1c85c7e897dddc2f01a69e41592cc66cd7524759bf40a3136L3-R11)`)

### Dependency adjustments:

* **Imports updated**: Adjusted imports in `src/ffmpeg/schema.py` to include `Serializable` and `FrozenDict` from their respective modules, supporting the new `FFMpegOptionGroup` class. (`[src/ffmpeg/schema.pyR10-R14](diffhunk://#diff-5200ac8aabfe20f55deac686618b7de693c3d0a0e3261ea15f3c187ead97c1a4R10-R14)`)