### PR TITLE
Fix #736 handle template auto

### DIFF
--- a/src/ffmpeg/dag/global_runnable/global_args.py
+++ b/src/ffmpeg/dag/global_runnable/global_args.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ...types import (
     Boolean,
@@ -13,11 +13,9 @@ from ...types import (
     Int,
 )
 from ...utils.frozendict import merge
-from ..nodes import (
-    GlobalNode,
-    GlobalStream,
-    OutputStream,
-)
+
+if TYPE_CHECKING:
+    from ..nodes import GlobalNode, GlobalStream, OutputStream
 
 
 class GlobalArgs(ABC):

--- a/src/ffmpeg/dag/global_runnable/global_args.py
+++ b/src/ffmpeg/dag/global_runnable/global_args.py
@@ -4,8 +4,13 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
+from ...dag.nodes import (
+    GlobalNode,
+    GlobalStream,
+    OutputStream,
+)
 from ...types import (
     Boolean,
     Float,
@@ -13,9 +18,6 @@ from ...types import (
     Int,
 )
 from ...utils.frozendict import merge
-
-if TYPE_CHECKING:
-    from ..nodes import GlobalNode, GlobalStream, OutputStream
 
 
 class GlobalArgs(ABC):

--- a/src/ffmpeg/dag/global_runnable/global_args.py
+++ b/src/ffmpeg/dag/global_runnable/global_args.py
@@ -6,11 +6,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 
-from ...dag.nodes import (
-    GlobalNode,
-    GlobalStream,
-    OutputStream,
-)
 from ...types import (
     Boolean,
     Float,
@@ -18,6 +13,11 @@ from ...types import (
     Int,
 )
 from ...utils.frozendict import merge
+from ..nodes import (
+    GlobalNode,
+    GlobalStream,
+    OutputStream,
+)
 
 
 class GlobalArgs(ABC):

--- a/src/ffmpeg/dag/io/_input.py
+++ b/src/ffmpeg/dag/io/_input.py
@@ -5,6 +5,9 @@ from pathlib import Path
 from typing import Any
 
 from ...codecs.schema import FFMpegDecoderOption
+from ...dag.nodes import (
+    InputNode,
+)
 from ...formats.schema import FFMpegDemuxerOption
 from ...streams.av import AVStream
 from ...types import (
@@ -16,7 +19,6 @@ from ...types import (
     Time,
 )
 from ...utils.frozendict import merge
-from ..nodes import InputNode
 
 
 def input(

--- a/src/ffmpeg/dag/io/_input.py
+++ b/src/ffmpeg/dag/io/_input.py
@@ -5,9 +5,6 @@ from pathlib import Path
 from typing import Any
 
 from ...codecs.schema import FFMpegDecoderOption
-from ...dag.nodes import (
-    InputNode,
-)
 from ...formats.schema import FFMpegDemuxerOption
 from ...streams.av import AVStream
 from ...types import (
@@ -19,6 +16,9 @@ from ...types import (
     Time,
 )
 from ...utils.frozendict import merge
+from ..nodes import (
+    InputNode,
+)
 
 
 def input(

--- a/src/ffmpeg/dag/io/_output.py
+++ b/src/ffmpeg/dag/io/_output.py
@@ -5,11 +5,6 @@ from pathlib import Path
 from typing import Any
 
 from ...codecs.schema import FFMpegEncoderOption
-from ...dag.nodes import (
-    FilterableStream,
-    OutputNode,
-    OutputStream,
-)
 from ...formats.schema import FFMpegMuxerOption
 from ...types import (
     Boolean,
@@ -21,6 +16,11 @@ from ...types import (
     Time,
 )
 from ...utils.frozendict import merge
+from ..nodes import (
+    FilterableStream,
+    OutputNode,
+    OutputStream,
+)
 
 
 def output(

--- a/src/ffmpeg/dag/io/_output.py
+++ b/src/ffmpeg/dag/io/_output.py
@@ -5,6 +5,11 @@ from pathlib import Path
 from typing import Any
 
 from ...codecs.schema import FFMpegEncoderOption
+from ...dag.nodes import (
+    FilterableStream,
+    OutputNode,
+    OutputStream,
+)
 from ...formats.schema import FFMpegMuxerOption
 from ...types import (
     Boolean,
@@ -16,7 +21,6 @@ from ...types import (
     Time,
 )
 from ...utils.frozendict import merge
-from ..nodes import FilterableStream, OutputNode, OutputStream
 
 
 def output(

--- a/src/ffmpeg/dag/io/output_args.py
+++ b/src/ffmpeg/dag/io/output_args.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from ...codecs.schema import FFMpegEncoderOption
+from ...dag.nodes import (
+    FilterableStream,
+    OutputNode,
+    OutputStream,
+)
 from ...formats.schema import FFMpegMuxerOption
 from ...types import (
     Boolean,
@@ -19,9 +24,6 @@ from ...types import (
     Time,
 )
 from ...utils.frozendict import merge
-
-if TYPE_CHECKING:
-    from ..nodes import FilterableStream, OutputNode, OutputStream
 
 
 class OutputArgs(ABC):

--- a/src/ffmpeg/dag/io/output_args.py
+++ b/src/ffmpeg/dag/io/output_args.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from ...codecs.schema import FFMpegEncoderOption
 from ...formats.schema import FFMpegMuxerOption
@@ -19,11 +19,9 @@ from ...types import (
     Time,
 )
 from ...utils.frozendict import merge
-from ..nodes import (
-    FilterableStream,
-    OutputNode,
-    OutputStream,
-)
+
+if TYPE_CHECKING:
+    from ..nodes import FilterableStream, OutputNode, OutputStream
 
 
 class OutputArgs(ABC):

--- a/src/ffmpeg/dag/io/output_args.py
+++ b/src/ffmpeg/dag/io/output_args.py
@@ -8,11 +8,6 @@ from pathlib import Path
 from typing import Any
 
 from ...codecs.schema import FFMpegEncoderOption
-from ...dag.nodes import (
-    FilterableStream,
-    OutputNode,
-    OutputStream,
-)
 from ...formats.schema import FFMpegMuxerOption
 from ...types import (
     Boolean,
@@ -24,6 +19,11 @@ from ...types import (
     Time,
 )
 from ...utils.frozendict import merge
+from ..nodes import (
+    FilterableStream,
+    OutputNode,
+    OutputStream,
+)
 
 
 class OutputArgs(ABC):

--- a/src/ffmpeg/filters.py
+++ b/src/ffmpeg/filters.py
@@ -5,7 +5,10 @@ from typing import Any, Literal
 
 from .common.schema import FFMpegFilterDef
 from .dag.factory import filter_node_factory
-from .dag.nodes import FilterableStream, FilterNode
+from .dag.nodes import (
+    FilterableStream,
+    FilterNode,
+)
 from .options.framesync import FFMpegFrameSyncOption
 from .schema import Auto, Default
 from .streams.audio import AudioStream

--- a/src/ffmpeg/sources.py
+++ b/src/ffmpeg/sources.py
@@ -5,7 +5,10 @@ from typing import Any, Literal
 
 from .common.schema import FFMpegFilterDef
 from .dag.factory import filter_node_factory
-from .dag.nodes import FilterableStream, FilterNode
+from .dag.nodes import (
+    FilterableStream,
+    FilterNode,
+)
 from .options.framesync import FFMpegFrameSyncOption
 from .schema import Auto, Default
 from .streams.audio import AudioStream

--- a/src/ffmpeg/streams/audio.py
+++ b/src/ffmpeg/streams/audio.py
@@ -7,7 +7,10 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from ..common.schema import FFMpegFilterDef
 from ..dag.factory import filter_node_factory
-from ..dag.nodes import FilterableStream, FilterNode
+from ..dag.nodes import (
+    FilterableStream,
+    FilterNode,
+)
 from ..schema import Default
 from ..types import (
     Boolean,
@@ -24,6 +27,7 @@ from ..types import (
     Video_rate,
 )
 from ..utils.frozendict import merge
+from .video import VideoStream
 
 if TYPE_CHECKING:
     from .video import VideoStream

--- a/src/ffmpeg/streams/audio.py
+++ b/src/ffmpeg/streams/audio.py
@@ -27,7 +27,6 @@ from ..types import (
     Video_rate,
 )
 from ..utils.frozendict import merge
-from .video import VideoStream
 
 if TYPE_CHECKING:
     from .video import VideoStream

--- a/src/ffmpeg/streams/video.py
+++ b/src/ffmpeg/streams/video.py
@@ -7,7 +7,10 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from ..common.schema import FFMpegFilterDef
 from ..dag.factory import filter_node_factory
-from ..dag.nodes import FilterableStream, FilterNode
+from ..dag.nodes import (
+    FilterableStream,
+    FilterNode,
+)
 from ..options.framesync import FFMpegFrameSyncOption
 from ..schema import Default
 from ..types import (
@@ -26,6 +29,7 @@ from ..types import (
     Video_rate,
 )
 from ..utils.frozendict import merge
+from .audio import AudioStream
 
 if TYPE_CHECKING:
     from .audio import AudioStream

--- a/src/ffmpeg/streams/video.py
+++ b/src/ffmpeg/streams/video.py
@@ -29,7 +29,6 @@ from ..types import (
     Video_rate,
 )
 from ..utils.frozendict import merge
-from .audio import AudioStream
 
 if TYPE_CHECKING:
     from .audio import AudioStream

--- a/src/scripts/code_gen/gen.py
+++ b/src/scripts/code_gen/gen.py
@@ -16,6 +16,8 @@ from ffmpeg.common.schema import (
     FFMpegOptionType,
 )
 
+from .utils import get_relative_path
+
 template_folder = Path(__file__).parent / "templates"
 
 loader = jinja2.FileSystemLoader(template_folder)
@@ -260,6 +262,7 @@ env.filters["option_typing"] = option_typing
 env.filters["input_typings"] = input_typings
 env.filters["output_typings"] = output_typings
 env.filters["filter_option_typings"] = filter_option_typings
+env.globals["get_relative_path"] = get_relative_path
 
 
 def render(
@@ -285,7 +288,7 @@ def render(
         template_path = template_file.relative_to(template_folder)
 
         template = env.get_template(str(template_path))
-        code = template.render(**kwargs)
+        code = template.render(template_path=template_path, **kwargs)
 
         opath = outpath / str(template_path).replace(".jinja", "")
         opath.parent.mkdir(parents=True, exist_ok=True)

--- a/src/scripts/code_gen/gen.py
+++ b/src/scripts/code_gen/gen.py
@@ -16,7 +16,7 @@ from ffmpeg.common.schema import (
     FFMpegOptionType,
 )
 
-from .utils import get_relative_import, get_relative_path
+from .utils import get_relative_path
 
 template_folder = Path(__file__).parent / "templates"
 
@@ -263,7 +263,6 @@ env.filters["input_typings"] = input_typings
 env.filters["output_typings"] = output_typings
 env.filters["filter_option_typings"] = filter_option_typings
 env.globals["get_relative_path"] = get_relative_path
-env.globals["get_relative_import"] = get_relative_import
 
 
 def render(

--- a/src/scripts/code_gen/gen.py
+++ b/src/scripts/code_gen/gen.py
@@ -16,7 +16,7 @@ from ffmpeg.common.schema import (
     FFMpegOptionType,
 )
 
-from .utils import get_relative_path
+from .utils import get_relative_import, get_relative_path
 
 template_folder = Path(__file__).parent / "templates"
 
@@ -263,6 +263,7 @@ env.filters["input_typings"] = input_typings
 env.filters["output_typings"] = output_typings
 env.filters["filter_option_typings"] = filter_option_typings
 env.globals["get_relative_path"] = get_relative_path
+env.globals["get_relative_import"] = get_relative_import
 
 
 def render(

--- a/src/scripts/code_gen/gen.py
+++ b/src/scripts/code_gen/gen.py
@@ -16,7 +16,7 @@ from ffmpeg.common.schema import (
     FFMpegOptionType,
 )
 
-from .utils import get_relative_path
+from .utils import get_relative_import
 
 template_folder = Path(__file__).parent / "templates"
 
@@ -262,7 +262,7 @@ env.filters["option_typing"] = option_typing
 env.filters["input_typings"] = input_typings
 env.filters["output_typings"] = output_typings
 env.filters["filter_option_typings"] = filter_option_typings
-env.globals["get_relative_path"] = get_relative_path
+env.globals["get_relative_import"] = get_relative_import
 
 
 def render(

--- a/src/scripts/code_gen/templates/_components.jinja
+++ b/src/scripts/code_gen/templates/_components.jinja
@@ -178,19 +178,19 @@ def {{f.name}}(
 from {{get_relative_path(f, template_path)}} import Binary, Boolean, Color, Dictionary, Double, Duration, Flags, Float, Func, Image_size, Int, Int64, Pix_fmt, Rational, Sample_fmt, String, Time, Video_rate
 {% endmacro %}
 
-{% macro import_all(f, template_path) %}
-from {{get_relative_path("types", template_path)}} import Binary, Boolean, Color, Dictionary, Double, Duration, Flags, Float, Func, Image_size, Int, Int64, Pix_fmt, Rational, Sample_fmt, String, Time, Video_rate
-from {{get_relative_path("dag.nodes", template_path)}} import FilterableStream, FilterNode, OutputStream, OutputNode, InputNode, GlobalNode, GlobalStream
-from {{get_relative_path("dag.factory", template_path)}} import filter_node_factory
-from {{get_relative_path("utils.frozendict", template_path)}} import FrozenDict, merge
-from {{get_relative_path("utils.typing", template_path)}} import override
-from {{get_relative_path("schema", template_path)}} import Default, StreamType, Auto
-from {{get_relative_path("common.schema", template_path)}} import FFMpegFilterDef
-from {{get_relative_path("options.framesync", template_path)}} import FFMpegFrameSyncOption
-from {{get_relative_path("streams.video", template_path)}} import VideoStream
-from {{get_relative_path("streams.audio", template_path)}} import AudioStream
-from {{get_relative_path("streams.av", template_path)}} import AVStream
-from {{get_relative_path("streams.channel_layout", template_path)}} import CHANNEL_LAYOUT
-from {{get_relative_path("codecs.schema", template_path)}} import FFMpegEncoderOption, FFMpegDecoderOption
-from {{get_relative_path("formats.schema", template_path)}} import FFMpegMuxerOption, FFMpegDemuxerOption
+{% macro import_all(template_path) %}
+{{get_relative_import("types", template_path, "Binary, Boolean, Color, Dictionary, Double, Duration, Flags, Float, Func, Image_size, Int, Int64, Pix_fmt, Rational, Sample_fmt, String, Time, Video_rate")}}
+{{get_relative_import("dag.nodes", template_path, "FilterableStream, FilterNode, OutputStream, OutputNode, InputNode, GlobalNode, GlobalStream")}}
+{{get_relative_import("dag.factory", template_path, "filter_node_factory")}}
+{{get_relative_import("utils.frozendict", template_path, "FrozenDict, merge")}}
+{{get_relative_import("utils.typing", template_path, "override")}}
+{{get_relative_import("schema", template_path, "Default, StreamType, Auto")}}
+{{get_relative_import("common.schema", template_path, "FFMpegFilterDef")}}
+{{get_relative_import("options.framesync", template_path, "FFMpegFrameSyncOption")}}
+{{get_relative_import("streams.video", template_path, "VideoStream")}}
+{{get_relative_import("streams.audio", template_path, "AudioStream")}}
+{{get_relative_import("streams.av", template_path, "AVStream")}}
+{{get_relative_import("streams.channel_layout", template_path, "CHANNEL_LAYOUT")}}
+{{get_relative_import("codecs.schema", template_path, "FFMpegEncoderOption, FFMpegDecoderOption")}}
+{{get_relative_import("formats.schema", template_path, "FFMpegMuxerOption, FFMpegDemuxerOption")}}
 {% endmacro %}

--- a/src/scripts/code_gen/templates/_components.jinja
+++ b/src/scripts/code_gen/templates/_components.jinja
@@ -177,3 +177,20 @@ def {{f.name}}(
 {% macro import_types(f, template_path) %}
 from {{get_relative_path(f, template_path)}} import Binary, Boolean, Color, Dictionary, Double, Duration, Flags, Float, Func, Image_size, Int, Int64, Pix_fmt, Rational, Sample_fmt, String, Time, Video_rate
 {% endmacro %}
+
+{% macro import_all(f, template_path) %}
+from {{get_relative_path("types", template_path)}} import Binary, Boolean, Color, Dictionary, Double, Duration, Flags, Float, Func, Image_size, Int, Int64, Pix_fmt, Rational, Sample_fmt, String, Time, Video_rate
+from {{get_relative_path("dag.nodes", template_path)}} import FilterableStream, FilterNode, OutputStream, OutputNode, InputNode, GlobalNode, GlobalStream
+from {{get_relative_path("dag.factory", template_path)}} import filter_node_factory
+from {{get_relative_path("utils.frozendict", template_path)}} import FrozenDict, merge
+from {{get_relative_path("utils.typing", template_path)}} import override
+from {{get_relative_path("schema", template_path)}} import Default, StreamType, Auto
+from {{get_relative_path("common.schema", template_path)}} import FFMpegFilterDef
+from {{get_relative_path("options.framesync", template_path)}} import FFMpegFrameSyncOption
+from {{get_relative_path("streams.video", template_path)}} import VideoStream
+from {{get_relative_path("streams.audio", template_path)}} import AudioStream
+from {{get_relative_path("streams.av", template_path)}} import AVStream
+from {{get_relative_path("streams.channel_layout", template_path)}} import CHANNEL_LAYOUT
+from {{get_relative_path("codecs.schema", template_path)}} import FFMpegEncoderOption, FFMpegDecoderOption
+from {{get_relative_path("formats.schema", template_path)}} import FFMpegMuxerOption, FFMpegDemuxerOption
+{% endmacro %}

--- a/src/scripts/code_gen/templates/_components.jinja
+++ b/src/scripts/code_gen/templates/_components.jinja
@@ -178,19 +178,25 @@ def {{f.name}}(
 from {{get_relative_path(f, template_path)}} import Binary, Boolean, Color, Dictionary, Double, Duration, Flags, Float, Func, Image_size, Int, Int64, Pix_fmt, Rational, Sample_fmt, String, Time, Video_rate
 {% endmacro %}
 
-{% macro import_all(template_path) %}
+{% macro import_all(template_path, import_video=True, import_audio=True, import_nodes=True) %}
 {{get_relative_import("types", template_path, "Binary, Boolean, Color, Dictionary, Double, Duration, Flags, Float, Func, Image_size, Int, Int64, Pix_fmt, Rational, Sample_fmt, String, Time, Video_rate")}}
-{{get_relative_import("dag.nodes", template_path, "FilterableStream, FilterNode, OutputStream, OutputNode, InputNode, GlobalNode, GlobalStream")}}
 {{get_relative_import("dag.factory", template_path, "filter_node_factory")}}
 {{get_relative_import("utils.frozendict", template_path, "FrozenDict, merge")}}
 {{get_relative_import("utils.typing", template_path, "override")}}
 {{get_relative_import("schema", template_path, "Default, StreamType, Auto")}}
 {{get_relative_import("common.schema", template_path, "FFMpegFilterDef")}}
 {{get_relative_import("options.framesync", template_path, "FFMpegFrameSyncOption")}}
-{{get_relative_import("streams.video", template_path, "VideoStream")}}
-{{get_relative_import("streams.audio", template_path, "AudioStream")}}
 {{get_relative_import("streams.av", template_path, "AVStream")}}
 {{get_relative_import("streams.channel_layout", template_path, "CHANNEL_LAYOUT")}}
 {{get_relative_import("codecs.schema", template_path, "FFMpegEncoderOption, FFMpegDecoderOption")}}
 {{get_relative_import("formats.schema", template_path, "FFMpegMuxerOption, FFMpegDemuxerOption")}}
+{% if import_nodes %}
+{{get_relative_import("dag.nodes", template_path, "FilterableStream, FilterNode, OutputStream, OutputNode, InputNode, GlobalNode, GlobalStream")}}
+{% endif %}
+{% if import_video %}
+{{get_relative_import("streams.video", template_path, "VideoStream")}}
+{% endif %}
+{% if import_audio %}
+{{get_relative_import("streams.audio", template_path, "AudioStream")}}
+{% endif %}
 {% endmacro %}

--- a/src/scripts/code_gen/templates/_components.jinja
+++ b/src/scripts/code_gen/templates/_components.jinja
@@ -174,6 +174,6 @@ def {{f.name}}(
 {{ process(f, "function") | indent(4, True) }}
 {% endmacro %}
 
-{% macro import_types(f) %}
-from {{f}} import Binary, Boolean, Color, Dictionary, Double, Duration, Flags, Float, Func, Image_size, Int, Int64, Pix_fmt, Rational, Sample_fmt, String, Time, Video_rate
+{% macro import_types(f, template_path) %}
+from {{get_relative_path(f, template_path)}} import Binary, Boolean, Color, Dictionary, Double, Duration, Flags, Float, Func, Image_size, Int, Int64, Pix_fmt, Rational, Sample_fmt, String, Time, Video_rate
 {% endmacro %}

--- a/src/scripts/code_gen/templates/codecs/decoders.py.jinja
+++ b/src/scripts/code_gen/templates/codecs/decoders.py.jinja
@@ -2,9 +2,11 @@
 FFmpeg decoders.
 """
 
+{% import "_components.jinja" as _components %}
+
 from typing import Literal
-from .schema import FFMpegDecoderOption
-from ..utils.frozendict import FrozenDict, merge
+
+{{ _components.import_all(template_path) }}
 
 {% for codec in codecs %}
 {% if codec.is_decoder %}

--- a/src/scripts/code_gen/templates/codecs/encoders.py.jinja
+++ b/src/scripts/code_gen/templates/codecs/encoders.py.jinja
@@ -2,9 +2,11 @@
 FFmpeg encoders.
 """
 
+{% import "_components.jinja" as _components %}
+
 from typing import Literal
-from .schema import FFMpegEncoderOption
-from ..utils.frozendict import FrozenDict, merge
+
+{{ _components.import_all(template_path) }}
 
 {% for codec in codecs %}
 {% if codec.is_encoder %}

--- a/src/scripts/code_gen/templates/dag/global_runnable/global_args.py.jinja
+++ b/src/scripts/code_gen/templates/dag/global_runnable/global_args.py.jinja
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
-{{ _components.import_types('...types') }}
+{{ _components.import_types('types', template_path) }}
 from ...utils.frozendict import merge
 
 if TYPE_CHECKING:

--- a/src/scripts/code_gen/templates/dag/global_runnable/global_args.py.jinja
+++ b/src/scripts/code_gen/templates/dag/global_runnable/global_args.py.jinja
@@ -9,7 +9,9 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
-{{ _components.import_all(template_path) }}
+{{ _components.import_all(template_path, import_nodes=False) }}
+if TYPE_CHECKING:
+    from ..nodes import GlobalNode, GlobalStream, OutputStream
 
 class GlobalArgs(ABC):
     """

--- a/src/scripts/code_gen/templates/dag/global_runnable/global_args.py.jinja
+++ b/src/scripts/code_gen/templates/dag/global_runnable/global_args.py.jinja
@@ -8,11 +8,8 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
-{{ _components.import_types('types', template_path) }}
-from ...utils.frozendict import merge
 
-if TYPE_CHECKING:
-    from ..nodes import GlobalNode, GlobalStream, OutputStream
+{{ _components.import_all(template_path) }}
 
 class GlobalArgs(ABC):
     """

--- a/src/scripts/code_gen/templates/dag/io/_input.py.jinja
+++ b/src/scripts/code_gen/templates/dag/io/_input.py.jinja
@@ -14,7 +14,7 @@ from ...utils.frozendict import merge
 from ...codecs.schema import FFMpegDecoderOption
 from ...formats.schema import FFMpegDemuxerOption
 
-{{ _components.import_types('...types') }}
+{{ _components.import_types('types', template_path) }}
 
 def input(
     filename: str | Path,

--- a/src/scripts/code_gen/templates/dag/io/_input.py.jinja
+++ b/src/scripts/code_gen/templates/dag/io/_input.py.jinja
@@ -5,16 +5,9 @@ Input node.
 {% import "_components.jinja" as _components %}
 
 from pathlib import Path
-from ...utils.frozendict import FrozenDict
-
-from ..nodes import InputNode
-from ...streams.av import AVStream
 from typing import Any
-from ...utils.frozendict import merge
-from ...codecs.schema import FFMpegDecoderOption
-from ...formats.schema import FFMpegDemuxerOption
 
-{{ _components.import_types('types', template_path) }}
+{{ _components.import_all(template_path) }}
 
 def input(
     filename: str | Path,

--- a/src/scripts/code_gen/templates/dag/io/_output.py.jinja
+++ b/src/scripts/code_gen/templates/dag/io/_output.py.jinja
@@ -9,7 +9,7 @@ from ...formats.schema import FFMpegMuxerOption
 
 from ..nodes import OutputNode, OutputStream, FilterableStream
 from typing import Any
-{{ _components.import_types('...types') }}
+{{ _components.import_types('types', template_path) }}
 
 from ...utils.frozendict import FrozenDict
 from ...utils.frozendict import merge

--- a/src/scripts/code_gen/templates/dag/io/_output.py.jinja
+++ b/src/scripts/code_gen/templates/dag/io/_output.py.jinja
@@ -4,15 +4,9 @@ Output node.
 {% import "_components.jinja" as _components %}
 
 from pathlib import Path
-from ...codecs.schema import FFMpegEncoderOption
-from ...formats.schema import FFMpegMuxerOption
-
-from ..nodes import OutputNode, OutputStream, FilterableStream
 from typing import Any
-{{ _components.import_types('types', template_path) }}
 
-from ...utils.frozendict import FrozenDict
-from ...utils.frozendict import merge
+{{ _components.import_all(template_path) }}
 
 def output(
     *streams: FilterableStream,

--- a/src/scripts/code_gen/templates/dag/io/output_args.py.jinja
+++ b/src/scripts/code_gen/templates/dag/io/output_args.py.jinja
@@ -9,7 +9,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-{{ _components.import_types('...types') }}
+{{ _components.import_types('types', template_path) }}
 from ...utils.frozendict import merge
 from ...codecs.schema import FFMpegEncoderOption
 from ...formats.schema import FFMpegMuxerOption

--- a/src/scripts/code_gen/templates/dag/io/output_args.py.jinja
+++ b/src/scripts/code_gen/templates/dag/io/output_args.py.jinja
@@ -9,14 +9,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
-{{ _components.import_types('types', template_path) }}
-from ...utils.frozendict import merge
-from ...codecs.schema import FFMpegEncoderOption
-from ...formats.schema import FFMpegMuxerOption
 
-
-if TYPE_CHECKING:
-    from ..nodes import FilterableStream, OutputNode, OutputStream
+{{ _components.import_all(template_path) }}
 
 
 class OutputArgs(ABC):

--- a/src/scripts/code_gen/templates/dag/io/output_args.py.jinja
+++ b/src/scripts/code_gen/templates/dag/io/output_args.py.jinja
@@ -10,8 +10,10 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-{{ _components.import_all(template_path) }}
+{{ _components.import_all(template_path, import_nodes=False) }}
 
+if TYPE_CHECKING:
+    from ..nodes import FilterableStream, OutputNode, OutputStream
 
 class OutputArgs(ABC):
     """Output arguments interface."""

--- a/src/scripts/code_gen/templates/filters.py.jinja
+++ b/src/scripts/code_gen/templates/filters.py.jinja
@@ -6,17 +6,7 @@ FFmpeg filters.
 
 from typing import Any, Literal
 
-from .dag.nodes import FilterNode, FilterableStream
-from .schema import Default, StreamType, Auto
-{{ _components.import_types('types', template_path) }}
-from .streams.video import VideoStream
-from .streams.audio import AudioStream
-from .streams.av import AVStream
-from .streams.channel_layout import CHANNEL_LAYOUT
-from .common.schema import FFMpegFilterDef
-from .options.framesync import FFMpegFrameSyncOption
-from .dag.factory import filter_node_factory
-from .utils.frozendict import merge
+{{ _components.import_all(template_path) }}
 
 import re
 

--- a/src/scripts/code_gen/templates/filters.py.jinja
+++ b/src/scripts/code_gen/templates/filters.py.jinja
@@ -8,7 +8,7 @@ from typing import Any, Literal
 
 from .dag.nodes import FilterNode, FilterableStream
 from .schema import Default, StreamType, Auto
-{{ _components.import_types('.types') }}
+{{ _components.import_types('types', template_path) }}
 from .streams.video import VideoStream
 from .streams.audio import AudioStream
 from .streams.av import AVStream

--- a/src/scripts/code_gen/templates/formats/demuxers.py.jinja
+++ b/src/scripts/code_gen/templates/formats/demuxers.py.jinja
@@ -1,9 +1,12 @@
 """
 FFmpeg demuxers.
 """
+
+{% import "_components.jinja" as _components %}
+
 from typing import Literal
-from .schema import FFMpegDemuxerOption
-from ..utils.frozendict import FrozenDict, merge
+
+{{ _components.import_all(template_path) }}
 
 {% for codec in muxers %}
 {% if codec.is_demuxer %}

--- a/src/scripts/code_gen/templates/formats/muxers.py.jinja
+++ b/src/scripts/code_gen/templates/formats/muxers.py.jinja
@@ -2,9 +2,11 @@
 FFmpeg muxers.
 """
 
+{% import "_components.jinja" as _components %}
+
 from typing import Literal
-from .schema import FFMpegMuxerOption
-from ..utils.frozendict import FrozenDict, merge
+
+{{ _components.import_all(template_path) }}
 
 {% for codec in muxers %}
 {% if codec.is_muxer %}

--- a/src/scripts/code_gen/templates/sources.py.jinja
+++ b/src/scripts/code_gen/templates/sources.py.jinja
@@ -7,7 +7,7 @@ from typing import Any, Literal
 
 from .dag.nodes import FilterNode, FilterableStream
 from .schema import Default, StreamType, Auto
-{{ _components.import_types('.types') }}
+{{ _components.import_types('types', template_path) }}
 from .streams.video import VideoStream
 from .streams.audio import AudioStream
 from .streams.av import AVStream

--- a/src/scripts/code_gen/templates/sources.py.jinja
+++ b/src/scripts/code_gen/templates/sources.py.jinja
@@ -5,17 +5,7 @@ FFmpeg sources.
 {% import "_components.jinja" as _components %}
 from typing import Any, Literal
 
-from .dag.nodes import FilterNode, FilterableStream
-from .schema import Default, StreamType, Auto
-{{ _components.import_types('types', template_path) }}
-from .streams.video import VideoStream
-from .streams.audio import AudioStream
-from .streams.av import AVStream
-from .streams.channel_layout import CHANNEL_LAYOUT
-from .common.schema import FFMpegFilterDef
-from .dag.factory import filter_node_factory
-from .utils.frozendict import merge
-from .options.framesync import FFMpegFrameSyncOption
+{{ _components.import_all(template_path) }}
 
 import re
 

--- a/src/scripts/code_gen/templates/streams/audio.py.jinja
+++ b/src/scripts/code_gen/templates/streams/audio.py.jinja
@@ -8,7 +8,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Literal
 
-{{ _components.import_all(template_path) }}
+{{ _components.import_all(template_path, import_video=False) }}
 
 if TYPE_CHECKING:
     from .video import VideoStream

--- a/src/scripts/code_gen/templates/streams/audio.py.jinja
+++ b/src/scripts/code_gen/templates/streams/audio.py.jinja
@@ -8,15 +8,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Literal
 
-from ..dag.nodes import FilterableStream, FilterNode
-from ..schema import Default, StreamType, Auto
-{{ _components.import_types('types', template_path) }}
-from ..utils.typing import override
-from .channel_layout import CHANNEL_LAYOUT
-from ..common.schema import FFMpegFilterDef
-from ..dag.factory import filter_node_factory
-from ..utils.frozendict import merge
-from ..options.framesync import FFMpegFrameSyncOption
+{{ _components.import_all(template_path) }}
 
 if TYPE_CHECKING:
     from .video import VideoStream

--- a/src/scripts/code_gen/templates/streams/audio.py.jinja
+++ b/src/scripts/code_gen/templates/streams/audio.py.jinja
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from ..dag.nodes import FilterableStream, FilterNode
 from ..schema import Default, StreamType, Auto
-{{ _components.import_types('..types') }}
+{{ _components.import_types('types', template_path) }}
 from ..utils.typing import override
 from .channel_layout import CHANNEL_LAYOUT
 from ..common.schema import FFMpegFilterDef

--- a/src/scripts/code_gen/templates/streams/video.py.jinja
+++ b/src/scripts/code_gen/templates/streams/video.py.jinja
@@ -8,14 +8,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Literal
 
-from ..dag.nodes import FilterableStream, FilterNode
-from ..schema import Default, StreamType, Auto
-{{ _components.import_types('types', template_path) }}
-from ..utils.typing import override
-from ..common.schema import FFMpegFilterDef
-from ..dag.factory import filter_node_factory
-from ..utils.frozendict import merge
-from ..options.framesync import FFMpegFrameSyncOption
+{{ _components.import_all(template_path) }}
 
 if TYPE_CHECKING:
     from .audio import AudioStream

--- a/src/scripts/code_gen/templates/streams/video.py.jinja
+++ b/src/scripts/code_gen/templates/streams/video.py.jinja
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from ..dag.nodes import FilterableStream, FilterNode
 from ..schema import Default, StreamType, Auto
-{{ _components.import_types('..types') }}
+{{ _components.import_types('types', template_path) }}
 from ..utils.typing import override
 from ..common.schema import FFMpegFilterDef
 from ..dag.factory import filter_node_factory

--- a/src/scripts/code_gen/templates/streams/video.py.jinja
+++ b/src/scripts/code_gen/templates/streams/video.py.jinja
@@ -8,7 +8,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Literal
 
-{{ _components.import_all(template_path) }}
+{{ _components.import_all(template_path, import_audio=False) }}
 
 if TYPE_CHECKING:
     from .audio import AudioStream

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[_input.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[_input.py].raw
@@ -6,17 +6,29 @@ Input node.
 
 
 from pathlib import Path
-from ...utils.frozendict import FrozenDict
-
-from ..nodes import InputNode
-from ...streams.av import AVStream
 from typing import Any
-from ...utils.frozendict import merge
-from ...codecs.schema import FFMpegDecoderOption
-from ...formats.schema import FFMpegDemuxerOption
 
 
 from ...types import Binary, Boolean, Color, Dictionary, Double, Duration, Flags, Float, Func, Image_size, Int, Int64, Pix_fmt, Rational, Sample_fmt, String, Time, Video_rate
+from ..factory import filter_node_factory
+from ...utils.frozendict import FrozenDict, merge
+from ...utils.typing import override
+from ...schema import Default, StreamType, Auto
+from ...common.schema import FFMpegFilterDef
+from ...options.framesync import FFMpegFrameSyncOption
+from ...streams.av import AVStream
+from ...streams.channel_layout import CHANNEL_LAYOUT
+from ...codecs.schema import FFMpegEncoderOption, FFMpegDecoderOption
+from ...formats.schema import FFMpegMuxerOption, FFMpegDemuxerOption
+
+from ..nodes import FilterableStream, FilterNode, OutputStream, OutputNode, InputNode, GlobalNode, GlobalStream
+
+
+from ...streams.video import VideoStream
+
+
+from ...streams.audio import AudioStream
+
 
 
 def input(

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[_output.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[_output.py].raw
@@ -5,17 +5,30 @@ Output node.
 
 
 from pathlib import Path
-from ...codecs.schema import FFMpegEncoderOption
-from ...formats.schema import FFMpegMuxerOption
-
-from ..nodes import OutputNode, OutputStream, FilterableStream
 from typing import Any
 
+
 from ...types import Binary, Boolean, Color, Dictionary, Double, Duration, Flags, Float, Func, Image_size, Int, Int64, Pix_fmt, Rational, Sample_fmt, String, Time, Video_rate
+from ..factory import filter_node_factory
+from ...utils.frozendict import FrozenDict, merge
+from ...utils.typing import override
+from ...schema import Default, StreamType, Auto
+from ...common.schema import FFMpegFilterDef
+from ...options.framesync import FFMpegFrameSyncOption
+from ...streams.av import AVStream
+from ...streams.channel_layout import CHANNEL_LAYOUT
+from ...codecs.schema import FFMpegEncoderOption, FFMpegDecoderOption
+from ...formats.schema import FFMpegMuxerOption, FFMpegDemuxerOption
+
+from ..nodes import FilterableStream, FilterNode, OutputStream, OutputNode, InputNode, GlobalNode, GlobalStream
 
 
-from ...utils.frozendict import FrozenDict
-from ...utils.frozendict import merge
+from ...streams.video import VideoStream
+
+
+from ...streams.audio import AudioStream
+
+
 
 def output(
     *streams: FilterableStream,

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[audio.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[audio.py].raw
@@ -9,17 +9,26 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Literal
 
-from ..dag.nodes import FilterableStream, FilterNode
-from ..schema import Default, StreamType, Auto
 
 from ..types import Binary, Boolean, Color, Dictionary, Double, Duration, Flags, Float, Func, Image_size, Int, Int64, Pix_fmt, Rational, Sample_fmt, String, Time, Video_rate
-
-from ..utils.typing import override
-from .channel_layout import CHANNEL_LAYOUT
-from ..common.schema import FFMpegFilterDef
 from ..dag.factory import filter_node_factory
-from ..utils.frozendict import merge
+from ..utils.frozendict import FrozenDict, merge
+from ..utils.typing import override
+from ..schema import Default, StreamType, Auto
+from ..common.schema import FFMpegFilterDef
 from ..options.framesync import FFMpegFrameSyncOption
+from .av import AVStream
+from .channel_layout import CHANNEL_LAYOUT
+from ..codecs.schema import FFMpegEncoderOption, FFMpegDecoderOption
+from ..formats.schema import FFMpegMuxerOption, FFMpegDemuxerOption
+
+from ..dag.nodes import FilterableStream, FilterNode, OutputStream, OutputNode, InputNode, GlobalNode, GlobalStream
+
+
+
+
+
+
 
 if TYPE_CHECKING:
     from .video import VideoStream

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[decoders.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[decoders.py].raw
@@ -3,7 +3,30 @@
 FFmpeg decoders.
 """
 
+
+
 from typing import Literal
-from .schema import FFMpegDecoderOption
+
+
+from ..types import Binary, Boolean, Color, Dictionary, Double, Duration, Flags, Float, Func, Image_size, Int, Int64, Pix_fmt, Rational, Sample_fmt, String, Time, Video_rate
+from ..dag.factory import filter_node_factory
 from ..utils.frozendict import FrozenDict, merge
+from ..utils.typing import override
+from ..schema import Default, StreamType, Auto
+from ..common.schema import FFMpegFilterDef
+from ..options.framesync import FFMpegFrameSyncOption
+from ..streams.av import AVStream
+from ..streams.channel_layout import CHANNEL_LAYOUT
+from .schema import FFMpegEncoderOption, FFMpegDecoderOption
+from ..formats.schema import FFMpegMuxerOption, FFMpegDemuxerOption
+
+from ..dag.nodes import FilterableStream, FilterNode, OutputStream, OutputNode, InputNode, GlobalNode, GlobalStream
+
+
+from ..streams.video import VideoStream
+
+
+from ..streams.audio import AudioStream
+
+
 

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[demuxers.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[demuxers.py].raw
@@ -2,7 +2,31 @@
 """
 FFmpeg demuxers.
 """
+
+
+
 from typing import Literal
-from .schema import FFMpegDemuxerOption
+
+
+from ..types import Binary, Boolean, Color, Dictionary, Double, Duration, Flags, Float, Func, Image_size, Int, Int64, Pix_fmt, Rational, Sample_fmt, String, Time, Video_rate
+from ..dag.factory import filter_node_factory
 from ..utils.frozendict import FrozenDict, merge
+from ..utils.typing import override
+from ..schema import Default, StreamType, Auto
+from ..common.schema import FFMpegFilterDef
+from ..options.framesync import FFMpegFrameSyncOption
+from ..streams.av import AVStream
+from ..streams.channel_layout import CHANNEL_LAYOUT
+from ..codecs.schema import FFMpegEncoderOption, FFMpegDecoderOption
+from .schema import FFMpegMuxerOption, FFMpegDemuxerOption
+
+from ..dag.nodes import FilterableStream, FilterNode, OutputStream, OutputNode, InputNode, GlobalNode, GlobalStream
+
+
+from ..streams.video import VideoStream
+
+
+from ..streams.audio import AudioStream
+
+
 

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[encoders.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[encoders.py].raw
@@ -3,7 +3,30 @@
 FFmpeg encoders.
 """
 
+
+
 from typing import Literal
-from .schema import FFMpegEncoderOption
+
+
+from ..types import Binary, Boolean, Color, Dictionary, Double, Duration, Flags, Float, Func, Image_size, Int, Int64, Pix_fmt, Rational, Sample_fmt, String, Time, Video_rate
+from ..dag.factory import filter_node_factory
 from ..utils.frozendict import FrozenDict, merge
+from ..utils.typing import override
+from ..schema import Default, StreamType, Auto
+from ..common.schema import FFMpegFilterDef
+from ..options.framesync import FFMpegFrameSyncOption
+from ..streams.av import AVStream
+from ..streams.channel_layout import CHANNEL_LAYOUT
+from .schema import FFMpegEncoderOption, FFMpegDecoderOption
+from ..formats.schema import FFMpegMuxerOption, FFMpegDemuxerOption
+
+from ..dag.nodes import FilterableStream, FilterNode, OutputStream, OutputNode, InputNode, GlobalNode, GlobalStream
+
+
+from ..streams.video import VideoStream
+
+
+from ..streams.audio import AudioStream
+
+
 

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[filters.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[filters.py].raw
@@ -7,19 +7,28 @@ FFmpeg filters.
 
 from typing import Any, Literal
 
-from .dag.nodes import FilterNode, FilterableStream
-from .schema import Default, StreamType, Auto
 
 from .types import Binary, Boolean, Color, Dictionary, Double, Duration, Flags, Float, Func, Image_size, Int, Int64, Pix_fmt, Rational, Sample_fmt, String, Time, Video_rate
-
-from .streams.video import VideoStream
-from .streams.audio import AudioStream
-from .streams.av import AVStream
-from .streams.channel_layout import CHANNEL_LAYOUT
+from .dag.factory import filter_node_factory
+from .utils.frozendict import FrozenDict, merge
+from .utils.typing import override
+from .schema import Default, StreamType, Auto
 from .common.schema import FFMpegFilterDef
 from .options.framesync import FFMpegFrameSyncOption
-from .dag.factory import filter_node_factory
-from .utils.frozendict import merge
+from .streams.av import AVStream
+from .streams.channel_layout import CHANNEL_LAYOUT
+from .codecs.schema import FFMpegEncoderOption, FFMpegDecoderOption
+from .formats.schema import FFMpegMuxerOption, FFMpegDemuxerOption
+
+from .dag.nodes import FilterableStream, FilterNode, OutputStream, OutputNode, InputNode, GlobalNode, GlobalStream
+
+
+from .streams.video import VideoStream
+
+
+from .streams.audio import AudioStream
+
+
 
 import re
 

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[global_args.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[global_args.py].raw
@@ -10,9 +10,25 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
-from ...types import Binary, Boolean, Color, Dictionary, Double, Duration, Flags, Float, Func, Image_size, Int, Int64, Pix_fmt, Rational, Sample_fmt, String, Time, Video_rate
 
-from ...utils.frozendict import merge
+from ...types import Binary, Boolean, Color, Dictionary, Double, Duration, Flags, Float, Func, Image_size, Int, Int64, Pix_fmt, Rational, Sample_fmt, String, Time, Video_rate
+from ..factory import filter_node_factory
+from ...utils.frozendict import FrozenDict, merge
+from ...utils.typing import override
+from ...schema import Default, StreamType, Auto
+from ...common.schema import FFMpegFilterDef
+from ...options.framesync import FFMpegFrameSyncOption
+from ...streams.av import AVStream
+from ...streams.channel_layout import CHANNEL_LAYOUT
+from ...codecs.schema import FFMpegEncoderOption, FFMpegDecoderOption
+from ...formats.schema import FFMpegMuxerOption, FFMpegDemuxerOption
+
+
+from ...streams.video import VideoStream
+
+
+from ...streams.audio import AudioStream
+
 
 if TYPE_CHECKING:
     from ..nodes import GlobalNode, GlobalStream, OutputStream

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[muxers.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[muxers.py].raw
@@ -3,7 +3,30 @@
 FFmpeg muxers.
 """
 
+
+
 from typing import Literal
-from .schema import FFMpegMuxerOption
+
+
+from ..types import Binary, Boolean, Color, Dictionary, Double, Duration, Flags, Float, Func, Image_size, Int, Int64, Pix_fmt, Rational, Sample_fmt, String, Time, Video_rate
+from ..dag.factory import filter_node_factory
 from ..utils.frozendict import FrozenDict, merge
+from ..utils.typing import override
+from ..schema import Default, StreamType, Auto
+from ..common.schema import FFMpegFilterDef
+from ..options.framesync import FFMpegFrameSyncOption
+from ..streams.av import AVStream
+from ..streams.channel_layout import CHANNEL_LAYOUT
+from ..codecs.schema import FFMpegEncoderOption, FFMpegDecoderOption
+from .schema import FFMpegMuxerOption, FFMpegDemuxerOption
+
+from ..dag.nodes import FilterableStream, FilterNode, OutputStream, OutputNode, InputNode, GlobalNode, GlobalStream
+
+
+from ..streams.video import VideoStream
+
+
+from ..streams.audio import AudioStream
+
+
 

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[output_args.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[output_args.py].raw
@@ -11,16 +11,29 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from ...types import Binary, Boolean, Color, Dictionary, Double, Duration, Flags, Float, Func, Image_size, Int, Int64, Pix_fmt, Rational, Sample_fmt, String, Time, Video_rate
 
-from ...utils.frozendict import merge
-from ...codecs.schema import FFMpegEncoderOption
-from ...formats.schema import FFMpegMuxerOption
+from ...types import Binary, Boolean, Color, Dictionary, Double, Duration, Flags, Float, Func, Image_size, Int, Int64, Pix_fmt, Rational, Sample_fmt, String, Time, Video_rate
+from ..factory import filter_node_factory
+from ...utils.frozendict import FrozenDict, merge
+from ...utils.typing import override
+from ...schema import Default, StreamType, Auto
+from ...common.schema import FFMpegFilterDef
+from ...options.framesync import FFMpegFrameSyncOption
+from ...streams.av import AVStream
+from ...streams.channel_layout import CHANNEL_LAYOUT
+from ...codecs.schema import FFMpegEncoderOption, FFMpegDecoderOption
+from ...formats.schema import FFMpegMuxerOption, FFMpegDemuxerOption
+
+
+from ...streams.video import VideoStream
+
+
+from ...streams.audio import AudioStream
+
 
 
 if TYPE_CHECKING:
     from ..nodes import FilterableStream, OutputNode, OutputStream
-
 
 class OutputArgs(ABC):
     """Output arguments interface."""

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[sources.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[sources.py].raw
@@ -6,19 +6,28 @@ FFmpeg sources.
 
 from typing import Any, Literal
 
-from .dag.nodes import FilterNode, FilterableStream
-from .schema import Default, StreamType, Auto
 
 from .types import Binary, Boolean, Color, Dictionary, Double, Duration, Flags, Float, Func, Image_size, Int, Int64, Pix_fmt, Rational, Sample_fmt, String, Time, Video_rate
-
-from .streams.video import VideoStream
-from .streams.audio import AudioStream
+from .dag.factory import filter_node_factory
+from .utils.frozendict import FrozenDict, merge
+from .utils.typing import override
+from .schema import Default, StreamType, Auto
+from .common.schema import FFMpegFilterDef
+from .options.framesync import FFMpegFrameSyncOption
 from .streams.av import AVStream
 from .streams.channel_layout import CHANNEL_LAYOUT
-from .common.schema import FFMpegFilterDef
-from .dag.factory import filter_node_factory
-from .utils.frozendict import merge
-from .options.framesync import FFMpegFrameSyncOption
+from .codecs.schema import FFMpegEncoderOption, FFMpegDecoderOption
+from .formats.schema import FFMpegMuxerOption, FFMpegDemuxerOption
+
+from .dag.nodes import FilterableStream, FilterNode, OutputStream, OutputNode, InputNode, GlobalNode, GlobalStream
+
+
+from .streams.video import VideoStream
+
+
+from .streams.audio import AudioStream
+
+
 
 import re
 

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[video.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[video.py].raw
@@ -9,16 +9,26 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Literal
 
-from ..dag.nodes import FilterableStream, FilterNode
-from ..schema import Default, StreamType, Auto
 
 from ..types import Binary, Boolean, Color, Dictionary, Double, Duration, Flags, Float, Func, Image_size, Int, Int64, Pix_fmt, Rational, Sample_fmt, String, Time, Video_rate
-
-from ..utils.typing import override
-from ..common.schema import FFMpegFilterDef
 from ..dag.factory import filter_node_factory
-from ..utils.frozendict import merge
+from ..utils.frozendict import FrozenDict, merge
+from ..utils.typing import override
+from ..schema import Default, StreamType, Auto
+from ..common.schema import FFMpegFilterDef
 from ..options.framesync import FFMpegFrameSyncOption
+from .av import AVStream
+from .channel_layout import CHANNEL_LAYOUT
+from ..codecs.schema import FFMpegEncoderOption, FFMpegDecoderOption
+from ..formats.schema import FFMpegMuxerOption, FFMpegDemuxerOption
+
+from ..dag.nodes import FilterableStream, FilterNode, OutputStream, OutputNode, InputNode, GlobalNode, GlobalStream
+
+
+
+
+
+
 
 if TYPE_CHECKING:
     from .audio import AudioStream

--- a/src/scripts/code_gen/tests/test_utils.py
+++ b/src/scripts/code_gen/tests/test_utils.py
@@ -1,9 +1,63 @@
-from ..utils import get_relative_path
+from pathlib import Path
+
+from ..utils import get_relative_import, get_relative_path
 
 
 def test_get_relative_path() -> None:
+    print(
+        "types/options/framesync:",
+        get_relative_path("types", "options/framesync.py.jinja"),
+    )
     assert get_relative_path("types", "options/framesync.py.jinja") == "..types"
+    print(
+        "types/dag/global_runnable/global_args:",
+        get_relative_path("types", "dag/global_runnable/global_args.py.jinja"),
+    )
     assert (
         get_relative_path("types", "dag/global_runnable/global_args.py.jinja")
         == "...types"
     )
+    print(
+        "streams.audio/streams/audio:",
+        get_relative_path("streams.audio", "streams/audio.py.jinja"),
+    )
+    assert get_relative_path("streams.audio", "streams/audio.py.jinja") is None
+    print(
+        "streams.video/streams/audio:",
+        get_relative_path("streams.video", "streams/audio.py.jinja"),
+    )
+    assert get_relative_path("streams.video", "streams/audio.py.jinja") == ".video"
+    print("dag.nodes/filters:", get_relative_path("dag.nodes", "filters.py.jinja"))
+    assert get_relative_path("dag.nodes", "filters.py.jinja") == ".dag.nodes"
+    print(
+        "dag.nodes/streams.audio:",
+        get_relative_path("dag.nodes", "streams.audio.py.jinja"),
+    )
+    print("import_path_obj.parts:", Path("dag/nodes").parts)
+    assert get_relative_path("dag.nodes", "streams.audio.py.jinja") == "..dag.nodes"
+    # New test case: importing from nested directory to root-level module
+    print("types/streams/audio:", get_relative_path("types", "streams/audio.py.jinja"))
+    assert get_relative_path("types", "streams/audio.py.jinja") == "..types"
+    # New test case: importing between different root-level modules
+    print(
+        "filters/streams/audio:", get_relative_path("filters", "streams/audio.py.jinja")
+    )
+    assert get_relative_path("filters", "streams/audio.py.jinja") == "..filters"
+
+
+def test_get_relative_import() -> None:
+    # Test normal import
+    result = get_relative_import(
+        "types", "options/framesync.py.jinja", "Binary, Boolean"
+    )
+    assert result == "from ..types import Binary, Boolean"
+
+    # Test same file import (should return empty string)
+    result = get_relative_import(
+        "streams.audio", "streams/audio.py.jinja", "AudioStream"
+    )
+    assert result == ""
+
+    # Test nested import
+    result = get_relative_import("dag.nodes", "streams/audio.py.jinja", "FilterNode")
+    assert result == "from ..dag.nodes import FilterNode"

--- a/src/scripts/code_gen/tests/test_utils.py
+++ b/src/scripts/code_gen/tests/test_utils.py
@@ -1,0 +1,9 @@
+from ..utils import get_relative_path
+
+
+def test_get_relative_path() -> None:
+    assert get_relative_path("types", "options/framesync.py.jinja") == "..types"
+    assert (
+        get_relative_path("types", "dag/global_runnable/global_args.py.jinja")
+        == "...types"
+    )

--- a/src/scripts/code_gen/tests/test_utils.py
+++ b/src/scripts/code_gen/tests/test_utils.py
@@ -1,48 +1,26 @@
-from pathlib import Path
+import pytest
 
 from ..utils import get_relative_import, get_relative_path
 
 
-def test_get_relative_path() -> None:
-    print(
-        "types/options/framesync:",
-        get_relative_path("types", "options/framesync.py.jinja"),
-    )
-    assert get_relative_path("types", "options/framesync.py.jinja") == "..types"
-    print(
-        "types/dag/global_runnable/global_args:",
-        get_relative_path("types", "dag/global_runnable/global_args.py.jinja"),
-    )
-    assert (
-        get_relative_path("types", "dag/global_runnable/global_args.py.jinja")
-        == "...types"
-    )
-    print(
-        "streams.audio/streams/audio:",
-        get_relative_path("streams.audio", "streams/audio.py.jinja"),
-    )
-    assert get_relative_path("streams.audio", "streams/audio.py.jinja") is None
-    print(
-        "streams.video/streams/audio:",
-        get_relative_path("streams.video", "streams/audio.py.jinja"),
-    )
-    assert get_relative_path("streams.video", "streams/audio.py.jinja") == ".video"
-    print("dag.nodes/filters:", get_relative_path("dag.nodes", "filters.py.jinja"))
-    assert get_relative_path("dag.nodes", "filters.py.jinja") == ".dag.nodes"
-    print(
-        "dag.nodes/streams.audio:",
-        get_relative_path("dag.nodes", "streams.audio.py.jinja"),
-    )
-    print("import_path_obj.parts:", Path("dag/nodes").parts)
-    assert get_relative_path("dag.nodes", "streams.audio.py.jinja") == "..dag.nodes"
-    # New test case: importing from nested directory to root-level module
-    print("types/streams/audio:", get_relative_path("types", "streams/audio.py.jinja"))
-    assert get_relative_path("types", "streams/audio.py.jinja") == "..types"
-    # New test case: importing between different root-level modules
-    print(
-        "filters/streams/audio:", get_relative_path("filters", "streams/audio.py.jinja")
-    )
-    assert get_relative_path("filters", "streams/audio.py.jinja") == "..filters"
+@pytest.mark.parametrize(
+    "import_path, template_path, expected",
+    [
+        ("types", "options/framesync.py.jinja", "..types"),
+        ("types", "dag/global_runnable/global_args.py.jinja", "...types"),
+        ("streams.audio", "streams/audio.py.jinja", None),
+        ("streams.video", "streams/audio.py.jinja", ".video"),
+        ("dag.nodes", "filters.py.jinja", ".dag.nodes"),
+        ("dag.nodes", "streams/audio.py.jinja", "..dag.nodes"),
+        ("types", "streams/audio.py.jinja", "..types"),
+        ("filters", "streams/audio.py.jinja", "..filters"),
+        ("dag.nodes", "dag/io/_input.py.jinja", "..nodes"),
+    ],
+)
+def test_get_relative_path(
+    import_path: str, template_path: str, expected: str | None
+) -> None:
+    assert get_relative_path(import_path, template_path) == expected
 
 
 def test_get_relative_import() -> None:

--- a/src/scripts/code_gen/utils.py
+++ b/src/scripts/code_gen/utils.py
@@ -1,0 +1,45 @@
+"""Utils for code generation."""
+
+from pathlib import Path
+
+
+def get_relative_path(import_path: str, template_path: str) -> str:
+    """
+    Get the relative path of the template.
+
+    Args:
+        import_path: The import path
+        template_path: The template path
+
+    Returns:
+        The relative path of the template
+
+    """
+    template_parent = Path(template_path).parent
+    import_path_obj = Path(import_path)
+
+    # If import_path is a top-level directory, return the correct number of dots + import_path
+    if len(import_path_obj.parts) == 1:
+        dots = "." * (len(template_parent.parts) + 1)
+        return dots + str(import_path_obj)
+
+    try:
+        return str(import_path_obj.relative_to(template_parent))
+    except ValueError:
+        # Find common ancestor and calculate relative path
+        common_parts = 0
+        for i, (part1, part2) in enumerate(
+            zip(template_parent.parts, import_path_obj.parts)
+        ):
+            if part1 == part2:
+                common_parts = i + 1
+            else:
+                break
+        up_levels = len(template_parent.parts) - common_parts
+        down_parts = import_path_obj.parts[common_parts:]
+        if up_levels == 0:
+            return str(Path(*down_parts)) if down_parts else "."
+        else:
+            # Return as many dots as up_levels + 1 + import_path
+            dots = "." * (up_levels + 1)
+            return dots + str(import_path_obj)

--- a/src/scripts/code_gen/utils.py
+++ b/src/scripts/code_gen/utils.py
@@ -3,43 +3,72 @@
 from pathlib import Path
 
 
-def get_relative_path(import_path: str, template_path: str) -> str:
+def get_relative_path(import_path: str, template_path: str) -> str | None:
     """
     Get the relative path of the template.
 
     Args:
-        import_path: The import path
-        template_path: The template path
+        import_path: The import path (dot notation, e.g., streams.audio)
+        template_path: The template path (e.g., streams/audio.py.jinja)
 
     Returns:
-        The relative path of the template
+        The relative path of the template, or None if importing from same file
 
     """
-    template_parent = Path(template_path).parent
-    import_path_obj = Path(import_path)
+    template_path_obj = Path(template_path)
+    template_parent = template_path_obj.parent
+    import_path_obj = Path(import_path.replace(".", "/"))
 
-    # If import_path is a top-level directory, return the correct number of dots + import_path
-    if len(import_path_obj.parts) == 1:
-        dots = "." * (len(template_parent.parts) + 1)
-        return dots + str(import_path_obj)
+    print(
+        f"DEBUG: template_path={template_path}, template_parent='{template_parent}', str(template_parent)='{str(template_parent)}', stem='{template_path_obj.stem}'"
+    )
 
-    try:
-        return str(import_path_obj.relative_to(template_parent))
-    except ValueError:
-        # Find common ancestor and calculate relative path
-        common_parts = 0
-        for i, (part1, part2) in enumerate(
-            zip(template_parent.parts, import_path_obj.parts)
-        ):
-            if part1 == part2:
-                common_parts = i + 1
+    # Remove both .jinja and .py suffixes to get the module name
+    stem = template_path_obj.name
+    for ext in (".jinja", ".py"):
+        while stem.endswith(ext):
+            stem = stem[: -len(ext)]
+    print(f"DEBUG: final stem after suffix removal: '{stem}'")
+    template_module = (
+        ".".join(list(template_parent.parts) + [stem]) if str(template_parent) else stem
+    )
+
+    # If importing from the same file, return None
+    if import_path == template_module:
+        return None
+
+    # If importing from a sibling module (same parent, but not the same module)
+    if template_parent == import_path_obj.parent and import_path != template_module:
+        return f".{import_path_obj.name}"
+
+    # If template is at root
+    if str(template_parent) in ("", "."):
+        if "." in import_path:
+            if "." in stem:
+                return f"..{import_path}"
             else:
-                break
-        up_levels = len(template_parent.parts) - common_parts
-        down_parts = import_path_obj.parts[common_parts:]
-        if up_levels == 0:
-            return str(Path(*down_parts)) if down_parts else "."
-        else:
-            # Return as many dots as up_levels + 1 + import_path
-            dots = "." * (up_levels + 1)
-            return dots + str(import_path_obj)
+                return f".{import_path}"
+        return f".{import_path}"
+
+    # Otherwise, number of dots = len(template_parent.parts) + 1
+    dots = "." * (len(template_parent.parts) + 1)
+    return f"{dots}{import_path}"
+
+
+def get_relative_import(import_path: str, template_path: str, imports: str) -> str:
+    """
+    Get a complete import statement or empty string if importing from same file.
+
+    Args:
+        import_path: The import path (dot notation, e.g., streams.audio)
+        template_path: The template path (e.g., streams/audio.py.jinja)
+        imports: The comma-separated list of imports
+
+    Returns:
+        The complete import statement or empty string if importing from same file
+
+    """
+    relative_path = get_relative_path(import_path, template_path)
+    if relative_path is None:
+        return ""
+    return f"from {relative_path} import {imports}"

--- a/src/scripts/code_gen/utils.py
+++ b/src/scripts/code_gen/utils.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 
-def get_relative_path(import_path: str, template_path: str) -> str | None:
+def get_relative_path(import_path: str, template_path: str | Path) -> str | None:
     """
     Get the relative path of the template.
 
@@ -15,7 +15,7 @@ def get_relative_path(import_path: str, template_path: str) -> str | None:
         The relative path of the template, or None if importing from same file
 
     """
-    template_path_obj = Path(template_path.split(".")[0])
+    template_path_obj = Path(str(template_path).split(".")[0])
     import_path_obj = Path(import_path.replace(".", "/"))
 
     if template_path_obj == import_path_obj:


### PR DESCRIPTION
- fix #736 
This pull request refactors import statements across multiple files in the `src/ffmpeg` and `src/scripts/code_gen/templates` directories to improve maintainability and consistency. The changes primarily involve replacing individual import statements with grouped imports using helper methods like `get_relative_import` and macros like `import_all`. Additionally, a new utility function `get_relative_import` is introduced in the code generation script to dynamically resolve relative import paths.

### Refactoring import statements for maintainability:

* **Grouped imports in `src/ffmpeg` files**:
  - Consolidated imports of `FilterableStream`, `FilterNode`, and other related classes in files such as `src/ffmpeg/dag/io/_input.py`, `src/ffmpeg/dag/io/_output.py`, `src/ffmpeg/filters.py`, `src/ffmpeg/sources.py`, `src/ffmpeg/streams/audio.py`, and `src/ffmpeg/streams/video.py`. This improves readability and consistency across the codebase. [[1]](diffhunk://#diff-a89ab89f0249537fc264610f8dbfeb6a16b92866ccb15636f1e305b68062d39eL19-R21) [[2]](diffhunk://#diff-e08b8eb703de06409ac7d2305f43158549b6bb89320bf544f2eea10b74f8d3c0L19-R23) [[3]](diffhunk://#diff-5889ef24c4a666c631461f60ba32f2fb7cc56682cafd2743616e8e3e7b2f7005L8-R11) [[4]](diffhunk://#diff-caa733877e52ae9ec0319980b074df032ac8f3e1cedae2a522dcfd26d517f499L8-R11) [[5]](diffhunk://#diff-21044cca3fe0c19a32fb589bbcaefdf897ea099db7a196ed525781e2844ca49dL10-R13) [[6]](diffhunk://#diff-a6daec70e0b250cdff543293b449c058bc616663b8a7df1c573711583ac85983L10-R13)

* **Dynamic relative imports in code generation templates**:
  - Replaced hardcoded relative imports with the `import_all` macro in various code generation template files, such as `codecs/encoders.py.jinja`, `codecs/decoders.py.jinja`, `formats/muxers.py.jinja`, `formats/demuxers.py.jinja`, `streams/audio.py.jinja`, `streams/video.py.jinja`, and others. This ensures imports are dynamically resolved based on the template's path, reducing the risk of errors during code generation. [[1]](diffhunk://#diff-8a8d1c1111b3618a30f3058d522469ba4d3a9093fbe8b104f6dacff503a894c0R5-R9) [[2]](diffhunk://#diff-3df2f58a6b8e8d175662f0549e55d7f9103b0abdfb74cff0506435b1b40a23faR5-R9) [[3]](diffhunk://#diff-d2f73bd422860d5adc5a3f3869c0a304abcec963c9336369a3bb1146014c87caR4-R9) [[4]](diffhunk://#diff-01149fc7d5b0ccc4dd6b9bb157f64aa65c00a860fd9473534cfe92558fdc7f5dR5-R9) [[5]](diffhunk://#diff-4623cc4b1a2abebc11fa6b09edbc30a1bd7c494b59a9ce3237041421c8a94800L11-R11) [[6]](diffhunk://#diff-80d2a398193342d025f7cf5e192117bc176c5aec369ef430f604f7e18d0dd2feL11-R11)

### Enhancements to code generation utilities:

* **Introduction of `get_relative_import` utility**:
  - Added the `get_relative_import` function in `src/scripts/code_gen/gen.py` to dynamically compute relative import paths for templates. This function is registered as a global in the Jinja environment for use in templates. [[1]](diffhunk://#diff-a34f95f7e4433ae4ce2278eba1d6f83ad7845799252d143942ef1a539769a621R19-R20) [[2]](diffhunk://#diff-a34f95f7e4433ae4ce2278eba1d6f83ad7845799252d143942ef1a539769a621R265)

* **Template rendering improvements**:
  - Modified the `render` function in `src/scripts/code_gen/gen.py` to pass the `template_path` as a parameter during rendering. This enables templates to use the `template_path` for resolving imports dynamically.

### Updates to template structure:

* **Refactored `_components.jinja`**:
  - Introduced the `import_all` macro in `_components.jinja` to centralize and simplify import management across templates. It supports optional inclusion of video, audio, and node-related imports based on the template's requirements.

* **Unified imports in templates**:
  - Updated templates like `dag/io/_input.py.jinja`, `dag/io/_output.py.jinja`, `filters.py.jinja`, `sources.py.jinja`, and others to use the `import_all` macro instead of individual import statements. This reduces redundancy and ensures consistency. [[1]](diffhunk://#diff-b02fb7ba72f7f034226af017985dd08c8da3ab6446e0bf4f899ab1d5367c9a08L8-R10) [[2]](diffhunk://#diff-96f21172090d46bac7560ee7661955a80b8957a49696f033fbf9da038c768dcbL7-R9) [[3]](diffhunk://#diff-13be2e98165290d1ba94666cd6c8989a30dcb5c76f7e8e989f3e8b48223b554fL8-R8) [[4]](diffhunk://#diff-57d48a467a12e79437abd68fa1daa54490e7c1311bc310508914f4a23bafbff8L9-R9)

These changes streamline the codebase by reducing repetitive import statements, improving readability, and enhancing the maintainability of both source files and code generation templates.