### PR TITLE
fix #729 support timeline edit

### DIFF
--- a/src/ffmpeg/expressions.py
+++ b/src/ffmpeg/expressions.py
@@ -119,7 +119,7 @@ class Expression(str):
         return Expression(f"+{self.expression}")
 
 
-def abs(x: str) -> Expression:
+def abs(x: Any) -> Expression:
     """
     Compute absolute value of x.
 
@@ -133,7 +133,7 @@ def abs(x: str) -> Expression:
     return Expression(f"abs({x})")
 
 
-def acos(x: str) -> Expression:
+def acos(x: Any) -> Expression:
     """
     Compute arccosine of x.
 
@@ -147,7 +147,7 @@ def acos(x: str) -> Expression:
     return Expression(f"acos({x})")
 
 
-def asin(x: str) -> Expression:
+def asin(x: Any) -> Expression:
     """
     Compute arcsine of x.
 
@@ -161,7 +161,7 @@ def asin(x: str) -> Expression:
     return Expression(f"asin({x})")
 
 
-def atan(x: str) -> Expression:
+def atan(x: Any) -> Expression:
     """
     Compute arctangent of x.
 
@@ -175,7 +175,7 @@ def atan(x: str) -> Expression:
     return Expression(f"atan({x})")
 
 
-def atan2(x: str) -> Expression:
+def atan2(x: Any) -> Expression:
     """
     Compute principal value of the arc tangent of y/x.
 
@@ -189,7 +189,7 @@ def atan2(x: str) -> Expression:
     return Expression(f"atan2({x})")
 
 
-def between(x: str, min: str, max: str) -> Expression:
+def between(x: Any, min: Any, max: Any) -> Expression:
     """
     Return 1 if x is greater than or equal to min and lesser than or equal to max, 0 otherwise.
 
@@ -205,7 +205,7 @@ def between(x: str, min: str, max: str) -> Expression:
     return Expression(f"between({x},{min},{max})")
 
 
-def bitand(x: str, y: str) -> Expression:
+def bitand(x: Any, y: Any) -> Expression:
     """
     Compute bitwise and/or operation on x and y.
 
@@ -220,7 +220,7 @@ def bitand(x: str, y: str) -> Expression:
     return Expression(f"bitand({x},{y})")
 
 
-def bitor(x: str, y: str) -> Expression:
+def bitor(x: Any, y: Any) -> Expression:
     """
     Compute bitwise and/or operation on x and y.
 
@@ -235,7 +235,7 @@ def bitor(x: str, y: str) -> Expression:
     return Expression(f"bitor({x},{y})")
 
 
-def ceil(expr: str) -> Expression:
+def ceil(expr: Any) -> Expression:
     """
     Round the value of expression expr upwards to the nearest integer. For example, "ceil(1.5)" is "2.0".
 
@@ -249,7 +249,7 @@ def ceil(expr: str) -> Expression:
     return Expression(f"ceil({expr})")
 
 
-def clip(x: str, min: str, max: str) -> Expression:
+def clip(x: Any, min: Any, max: Any) -> Expression:
     """
     Return the value of x clipped between min and max.
 
@@ -265,7 +265,7 @@ def clip(x: str, min: str, max: str) -> Expression:
     return Expression(f"clip({x},{min},{max})")
 
 
-def cos(x: str) -> Expression:
+def cos(x: Any) -> Expression:
     """
     Compute cosine of x.
 
@@ -279,7 +279,7 @@ def cos(x: str) -> Expression:
     return Expression(f"cos({x})")
 
 
-def cosh(x: str) -> Expression:
+def cosh(x: Any) -> Expression:
     """
     Compute hyperbolic cosine of x.
 
@@ -293,7 +293,7 @@ def cosh(x: str) -> Expression:
     return Expression(f"cosh({x})")
 
 
-def eq(x: str, y: str) -> Expression:
+def eq(x: Any, y: Any) -> Expression:
     """
     Return 1 if x and y are equivalent, 0 otherwise.
 
@@ -308,7 +308,7 @@ def eq(x: str, y: str) -> Expression:
     return Expression(f"eq({x},{y})")
 
 
-def exp(x: str) -> Expression:
+def exp(x: Any) -> Expression:
     """
     Compute exponential of x (with base e, the Euler's number).
 
@@ -322,7 +322,7 @@ def exp(x: str) -> Expression:
     return Expression(f"exp({x})")
 
 
-def floor(expr: str) -> Expression:
+def floor(expr: Any) -> Expression:
     """
     Round the value of expression expr downwards to the nearest integer. For example, "floor(-1.5)" is "-2.0".
 
@@ -336,7 +336,7 @@ def floor(expr: str) -> Expression:
     return Expression(f"floor({expr})")
 
 
-def gauss(x: str) -> Expression:
+def gauss(x: Any) -> Expression:
     """
     Compute Gauss function of x, corresponding to exp(-x*x/2) / sqrt(2*PI).
 
@@ -350,7 +350,7 @@ def gauss(x: str) -> Expression:
     return Expression(f"gauss({x})")
 
 
-def gcd(x: str, y: str) -> Expression:
+def gcd(x: Any, y: Any) -> Expression:
     """
     Return the greatest common divisor of x and y. If both x and y are 0 or either or both are less than zero then behavior is undefined.
 
@@ -365,7 +365,7 @@ def gcd(x: str, y: str) -> Expression:
     return Expression(f"gcd({x},{y})")
 
 
-def gt(x: str, y: str) -> Expression:
+def gt(x: Any, y: Any) -> Expression:
     """
     Return 1 if x is greater than y, 0 otherwise.
 
@@ -380,7 +380,7 @@ def gt(x: str, y: str) -> Expression:
     return Expression(f"gt({x},{y})")
 
 
-def gte(x: str, y: str) -> Expression:
+def gte(x: Any, y: Any) -> Expression:
     """
     Return 1 if x is greater than or equal to y, 0 otherwise.
 
@@ -395,7 +395,7 @@ def gte(x: str, y: str) -> Expression:
     return Expression(f"gte({x},{y})")
 
 
-def hypot(x: str, y: str) -> Expression:
+def hypot(x: Any, y: Any) -> Expression:
     """
     Return sqrt(x*x + y*y), the length of the hypotenuse of a right triangle with sides of length x and y, or the distance of the point (x, y) from the origin.
 
@@ -410,7 +410,7 @@ def hypot(x: str, y: str) -> Expression:
     return Expression(f"hypot({x},{y})")
 
 
-def if_(x: str, y: str, z: str | None = None) -> Expression:
+def if_(x: Any, y: Any, z: Any | None = None) -> Expression:
     """
     Evaluate x, and if the result is non-zero return the result of the evaluation of y, return 0 otherwise.
 
@@ -429,7 +429,7 @@ def if_(x: str, y: str, z: str | None = None) -> Expression:
         return Expression(f"if({x},{y},{z})")
 
 
-def ifnot(x: str, y: str, z: str | None = None) -> Expression:
+def ifnot(x: Any, y: Any, z: Any | None = None) -> Expression:
     """
     Evaluate x, and if the result is zero return the result of the evaluation of y, return 0 otherwise.
 
@@ -448,7 +448,7 @@ def ifnot(x: str, y: str, z: str | None = None) -> Expression:
         return Expression(f"ifnot({x},{y},{z})")
 
 
-def isinf(x: str) -> Expression:
+def isinf(x: Any) -> Expression:
     """
     Return 1.0 if x is +/-INFINITY, 0.0 otherwise.
 
@@ -462,7 +462,7 @@ def isinf(x: str) -> Expression:
     return Expression(f"isinf({x})")
 
 
-def isnan(x: str) -> Expression:
+def isnan(x: Any) -> Expression:
     """
     Return 1.0 if x is NAN, 0.0 otherwise.
 
@@ -476,7 +476,7 @@ def isnan(x: str) -> Expression:
     return Expression(f"isnan({x})")
 
 
-def ld(idx: str) -> Expression:
+def ld(idx: Any) -> Expression:
     """
     Load the value of the internal variable with index idx, which was previously stored with st(idx, expr). The function returns the loaded value.
 
@@ -490,7 +490,7 @@ def ld(idx: str) -> Expression:
     return Expression(f"ld({idx})")
 
 
-def lerp(x: str, y: str, z: str) -> Expression:
+def lerp(x: Any, y: Any, z: Any) -> Expression:
     """
     Return linear interpolation between x and y by amount of z.
 
@@ -506,7 +506,7 @@ def lerp(x: str, y: str, z: str) -> Expression:
     return Expression(f"lerp({x},{y},{z})")
 
 
-def log(x: str) -> Expression:
+def log(x: Any) -> Expression:
     """
     Compute natural logarithm of x.
 
@@ -520,7 +520,7 @@ def log(x: str) -> Expression:
     return Expression(f"log({x})")
 
 
-def lt(x: str, y: str) -> Expression:
+def lt(x: Any, y: Any) -> Expression:
     """
     Return 1 if x is lesser than y, 0 otherwise.
 
@@ -535,7 +535,7 @@ def lt(x: str, y: str) -> Expression:
     return Expression(f"lt({x},{y})")
 
 
-def lte(x: str, y: str) -> Expression:
+def lte(x: Any, y: Any) -> Expression:
     """
     Return 1 if x is lesser than or equal to y, 0 otherwise.
 
@@ -550,7 +550,7 @@ def lte(x: str, y: str) -> Expression:
     return Expression(f"lte({x},{y})")
 
 
-def max(x: str, y: str) -> Expression:
+def max(x: Any, y: Any) -> Expression:
     """
     Return the maximum between x and y.
 
@@ -565,7 +565,7 @@ def max(x: str, y: str) -> Expression:
     return Expression(f"max({x},{y})")
 
 
-def min(x: str, y: str) -> Expression:
+def min(x: Any, y: Any) -> Expression:
     """
     Return the minimum between x and y.
 
@@ -580,7 +580,7 @@ def min(x: str, y: str) -> Expression:
     return Expression(f"min({x},{y})")
 
 
-def mod(x: str, y: str) -> Expression:
+def mod(x: Any, y: Any) -> Expression:
     """
     Compute the remainder of division of x by y.
 
@@ -595,7 +595,7 @@ def mod(x: str, y: str) -> Expression:
     return Expression(f"mod({x},{y})")
 
 
-def not_(expr: str) -> Expression:
+def not_(expr: Any) -> Expression:
     """
     Return 1.0 if expr is zero, 0.0 otherwise.
 
@@ -609,7 +609,7 @@ def not_(expr: str) -> Expression:
     return Expression(f"not({expr})")
 
 
-def pow(x: str, y: str) -> Expression:
+def pow(x: Any, y: Any) -> Expression:
     """
     Compute the power of x elevated y, it is equivalent to "(x)^(y)".
 
@@ -624,7 +624,7 @@ def pow(x: str, y: str) -> Expression:
     return Expression(f"pow({x},{y})")
 
 
-def print(t: str, l: str | None = None) -> Expression:
+def print(t: Any, l: Any | None = None) -> Expression:
     """
     Print the value of expression t with loglevel l. If l is not specified then a default log level is used. Return the value of the expression printed.
 
@@ -642,7 +642,7 @@ def print(t: str, l: str | None = None) -> Expression:
         return Expression(f"print({t},{l})")
 
 
-def random(idx: str) -> Expression:
+def random(idx: Any) -> Expression:
     """
     Return a pseudo random value between 0.0 and 1.0. idx is the index of the internal variable used to save the seed/state, which can be previously stored with st(idx).
 
@@ -656,7 +656,7 @@ def random(idx: str) -> Expression:
     return Expression(f"random({idx})")
 
 
-def randomi(idx: str, min: str, max: str) -> Expression:
+def randomi(idx: Any, min: Any, max: Any) -> Expression:
     """
     Return a pseudo random value in the interval between min and max. idx is the index of the internal variable which will be used to save the seed/state, which can be previously stored with st(idx).
 
@@ -672,7 +672,7 @@ def randomi(idx: str, min: str, max: str) -> Expression:
     return Expression(f"randomi({idx},{min},{max})")
 
 
-def root(expr: str, max: str) -> Expression:
+def root(expr: Any, max: Any) -> Expression:
     """
     Find an input value for which the function represented by expr with argument ld(0) is 0 in the interval 0..max.
 
@@ -687,7 +687,7 @@ def root(expr: str, max: str) -> Expression:
     return Expression(f"root({expr},{max})")
 
 
-def round(expr: str) -> Expression:
+def round(expr: Any) -> Expression:
     """
     Round the value of expression expr to the nearest integer. For example, "round(1.5)" is "2.0".
 
@@ -701,7 +701,7 @@ def round(expr: str) -> Expression:
     return Expression(f"round({expr})")
 
 
-def sgn(x: str) -> Expression:
+def sgn(x: Any) -> Expression:
     """
     Compute sign of x.
 
@@ -715,7 +715,7 @@ def sgn(x: str) -> Expression:
     return Expression(f"sgn({x})")
 
 
-def sin(x: str) -> Expression:
+def sin(x: Any) -> Expression:
     """
     Compute sine of x.
 
@@ -729,7 +729,7 @@ def sin(x: str) -> Expression:
     return Expression(f"sin({x})")
 
 
-def sinh(x: str) -> Expression:
+def sinh(x: Any) -> Expression:
     """
     Compute hyperbolic sine of x.
 
@@ -743,7 +743,7 @@ def sinh(x: str) -> Expression:
     return Expression(f"sinh({x})")
 
 
-def sqrt(expr: str) -> Expression:
+def sqrt(expr: Any) -> Expression:
     """
     Compute the square root of expr. This is equivalent to "(expr)^.5".
 
@@ -757,7 +757,7 @@ def sqrt(expr: str) -> Expression:
     return Expression(f"sqrt({expr})")
 
 
-def squish(x: str) -> Expression:
+def squish(x: Any) -> Expression:
     """
     Compute expression 1/(1 + exp(4*x)).
 
@@ -771,7 +771,7 @@ def squish(x: str) -> Expression:
     return Expression(f"squish({x})")
 
 
-def st(idx: str, expr: str) -> Expression:
+def st(idx: Any, expr: Any) -> Expression:
     """
     Store the value of the expression expr in an internal variable. idx specifies the index of the variable where to store the value, and it is a value ranging from 0 to 9. The function returns the value stored in the internal variable.
 
@@ -786,7 +786,7 @@ def st(idx: str, expr: str) -> Expression:
     return Expression(f"st({idx},{expr})")
 
 
-def tan(x: str) -> Expression:
+def tan(x: Any) -> Expression:
     """
     Compute tangent of x.
 
@@ -800,7 +800,7 @@ def tan(x: str) -> Expression:
     return Expression(f"tan({x})")
 
 
-def tanh(x: str) -> Expression:
+def tanh(x: Any) -> Expression:
     """
     Compute hyperbolic tangent of x.
 
@@ -814,7 +814,7 @@ def tanh(x: str) -> Expression:
     return Expression(f"tanh({x})")
 
 
-def taylor(expr: str, x: str, idx: str | None = None) -> Expression:
+def taylor(expr: Any, x: Any, idx: Any | None = None) -> Expression:
     """
     Evaluate a Taylor series at x, given an expression representing the ld(idx)-th derivative of a function at 0.
 
@@ -833,7 +833,7 @@ def taylor(expr: str, x: str, idx: str | None = None) -> Expression:
         return Expression(f"taylor({expr},{x},{idx})")
 
 
-def time(x: str) -> Expression:
+def time(x: Any) -> Expression:
     """
     Return the current (wallclock) time in seconds.
 
@@ -847,7 +847,7 @@ def time(x: str) -> Expression:
     return Expression(f"time({x})")
 
 
-def trunc(expr: str) -> Expression:
+def trunc(expr: Any) -> Expression:
     """
     Round the value of expression expr towards zero to the nearest integer. For example, "trunc(-1.5)" is "-1.0".
 
@@ -861,7 +861,7 @@ def trunc(expr: str) -> Expression:
     return Expression(f"trunc({expr})")
 
 
-def while_(cond: str, expr: str) -> Expression:
+def while_(cond: Any, expr: Any) -> Expression:
     """
     Evaluate expression expr while the expression cond is non-zero, and returns the value of the last expr evaluation, or NAN if cond was always false.
 

--- a/src/ffmpeg/filters.py
+++ b/src/ffmpeg/filters.py
@@ -10,6 +10,7 @@ from .dag.nodes import (
     FilterNode,
 )
 from .options.framesync import FFMpegFrameSyncOption
+from .options.timeline import FFMpegTimelineOption
 from .schema import Auto, Default
 from .streams.audio import AudioStream
 from .streams.video import VideoStream
@@ -183,6 +184,7 @@ def alphamerge(
     _main: VideoStream,
     _alpha: VideoStream,
     framesync_options: FFMpegFrameSyncOption | None = None,
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -191,6 +193,7 @@ def alphamerge(
 
     Args:
         framesync_options: Framesync options
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -208,7 +211,12 @@ def alphamerge(
         ),
         _main,
         _alpha,
-        **merge({}, extra_options, framesync_options),
+        **merge(
+            {},
+            extra_options,
+            framesync_options,
+            timeline_options,
+        ),
     )
     return filter_node.video(0)
 
@@ -345,6 +353,7 @@ def anlmf(
     eps: Float = Default("1"),
     leakage: Float = Default("0"),
     out_mode: Int | Literal["i", "d", "o", "n", "e"] | Default = Default("o"),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> AudioStream:
     """
@@ -357,6 +366,7 @@ def anlmf(
         eps: set the filter eps (from 0 to 1) (default 1)
         leakage: set the filter leakage (from 0 to 1) (default 0)
         out_mode: set output mode (from 0 to 4) (default o)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -381,6 +391,7 @@ def anlmf(
                 "out_mode": out_mode,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.audio(0)
@@ -395,6 +406,7 @@ def anlms(
     eps: Float = Default("1"),
     leakage: Float = Default("0"),
     out_mode: Int | Literal["i", "d", "o", "n", "e"] | Default = Default("o"),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> AudioStream:
     """
@@ -407,6 +419,7 @@ def anlms(
         eps: set the filter eps (from 0 to 1) (default 1)
         leakage: set the filter leakage (from 0 to 1) (default 0)
         out_mode: set output mode (from 0 to 4) (default o)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -431,6 +444,7 @@ def anlms(
                 "out_mode": out_mode,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.audio(0)
@@ -439,6 +453,7 @@ def anlms(
 def apsnr(
     _input0: AudioStream,
     _input1: AudioStream,
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> AudioStream:
     """
@@ -446,6 +461,7 @@ def apsnr(
     Measure Audio Peak Signal-to-Noise Ratio.
 
     Args:
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -464,6 +480,7 @@ def apsnr(
         **merge(
             {},
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.audio(0)
@@ -477,6 +494,7 @@ def arls(
     _lambda: Float = Default("1"),
     delta: Float = Default("2"),
     out_mode: Int | Literal["i", "d", "o", "n", "e"] | Default = Default("o"),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> AudioStream:
     """
@@ -488,6 +506,7 @@ def arls(
         _lambda: set the filter lambda (from 0 to 1) (default 1)
         delta: set the filter delta (from 0 to 32767) (default 2)
         out_mode: set output mode (from 0 to 4) (default o)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -511,6 +530,7 @@ def arls(
                 "out_mode": out_mode,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.audio(0)
@@ -519,6 +539,7 @@ def arls(
 def asdr(
     _input0: AudioStream,
     _input1: AudioStream,
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> AudioStream:
     """
@@ -526,6 +547,7 @@ def asdr(
     Measure Audio Signal-to-Distortion Ratio.
 
     Args:
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -544,6 +566,7 @@ def asdr(
         **merge(
             {},
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.audio(0)
@@ -552,6 +575,7 @@ def asdr(
 def asisdr(
     _input0: AudioStream,
     _input1: AudioStream,
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> AudioStream:
     """
@@ -559,6 +583,7 @@ def asisdr(
     Measure Audio Scale-Invariant Signal-to-Distortion Ratio.
 
     Args:
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -577,6 +602,7 @@ def asisdr(
         **merge(
             {},
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.audio(0)
@@ -912,6 +938,7 @@ def blend(
     c3_opacity: Double = Default("1"),
     all_opacity: Double = Default("1"),
     framesync_options: FFMpegFrameSyncOption | None = None,
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -935,6 +962,7 @@ def blend(
         c3_opacity: set color component #3 opacity (from 0 to 1) (default 1)
         all_opacity: set opacity for all color components (from 0 to 1) (default 1)
         framesync_options: Framesync options
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -970,6 +998,7 @@ def blend(
             },
             extra_options,
             framesync_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -1055,6 +1084,7 @@ def bm3d(
     estim: Int | Literal["basic", "final"] | Default = Default("basic"),
     ref: Boolean = Default("false"),
     planes: Int = Default("7"),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -1073,6 +1103,7 @@ def bm3d(
         estim: set filtering estimation mode (from 0 to 1) (default basic)
         ref: have reference stream (default false)
         planes: set planes to filter (from 0 to 15) (default 7)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -1104,6 +1135,7 @@ def bm3d(
                 "planes": planes,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -1118,6 +1150,7 @@ def colormap(
     nb_patches: Int = Default("0"),
     type: Int | Literal["relative", "absolute"] | Default = Default("absolute"),
     kernel: Int | Literal["euclidean", "weuclidean"] | Default = Default("euclidean"),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -1129,6 +1162,7 @@ def colormap(
         nb_patches: set number of patches (from 0 to 64) (default 0)
         type: set the target type used (from 0 to 1) (default absolute)
         kernel: set the kernel used for measuring color difference (from 0 to 1) (default euclidean)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -1155,6 +1189,7 @@ def colormap(
                 "kernel": kernel,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -1216,6 +1251,7 @@ def convolve(
     impulse: Int | Literal["first", "all"] | Default = Default("all"),
     noise: Float = Default("1e-07"),
     framesync_options: FFMpegFrameSyncOption | None = None,
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -1227,6 +1263,7 @@ def convolve(
         impulse: when to process impulses (from 0 to 1) (default all)
         noise: set noise (from 0 to 1) (default 1e-07)
         framesync_options: Framesync options
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -1250,6 +1287,7 @@ def convolve(
             },
             extra_options,
             framesync_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -1259,6 +1297,7 @@ def corr(
     _main: VideoStream,
     _reference: VideoStream,
     framesync_options: FFMpegFrameSyncOption | None = None,
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -1267,6 +1306,7 @@ def corr(
 
     Args:
         framesync_options: Framesync options
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -1282,7 +1322,12 @@ def corr(
         ),
         _main,
         _reference,
-        **merge({}, extra_options, framesync_options),
+        **merge(
+            {},
+            extra_options,
+            framesync_options,
+            timeline_options,
+        ),
     )
     return filter_node.video(0)
 
@@ -1353,6 +1398,7 @@ def deconvolve(
     impulse: Int | Literal["first", "all"] | Default = Default("all"),
     noise: Float = Default("1e-07"),
     framesync_options: FFMpegFrameSyncOption | None = None,
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -1364,6 +1410,7 @@ def deconvolve(
         impulse: when to process impulses (from 0 to 1) (default all)
         noise: set noise (from 0 to 1) (default 1e-07)
         framesync_options: Framesync options
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -1389,6 +1436,7 @@ def deconvolve(
             },
             extra_options,
             framesync_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -1402,6 +1450,7 @@ def displace(
     edge: Int | Literal["blank", "smear", "wrap", "mirror"] | Default = Default(
         "smear"
     ),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -1410,6 +1459,7 @@ def displace(
 
     Args:
         edge: set edge mode (from 0 to 3) (default smear)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -1433,6 +1483,7 @@ def displace(
                 "edge": edge,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -1662,6 +1713,7 @@ def guided(
     sub: Int = Default("4"),
     guidance: Int | Literal["off", "on"] | Default = Default("off"),
     planes: Int = Default("1"),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -1675,6 +1727,7 @@ def guided(
         sub: subsampling ratio for fast mode (from 2 to 64) (default 4)
         guidance: set guidance mode (0: off mode; 1: on mode) (from 0 to 1) (default off)
         planes: set planes to filter (from 0 to 15) (default 1)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -1701,6 +1754,7 @@ def guided(
                 "planes": planes,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -1715,6 +1769,7 @@ def haldclut(
     | Literal["nearest", "trilinear", "tetrahedral", "pyramid", "prism"]
     | Default = Default("tetrahedral"),
     framesync_options: FFMpegFrameSyncOption | None = None,
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -1725,6 +1780,7 @@ def haldclut(
         clut: when to process CLUT (from 0 to 1) (default all)
         interp: select interpolation mode (from 0 to 4) (default tetrahedral)
         framesync_options: Framesync options
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -1747,6 +1803,7 @@ def haldclut(
             },
             extra_options,
             framesync_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -1894,6 +1951,7 @@ def hysteresis(
     planes: Int = Default("15"),
     threshold: Int = Default("0"),
     framesync_options: FFMpegFrameSyncOption | None = None,
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -1904,6 +1962,7 @@ def hysteresis(
         planes: set planes (from 0 to 15) (default 15)
         threshold: set threshold (from 0 to 65535) (default 0)
         framesync_options: Framesync options
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -1928,6 +1987,7 @@ def hysteresis(
             },
             extra_options,
             framesync_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -1937,6 +1997,7 @@ def identity(
     _main: VideoStream,
     _reference: VideoStream,
     framesync_options: FFMpegFrameSyncOption | None = None,
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -1945,6 +2006,7 @@ def identity(
 
     Args:
         framesync_options: Framesync options
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -1960,7 +2022,12 @@ def identity(
         ),
         _main,
         _reference,
-        **merge({}, extra_options, framesync_options),
+        **merge(
+            {},
+            extra_options,
+            framesync_options,
+            timeline_options,
+        ),
     )
     return filter_node.video(0)
 
@@ -2465,6 +2532,7 @@ def limitdiff(
     elasticity: Float = Default("2"),
     reference: Boolean = Default("false"),
     planes: Int = Default("15"),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -2476,6 +2544,7 @@ def limitdiff(
         elasticity: set the elasticity (from 0 to 10) (default 2)
         reference: enable reference stream (default false)
         planes: set the planes to filter (from 0 to 15) (default 15)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -2500,6 +2569,7 @@ def limitdiff(
                 "planes": planes,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -2515,6 +2585,7 @@ def lut2(
     c3: String = Default("x"),
     d: Int = Default("0"),
     framesync_options: FFMpegFrameSyncOption | None = None,
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -2528,6 +2599,7 @@ def lut2(
         c3: set component #3 expression (default "x")
         d: set output depth (from 0 to 16) (default 0)
         framesync_options: Framesync options
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -2553,6 +2625,7 @@ def lut2(
             },
             extra_options,
             framesync_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -2613,6 +2686,7 @@ def maskedclamp(
     undershoot: Int = Default("0"),
     overshoot: Int = Default("0"),
     planes: Int = Default("15"),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -2623,6 +2697,7 @@ def maskedclamp(
         undershoot: set undershoot (from 0 to 65535) (default 0)
         overshoot: set overshoot (from 0 to 65535) (default 0)
         planes: set planes (from 0 to 15) (default 15)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -2648,6 +2723,7 @@ def maskedclamp(
                 "planes": planes,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -2659,6 +2735,7 @@ def maskedmax(
     _filter2: VideoStream,
     *,
     planes: Int = Default("15"),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -2667,6 +2744,7 @@ def maskedmax(
 
     Args:
         planes: set planes (from 0 to 15) (default 15)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -2690,6 +2768,7 @@ def maskedmax(
                 "planes": planes,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -2701,6 +2780,7 @@ def maskedmerge(
     _mask: VideoStream,
     *,
     planes: Int = Default("15"),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -2709,6 +2789,7 @@ def maskedmerge(
 
     Args:
         planes: set planes (from 0 to 15) (default 15)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -2732,6 +2813,7 @@ def maskedmerge(
                 "planes": planes,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -2743,6 +2825,7 @@ def maskedmin(
     _filter2: VideoStream,
     *,
     planes: Int = Default("15"),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -2751,6 +2834,7 @@ def maskedmin(
 
     Args:
         planes: set planes (from 0 to 15) (default 15)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -2774,6 +2858,7 @@ def maskedmin(
                 "planes": planes,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -2786,6 +2871,7 @@ def maskedthreshold(
     threshold: Int = Default("1"),
     planes: Int = Default("15"),
     mode: Int | Literal["abs", "diff"] | Default = Default("abs"),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -2796,6 +2882,7 @@ def maskedthreshold(
         threshold: set threshold (from 0 to 65535) (default 1)
         planes: set planes (from 0 to 15) (default 15)
         mode: set mode (from 0 to 1) (default abs)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -2820,6 +2907,7 @@ def maskedthreshold(
                 "mode": mode,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -2894,6 +2982,7 @@ def midequalizer(
     _in1: VideoStream,
     *,
     planes: Int = Default("15"),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -2902,6 +2991,7 @@ def midequalizer(
 
     Args:
         planes: set planes (from 0 to 15) (default 15)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -2924,6 +3014,7 @@ def midequalizer(
                 "planes": planes,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -2938,6 +3029,7 @@ def mix(
     duration: Int | Literal["longest", "shortest", "first"] | Default = Default(
         "longest"
     ),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -2950,6 +3042,7 @@ def mix(
         scale: set scale (from 0 to 32767) (default 0)
         planes: set what planes to filter (default F)
         duration: how to determine end of stream (from 0 to 2) (default longest)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -2975,6 +3068,7 @@ def mix(
                 "duration": duration,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -2990,6 +3084,7 @@ def morpho(
     planes: Int = Default("7"),
     structure: Int | Literal["first", "all"] | Default = Default("all"),
     framesync_options: FFMpegFrameSyncOption | None = None,
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -3001,6 +3096,7 @@ def morpho(
         planes: set planes to filter (from 0 to 15) (default 7)
         structure: when to process structures (from 0 to 1) (default all)
         framesync_options: Framesync options
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -3024,6 +3120,7 @@ def morpho(
             },
             extra_options,
             framesync_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -3033,6 +3130,7 @@ def msad(
     _main: VideoStream,
     _reference: VideoStream,
     framesync_options: FFMpegFrameSyncOption | None = None,
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -3041,6 +3139,7 @@ def msad(
 
     Args:
         framesync_options: Framesync options
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -3056,7 +3155,12 @@ def msad(
         ),
         _main,
         _reference,
-        **merge({}, extra_options, framesync_options),
+        **merge(
+            {},
+            extra_options,
+            framesync_options,
+            timeline_options,
+        ),
     )
     return filter_node.video(0)
 
@@ -3068,6 +3172,7 @@ def multiply(
     scale: Float = Default("1"),
     offset: Float = Default("0.5"),
     planes: Flags = Default("F"),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -3078,6 +3183,7 @@ def multiply(
         scale: set scale (from 0 to 9) (default 1)
         offset: set offset (from -1 to 1) (default 0.5)
         planes: set planes (default F)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -3100,6 +3206,7 @@ def multiply(
                 "planes": planes,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -3130,6 +3237,7 @@ def overlay(
     repeatlast: Boolean = Default("true"),
     alpha: Int | Literal["straight", "premultiplied"] | Default = Default("straight"),
     framesync_options: FFMpegFrameSyncOption | None = None,
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -3146,6 +3254,7 @@ def overlay(
         repeatlast: repeat overlay of the last overlay frame (default true)
         alpha: alpha format (from 0 to 1) (default straight)
         framesync_options: Framesync options
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -3174,6 +3283,7 @@ def overlay(
             },
             extra_options,
             framesync_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -3399,6 +3509,7 @@ def premultiply(
     *streams: VideoStream,
     planes: Int = Default("15"),
     inplace: Boolean = Default("false"),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -3408,6 +3519,7 @@ def premultiply(
     Args:
         planes: set planes (from 0 to 15) (default 15)
         inplace: enable inplace mode (default false)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -3430,6 +3542,7 @@ def premultiply(
                 "inplace": inplace,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -3492,6 +3605,7 @@ def psnr(
     stats_version: Int = Default("1"),
     output_max: Boolean = Default("false"),
     framesync_options: FFMpegFrameSyncOption | None = None,
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -3503,6 +3617,7 @@ def psnr(
         stats_version: Set the format version for the stats file. (from 1 to 2) (default 1)
         output_max: Add raw stats (max values) to the output log. (default false)
         framesync_options: Framesync options
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -3526,6 +3641,7 @@ def psnr(
             },
             extra_options,
             framesync_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -3710,6 +3826,7 @@ def sidechaingate(
     detection: Int | Literal["peak", "rms"] | Default = Default("rms"),
     link: Int | Literal["average", "maximum"] | Default = Default("average"),
     level_sc: Double = Default("1"),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> AudioStream:
     """
@@ -3729,6 +3846,7 @@ def sidechaingate(
         detection: set detection (from 0 to 1) (default rms)
         link: set link (from 0 to 1) (default average)
         level_sc: set sidechain gain (from 0.015625 to 64) (default 1)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -3762,6 +3880,7 @@ def sidechaingate(
                 "level_sc": level_sc,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.audio(0)
@@ -3921,6 +4040,7 @@ def ssim(
     *,
     stats_file: String = Default(None),
     framesync_options: FFMpegFrameSyncOption | None = None,
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -3930,6 +4050,7 @@ def ssim(
     Args:
         stats_file: Set file where to store per-frame difference information
         framesync_options: Framesync options
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -3951,6 +4072,7 @@ def ssim(
             },
             extra_options,
             framesync_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -4005,6 +4127,7 @@ def threshold(
     _max: VideoStream,
     *,
     planes: Int = Default("15"),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -4013,6 +4136,7 @@ def threshold(
 
     Args:
         planes: set planes to filter (from 0 to 15) (default 15)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -4037,6 +4161,7 @@ def threshold(
                 "planes": planes,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -4046,6 +4171,7 @@ def unpremultiply(
     *streams: VideoStream,
     planes: Int = Default("15"),
     inplace: Boolean = Default("false"),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -4055,6 +4181,7 @@ def unpremultiply(
     Args:
         planes: set planes (from 0 to 15) (default 15)
         inplace: enable inplace mode (default false)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -4077,6 +4204,7 @@ def unpremultiply(
                 "inplace": inplace,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -4090,6 +4218,7 @@ def varblur(
     max_r: Int = Default("8"),
     planes: Int = Default("15"),
     framesync_options: FFMpegFrameSyncOption | None = None,
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -4101,6 +4230,7 @@ def varblur(
         max_r: set max blur radius (from 1 to 255) (default 8)
         planes: set planes to filter (from 0 to 15) (default 15)
         framesync_options: Framesync options
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -4124,6 +4254,7 @@ def varblur(
             },
             extra_options,
             framesync_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -4133,6 +4264,7 @@ def vif(
     _main: VideoStream,
     _reference: VideoStream,
     framesync_options: FFMpegFrameSyncOption | None = None,
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -4141,6 +4273,7 @@ def vif(
 
     Args:
         framesync_options: Framesync options
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -4156,7 +4289,12 @@ def vif(
         ),
         _main,
         _reference,
-        **merge({}, extra_options, framesync_options),
+        **merge(
+            {},
+            extra_options,
+            framesync_options,
+            timeline_options,
+        ),
     )
     return filter_node.video(0)
 
@@ -4251,6 +4389,7 @@ def xcorrelate(
     planes: Int = Default("7"),
     secondary: Int | Literal["first", "all"] | Default = Default("all"),
     framesync_options: FFMpegFrameSyncOption | None = None,
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -4261,6 +4400,7 @@ def xcorrelate(
         planes: set planes to cross-correlate (from 0 to 15) (default 7)
         secondary: when to process secondary frame (from 0 to 1) (default all)
         framesync_options: Framesync options
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -4285,6 +4425,7 @@ def xcorrelate(
             },
             extra_options,
             framesync_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -4470,6 +4611,7 @@ def xmedian(
     planes: Int = Default("15"),
     percentile: Float = Default("0.5"),
     framesync_options: FFMpegFrameSyncOption | None = None,
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -4481,6 +4623,7 @@ def xmedian(
         planes: set planes to filter (from 0 to 15) (default 15)
         percentile: set percentile (from 0 to 1) (default 0.5)
         framesync_options: Framesync options
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -4505,6 +4648,7 @@ def xmedian(
             },
             extra_options,
             framesync_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)

--- a/src/ffmpeg/options/__init__.py
+++ b/src/ffmpeg/options/__init__.py
@@ -1,5 +1,6 @@
 """FFmpeg options."""
 
 from .framesync import framesync
+from .timeline import timeline
 
-__all__ = ["framesync"]
+__all__ = ["framesync", "timeline"]

--- a/src/ffmpeg/options/timeline.py
+++ b/src/ffmpeg/options/timeline.py
@@ -1,0 +1,11 @@
+from ..expressions import Expression
+from ..schema import FFMpegOptionGroup
+
+
+class FFMpegTimelineOption(FFMpegOptionGroup):
+    """Timeline options."""
+
+
+def timeline(enable: str | Expression) -> FFMpegTimelineOption:
+    """Timeline options."""
+    return FFMpegTimelineOption(enable=enable)

--- a/src/ffmpeg/options/timeline.py
+++ b/src/ffmpeg/options/timeline.py
@@ -1,3 +1,5 @@
+"""FFmpeg timeline options module."""
+
 from ..expressions import Expression
 from ..schema import FFMpegOptionGroup
 
@@ -7,5 +9,14 @@ class FFMpegTimelineOption(FFMpegOptionGroup):
 
 
 def timeline(enable: str | Expression) -> FFMpegTimelineOption:
-    """Timeline options."""
+    """
+    Create timeline options.
+
+    Args:
+        enable: The timeline enable parameter.
+
+    Returns:
+        FFMpegTimelineOption with the specified enable parameter.
+
+    """
     return FFMpegTimelineOption(enable=enable)

--- a/src/ffmpeg/sources.py
+++ b/src/ffmpeg/sources.py
@@ -10,6 +10,7 @@ from .dag.nodes import (
     FilterNode,
 )
 from .options.framesync import FFMpegFrameSyncOption
+from .options.timeline import FFMpegTimelineOption
 from .schema import Auto, Default
 from .streams.audio import AudioStream
 from .streams.video import VideoStream
@@ -805,6 +806,7 @@ def bm3d(
     estim: Int | Literal["basic", "final"] | Default = Default("basic"),
     ref: Boolean = Default("false"),
     planes: Int = Default("7"),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -823,6 +825,7 @@ def bm3d(
         estim: set filtering estimation mode (from 0 to 1) (default basic)
         ref: have reference stream (default false)
         planes: set planes to filter (from 0 to 15) (default 7)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -854,6 +857,7 @@ def bm3d(
                 "planes": planes,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -1518,6 +1522,7 @@ def guided(
     sub: Int = Default("4"),
     guidance: Int | Literal["off", "on"] | Default = Default("off"),
     planes: Int = Default("1"),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -1531,6 +1536,7 @@ def guided(
         sub: subsampling ratio for fast mode (from 2 to 64) (default 4)
         guidance: set guidance mode (0: off mode; 1: on mode) (from 0 to 1) (default off)
         planes: set planes to filter (from 0 to 15) (default 1)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -1557,6 +1563,7 @@ def guided(
                 "planes": planes,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -2368,6 +2375,7 @@ def limitdiff(
     elasticity: Float = Default("2"),
     reference: Boolean = Default("false"),
     planes: Int = Default("15"),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -2379,6 +2387,7 @@ def limitdiff(
         elasticity: set the elasticity (from 0 to 10) (default 2)
         reference: enable reference stream (default false)
         planes: set the planes to filter (from 0 to 15) (default 15)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -2403,6 +2412,7 @@ def limitdiff(
                 "planes": planes,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -2603,6 +2613,7 @@ def mix(
     duration: Int | Literal["longest", "shortest", "first"] | Default = Default(
         "longest"
     ),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -2615,6 +2626,7 @@ def mix(
         scale: set scale (from 0 to 32767) (default 0)
         planes: set what planes to filter (default F)
         duration: how to determine end of stream (from 0 to 2) (default longest)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -2640,6 +2652,7 @@ def mix(
                 "duration": duration,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -2933,6 +2946,7 @@ def premultiply(
     *streams: VideoStream,
     planes: Int = Default("15"),
     inplace: Boolean = Default("false"),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -2942,6 +2956,7 @@ def premultiply(
     Args:
         planes: set planes (from 0 to 15) (default 15)
         inplace: enable inplace mode (default false)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -2964,6 +2979,7 @@ def premultiply(
                 "inplace": inplace,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -3488,6 +3504,7 @@ def unpremultiply(
     *streams: VideoStream,
     planes: Int = Default("15"),
     inplace: Boolean = Default("false"),
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -3497,6 +3514,7 @@ def unpremultiply(
     Args:
         planes: set planes (from 0 to 15) (default 15)
         inplace: enable inplace mode (default false)
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -3519,6 +3537,7 @@ def unpremultiply(
                 "inplace": inplace,
             },
             extra_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)
@@ -3613,6 +3632,7 @@ def xmedian(
     planes: Int = Default("15"),
     percentile: Float = Default("0.5"),
     framesync_options: FFMpegFrameSyncOption | None = None,
+    timeline_options: FFMpegTimelineOption | None = None,
     extra_options: dict[str, Any] | None = None,
 ) -> VideoStream:
     """
@@ -3624,6 +3644,7 @@ def xmedian(
         planes: set planes to filter (from 0 to 15) (default 15)
         percentile: set percentile (from 0 to 1) (default 0.5)
         framesync_options: Framesync options
+        timeline_options: Timeline options
         extra_options: Extra options for the filter
 
     Returns:
@@ -3648,6 +3669,7 @@ def xmedian(
             },
             extra_options,
             framesync_options,
+            timeline_options,
         ),
     )
     return filter_node.video(0)

--- a/src/ffmpeg/streams/audio.py
+++ b/src/ffmpeg/streams/audio.py
@@ -11,6 +11,7 @@ from ..dag.nodes import (
     FilterableStream,
     FilterNode,
 )
+from ..options.timeline import FFMpegTimelineOption
 from ..schema import Default
 from ..types import (
     Boolean,
@@ -482,6 +483,7 @@ class AudioStream(FilterableStream):
         lfo: Boolean = Default("false"),
         lforange: Double = Default("20"),
         lforate: Double = Default("0.3"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -500,6 +502,7 @@ class AudioStream(FilterableStream):
             lfo: enable LFO (default false)
             lforange: set LFO depth (from 1 to 250) (default 20)
             lforate: set LFO rate (from 0.01 to 200) (default 0.3)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -529,6 +532,7 @@ class AudioStream(FilterableStream):
                     "lforate": lforate,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -583,6 +587,7 @@ class AudioStream(FilterableStream):
         threshold: Double = Default("2"),
         burst: Double = Default("2"),
         method: Int | Literal["add", "a", "save", "s"] | Default = Default("add"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -596,6 +601,7 @@ class AudioStream(FilterableStream):
             threshold: set threshold (from 1 to 100) (default 2)
             burst: set burst fusion (from 0 to 10) (default 2)
             method: set overlap method (from 0 to 1) (default add)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -620,6 +626,7 @@ class AudioStream(FilterableStream):
                     "method": method,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -633,6 +640,7 @@ class AudioStream(FilterableStream):
         threshold: Double = Default("10"),
         hsize: Int = Default("1000"),
         method: Int | Literal["add", "a", "save", "s"] | Default = Default("add"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -646,6 +654,7 @@ class AudioStream(FilterableStream):
             threshold: set threshold (from 1 to 100) (default 10)
             hsize: set histogram size (from 100 to 9999) (default 1000)
             method: set overlap method (from 0 to 1) (default add)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -670,6 +679,7 @@ class AudioStream(FilterableStream):
                     "method": method,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -679,6 +689,7 @@ class AudioStream(FilterableStream):
         *,
         stages: Int = Default("6"),
         seed: Int64 = Default("-1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -688,6 +699,7 @@ class AudioStream(FilterableStream):
         Args:
             stages: set filtering stages (from 1 to 16) (default 6)
             seed: set random seed (from -1 to UINT32_MAX) (default -1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -708,6 +720,7 @@ class AudioStream(FilterableStream):
                     "seed": seed,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -717,6 +730,7 @@ class AudioStream(FilterableStream):
         *,
         delays: String = Default(None),
         all: Boolean = Default("false"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -726,6 +740,7 @@ class AudioStream(FilterableStream):
         Args:
             delays: set list of delays for each channel
             all: use last available delay for remained channels (default false)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -746,6 +761,7 @@ class AudioStream(FilterableStream):
                     "all": all,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -755,6 +771,7 @@ class AudioStream(FilterableStream):
         *,
         level: Double = Default("-351"),
         type: Int | Literal["dc", "ac", "square", "pulse"] | Default = Default("dc"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -764,6 +781,7 @@ class AudioStream(FilterableStream):
         Args:
             level: set level (from -451 to -90) (default -351)
             type: set type (from 0 to 3) (default dc)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -784,12 +802,14 @@ class AudioStream(FilterableStream):
                     "type": type,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
 
     def aderivative(
         self,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -797,6 +817,7 @@ class AudioStream(FilterableStream):
         Compute derivative of input audio.
 
         Args:
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -814,6 +835,7 @@ class AudioStream(FilterableStream):
             **merge(
                 {},
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -904,6 +926,7 @@ class AudioStream(FilterableStream):
         attack: Double = Default("50"),
         release: Double = Default("100"),
         channels: String = Default("all"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -915,6 +938,7 @@ class AudioStream(FilterableStream):
             attack: set the attack (from 1 to 1000) (default 50)
             release: set the release (from 5 to 2000) (default 100)
             channels: set channels to filter (default "all")
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -937,6 +961,7 @@ class AudioStream(FilterableStream):
                     "channels": channels,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -964,6 +989,7 @@ class AudioStream(FilterableStream):
         direction: Int | Literal["downward", "upward"] | Default = Default("downward"),
         auto: Int | Literal["disabled", "off", "on"] | Default = Default("disabled"),
         precision: Int | Literal["auto", "float", "double"] | Default = Default("auto"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -987,6 +1013,7 @@ class AudioStream(FilterableStream):
             direction: set direction (from 0 to 1) (default downward)
             auto: set auto threshold (from -1 to 1) (default disabled)
             precision: set processing precision (from 0 to 2) (default auto)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -1023,6 +1050,7 @@ class AudioStream(FilterableStream):
                     "precision": precision,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -1032,6 +1060,7 @@ class AudioStream(FilterableStream):
         *,
         sensitivity: Double = Default("2"),
         basefreq: Double = Default("22050"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -1041,6 +1070,7 @@ class AudioStream(FilterableStream):
         Args:
             sensitivity: set smooth sensitivity (from 0 to 1e+06) (default 2)
             basefreq: set base frequency (from 2 to 1e+06) (default 22050)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -1063,6 +1093,7 @@ class AudioStream(FilterableStream):
                     "basefreq": basefreq,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -1122,6 +1153,7 @@ class AudioStream(FilterableStream):
         type: Int
         | Literal["col", "emi", "bsi", "riaa", "cd", "50fm", "75fm", "50kf", "75kf"]
         | Default = Default("cd"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -1133,6 +1165,7 @@ class AudioStream(FilterableStream):
             level_out: set output gain (from 0 to 64) (default 1)
             mode: set filter mode (from 0 to 1) (default reproduction)
             type: set filter type (from 0 to 8) (default cd)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -1155,6 +1188,7 @@ class AudioStream(FilterableStream):
                     "type": type,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -1164,6 +1198,7 @@ class AudioStream(FilterableStream):
         *,
         exprs: String = Default(None),
         channel_layout: String = Default(None),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -1173,6 +1208,7 @@ class AudioStream(FilterableStream):
         Args:
             exprs: set the '|'-separated list of channels expressions
             channel_layout: set channel layout
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -1193,6 +1229,7 @@ class AudioStream(FilterableStream):
                     "channel_layout": channel_layout,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -1208,6 +1245,7 @@ class AudioStream(FilterableStream):
         freq: Double = Default("7500"),
         ceil: Double = Default("9999"),
         listen: Boolean = Default("false"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -1223,6 +1261,7 @@ class AudioStream(FilterableStream):
             freq: set scope (from 2000 to 12000) (default 7500)
             ceil: set ceiling (from 9999 to 20000) (default 9999)
             listen: enable listen mode (default false)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -1249,6 +1288,7 @@ class AudioStream(FilterableStream):
                     "listen": listen,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -1291,6 +1331,7 @@ class AudioStream(FilterableStream):
         | Default = Default("tri"),
         silence: Double = Default("0"),
         unity: Double = Default("1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -1306,6 +1347,7 @@ class AudioStream(FilterableStream):
             curve: set fade curve type (from -1 to 22) (default tri)
             silence: set the silence gain (from 0 to 1) (default 0)
             unity: set the unity gain (from 0 to 1) (default 1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -1332,6 +1374,7 @@ class AudioStream(FilterableStream):
                     "unity": unity,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -1361,6 +1404,7 @@ class AudioStream(FilterableStream):
         | Literal["none", "start", "begin", "stop", "end"]
         | Default = Default("none"),
         gain_smooth: Int = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -1382,6 +1426,7 @@ class AudioStream(FilterableStream):
             band_multiplier: set band multiplier (from 0.2 to 5) (default 1.25)
             sample_noise: set sample noise mode (from 0 to 2) (default none)
             gain_smooth: set gain smooth radius (from 0 to 50) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -1414,6 +1459,7 @@ class AudioStream(FilterableStream):
                     "gain_smooth": gain_smooth,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -1451,6 +1497,7 @@ class AudioStream(FilterableStream):
         ]
         | Default = Default("hann"),
         overlap: Float = Default("0.75"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -1463,6 +1510,7 @@ class AudioStream(FilterableStream):
             win_size: set window size (from 16 to 131072) (default 4096)
             win_func: set window function (from 0 to 20) (default hann)
             overlap: set window overlap (from 0 to 1) (default 0.75)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -1486,6 +1534,7 @@ class AudioStream(FilterableStream):
                     "overlap": overlap,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -1537,6 +1586,7 @@ class AudioStream(FilterableStream):
         shift: Double = Default("0"),
         level: Double = Default("1"),
         order: Int = Default("8"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -1547,6 +1597,7 @@ class AudioStream(FilterableStream):
             shift: set frequency shift (from -2.14748e+09 to INT_MAX) (default 0)
             level: set output level (from 0 to 1) (default 1)
             order: set filter order (from 1 to 16) (default 8)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -1568,6 +1619,7 @@ class AudioStream(FilterableStream):
                     "order": order,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -1585,6 +1637,7 @@ class AudioStream(FilterableStream):
         adaptive: Boolean = Default("false"),
         samples: Int = Default("8192"),
         softness: Double = Default("1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -1600,6 +1653,7 @@ class AudioStream(FilterableStream):
             adaptive: adaptive profiling of noise (default false)
             samples: set frame size in number of samples (from 512 to 65536) (default 8192)
             softness: set thresholding softness (from 0 to 10) (default 1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -1626,6 +1680,7 @@ class AudioStream(FilterableStream):
                     "softness": softness,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -1645,6 +1700,7 @@ class AudioStream(FilterableStream):
         detection: Int | Literal["peak", "rms"] | Default = Default("rms"),
         link: Int | Literal["average", "maximum"] | Default = Default("average"),
         level_sc: Double = Default("1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -1664,6 +1720,7 @@ class AudioStream(FilterableStream):
             detection: set detection (from 0 to 1) (default rms)
             link: set link (from 0 to 1) (default average)
             level_sc: set sidechain gain (from 0.015625 to 64) (default 1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -1694,6 +1751,7 @@ class AudioStream(FilterableStream):
                     "level_sc": level_sc,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -1917,6 +1975,7 @@ class AudioStream(FilterableStream):
 
     def aintegral(
         self,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -1924,6 +1983,7 @@ class AudioStream(FilterableStream):
         Compute integral of input audio.
 
         Args:
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -1941,12 +2001,14 @@ class AudioStream(FilterableStream):
             **merge(
                 {},
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
 
     def alatency(
         self,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -1954,6 +2016,7 @@ class AudioStream(FilterableStream):
         Report audio filtering latency.
 
         Args:
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -1971,6 +2034,7 @@ class AudioStream(FilterableStream):
             **merge(
                 {},
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -1987,6 +2051,7 @@ class AudioStream(FilterableStream):
         asc_level: Double = Default("0.5"),
         level: Boolean = Default("true"),
         latency: Boolean = Default("false"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -2003,6 +2068,7 @@ class AudioStream(FilterableStream):
             asc_level: set asc level (from 0 to 1) (default 0.5)
             level: auto level (default true)
             latency: compensate delay (default false)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -2030,6 +2096,7 @@ class AudioStream(FilterableStream):
                     "latency": latency,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -2050,6 +2117,7 @@ class AudioStream(FilterableStream):
         precision: Int
         | Literal["auto", "s16", "s32", "f32", "f64"]
         | Default = Default("auto"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -2066,6 +2134,7 @@ class AudioStream(FilterableStream):
             order: set filter order (from 1 to 2) (default 2)
             transform: set transform type (from 0 to 6) (default di)
             precision: set filtering precision (from -1 to 3) (default auto)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -2093,6 +2162,7 @@ class AudioStream(FilterableStream):
                     "precision": precision,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -2157,6 +2227,7 @@ class AudioStream(FilterableStream):
         expr: String = Default(None),
         file: String = Default(None),
         direct: Boolean = Default("false"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -2171,6 +2242,7 @@ class AudioStream(FilterableStream):
             expr: set expression for expr function
             file: set file where to print metadata information
             direct: reduce buffering when printing to user-set file or pipe (default false)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -2196,6 +2268,7 @@ class AudioStream(FilterableStream):
                     "direct": direct,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -2245,6 +2318,7 @@ class AudioStream(FilterableStream):
         colors: String = Default(
             "red|green|blue|yellow|orange|lime|pink|magenta|brown"
         ),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> FilterNode:
         """
@@ -2258,6 +2332,7 @@ class AudioStream(FilterableStream):
             mgain: set max gain (from -900 to 900) (default 60)
             fscale: set frequency scale (from 0 to 1) (default log)
             colors: set channels curves colors (default "red|green|blue|yellow|orange|lime|pink|magenta|brown")
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -2285,6 +2360,7 @@ class AudioStream(FilterableStream):
                     "colors": colors,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
 
@@ -2298,6 +2374,7 @@ class AudioStream(FilterableStream):
         research: Duration = Default("0.006"),
         output: Int | Literal["i", "o", "n"] | Default = Default("o"),
         smooth: Float = Default("11"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -2310,6 +2387,7 @@ class AudioStream(FilterableStream):
             research: set research duration (default 0.006)
             output: set output mode (from 0 to 2) (default o)
             smooth: set smooth factor (from 1 to 1000) (default 11)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -2333,6 +2411,7 @@ class AudioStream(FilterableStream):
                     "smooth": smooth,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -2346,6 +2425,7 @@ class AudioStream(FilterableStream):
         eps: Float = Default("1"),
         leakage: Float = Default("0"),
         out_mode: Int | Literal["i", "d", "o", "n", "e"] | Default = Default("o"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -2358,6 +2438,7 @@ class AudioStream(FilterableStream):
             eps: set the filter eps (from 0 to 1) (default 1)
             leakage: set the filter leakage (from 0 to 1) (default 0)
             out_mode: set output mode (from 0 to 4) (default o)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -2384,6 +2465,7 @@ class AudioStream(FilterableStream):
                     "out_mode": out_mode,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -2397,6 +2479,7 @@ class AudioStream(FilterableStream):
         eps: Float = Default("1"),
         leakage: Float = Default("0"),
         out_mode: Int | Literal["i", "d", "o", "n", "e"] | Default = Default("o"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -2409,6 +2492,7 @@ class AudioStream(FilterableStream):
             eps: set the filter eps (from 0 to 1) (default 1)
             leakage: set the filter leakage (from 0 to 1) (default 0)
             out_mode: set output mode (from 0 to 4) (default o)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -2435,6 +2519,7 @@ class AudioStream(FilterableStream):
                     "out_mode": out_mode,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -2477,6 +2562,7 @@ class AudioStream(FilterableStream):
         whole_len: Int64 = Default("-1"),
         pad_dur: Duration = Default("-0.000001"),
         whole_dur: Duration = Default("-0.000001"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -2489,6 +2575,7 @@ class AudioStream(FilterableStream):
             whole_len: set minimum target number of samples in the audio stream (from -1 to I64_MAX) (default -1)
             pad_dur: set duration of silence to add (default -0.000001)
             whole_dur: set minimum target duration in the audio stream (default -0.000001)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -2512,6 +2599,7 @@ class AudioStream(FilterableStream):
                     "whole_dur": whole_dur,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -2523,6 +2611,7 @@ class AudioStream(FilterableStream):
             "none"
         ),
         seed: Int64 = Default("-1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -2532,6 +2621,7 @@ class AudioStream(FilterableStream):
         Args:
             mode: select permissions mode (from 0 to 4) (default none)
             seed: set the seed for the random mode (from -1 to UINT32_MAX) (default -1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -2552,6 +2642,7 @@ class AudioStream(FilterableStream):
                     "seed": seed,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -2683,6 +2774,7 @@ class AudioStream(FilterableStream):
         shift: Double = Default("0"),
         level: Double = Default("1"),
         order: Int = Default("8"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -2693,6 +2785,7 @@ class AudioStream(FilterableStream):
             shift: set phase shift (from -1 to 1) (default 0)
             level: set output level (from 0 to 1) (default 1)
             order: set filter order (from 1 to 16) (default 8)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -2714,6 +2807,7 @@ class AudioStream(FilterableStream):
                     "order": order,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -2721,6 +2815,7 @@ class AudioStream(FilterableStream):
     def apsnr(
         self,
         _input1: AudioStream,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -2728,6 +2823,7 @@ class AudioStream(FilterableStream):
         Measure Audio Peak Signal-to-Noise Ratio.
 
         Args:
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -2748,6 +2844,7 @@ class AudioStream(FilterableStream):
             **merge(
                 {},
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -2762,6 +2859,7 @@ class AudioStream(FilterableStream):
         adaptive: Double = Default("0.5"),
         iterations: Int = Default("10"),
         level: Boolean = Default("false"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -2776,6 +2874,7 @@ class AudioStream(FilterableStream):
             adaptive: set adaptive distortion (from 0 to 1) (default 0.5)
             iterations: set iterations (from 1 to 20) (default 10)
             level: set auto level (default false)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -2801,6 +2900,7 @@ class AudioStream(FilterableStream):
                     "level": level,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -2983,6 +3083,7 @@ class AudioStream(FilterableStream):
         _lambda: Float = Default("1"),
         delta: Float = Default("2"),
         out_mode: Int | Literal["i", "d", "o", "n", "e"] | Default = Default("o"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -2994,6 +3095,7 @@ class AudioStream(FilterableStream):
             _lambda: set the filter lambda (from 0 to 1) (default 1)
             delta: set the filter delta (from 0 to 32767) (default 2)
             out_mode: set output mode (from 0 to 4) (default o)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -3017,6 +3119,7 @@ class AudioStream(FilterableStream):
                     "out_mode": out_mode,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -3026,6 +3129,7 @@ class AudioStream(FilterableStream):
         *,
         model: String = Default(None),
         mix: Float = Default("1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -3035,6 +3139,7 @@ class AudioStream(FilterableStream):
         Args:
             model: set model name
             mix: set output vs input mix (from -1 to 1) (default 1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -3055,6 +3160,7 @@ class AudioStream(FilterableStream):
                     "mix": mix,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -3062,6 +3168,7 @@ class AudioStream(FilterableStream):
     def asdr(
         self,
         _input1: AudioStream,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -3069,6 +3176,7 @@ class AudioStream(FilterableStream):
         Measure Audio Signal-to-Distortion Ratio.
 
         Args:
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -3087,6 +3195,7 @@ class AudioStream(FilterableStream):
             **merge(
                 {},
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -3218,6 +3327,7 @@ class AudioStream(FilterableStream):
         *,
         nb_out_samples: Int = Default("1024"),
         pad: Boolean = Default("true"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -3227,6 +3337,7 @@ class AudioStream(FilterableStream):
         Args:
             nb_out_samples: set the number of per-frame output samples (from 1 to INT_MAX) (default 1024)
             pad: pad last frame with zeros (default true)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -3247,6 +3358,7 @@ class AudioStream(FilterableStream):
                     "pad": pad,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -3415,6 +3527,7 @@ class AudioStream(FilterableStream):
             "SEI_UNREGISTERED",
         ]
         | Default = Default("-1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -3424,6 +3537,7 @@ class AudioStream(FilterableStream):
         Args:
             mode: set a mode of operation (from 0 to 1) (default select)
             type: set side data type (from -1 to INT_MAX) (default -1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -3444,6 +3558,7 @@ class AudioStream(FilterableStream):
                     "type": type,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -3451,6 +3566,7 @@ class AudioStream(FilterableStream):
     def asisdr(
         self,
         _input1: AudioStream,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -3458,6 +3574,7 @@ class AudioStream(FilterableStream):
         Measure Audio Scale-Invariant Signal-to-Distortion Ratio.
 
         Args:
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -3478,6 +3595,7 @@ class AudioStream(FilterableStream):
             **merge(
                 {},
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -3494,6 +3612,7 @@ class AudioStream(FilterableStream):
         output: Double = Default("1"),
         param: Double = Default("1"),
         oversample: Int = Default("1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -3506,6 +3625,7 @@ class AudioStream(FilterableStream):
             output: set softclip output gain (from 1e-06 to 16) (default 1)
             param: set softclip parameter (from 0.01 to 3) (default 1)
             oversample: set oversample factor (from 1 to 64) (default 1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -3529,6 +3649,7 @@ class AudioStream(FilterableStream):
                     "oversample": oversample,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -3841,6 +3962,7 @@ class AudioStream(FilterableStream):
         slope: Double = Default("0.5"),
         delay: Double = Default("20"),
         channels: String = Default("all"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -3857,6 +3979,7 @@ class AudioStream(FilterableStream):
             slope: set slope (from 0.0001 to 1) (default 0.5)
             delay: set delay (from 1 to 100) (default 20)
             channels: set channels to filter (default "all")
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -3884,6 +4007,7 @@ class AudioStream(FilterableStream):
                     "channels": channels,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -3894,6 +4018,7 @@ class AudioStream(FilterableStream):
         cutoff: Double = Default("20"),
         order: Int = Default("10"),
         level: Double = Default("1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -3904,6 +4029,7 @@ class AudioStream(FilterableStream):
             cutoff: set cutoff frequency (from 2 to 200) (default 20)
             order: set filter order (from 3 to 20) (default 10)
             level: set input level (from 0 to 1) (default 1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -3925,6 +4051,7 @@ class AudioStream(FilterableStream):
                     "level": level,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -3935,6 +4062,7 @@ class AudioStream(FilterableStream):
         cutoff: Double = Default("20000"),
         order: Int = Default("10"),
         level: Double = Default("1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -3945,6 +4073,7 @@ class AudioStream(FilterableStream):
             cutoff: set cutoff frequency (from 20000 to 192000) (default 20000)
             order: set filter order (from 3 to 20) (default 10)
             level: set input level (from 0 to 1) (default 1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -3966,6 +4095,7 @@ class AudioStream(FilterableStream):
                     "level": level,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -3977,6 +4107,7 @@ class AudioStream(FilterableStream):
         order: Int = Default("4"),
         qfactor: Double = Default("1"),
         level: Double = Default("1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -3988,6 +4119,7 @@ class AudioStream(FilterableStream):
             order: set filter order (from 4 to 20) (default 4)
             qfactor: set Q-factor (from 0.01 to 100) (default 1)
             level: set input level (from 0 to 2) (default 1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -4010,6 +4142,7 @@ class AudioStream(FilterableStream):
                     "level": level,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -4021,6 +4154,7 @@ class AudioStream(FilterableStream):
         order: Int = Default("4"),
         qfactor: Double = Default("1"),
         level: Double = Default("1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -4032,6 +4166,7 @@ class AudioStream(FilterableStream):
             order: set filter order (from 4 to 20) (default 4)
             qfactor: set Q-factor (from 0.01 to 100) (default 1)
             level: set input level (from 0 to 2) (default 1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -4054,6 +4189,7 @@ class AudioStream(FilterableStream):
                     "level": level,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -4101,6 +4237,7 @@ class AudioStream(FilterableStream):
         width: Double = Default("1000"),
         order: Int = Default("5"),
         level: Double = Default("1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -4113,6 +4250,7 @@ class AudioStream(FilterableStream):
             width: set filter width (from 100 to 10000) (default 1000)
             order: set filter order (from 2 to 30) (default 5)
             level: set input level (from 0 to 4) (default 1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -4136,6 +4274,7 @@ class AudioStream(FilterableStream):
                     "level": level,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -4369,6 +4508,7 @@ class AudioStream(FilterableStream):
         | Literal["auto", "s16", "s32", "f32", "f64"]
         | Default = Default("auto"),
         blocksize: Int = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -4386,6 +4526,7 @@ class AudioStream(FilterableStream):
             transform: set transform type (from 0 to 6) (default di)
             precision: set filtering precision (from -1 to 3) (default auto)
             blocksize: set the block size (from 0 to 32768) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -4414,6 +4555,7 @@ class AudioStream(FilterableStream):
                     "blocksize": blocksize,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -4434,6 +4576,7 @@ class AudioStream(FilterableStream):
         | Literal["auto", "s16", "s32", "f32", "f64"]
         | Default = Default("auto"),
         blocksize: Int = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -4450,6 +4593,7 @@ class AudioStream(FilterableStream):
             transform: set transform type (from 0 to 6) (default di)
             precision: set filtering precision (from -1 to 3) (default auto)
             blocksize: set the block size (from 0 to 32768) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -4477,6 +4621,7 @@ class AudioStream(FilterableStream):
                     "blocksize": blocksize,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -4499,6 +4644,7 @@ class AudioStream(FilterableStream):
         | Literal["auto", "s16", "s32", "f32", "f64"]
         | Default = Default("auto"),
         blocksize: Int = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -4517,6 +4663,7 @@ class AudioStream(FilterableStream):
             transform: set transform type (from 0 to 6) (default di)
             precision: set filtering precision (from -1 to 3) (default auto)
             blocksize: set the block size (from 0 to 32768) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -4546,6 +4693,7 @@ class AudioStream(FilterableStream):
                     "blocksize": blocksize,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -4565,6 +4713,7 @@ class AudioStream(FilterableStream):
         | Literal["auto", "s16", "s32", "f32", "f64"]
         | Default = Default("auto"),
         blocksize: Int = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -4580,6 +4729,7 @@ class AudioStream(FilterableStream):
             transform: set transform type (from 0 to 6) (default di)
             precision: set filtering precision (from -1 to 3) (default auto)
             blocksize: set the block size (from 0 to 32768) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -4606,6 +4756,7 @@ class AudioStream(FilterableStream):
                     "blocksize": blocksize,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -4845,6 +4996,7 @@ class AudioStream(FilterableStream):
         dry: Double = Default("0"),
         wet: Double = Default("1"),
         temp: Int = Default("20"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -4858,6 +5010,7 @@ class AudioStream(FilterableStream):
             dry: set dry amount (from 0 to 1) (default 0)
             wet: set wet amount (from 0 to 1) (default 1)
             temp: set temperature °C (from -50 to 50) (default 20)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -4884,6 +5037,7 @@ class AudioStream(FilterableStream):
                     "temp": temp,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -4897,6 +5051,7 @@ class AudioStream(FilterableStream):
         level_in: Double = Default("0.9"),
         level_out: Double = Default("1"),
         block_size: Int = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -4910,6 +5065,7 @@ class AudioStream(FilterableStream):
             level_in: set level in (from 0 to 1) (default 0.9)
             level_out: set level out (from 0 to 1) (default 1)
             block_size: set the block size (from 0 to 32768) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -4934,6 +5090,7 @@ class AudioStream(FilterableStream):
                     "block_size": block_size,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -4943,6 +5100,7 @@ class AudioStream(FilterableStream):
         *,
         i: Float = Default("2"),
         c: Boolean = Default("true"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -4952,6 +5110,7 @@ class AudioStream(FilterableStream):
         Args:
             i: set intensity (from -10 to 10) (default 2)
             c: enable clipping (default true)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -4972,6 +5131,7 @@ class AudioStream(FilterableStream):
                     "c": c,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -4981,6 +5141,7 @@ class AudioStream(FilterableStream):
         *,
         shift: Double = Default("0"),
         limitergain: Double = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -4990,6 +5151,7 @@ class AudioStream(FilterableStream):
         Args:
             shift: set DC shift (from -1 to 1) (default 0)
             limitergain: set limiter gain (from 0 to 1) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -5010,6 +5172,7 @@ class AudioStream(FilterableStream):
                     "limitergain": limitergain,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -5021,6 +5184,7 @@ class AudioStream(FilterableStream):
         m: Double = Default("0.5"),
         f: Double = Default("0.5"),
         s: Int | Literal["i", "o", "e"] | Default = Default("o"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -5032,6 +5196,7 @@ class AudioStream(FilterableStream):
             m: set max deessing (from 0 to 1) (default 0.5)
             f: set frequency (from 0 to 1) (default 0.5)
             s: set output mode (from 0 to 2) (default o)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -5054,6 +5219,7 @@ class AudioStream(FilterableStream):
                     "s": s,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -5064,6 +5230,7 @@ class AudioStream(FilterableStream):
         original: Double = Default("1"),
         enhance: Double = Default("1"),
         voice: Double = Default("2"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -5074,6 +5241,7 @@ class AudioStream(FilterableStream):
             original: set original center factor (from 0 to 1) (default 1)
             enhance: set dialogue enhance factor (from 0 to 3) (default 1)
             voice: set voice detection factor (from 2 to 32) (default 2)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -5097,6 +5265,7 @@ class AudioStream(FilterableStream):
                     "voice": voice,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -5152,6 +5321,7 @@ class AudioStream(FilterableStream):
         channels: String = Default("all"),
         overlap: Double = Default("0"),
         curve: String = Default(None),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -5172,6 +5342,7 @@ class AudioStream(FilterableStream):
             channels: set channels to filter (default "all")
             overlap: set the frame overlap (from 0 to 1) (default 0)
             curve: set the custom peak mapping curve
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -5203,6 +5374,7 @@ class AudioStream(FilterableStream):
                     "curve": curve,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -5345,6 +5517,7 @@ class AudioStream(FilterableStream):
         | Literal["auto", "s16", "s32", "f32", "f64"]
         | Default = Default("auto"),
         blocksize: Int = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -5362,6 +5535,7 @@ class AudioStream(FilterableStream):
             transform: set transform type (from 0 to 6) (default di)
             precision: set filtering precision (from -1 to 3) (default auto)
             blocksize: set the block size (from 0 to 32768) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -5390,6 +5564,7 @@ class AudioStream(FilterableStream):
                     "blocksize": blocksize,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -5399,6 +5574,7 @@ class AudioStream(FilterableStream):
         *,
         m: Float = Default("2.5"),
         c: Boolean = Default("true"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -5408,6 +5584,7 @@ class AudioStream(FilterableStream):
         Args:
             m: set the difference coefficient (from -10 to 10) (default 2.5)
             c: enable clipping (default true)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -5428,6 +5605,7 @@ class AudioStream(FilterableStream):
                     "c": c,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -5720,6 +5898,7 @@ class AudioStream(FilterableStream):
         | Literal["auto", "s16", "s32", "f32", "f64"]
         | Default = Default("auto"),
         blocksize: Int = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -5737,6 +5916,7 @@ class AudioStream(FilterableStream):
             transform: set transform type (from 0 to 6) (default di)
             precision: set filtering precision (from -1 to 3) (default auto)
             blocksize: set the block size (from 0 to 32768) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -5765,6 +5945,7 @@ class AudioStream(FilterableStream):
                     "blocksize": blocksize,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -5787,6 +5968,7 @@ class AudioStream(FilterableStream):
         | Literal["auto", "s16", "s32", "f32", "f64"]
         | Default = Default("auto"),
         blocksize: Int = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -5805,6 +5987,7 @@ class AudioStream(FilterableStream):
             transform: set transform type (from 0 to 6) (default di)
             precision: set filtering precision (from -1 to 3) (default auto)
             blocksize: set the block size (from 0 to 32768) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -5834,6 +6017,7 @@ class AudioStream(FilterableStream):
                     "blocksize": blocksize,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -5922,6 +6106,7 @@ class AudioStream(FilterableStream):
         | Literal["auto", "s16", "s32", "f32", "f64"]
         | Default = Default("auto"),
         blocksize: Int = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -5939,6 +6124,7 @@ class AudioStream(FilterableStream):
             transform: set transform type (from 0 to 6) (default di)
             precision: set filtering precision (from -1 to 3) (default auto)
             blocksize: set the block size (from 0 to 32768) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -5967,6 +6153,7 @@ class AudioStream(FilterableStream):
                     "blocksize": blocksize,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -5989,6 +6176,7 @@ class AudioStream(FilterableStream):
         | Literal["auto", "s16", "s32", "f32", "f64"]
         | Default = Default("auto"),
         blocksize: Int = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -6007,6 +6195,7 @@ class AudioStream(FilterableStream):
             transform: set transform type (from 0 to 6) (default di)
             precision: set filtering precision (from -1 to 3) (default auto)
             blocksize: set the block size (from 0 to 32768) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -6036,6 +6225,7 @@ class AudioStream(FilterableStream):
                     "blocksize": blocksize,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -7151,6 +7341,7 @@ class AudioStream(FilterableStream):
         detection: Int | Literal["peak", "rms"] | Default = Default("rms"),
         link: Int | Literal["average", "maximum"] | Default = Default("average"),
         level_sc: Double = Default("1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -7170,6 +7361,7 @@ class AudioStream(FilterableStream):
             detection: set detection (from 0 to 1) (default rms)
             link: set link (from 0 to 1) (default average)
             level_sc: set sidechain gain (from 0.015625 to 64) (default 1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -7203,6 +7395,7 @@ class AudioStream(FilterableStream):
                     "level_sc": level_sc,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -7268,6 +7461,7 @@ class AudioStream(FilterableStream):
         | Default = Default("rms"),
         window: Duration = Default("0.02"),
         timestamp: Int | Literal["write", "copy"] | Default = Default("write"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -7288,6 +7482,7 @@ class AudioStream(FilterableStream):
             detection: set how silence is detected (from 0 to 5) (default rms)
             window: set duration of window for silence detection (default 0.02)
             timestamp: set how every output frame timestamp is processed (from 0 to 1) (default write)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -7321,6 +7516,7 @@ class AudioStream(FilterableStream):
                     "timestamp": timestamp,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -7412,6 +7608,7 @@ class AudioStream(FilterableStream):
         invert: Boolean = Default("false"),
         link: Boolean = Default("false"),
         rms: Double = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -7429,6 +7626,7 @@ class AudioStream(FilterableStream):
             invert: set inverted filtering (default false)
             link: set linked channels filtering (default false)
             rms: set the RMS value (from 0 to 1) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -7457,6 +7655,7 @@ class AudioStream(FilterableStream):
                     "rms": rms,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -7502,6 +7701,7 @@ class AudioStream(FilterableStream):
         bmode_out: Int | Literal["balance", "amplitude", "power"] | Default = Default(
             "balance"
         ),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -7529,6 +7729,7 @@ class AudioStream(FilterableStream):
             phase: set stereo phase (from 0 to 360) (default 0)
             bmode_in: set balance in mode (from 0 to 2) (default balance)
             bmode_out: set balance out mode (from 0 to 2) (default balance)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -7567,6 +7768,7 @@ class AudioStream(FilterableStream):
                     "bmode_out": bmode_out,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -7578,6 +7780,7 @@ class AudioStream(FilterableStream):
         feedback: Float = Default("0.3"),
         crossfeed: Float = Default("0.3"),
         drymix: Float = Default("0.8"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -7589,6 +7792,7 @@ class AudioStream(FilterableStream):
             feedback: set feedback gain (from 0 to 0.9) (default 0.3)
             crossfeed: set cross feed (from 0 to 0.8) (default 0.3)
             drymix: set dry-mix (from 0 to 1) (default 0.8)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -7611,6 +7815,7 @@ class AudioStream(FilterableStream):
                     "drymix": drymix,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -7928,6 +8133,7 @@ class AudioStream(FilterableStream):
         | Literal["auto", "s16", "s32", "f32", "f64"]
         | Default = Default("auto"),
         blocksize: Int = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -7946,6 +8152,7 @@ class AudioStream(FilterableStream):
             transform: set transform type (from 0 to 6) (default di)
             precision: set filtering precision (from -1 to 3) (default auto)
             blocksize: set the block size (from 0 to 32768) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -7975,6 +8182,7 @@ class AudioStream(FilterableStream):
                     "blocksize": blocksize,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -7997,6 +8205,7 @@ class AudioStream(FilterableStream):
         | Literal["auto", "s16", "s32", "f32", "f64"]
         | Default = Default("auto"),
         blocksize: Int = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -8015,6 +8224,7 @@ class AudioStream(FilterableStream):
             transform: set transform type (from 0 to 6) (default di)
             precision: set filtering precision (from -1 to 3) (default auto)
             blocksize: set the block size (from 0 to 32768) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -8044,6 +8254,7 @@ class AudioStream(FilterableStream):
                     "blocksize": blocksize,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -8053,6 +8264,7 @@ class AudioStream(FilterableStream):
         *,
         f: Double = Default("5"),
         d: Double = Default("0.5"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -8062,6 +8274,7 @@ class AudioStream(FilterableStream):
         Args:
             f: set frequency in hertz (from 0.1 to 20000) (default 5)
             d: set depth as percentage (from 0 to 1) (default 0.5)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -8082,6 +8295,7 @@ class AudioStream(FilterableStream):
                     "d": d,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -8091,6 +8305,7 @@ class AudioStream(FilterableStream):
         *,
         f: Double = Default("5"),
         d: Double = Default("0.5"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -8100,6 +8315,7 @@ class AudioStream(FilterableStream):
         Args:
             f: set frequency in hertz (from 0.1 to 20000) (default 5)
             d: set depth as percentage (from 0 to 1) (default 0.5)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -8120,6 +8336,7 @@ class AudioStream(FilterableStream):
                     "d": d,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -8129,6 +8346,7 @@ class AudioStream(FilterableStream):
         *,
         cutoff: Double = Default("250"),
         strength: Double = Default("3"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -8138,6 +8356,7 @@ class AudioStream(FilterableStream):
         Args:
             cutoff: set virtual bass cutoff (from 100 to 500) (default 250)
             strength: set virtual bass strength (from 0.5 to 3) (default 3)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -8158,6 +8377,7 @@ class AudioStream(FilterableStream):
                     "strength": strength,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)
@@ -8175,6 +8395,7 @@ class AudioStream(FilterableStream):
         | Default = Default("drop"),
         replaygain_preamp: Double = Default("0"),
         replaygain_noclip: Boolean = Default("true"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> AudioStream:
         """
@@ -8188,6 +8409,7 @@ class AudioStream(FilterableStream):
             replaygain: Apply replaygain side data when present (from 0 to 3) (default drop)
             replaygain_preamp: Apply replaygain pre-amplification (from -15 to 15) (default 0)
             replaygain_noclip: Apply replaygain clipping prevention (default true)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -8212,6 +8434,7 @@ class AudioStream(FilterableStream):
                     "replaygain_noclip": replaygain_noclip,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.audio(0)

--- a/src/ffmpeg/streams/video.py
+++ b/src/ffmpeg/streams/video.py
@@ -12,6 +12,7 @@ from ..dag.nodes import (
     FilterNode,
 )
 from ..options.framesync import FFMpegFrameSyncOption
+from ..options.timeline import FFMpegTimelineOption
 from ..schema import Default
 from ..types import (
     Boolean,
@@ -121,6 +122,7 @@ class VideoStream(FilterableStream):
         self,
         _alpha: VideoStream,
         framesync_options: FFMpegFrameSyncOption | None = None,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -129,6 +131,7 @@ class VideoStream(FilterableStream):
 
         Args:
             framesync_options: Framesync options
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -146,7 +149,12 @@ class VideoStream(FilterableStream):
             ),
             self,
             _alpha,
-            **merge({}, extra_options, framesync_options),
+            **merge(
+                {},
+                extra_options,
+                framesync_options,
+                timeline_options,
+            ),
         )
         return filter_node.video(0)
 
@@ -160,6 +168,7 @@ class VideoStream(FilterableStream):
         low: Float = Default("65535"),
         high: Float = Default("65535"),
         planes: Flags = Default("7"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -174,6 +183,7 @@ class VideoStream(FilterableStream):
             low: set low limit for amplification (from 0 to 65535) (default 65535)
             high: set high limit for amplification (from 0 to 65535) (default 65535)
             planes: set what planes to filter (default 7)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -199,6 +209,7 @@ class VideoStream(FilterableStream):
                     "planes": planes,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -265,6 +276,7 @@ class VideoStream(FilterableStream):
         _0s: Float = Default("32767"),
         _1s: Float = Default("32767"),
         _2s: Float = Default("32767"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -284,6 +296,7 @@ class VideoStream(FilterableStream):
             _0s: set sigma for 1st plane (from 0 to 32767) (default 32767)
             _1s: set sigma for 2nd plane (from 0 to 32767) (default 32767)
             _2s: set sigma for 3rd plane (from 0 to 32767) (default 32767)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -314,6 +327,7 @@ class VideoStream(FilterableStream):
                     "2s": _2s,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -324,6 +338,7 @@ class VideoStream(FilterableStream):
         sizeX: Int = Default("1"),
         planes: Int = Default("15"),
         sizeY: Int = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -334,6 +349,7 @@ class VideoStream(FilterableStream):
             sizeX: set horizontal size (from 1 to 1024) (default 1)
             planes: set planes to filter (from 0 to 15) (default 15)
             sizeY: set vertical size (from 0 to 1024) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -355,6 +371,7 @@ class VideoStream(FilterableStream):
                     "sizeY": sizeY,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -451,6 +468,7 @@ class VideoStream(FilterableStream):
         threshold: Float = Default("0.08"),
         similarity: Float = Default("0.1"),
         blend: Float = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -461,6 +479,7 @@ class VideoStream(FilterableStream):
             threshold: set the scene change threshold (from 0 to 1) (default 0.08)
             similarity: set the similarity (from 0 to 1) (default 0.1)
             blend: set the blend value (from 0 to 1) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -484,6 +503,7 @@ class VideoStream(FilterableStream):
                     "blend": blend,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -492,6 +512,7 @@ class VideoStream(FilterableStream):
         self,
         *,
         min_val: Int = Default("16"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -500,6 +521,7 @@ class VideoStream(FilterableStream):
 
         Args:
             min_val: set minimum luminance value for bounding box (from 0 to 65535) (default 16)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -519,6 +541,7 @@ class VideoStream(FilterableStream):
                     "min_val": min_val,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -564,6 +587,7 @@ class VideoStream(FilterableStream):
         sigmaS: Float = Default("0.1"),
         sigmaR: Float = Default("0.1"),
         planes: Int = Default("1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -574,6 +598,7 @@ class VideoStream(FilterableStream):
             sigmaS: set spatial sigma (from 0 to 512) (default 0.1)
             sigmaR: set range sigma (from 0 to 1) (default 0.1)
             planes: set planes to filter (from 0 to 15) (default 1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -595,6 +620,7 @@ class VideoStream(FilterableStream):
                     "planes": planes,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -604,6 +630,7 @@ class VideoStream(FilterableStream):
         *,
         bitplane: Int = Default("1"),
         filter: Boolean = Default("false"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -613,6 +640,7 @@ class VideoStream(FilterableStream):
         Args:
             bitplane: set bit plane to use for measuring noise (from 1 to 16) (default 1)
             filter: show noisy pixels (default false)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -635,6 +663,7 @@ class VideoStream(FilterableStream):
                     "filter": filter,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -963,6 +992,7 @@ class VideoStream(FilterableStream):
         c3_opacity: Double = Default("1"),
         all_opacity: Double = Default("1"),
         framesync_options: FFMpegFrameSyncOption | None = None,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -986,6 +1016,7 @@ class VideoStream(FilterableStream):
             c3_opacity: set color component #3 opacity (from 0 to 1) (default 1)
             all_opacity: set opacity for all color components (from 0 to 1) (default 1)
             framesync_options: Framesync options
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -1023,6 +1054,7 @@ class VideoStream(FilterableStream):
                 },
                 extra_options,
                 framesync_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -1193,6 +1225,7 @@ class VideoStream(FilterableStream):
         chroma_power: Int = Default("-1"),
         alpha_radius: String = Default(None),
         alpha_power: Int = Default("-1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -1206,6 +1239,7 @@ class VideoStream(FilterableStream):
             chroma_power: How many times should the boxblur be applied to chroma (from -1 to INT_MAX) (default -1)
             alpha_radius: Radius of the alpha blurring box
             alpha_power: How many times should the boxblur be applied to alpha (from -1 to INT_MAX) (default -1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -1230,6 +1264,7 @@ class VideoStream(FilterableStream):
                     "alpha_power": alpha_power,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -1294,6 +1329,7 @@ class VideoStream(FilterableStream):
         ),
         parity: Int | Literal["tff", "bff", "auto"] | Default = Default("auto"),
         deint: Int | Literal["all", "interlaced"] | Default = Default("all"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -1304,6 +1340,7 @@ class VideoStream(FilterableStream):
             mode: specify the interlacing mode (from 0 to 1) (default send_field)
             parity: specify the assumed picture field parity (from -1 to 1) (default auto)
             deint: specify which frames to deinterlace (from 0 to 1) (default all)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -1325,6 +1362,7 @@ class VideoStream(FilterableStream):
                     "deint": deint,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -1339,6 +1377,7 @@ class VideoStream(FilterableStream):
         | Default = Default("send_frame"),
         parity: Int | Literal["tff", "bff", "auto"] | Default = Default("auto"),
         deint: Int | Literal["all", "interlaced"] | Default = Default("all"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -1349,6 +1388,7 @@ class VideoStream(FilterableStream):
             mode: specify the interlacing mode (from 0 to 3) (default send_frame)
             parity: specify the assumed picture field parity (from -1 to 1) (default auto)
             deint: specify which frames to deinterlace (from 0 to 1) (default all)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -1370,6 +1410,7 @@ class VideoStream(FilterableStream):
                     "deint": deint,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -1379,6 +1420,7 @@ class VideoStream(FilterableStream):
         *,
         strength: Float = Default("0"),
         planes: Flags = Default("7"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -1388,6 +1430,7 @@ class VideoStream(FilterableStream):
         Args:
             strength: set the sharpening strength (from 0 to 1) (default 0)
             planes: set what planes to filter (default 7)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -1408,6 +1451,7 @@ class VideoStream(FilterableStream):
                     "planes": planes,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -1489,6 +1533,7 @@ class VideoStream(FilterableStream):
         similarity: Float = Default("0.01"),
         blend: Float = Default("0"),
         yuv: Boolean = Default("false"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -1500,6 +1545,7 @@ class VideoStream(FilterableStream):
             similarity: set the chromahold similarity value (from 1e-05 to 1) (default 0.01)
             blend: set the chromahold blend value (from 0 to 1) (default 0)
             yuv: color parameter is in yuv instead of rgb (default false)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -1522,6 +1568,7 @@ class VideoStream(FilterableStream):
                     "yuv": yuv,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -1533,6 +1580,7 @@ class VideoStream(FilterableStream):
         similarity: Float = Default("0.01"),
         blend: Float = Default("0"),
         yuv: Boolean = Default("false"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -1544,6 +1592,7 @@ class VideoStream(FilterableStream):
             similarity: set the chromakey similarity value (from 1e-05 to 1) (default 0.01)
             blend: set the chromakey key blend value (from 0 to 1) (default 0)
             yuv: color parameter is in yuv instead of rgb (default false)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -1566,6 +1615,7 @@ class VideoStream(FilterableStream):
                     "yuv": yuv,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -1584,6 +1634,7 @@ class VideoStream(FilterableStream):
         distance: Int | Literal["manhattan", "euclidean"] | Default = Default(
             "manhattan"
         ),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -1600,6 +1651,7 @@ class VideoStream(FilterableStream):
             threu: set u threshold (from 1 to 200) (default 200)
             threv: set v threshold (from 1 to 200) (default 200)
             distance: set distance type (from 0 to 1) (default manhattan)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -1627,6 +1679,7 @@ class VideoStream(FilterableStream):
                     "distance": distance,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -1639,6 +1692,7 @@ class VideoStream(FilterableStream):
         crh: Int = Default("0"),
         crv: Int = Default("0"),
         edge: Int | Literal["smear", "wrap"] | Default = Default("smear"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -1651,6 +1705,7 @@ class VideoStream(FilterableStream):
             crh: shift chroma-red horizontally (from -255 to 255) (default 0)
             crv: shift chroma-red vertically (from -255 to 255) (default 0)
             edge: set edge operation (from 0 to 1) (default smear)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -1674,6 +1729,7 @@ class VideoStream(FilterableStream):
                     "edge": edge,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -1782,6 +1838,7 @@ class VideoStream(FilterableStream):
         mv_type: Flags | Literal["fp", "bp"] | Default = Default("0"),
         frame_type: Flags | Literal["if", "pf", "bf"] | Default = Default("0"),
         block: Boolean = Default("false"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -1794,6 +1851,7 @@ class VideoStream(FilterableStream):
             mv_type: set motion vectors type (default 0)
             frame_type: set frame types to visualize motion vectors of (default 0)
             block: set block partitioning structure to visualize (default false)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -1817,6 +1875,7 @@ class VideoStream(FilterableStream):
                     "block": block,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -1834,6 +1893,7 @@ class VideoStream(FilterableStream):
         gh: Float = Default("0"),
         bh: Float = Default("0"),
         pl: Boolean = Default("false"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -1851,6 +1911,7 @@ class VideoStream(FilterableStream):
             gh: set green highlights (from -1 to 1) (default 0)
             bh: set blue highlights (from -1 to 1) (default 0)
             pl: preserve lightness (default false)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -1879,6 +1940,7 @@ class VideoStream(FilterableStream):
                     "pl": pl,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -1906,6 +1968,7 @@ class VideoStream(FilterableStream):
         | Literal["none", "lum", "max", "avg", "sum", "nrm", "pwr"]
         | Default = Default("none"),
         pa: Double = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -1931,6 +1994,7 @@ class VideoStream(FilterableStream):
             aa: set the alpha gain for the alpha channel (from -2 to 2) (default 1)
             pc: set the preserve color mode (from 0 to 6) (default none)
             pa: set the preserve color amount (from 0 to 1) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -1969,6 +2033,7 @@ class VideoStream(FilterableStream):
                     "pa": pa,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -1983,6 +2048,7 @@ class VideoStream(FilterableStream):
         gmw: Float = Default("0"),
         byw: Float = Default("0"),
         pl: Float = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -1997,6 +2063,7 @@ class VideoStream(FilterableStream):
             gmw: set the green-magenta weight (from 0 to 1) (default 0)
             byw: set the blue-yellow weight (from 0 to 1) (default 0)
             pl: set the amount of preserving lightness (from 0 to 1) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -2024,6 +2091,7 @@ class VideoStream(FilterableStream):
                     "pl": pl,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -2039,6 +2107,7 @@ class VideoStream(FilterableStream):
         analyze: Int
         | Literal["manual", "average", "minmax", "median"]
         | Default = Default("manual"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -2052,6 +2121,7 @@ class VideoStream(FilterableStream):
             bh: set the blue highlight spot (from -1 to 1) (default 0)
             saturation: set the amount of saturation (from -3 to 3) (default 1)
             analyze: set the analyze mode (from 0 to 3) (default manual)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -2076,6 +2146,7 @@ class VideoStream(FilterableStream):
                     "analyze": analyze,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -2086,6 +2157,7 @@ class VideoStream(FilterableStream):
         color: Color = Default("black"),
         similarity: Float = Default("0.01"),
         blend: Float = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -2096,6 +2168,7 @@ class VideoStream(FilterableStream):
             color: set the colorhold key color (default "black")
             similarity: set the colorhold similarity value (from 1e-05 to 1) (default 0.01)
             blend: set the colorhold blend value (from 0 to 1) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -2117,6 +2190,7 @@ class VideoStream(FilterableStream):
                     "blend": blend,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -2128,6 +2202,7 @@ class VideoStream(FilterableStream):
         saturation: Float = Default("0.5"),
         lightness: Float = Default("0.5"),
         mix: Float = Default("1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -2139,6 +2214,7 @@ class VideoStream(FilterableStream):
             saturation: set the saturation (from 0 to 1) (default 0.5)
             lightness: set the lightness (from 0 to 1) (default 0.5)
             mix: set the mix of source lightness (from 0 to 1) (default 1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -2161,6 +2237,7 @@ class VideoStream(FilterableStream):
                     "mix": mix,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -2171,6 +2248,7 @@ class VideoStream(FilterableStream):
         color: Color = Default("black"),
         similarity: Float = Default("0.01"),
         blend: Float = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -2181,6 +2259,7 @@ class VideoStream(FilterableStream):
             color: set the colorkey key color (default "black")
             similarity: set the colorkey similarity value (from 1e-05 to 1) (default 0.01)
             blend: set the colorkey key blend value (from 0 to 1) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -2202,6 +2281,7 @@ class VideoStream(FilterableStream):
                     "blend": blend,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -2271,6 +2351,7 @@ class VideoStream(FilterableStream):
         preserve: Int
         | Literal["none", "lum", "max", "avg", "sum", "nrm", "pwr"]
         | Default = Default("none"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -2295,6 +2376,7 @@ class VideoStream(FilterableStream):
             bomax: set output blue white point (from 0 to 1) (default 1)
             aomax: set output alpha white point (from 0 to 1) (default 1)
             preserve: set preserve color mode (from 0 to 6) (default none)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -2330,6 +2412,7 @@ class VideoStream(FilterableStream):
                     "preserve": preserve,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -2345,6 +2428,7 @@ class VideoStream(FilterableStream):
         kernel: Int | Literal["euclidean", "weuclidean"] | Default = Default(
             "euclidean"
         ),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -2356,6 +2440,7 @@ class VideoStream(FilterableStream):
             nb_patches: set number of patches (from 0 to 64) (default 0)
             type: set the target type used (from 0 to 1) (default absolute)
             kernel: set the kernel used for measuring color difference (from 0 to 1) (default euclidean)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -2382,6 +2467,7 @@ class VideoStream(FilterableStream):
                     "kernel": kernel,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -2413,6 +2499,7 @@ class VideoStream(FilterableStream):
             "bt2020",
         ]
         | Default = Default("-1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -2422,6 +2509,7 @@ class VideoStream(FilterableStream):
         Args:
             src: set source color matrix (from -1 to 4) (default -1)
             dst: set destination color matrix (from -1 to 4) (default -1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -2442,6 +2530,7 @@ class VideoStream(FilterableStream):
                     "dst": dst,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -2587,6 +2676,7 @@ class VideoStream(FilterableStream):
             "bt2020-12",
         ]
         | Default = Default("2"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -2608,6 +2698,7 @@ class VideoStream(FilterableStream):
             irange: Input color range (from 0 to 2) (default 0)
             iprimaries: Input color primaries (from 0 to 22) (default 2)
             itrc: Input transfer characteristics (from 0 to 18) (default 2)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -2640,6 +2731,7 @@ class VideoStream(FilterableStream):
                     "itrc": itrc,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -2650,6 +2742,7 @@ class VideoStream(FilterableStream):
         temperature: Float = Default("6500"),
         mix: Float = Default("1"),
         pl: Float = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -2660,6 +2753,7 @@ class VideoStream(FilterableStream):
             temperature: set the temperature in Kelvin (from 1000 to 40000) (default 6500)
             mix: set the mix with filtered output (from 0 to 1) (default 1)
             pl: set the amount of preserving lightness (from 0 to 1) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -2683,6 +2777,7 @@ class VideoStream(FilterableStream):
                     "pl": pl,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -2706,6 +2801,7 @@ class VideoStream(FilterableStream):
         _1mode: Int | Literal["square", "row", "column"] | Default = Default("square"),
         _2mode: Int | Literal["square", "row", "column"] | Default = Default("square"),
         _3mode: Int | Literal["square", "row", "column"] | Default = Default("square"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -2729,6 +2825,7 @@ class VideoStream(FilterableStream):
             _1mode: set matrix mode for 2nd plane (from 0 to 2) (default square)
             _2mode: set matrix mode for 3rd plane (from 0 to 2) (default square)
             _3mode: set matrix mode for 4th plane (from 0 to 2) (default square)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -2763,6 +2860,7 @@ class VideoStream(FilterableStream):
                     "3mode": _3mode,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -2842,6 +2940,7 @@ class VideoStream(FilterableStream):
         impulse: Int | Literal["first", "all"] | Default = Default("all"),
         noise: Float = Default("1e-07"),
         framesync_options: FFMpegFrameSyncOption | None = None,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -2853,6 +2952,7 @@ class VideoStream(FilterableStream):
             impulse: when to process impulses (from 0 to 1) (default all)
             noise: set noise (from 0 to 1) (default 1e-07)
             framesync_options: Framesync options
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -2878,6 +2978,7 @@ class VideoStream(FilterableStream):
                 },
                 extra_options,
                 framesync_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -2916,6 +3017,7 @@ class VideoStream(FilterableStream):
         self,
         _reference: VideoStream,
         framesync_options: FFMpegFrameSyncOption | None = None,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -2924,6 +3026,7 @@ class VideoStream(FilterableStream):
 
         Args:
             framesync_options: Framesync options
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -2939,7 +3042,12 @@ class VideoStream(FilterableStream):
             ),
             self,
             _reference,
-            **merge({}, extra_options, framesync_options),
+            **merge(
+                {},
+                extra_options,
+                framesync_options,
+                timeline_options,
+            ),
         )
         return filter_node.video(0)
 
@@ -3044,6 +3152,7 @@ class VideoStream(FilterableStream):
         high: Float = Default("0.0980392"),
         low: Float = Default("0.0588235"),
         mv_threshold: Int = Default("8"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -3061,6 +3170,7 @@ class VideoStream(FilterableStream):
             high: Set high threshold for edge detection (from 0 to 1) (default 0.0980392)
             low: Set low threshold for edge detection (from 0 to 1) (default 0.0588235)
             mv_threshold: motion vector threshold when estimating video window size (from 0 to 100) (default 8)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -3089,6 +3199,7 @@ class VideoStream(FilterableStream):
                     "mv_threshold": mv_threshold,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -3160,6 +3271,7 @@ class VideoStream(FilterableStream):
         psfile: String = Default(None),
         plot: String = Default(None),
         interp: Int | Literal["natural", "pchip"] | Default = Default("natural"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -3176,6 +3288,7 @@ class VideoStream(FilterableStream):
             psfile: set Photoshop curves file name
             plot: save Gnuplot script of the curves in specified file
             interp: specify the kind of interpolation (from 0 to 1) (default natural)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -3203,6 +3316,7 @@ class VideoStream(FilterableStream):
                     "interp": interp,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -3269,6 +3383,7 @@ class VideoStream(FilterableStream):
         angle: Float = Default("45"),
         radius: Float = Default("5"),
         planes: Int = Default("15"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -3279,6 +3394,7 @@ class VideoStream(FilterableStream):
             angle: set angle (from 0 to 360) (default 45)
             radius: set radius (from 0 to 8192) (default 5)
             planes: set planes to filter (from 0 to 15) (default 15)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -3300,6 +3416,7 @@ class VideoStream(FilterableStream):
                     "planes": planes,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -3311,6 +3428,7 @@ class VideoStream(FilterableStream):
         overlap: Int = Default("-1"),
         expr: String = Default(None),
         n: Int = Default("3"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -3322,6 +3440,7 @@ class VideoStream(FilterableStream):
             overlap: set number of block overlapping pixels (from -1 to 15) (default -1)
             expr: set coefficient factor expression
             n: set the block size, expressed in bits (from 3 to 4) (default 3)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -3344,6 +3463,7 @@ class VideoStream(FilterableStream):
                     "n": n,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -3359,6 +3479,7 @@ class VideoStream(FilterableStream):
         direction: Float = Default("6.28319"),
         blur: Boolean = Default("true"),
         coupling: Boolean = Default("false"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -3374,6 +3495,7 @@ class VideoStream(FilterableStream):
             direction: set direction (from -6.28319 to 6.28319) (default 6.28319)
             blur: set blur (default true)
             coupling: set plane coupling (default false)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -3400,6 +3522,7 @@ class VideoStream(FilterableStream):
                     "coupling": coupling,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -3414,6 +3537,7 @@ class VideoStream(FilterableStream):
         gamma: Float = Default("0.05"),
         delta: Float = Default("0.05"),
         planes: Int = Default("15"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -3428,6 +3552,7 @@ class VideoStream(FilterableStream):
             gamma: set 3rd detection threshold (from 0 to 1) (default 0.05)
             delta: set 4th detection threshold (from 0 to 1) (default 0.05)
             planes: set planes to filter (from 0 to 15) (default 15)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -3453,6 +3578,7 @@ class VideoStream(FilterableStream):
                     "planes": planes,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -3465,6 +3591,7 @@ class VideoStream(FilterableStream):
         impulse: Int | Literal["first", "all"] | Default = Default("all"),
         noise: Float = Default("1e-07"),
         framesync_options: FFMpegFrameSyncOption | None = None,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -3476,6 +3603,7 @@ class VideoStream(FilterableStream):
             impulse: when to process impulses (from 0 to 1) (default all)
             noise: set noise (from 0 to 1) (default 1e-07)
             framesync_options: Framesync options
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -3501,6 +3629,7 @@ class VideoStream(FilterableStream):
                 },
                 extra_options,
                 framesync_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -3515,6 +3644,7 @@ class VideoStream(FilterableStream):
         tl: Float = Default("0.079"),
         tc: Float = Default("0.058"),
         ct: Float = Default("0.019"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -3527,6 +3657,7 @@ class VideoStream(FilterableStream):
             tl: set tolerance for temporal luma (from 0 to 1) (default 0.079)
             tc: set tolerance for chroma temporal variation (from 0 to 1) (default 0.058)
             ct: set temporal chroma threshold (from 0 to 1) (default 0.019)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -3550,6 +3681,7 @@ class VideoStream(FilterableStream):
                     "ct": ct,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -3561,6 +3693,7 @@ class VideoStream(FilterableStream):
         threshold1: Int = Default("65535"),
         threshold2: Int = Default("65535"),
         threshold3: Int = Default("65535"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -3572,6 +3705,7 @@ class VideoStream(FilterableStream):
             threshold1: set threshold for 2nd plane (from 0 to 65535) (default 65535)
             threshold2: set threshold for 3rd plane (from 0 to 65535) (default 65535)
             threshold3: set threshold for 4th plane (from 0 to 65535) (default 65535)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -3594,6 +3728,7 @@ class VideoStream(FilterableStream):
                     "threshold3": threshold3,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -3684,6 +3819,7 @@ class VideoStream(FilterableStream):
         w: String = Default("-1"),
         h: String = Default("-1"),
         show: Boolean = Default("false"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -3696,6 +3832,7 @@ class VideoStream(FilterableStream):
             w: set logo width (default "-1")
             h: set logo height (default "-1")
             show: show delogo area (default false)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -3719,6 +3856,7 @@ class VideoStream(FilterableStream):
                     "show": show,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -3731,6 +3869,7 @@ class VideoStream(FilterableStream):
         model: String = Default(None),
         input: String = Default("x"),
         output: String = Default("y"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -3743,6 +3882,7 @@ class VideoStream(FilterableStream):
             model: path to model file
             input: input name of the model (default "x")
             output: output name of the model (default "y")
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -3766,6 +3906,7 @@ class VideoStream(FilterableStream):
                     "output": output,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -3903,6 +4044,7 @@ class VideoStream(FilterableStream):
         blue: Float = Default("0"),
         brightness: Float = Default("0"),
         alpha: Boolean = Default("false"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -3918,6 +4060,7 @@ class VideoStream(FilterableStream):
             blue: set blue scale (from -100 to 100) (default 0)
             brightness: set brightness (from -10 to 10) (default 0)
             alpha: change alpha component (default false)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -3944,6 +4087,7 @@ class VideoStream(FilterableStream):
                     "alpha": alpha,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -3999,6 +4143,7 @@ class VideoStream(FilterableStream):
         threshold1: Int = Default("65535"),
         threshold2: Int = Default("65535"),
         threshold3: Int = Default("65535"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -4011,6 +4156,7 @@ class VideoStream(FilterableStream):
             threshold1: set threshold for 2nd plane (from 0 to 65535) (default 65535)
             threshold2: set threshold for 3rd plane (from 0 to 65535) (default 65535)
             threshold3: set threshold for 4th plane (from 0 to 65535) (default 65535)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -4034,6 +4180,7 @@ class VideoStream(FilterableStream):
                     "threshold3": threshold3,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -4095,6 +4242,7 @@ class VideoStream(FilterableStream):
         edge: Int | Literal["blank", "smear", "wrap", "mirror"] | Default = Default(
             "smear"
         ),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -4103,6 +4251,7 @@ class VideoStream(FilterableStream):
 
         Args:
             edge: set edge mode (from 0 to 3) (default smear)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -4126,6 +4275,7 @@ class VideoStream(FilterableStream):
                     "edge": edge,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -4354,6 +4504,7 @@ class VideoStream(FilterableStream):
         thickness: String = Default("3"),
         replace: Boolean = Default("false"),
         box_source: String = Default(None),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -4369,6 +4520,7 @@ class VideoStream(FilterableStream):
             thickness: set the box thickness (default "3")
             replace: replace color & alpha (default false)
             box_source: use datas from bounding box in side data
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -4395,6 +4547,7 @@ class VideoStream(FilterableStream):
                     "box_source": box_source,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -4488,6 +4641,7 @@ class VideoStream(FilterableStream):
         color: String = Default("black"),
         thickness: String = Default("1"),
         replace: Boolean = Default("false"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -4502,6 +4656,7 @@ class VideoStream(FilterableStream):
             color: set color of the grid (default "black")
             thickness: set grid line thickness (default "1")
             replace: replace color & alpha (default false)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -4527,6 +4682,7 @@ class VideoStream(FilterableStream):
                     "replace": replace,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -4604,6 +4760,7 @@ class VideoStream(FilterableStream):
             "no_autohint",
         ]
         | Default = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -4646,6 +4803,7 @@ class VideoStream(FilterableStream):
             text_source: the source of text
             text_shaping: attempt to shape text before drawing (default true)
             ft_load_flags: set font loading flags for libfreetype (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -4699,6 +4857,7 @@ class VideoStream(FilterableStream):
                     "ft_load_flags": ft_load_flags,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -4712,6 +4871,7 @@ class VideoStream(FilterableStream):
         planes: Flags | Literal["y", "u", "v", "r", "g", "b"] | Default = Default(
             "y+u+v+r+g+b"
         ),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -4723,6 +4883,7 @@ class VideoStream(FilterableStream):
             low: set low threshold (from 0 to 1) (default 0.0784314)
             mode: set mode (from 0 to 2) (default wires)
             planes: set planes to filter (default y+u+v+r+g+b)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -4745,6 +4906,7 @@ class VideoStream(FilterableStream):
                     "planes": planes,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -4800,6 +4962,7 @@ class VideoStream(FilterableStream):
         self,
         *,
         mode: Int | Literal["normal", "diff"] | Default = Default("normal"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -4808,6 +4971,7 @@ class VideoStream(FilterableStream):
 
         Args:
             mode: set kind of histogram entropy measurement (from 0 to 1) (default normal)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -4827,6 +4991,7 @@ class VideoStream(FilterableStream):
                     "mode": mode,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -4878,6 +5043,7 @@ class VideoStream(FilterableStream):
         gamma_b: String = Default("1.0"),
         gamma_weight: String = Default("1.0"),
         eval: Int | Literal["init", "frame"] | Default = Default("init"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -4894,6 +5060,7 @@ class VideoStream(FilterableStream):
             gamma_b: gamma value for blue (default "1.0")
             gamma_weight: set the gamma weight which reduces the effect of gamma on bright areas (default "1.0")
             eval: specify when to evaluate expressions (from 0 to 1) (default init)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -4921,6 +5088,7 @@ class VideoStream(FilterableStream):
                     "eval": eval,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -4933,6 +5101,7 @@ class VideoStream(FilterableStream):
         threshold1: Int = Default("65535"),
         threshold2: Int = Default("65535"),
         threshold3: Int = Default("65535"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -4945,6 +5114,7 @@ class VideoStream(FilterableStream):
             threshold1: set threshold for 2nd plane (from 0 to 65535) (default 65535)
             threshold2: set threshold for 3rd plane (from 0 to 65535) (default 65535)
             threshold3: set threshold for 4th plane (from 0 to 65535) (default 65535)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -4968,6 +5138,7 @@ class VideoStream(FilterableStream):
                     "threshold3": threshold3,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -5033,6 +5204,7 @@ class VideoStream(FilterableStream):
         mcost: Int = Default("1"),
         dcost: Int = Default("1"),
         interp: Int | Literal["2p", "4p", "6p"] | Default = Default("4p"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -5049,6 +5221,7 @@ class VideoStream(FilterableStream):
             mcost: specify the middle cost for edge matching (from 0 to 50) (default 1)
             dcost: specify the distance cost for edge matching (from 0 to 50) (default 1)
             interp: specify the type of interpolation (from 0 to 2) (default 4p)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -5076,6 +5249,7 @@ class VideoStream(FilterableStream):
                     "interp": interp,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -5085,6 +5259,7 @@ class VideoStream(FilterableStream):
         *,
         exposure: Float = Default("0"),
         black: Float = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -5094,6 +5269,7 @@ class VideoStream(FilterableStream):
         Args:
             exposure: set the exposure correction (from -3 to 3) (default 0)
             black: set the black level correction (from -1 to 1) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -5114,6 +5290,7 @@ class VideoStream(FilterableStream):
                     "black": black,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -5169,6 +5346,7 @@ class VideoStream(FilterableStream):
         start_time: Duration = Default("0"),
         duration: Duration = Default("0"),
         color: Color = Default("black"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -5183,6 +5361,7 @@ class VideoStream(FilterableStream):
             start_time: Number of seconds of the beginning of the effect. (default 0)
             duration: Duration of the effect in seconds. (default 0)
             color: set color (default "black")
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -5208,6 +5387,7 @@ class VideoStream(FilterableStream):
                     "color": color,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -5298,6 +5478,7 @@ class VideoStream(FilterableStream):
             "kaiser",
         ]
         | Default = Default("hann"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -5314,6 +5495,7 @@ class VideoStream(FilterableStream):
             next: set number of next frames for temporal denoising (from 0 to 1) (default 0)
             planes: set planes to filter (from 0 to 15) (default 7)
             window: set window function (from 0 to 20) (default hann)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -5341,6 +5523,7 @@ class VideoStream(FilterableStream):
                     "window": window,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -5355,6 +5538,7 @@ class VideoStream(FilterableStream):
         weight_U: String = Default(None),
         weight_V: String = Default(None),
         eval: Int | Literal["init", "frame"] | Default = Default("init"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -5369,6 +5553,7 @@ class VideoStream(FilterableStream):
             weight_U: set chrominance expression in U plane
             weight_V: set chrominance expression in V plane
             eval: specify when to evaluate expressions (from 0 to 1) (default init)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -5394,6 +5579,7 @@ class VideoStream(FilterableStream):
                     "eval": eval,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -5477,6 +5663,7 @@ class VideoStream(FilterableStream):
         self,
         *,
         order: Int | Literal["bff", "tff"] | Default = Default("tff"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -5485,6 +5672,7 @@ class VideoStream(FilterableStream):
 
         Args:
             order: output field order (from 0 to 1) (default tff)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -5504,6 +5692,7 @@ class VideoStream(FilterableStream):
                     "order": order,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -5519,6 +5708,7 @@ class VideoStream(FilterableStream):
         | Literal["smear", "mirror", "fixed", "reflect", "wrap", "fade", "margins"]
         | Default = Default("smear"),
         color: Color = Default("black"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -5532,6 +5722,7 @@ class VideoStream(FilterableStream):
             bottom: set the bottom fill border (from 0 to INT_MAX) (default 0)
             mode: set the fill borders mode (from 0 to 6) (default smear)
             color: set the color for the fixed/fade mode (default "black")
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -5556,6 +5747,7 @@ class VideoStream(FilterableStream):
                     "color": color,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -5650,6 +5842,7 @@ class VideoStream(FilterableStream):
         d1: Int = Default("0"),
         d2: Int = Default("0"),
         d3: Int = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -5667,6 +5860,7 @@ class VideoStream(FilterableStream):
             d1: set destination #1 component value (from 0 to 65535) (default 0)
             d2: set destination #2 component value (from 0 to 65535) (default 0)
             d3: set destination #3 component value (from 0 to 65535) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -5695,6 +5889,7 @@ class VideoStream(FilterableStream):
                     "d3": d3,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -5874,6 +6069,7 @@ class VideoStream(FilterableStream):
         self,
         *,
         step: Int = Default("1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -5882,6 +6078,7 @@ class VideoStream(FilterableStream):
 
         Args:
             step: set frame step (from 1 to INT_MAX) (default 1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -5901,6 +6098,7 @@ class VideoStream(FilterableStream):
                     "step": step,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -5993,6 +6191,7 @@ class VideoStream(FilterableStream):
         *,
         filter_name: String = Default(None),
         filter_params: String = Default(None),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -6002,6 +6201,7 @@ class VideoStream(FilterableStream):
         Args:
             filter_name:
             filter_params:
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -6022,6 +6222,7 @@ class VideoStream(FilterableStream):
                     "filter_params": filter_params,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -6033,6 +6234,7 @@ class VideoStream(FilterableStream):
         qp: Int = Default("0"),
         strength: Int = Default("0"),
         use_bframe_qp: Boolean = Default("false"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -6044,6 +6246,7 @@ class VideoStream(FilterableStream):
             qp: force a constant quantizer parameter (from 0 to 64) (default 0)
             strength: set filter strength (from -15 to 32) (default 0)
             use_bframe_qp: use B-frames' QP (default false)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -6066,6 +6269,7 @@ class VideoStream(FilterableStream):
                     "use_bframe_qp": use_bframe_qp,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -6077,6 +6281,7 @@ class VideoStream(FilterableStream):
         steps: Int = Default("1"),
         planes: Int = Default("15"),
         sigmaV: Float = Default("-1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -6088,6 +6293,7 @@ class VideoStream(FilterableStream):
             steps: set number of steps (from 1 to 6) (default 1)
             planes: set planes to filter (from 0 to 15) (default 15)
             sigmaV: set vertical sigma (from -1 to 1024) (default -1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -6110,6 +6316,7 @@ class VideoStream(FilterableStream):
                     "sigmaV": sigmaV,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -6174,6 +6381,7 @@ class VideoStream(FilterableStream):
         interpolation: Int
         | Literal["nearest", "n", "bilinear", "b"]
         | Default = Default("bilinear"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -6189,6 +6397,7 @@ class VideoStream(FilterableStream):
             green_expr: set green expression
             blue_expr: set blue expression
             interpolation: set interpolation method (from 0 to 1) (default bilinear)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -6215,6 +6424,7 @@ class VideoStream(FilterableStream):
                     "interpolation": interpolation,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -6224,6 +6434,7 @@ class VideoStream(FilterableStream):
         *,
         strength: Float = Default("1.2"),
         radius: Int = Default("16"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -6233,6 +6444,7 @@ class VideoStream(FilterableStream):
         Args:
             strength: The maximum amount by which the filter will change any one pixel. (from 0.51 to 64) (default 1.2)
             radius: The neighborhood to fit the gradient to. (from 4 to 32) (default 16)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -6253,6 +6465,7 @@ class VideoStream(FilterableStream):
                     "radius": radius,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -6330,6 +6543,7 @@ class VideoStream(FilterableStream):
 
     def grayworld(
         self,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -6337,6 +6551,7 @@ class VideoStream(FilterableStream):
         Adjust white balance using LAB gray world algorithm.
 
         Args:
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -6354,6 +6569,7 @@ class VideoStream(FilterableStream):
             **merge(
                 {},
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -6364,6 +6580,7 @@ class VideoStream(FilterableStream):
         difford: Int = Default("1"),
         minknorm: Int = Default("1"),
         sigma: Double = Default("1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -6374,6 +6591,7 @@ class VideoStream(FilterableStream):
             difford: set differentiation order (from 0 to 2) (default 1)
             minknorm: set Minkowski norm (from 0 to 20) (default 1)
             sigma: set sigma (from 0 to 1024) (default 1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -6395,6 +6613,7 @@ class VideoStream(FilterableStream):
                     "sigma": sigma,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -6408,6 +6627,7 @@ class VideoStream(FilterableStream):
         | Literal["nearest", "trilinear", "tetrahedral", "pyramid", "prism"]
         | Default = Default("tetrahedral"),
         framesync_options: FFMpegFrameSyncOption | None = None,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -6418,6 +6638,7 @@ class VideoStream(FilterableStream):
             clut: when to process CLUT (from 0 to 1) (default all)
             interp: select interpolation mode (from 0 to 4) (default tetrahedral)
             framesync_options: Framesync options
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -6442,12 +6663,14 @@ class VideoStream(FilterableStream):
                 },
                 extra_options,
                 framesync_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
 
     def hflip(
         self,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -6455,6 +6678,7 @@ class VideoStream(FilterableStream):
         Horizontally flip the input video.
 
         Args:
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -6472,6 +6696,7 @@ class VideoStream(FilterableStream):
             **merge(
                 {},
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -6514,6 +6739,7 @@ class VideoStream(FilterableStream):
         antibanding: Int | Literal["none", "weak", "strong"] | Default = Default(
             "none"
         ),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -6524,6 +6750,7 @@ class VideoStream(FilterableStream):
             strength: set the strength (from 0 to 1) (default 0.2)
             intensity: set the intensity (from 0 to 1) (default 0.21)
             antibanding: set the antibanding level (from 0 to 2) (default none)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -6545,6 +6772,7 @@ class VideoStream(FilterableStream):
                     "antibanding": antibanding,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -6629,6 +6857,7 @@ class VideoStream(FilterableStream):
         chroma_spatial: Double = Default("0"),
         luma_tmp: Double = Default("0"),
         chroma_tmp: Double = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -6640,6 +6869,7 @@ class VideoStream(FilterableStream):
             chroma_spatial: spatial chroma strength (from 0 to DBL_MAX) (default 0)
             luma_tmp: temporal luma strength (from 0 to DBL_MAX) (default 0)
             chroma_tmp: temporal chroma strength (from 0 to DBL_MAX) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -6662,6 +6892,7 @@ class VideoStream(FilterableStream):
                     "chroma_tmp": chroma_tmp,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -6709,6 +6940,7 @@ class VideoStream(FilterableStream):
         val: Float = Default("0"),
         similarity: Float = Default("0.01"),
         blend: Float = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -6721,6 +6953,7 @@ class VideoStream(FilterableStream):
             val: set the value value (from -1 to 1) (default 0)
             similarity: set the hsvhold similarity value (from 1e-05 to 1) (default 0.01)
             blend: set the hsvhold blend value (from 0 to 1) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -6744,6 +6977,7 @@ class VideoStream(FilterableStream):
                     "blend": blend,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -6756,6 +6990,7 @@ class VideoStream(FilterableStream):
         val: Float = Default("0"),
         similarity: Float = Default("0.01"),
         blend: Float = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -6768,6 +7003,7 @@ class VideoStream(FilterableStream):
             val: set the value value (from -1 to 1) (default 0)
             similarity: set the hsvkey similarity value (from 1e-05 to 1) (default 0.01)
             blend: set the hsvkey blend value (from 0 to 1) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -6791,6 +7027,7 @@ class VideoStream(FilterableStream):
                     "blend": blend,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -6802,6 +7039,7 @@ class VideoStream(FilterableStream):
         s: String = Default("1"),
         H: String = Default(None),
         b: String = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -6813,6 +7051,7 @@ class VideoStream(FilterableStream):
             s: set the saturation expression (default "1")
             H: set the hue angle radians expression
             b: set the brightness expression (default "0")
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -6835,6 +7074,7 @@ class VideoStream(FilterableStream):
                     "b": b,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -6853,6 +7093,7 @@ class VideoStream(FilterableStream):
         gw: Float = Default("0.334"),
         bw: Float = Default("0.333"),
         lightness: Boolean = Default("false"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -6869,6 +7110,7 @@ class VideoStream(FilterableStream):
             gw: set the green weight (from 0 to 1) (default 0.334)
             bw: set the blue weight (from 0 to 1) (default 0.333)
             lightness: set the preserve lightness (default false)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -6898,6 +7140,7 @@ class VideoStream(FilterableStream):
                     "lightness": lightness,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -7054,6 +7297,7 @@ class VideoStream(FilterableStream):
         planes: Int = Default("15"),
         threshold: Int = Default("0"),
         framesync_options: FFMpegFrameSyncOption | None = None,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -7064,6 +7308,7 @@ class VideoStream(FilterableStream):
             planes: set planes (from 0 to 15) (default 15)
             threshold: set threshold (from 0 to 65535) (default 0)
             framesync_options: Framesync options
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -7088,6 +7333,7 @@ class VideoStream(FilterableStream):
                 },
                 extra_options,
                 framesync_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -7096,6 +7342,7 @@ class VideoStream(FilterableStream):
         self,
         _reference: VideoStream,
         framesync_options: FFMpegFrameSyncOption | None = None,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -7104,6 +7351,7 @@ class VideoStream(FilterableStream):
 
         Args:
             framesync_options: Framesync options
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -7121,7 +7369,12 @@ class VideoStream(FilterableStream):
             ),
             self,
             _reference,
-            **merge({}, extra_options, framesync_options),
+            **merge(
+                {},
+                extra_options,
+                framesync_options,
+                timeline_options,
+            ),
         )
         return filter_node.video(0)
 
@@ -7187,6 +7440,7 @@ class VideoStream(FilterableStream):
         luma_swap: Boolean = Default("false"),
         chroma_swap: Boolean = Default("false"),
         alpha_swap: Boolean = Default("false"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -7200,6 +7454,7 @@ class VideoStream(FilterableStream):
             luma_swap: swap luma fields (default false)
             chroma_swap: swap chroma fields (default false)
             alpha_swap: swap alpha fields (default false)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -7224,6 +7479,7 @@ class VideoStream(FilterableStream):
                     "alpha_swap": alpha_swap,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -7235,6 +7491,7 @@ class VideoStream(FilterableStream):
         threshold1: Int = Default("65535"),
         threshold2: Int = Default("65535"),
         threshold3: Int = Default("65535"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -7246,6 +7503,7 @@ class VideoStream(FilterableStream):
             threshold1: set threshold for 2nd plane (from 0 to 65535) (default 65535)
             threshold2: set threshold for 3rd plane (from 0 to 65535) (default 65535)
             threshold3: set threshold for 4th plane (from 0 to 65535) (default 65535)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -7268,6 +7526,7 @@ class VideoStream(FilterableStream):
                     "threshold3": threshold3,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -7365,6 +7624,7 @@ class VideoStream(FilterableStream):
         planes: Int = Default("15"),
         scale: Float = Default("1"),
         delta: Float = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -7375,6 +7635,7 @@ class VideoStream(FilterableStream):
             planes: set planes to filter (from 0 to 15) (default 15)
             scale: set scale (from 0 to 65535) (default 1)
             delta: set delta (from -65535 to 65535) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -7396,6 +7657,7 @@ class VideoStream(FilterableStream):
                     "delta": delta,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -7405,6 +7667,7 @@ class VideoStream(FilterableStream):
         *,
         decay: Float = Default("0.95"),
         planes: Flags = Default("F"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -7414,6 +7677,7 @@ class VideoStream(FilterableStream):
         Args:
             decay: set decay (from 0 to 1) (default 0.95)
             planes: set what planes to filter (default F)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -7434,12 +7698,14 @@ class VideoStream(FilterableStream):
                     "planes": planes,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
 
     def latency(
         self,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -7447,6 +7713,7 @@ class VideoStream(FilterableStream):
         Report video filtering latency.
 
         Args:
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -7464,6 +7731,7 @@ class VideoStream(FilterableStream):
             **merge(
                 {},
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -7477,6 +7745,7 @@ class VideoStream(FilterableStream):
         k2: Double = Default("0"),
         i: Int | Literal["nearest", "bilinear"] | Default = Default("nearest"),
         fc: Color = Default("black@0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -7490,6 +7759,7 @@ class VideoStream(FilterableStream):
             k2: set double quadratic distortion factor (from -1 to 1) (default 0)
             i: set interpolation type (from 0 to 64) (default nearest)
             fc: set the color of the unmapped pixels (default "black@0")
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -7516,6 +7786,7 @@ class VideoStream(FilterableStream):
                     "fc": fc,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -7526,6 +7797,7 @@ class VideoStream(FilterableStream):
         min: Int = Default("0"),
         max: Int = Default("65535"),
         planes: Int = Default("15"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -7536,6 +7808,7 @@ class VideoStream(FilterableStream):
             min: set min value (from 0 to 65535) (default 0)
             max: set max value (from 0 to 65535) (default 65535)
             planes: set planes (from 0 to 15) (default 15)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -7557,6 +7830,7 @@ class VideoStream(FilterableStream):
                     "planes": planes,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -7611,6 +7885,7 @@ class VideoStream(FilterableStream):
         threshold: Double = Default("0"),
         tolerance: Double = Default("0.01"),
         softness: Double = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -7621,6 +7896,7 @@ class VideoStream(FilterableStream):
             threshold: set the threshold value (from 0 to 1) (default 0)
             tolerance: set the tolerance value (from 0 to 1) (default 0.01)
             softness: set the softness value (from 0 to 1) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -7642,6 +7918,7 @@ class VideoStream(FilterableStream):
                     "softness": softness,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -7660,6 +7937,7 @@ class VideoStream(FilterableStream):
         g: String = Default("clipval"),
         b: String = Default("clipval"),
         a: String = Default("clipval"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -7678,6 +7956,7 @@ class VideoStream(FilterableStream):
             g: set G expression (default "clipval")
             b: set B expression (default "clipval")
             a: set A expression (default "clipval")
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -7707,6 +7986,7 @@ class VideoStream(FilterableStream):
                     "a": a,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -7718,6 +7998,7 @@ class VideoStream(FilterableStream):
         interp: Int
         | Literal["nearest", "linear", "cosine", "cubic", "spline"]
         | Default = Default("linear"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -7727,6 +8008,7 @@ class VideoStream(FilterableStream):
         Args:
             file: set 1D LUT file name
             interp: select interpolation mode (from 0 to 4) (default linear)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -7747,6 +8029,7 @@ class VideoStream(FilterableStream):
                     "interp": interp,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -7761,6 +8044,7 @@ class VideoStream(FilterableStream):
         c3: String = Default("x"),
         d: Int = Default("0"),
         framesync_options: FFMpegFrameSyncOption | None = None,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -7774,6 +8058,7 @@ class VideoStream(FilterableStream):
             c3: set component #3 expression (default "x")
             d: set output depth (from 0 to 16) (default 0)
             framesync_options: Framesync options
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -7799,6 +8084,7 @@ class VideoStream(FilterableStream):
                 },
                 extra_options,
                 framesync_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -7811,6 +8097,7 @@ class VideoStream(FilterableStream):
         interp: Int
         | Literal["nearest", "trilinear", "tetrahedral", "pyramid", "prism"]
         | Default = Default("tetrahedral"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -7821,6 +8108,7 @@ class VideoStream(FilterableStream):
             file: set 3D LUT file name
             clut: when to process CLUT (from 0 to 1) (default all)
             interp: select interpolation mode (from 0 to 4) (default tetrahedral)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -7842,6 +8130,7 @@ class VideoStream(FilterableStream):
                     "interp": interp,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -7860,6 +8149,7 @@ class VideoStream(FilterableStream):
         g: String = Default("clipval"),
         b: String = Default("clipval"),
         a: String = Default("clipval"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -7878,6 +8168,7 @@ class VideoStream(FilterableStream):
             g: set G expression (default "clipval")
             b: set B expression (default "clipval")
             a: set A expression (default "clipval")
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -7907,6 +8198,7 @@ class VideoStream(FilterableStream):
                     "a": a,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -7925,6 +8217,7 @@ class VideoStream(FilterableStream):
         g: String = Default("clipval"),
         b: String = Default("clipval"),
         a: String = Default("clipval"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -7943,6 +8236,7 @@ class VideoStream(FilterableStream):
             g: set G expression (default "clipval")
             b: set B expression (default "clipval")
             a: set A expression (default "clipval")
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -7972,6 +8266,7 @@ class VideoStream(FilterableStream):
                     "a": a,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -7984,6 +8279,7 @@ class VideoStream(FilterableStream):
         undershoot: Int = Default("0"),
         overshoot: Int = Default("0"),
         planes: Int = Default("15"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -7994,6 +8290,7 @@ class VideoStream(FilterableStream):
             undershoot: set undershoot (from 0 to 65535) (default 0)
             overshoot: set overshoot (from 0 to 65535) (default 0)
             planes: set planes (from 0 to 15) (default 15)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -8019,6 +8316,7 @@ class VideoStream(FilterableStream):
                     "planes": planes,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -8029,6 +8327,7 @@ class VideoStream(FilterableStream):
         _filter2: VideoStream,
         *,
         planes: Int = Default("15"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -8037,6 +8336,7 @@ class VideoStream(FilterableStream):
 
         Args:
             planes: set planes (from 0 to 15) (default 15)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -8060,6 +8360,7 @@ class VideoStream(FilterableStream):
                     "planes": planes,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -8070,6 +8371,7 @@ class VideoStream(FilterableStream):
         _mask: VideoStream,
         *,
         planes: Int = Default("15"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -8078,6 +8380,7 @@ class VideoStream(FilterableStream):
 
         Args:
             planes: set planes (from 0 to 15) (default 15)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -8101,6 +8404,7 @@ class VideoStream(FilterableStream):
                     "planes": planes,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -8111,6 +8415,7 @@ class VideoStream(FilterableStream):
         _filter2: VideoStream,
         *,
         planes: Int = Default("15"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -8119,6 +8424,7 @@ class VideoStream(FilterableStream):
 
         Args:
             planes: set planes (from 0 to 15) (default 15)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -8142,6 +8448,7 @@ class VideoStream(FilterableStream):
                     "planes": planes,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -8153,6 +8460,7 @@ class VideoStream(FilterableStream):
         threshold: Int = Default("1"),
         planes: Int = Default("15"),
         mode: Int | Literal["abs", "diff"] | Default = Default("abs"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -8163,6 +8471,7 @@ class VideoStream(FilterableStream):
             threshold: set threshold (from 0 to 65535) (default 1)
             planes: set planes (from 0 to 15) (default 15)
             mode: set mode (from 0 to 1) (default abs)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -8187,6 +8496,7 @@ class VideoStream(FilterableStream):
                     "mode": mode,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -8199,6 +8509,7 @@ class VideoStream(FilterableStream):
         planes: Int = Default("15"),
         fill: Int = Default("0"),
         sum: Int = Default("10"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -8211,6 +8522,7 @@ class VideoStream(FilterableStream):
             planes: set planes (from 0 to 15) (default 15)
             fill: set fill value (from 0 to 65535) (default 0)
             sum: set sum value (from 0 to 65535) (default 10)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -8234,6 +8546,7 @@ class VideoStream(FilterableStream):
                     "sum": sum,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -8288,6 +8601,7 @@ class VideoStream(FilterableStream):
         planes: Int = Default("15"),
         radiusV: Int = Default("0"),
         percentile: Float = Default("0.5"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -8299,6 +8613,7 @@ class VideoStream(FilterableStream):
             planes: set planes to filter (from 0 to 15) (default 15)
             radiusV: set median vertical radius (from 0 to 127) (default 0)
             percentile: set median percentile (from 0 to 1) (default 0.5)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -8321,6 +8636,7 @@ class VideoStream(FilterableStream):
                     "percentile": percentile,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -8384,6 +8700,7 @@ class VideoStream(FilterableStream):
         expr: String = Default(None),
         file: String = Default(None),
         direct: Boolean = Default("false"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -8398,6 +8715,7 @@ class VideoStream(FilterableStream):
             expr: set expression for expr function
             file: set file where to print metadata information
             direct: reduce buffering when printing to user-set file or pipe (default false)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -8423,6 +8741,7 @@ class VideoStream(FilterableStream):
                     "direct": direct,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -8432,6 +8751,7 @@ class VideoStream(FilterableStream):
         _in1: VideoStream,
         *,
         planes: Int = Default("15"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -8440,6 +8760,7 @@ class VideoStream(FilterableStream):
 
         Args:
             planes: set planes (from 0 to 15) (default 15)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -8462,6 +8783,7 @@ class VideoStream(FilterableStream):
                     "planes": planes,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -8537,6 +8859,7 @@ class VideoStream(FilterableStream):
         cr: Float = Default("0"),
         size: Float = Default("1"),
         high: Float = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -8548,6 +8871,7 @@ class VideoStream(FilterableStream):
             cr: set the chroma red spot (from -1 to 1) (default 0)
             size: set the color filter size (from 0.1 to 10) (default 1)
             high: set the highlights strength (from 0 to 1) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -8570,6 +8894,7 @@ class VideoStream(FilterableStream):
                     "high": high,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -8584,6 +8909,7 @@ class VideoStream(FilterableStream):
         planes: Int = Default("7"),
         structure: Int | Literal["first", "all"] | Default = Default("all"),
         framesync_options: FFMpegFrameSyncOption | None = None,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -8595,6 +8921,7 @@ class VideoStream(FilterableStream):
             planes: set planes to filter (from 0 to 15) (default 7)
             structure: when to process structures (from 0 to 1) (default all)
             framesync_options: Framesync options
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -8620,6 +8947,7 @@ class VideoStream(FilterableStream):
                 },
                 extra_options,
                 framesync_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -8675,6 +9003,7 @@ class VideoStream(FilterableStream):
         self,
         _reference: VideoStream,
         framesync_options: FFMpegFrameSyncOption | None = None,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -8683,6 +9012,7 @@ class VideoStream(FilterableStream):
 
         Args:
             framesync_options: Framesync options
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -8698,7 +9028,12 @@ class VideoStream(FilterableStream):
             ),
             self,
             _reference,
-            **merge({}, extra_options, framesync_options),
+            **merge(
+                {},
+                extra_options,
+                framesync_options,
+                timeline_options,
+            ),
         )
         return filter_node.video(0)
 
@@ -8709,6 +9044,7 @@ class VideoStream(FilterableStream):
         scale: Float = Default("1"),
         offset: Float = Default("0.5"),
         planes: Flags = Default("F"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -8719,6 +9055,7 @@ class VideoStream(FilterableStream):
             scale: set scale (from 0 to 9) (default 1)
             offset: set offset (from -1 to 1) (default 0.5)
             planes: set planes (default F)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -8743,6 +9080,7 @@ class VideoStream(FilterableStream):
                     "planes": planes,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -8754,6 +9092,7 @@ class VideoStream(FilterableStream):
         | Literal["y", "u", "v", "r", "g", "b", "a"]
         | Default = Default("y+u+v+r+g+b"),
         negate_alpha: Boolean = Default("false"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -8763,6 +9102,7 @@ class VideoStream(FilterableStream):
         Args:
             components: set components to negate (default y+u+v+r+g+b)
             negate_alpha: (default false)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -8783,6 +9123,7 @@ class VideoStream(FilterableStream):
                     "negate_alpha": negate_alpha,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -8795,6 +9136,7 @@ class VideoStream(FilterableStream):
         pc: Int = Default("0"),
         r: Int = Default("15"),
         rc: Int = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -8807,6 +9149,7 @@ class VideoStream(FilterableStream):
             pc: patch size for chroma planes (from 0 to 99) (default 0)
             r: research window (from 0 to 99) (default 15)
             rc: research window for chroma planes (from 0 to 99) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -8830,6 +9173,7 @@ class VideoStream(FilterableStream):
                     "rc": rc,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -8971,6 +9315,7 @@ class VideoStream(FilterableStream):
         pscrn: Int
         | Literal["none", "original", "new", "new2", "new3"]
         | Default = Default("new"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -8987,6 +9332,7 @@ class VideoStream(FilterableStream):
             qual: set quality (from 1 to 2) (default fast)
             etype: set which set of weights to use in the predictor (from 0 to 1) (default a)
             pscrn: set prescreening (from 0 to 4) (default new)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -9014,6 +9360,7 @@ class VideoStream(FilterableStream):
                     "pscrn": pscrn,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -9071,6 +9418,7 @@ class VideoStream(FilterableStream):
         c3_seed: Int = Default("-1"),
         c3_strength: Int = Default("0"),
         c3_flags: Flags | Literal["a", "p", "t", "u"] | Default = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -9093,6 +9441,7 @@ class VideoStream(FilterableStream):
             c3_seed: set component #3 noise seed (from -1 to INT_MAX) (default -1)
             c3_strength: set component #3 strength (from 0 to 100) (default 0)
             c3_flags: set component #3 flags (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -9126,6 +9475,7 @@ class VideoStream(FilterableStream):
                     "c3_flags": c3_flags,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -9138,6 +9488,7 @@ class VideoStream(FilterableStream):
         smoothing: Int = Default("0"),
         independence: Float = Default("1"),
         strength: Float = Default("1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -9150,6 +9501,7 @@ class VideoStream(FilterableStream):
             smoothing: amount of temporal smoothing of the input range, to reduce flicker (from 0 to 2.68435e+08) (default 0)
             independence: proportion of independent to linked channel normalization (from 0 to 1) (default 1)
             strength: strength of filter, from no effect to full normalization (from 0 to 1) (default 1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -9173,6 +9525,7 @@ class VideoStream(FilterableStream):
                     "strength": strength,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -9223,6 +9576,7 @@ class VideoStream(FilterableStream):
         g: Boolean = Default("true"),
         st: Boolean = Default("true"),
         sc: Boolean = Default("true"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -9243,6 +9597,7 @@ class VideoStream(FilterableStream):
             g: draw trace grid (default true)
             st: draw statistics (default true)
             sc: draw scope (default true)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -9274,6 +9629,7 @@ class VideoStream(FilterableStream):
                     "sc": sc,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -9307,6 +9663,7 @@ class VideoStream(FilterableStream):
             "straight"
         ),
         framesync_options: FFMpegFrameSyncOption | None = None,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -9323,6 +9680,7 @@ class VideoStream(FilterableStream):
             repeatlast: repeat overlay of the last overlay frame (default true)
             alpha: alpha format (from 0 to 1) (default straight)
             framesync_options: Framesync options
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -9353,6 +9711,7 @@ class VideoStream(FilterableStream):
                 },
                 extra_options,
                 framesync_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -9512,6 +9871,7 @@ class VideoStream(FilterableStream):
         depth: Int = Default("8"),
         luma_strength: Double = Default("1"),
         chroma_strength: Double = Default("1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -9522,6 +9882,7 @@ class VideoStream(FilterableStream):
             depth: set depth (from 8 to 16) (default 8)
             luma_strength: set luma strength (from 0 to 1000) (default 1)
             chroma_strength: set chroma strength (from 0 to 1000) (default 1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -9543,6 +9904,7 @@ class VideoStream(FilterableStream):
                     "chroma_strength": chroma_strength,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -9766,6 +10128,7 @@ class VideoStream(FilterableStream):
             "none"
         ),
         seed: Int64 = Default("-1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -9775,6 +10138,7 @@ class VideoStream(FilterableStream):
         Args:
             mode: select permissions mode (from 0 to 4) (default none)
             seed: set the seed for the random mode (from -1 to UINT32_MAX) (default -1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -9795,6 +10159,7 @@ class VideoStream(FilterableStream):
                     "seed": seed,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -9813,6 +10178,7 @@ class VideoStream(FilterableStream):
         interpolation: Int | Literal["linear", "cubic"] | Default = Default("linear"),
         sense: Int | Literal["source", "destination"] | Default = Default("source"),
         eval: Int | Literal["init", "frame"] | Default = Default("init"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -9831,6 +10197,7 @@ class VideoStream(FilterableStream):
             interpolation: set interpolation (from 0 to 1) (default linear)
             sense: specify the sense of the coordinates (from 0 to 1) (default source)
             eval: specify when to evaluate expressions (from 0 to 1) (default init)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -9860,6 +10227,7 @@ class VideoStream(FilterableStream):
                     "eval": eval,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -9870,6 +10238,7 @@ class VideoStream(FilterableStream):
         mode: Int
         | Literal["p", "t", "b", "T", "B", "u", "U", "a", "A"]
         | Default = Default("A"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -9878,6 +10247,7 @@ class VideoStream(FilterableStream):
 
         Args:
             mode: set phase mode (from 0 to 8) (default A)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -9897,6 +10267,7 @@ class VideoStream(FilterableStream):
                     "mode": mode,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -9984,6 +10355,7 @@ class VideoStream(FilterableStream):
         height: Int = Default("16"),
         mode: Int | Literal["avg", "min", "max"] | Default = Default("avg"),
         planes: Flags = Default("F"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -9995,6 +10367,7 @@ class VideoStream(FilterableStream):
             height: set block height (from 1 to 1024) (default 16)
             mode: set the pixelize mode (from 0 to 2) (default avg)
             planes: set what planes to filter (default F)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -10017,6 +10390,7 @@ class VideoStream(FilterableStream):
                     "planes": planes,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -10031,6 +10405,7 @@ class VideoStream(FilterableStream):
         o: Float = Default("0.5"),
         wx: Float = Default("-1"),
         wy: Float = Default("-1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -10045,6 +10420,7 @@ class VideoStream(FilterableStream):
             o: set window opacity (from 0 to 1) (default 0.5)
             wx: set window x offset (from -1 to 1) (default -1)
             wy: set window y offset (from -1 to 1) (default -1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -10070,6 +10446,7 @@ class VideoStream(FilterableStream):
                     "wy": wy,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -10079,6 +10456,7 @@ class VideoStream(FilterableStream):
         *,
         qp: Int = Default("0"),
         mode: Int | Literal["hard", "soft", "medium"] | Default = Default("medium"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -10088,6 +10466,7 @@ class VideoStream(FilterableStream):
         Args:
             qp: force a constant quantizer parameter (from 0 to 64) (default 0)
             mode: set thresholding mode (from 0 to 2) (default medium)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -10108,6 +10487,7 @@ class VideoStream(FilterableStream):
                     "mode": mode,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -10118,6 +10498,7 @@ class VideoStream(FilterableStream):
         planes: Int = Default("15"),
         scale: Float = Default("1"),
         delta: Float = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -10128,6 +10509,7 @@ class VideoStream(FilterableStream):
             planes: set planes to filter (from 0 to 15) (default 15)
             scale: set scale (from 0 to 65535) (default 1)
             delta: set delta (from -65535 to 65535) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -10149,6 +10531,7 @@ class VideoStream(FilterableStream):
                     "delta": delta,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -10231,6 +10614,7 @@ class VideoStream(FilterableStream):
         ]
         | Default = Default("none"),
         opacity: Float = Default("1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -10245,6 +10629,7 @@ class VideoStream(FilterableStream):
             index: set component as base (from 0 to 3) (default 0)
             preset: set preset (from -1 to 20) (default none)
             opacity: set pseudocolor opacity (from 0 to 1) (default 1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -10270,6 +10655,7 @@ class VideoStream(FilterableStream):
                     "opacity": opacity,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -10282,6 +10668,7 @@ class VideoStream(FilterableStream):
         stats_version: Int = Default("1"),
         output_max: Boolean = Default("false"),
         framesync_options: FFMpegFrameSyncOption | None = None,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -10293,6 +10680,7 @@ class VideoStream(FilterableStream):
             stats_version: Set the format version for the stats file. (from 1 to 2) (default 1)
             output_max: Add raw stats (max values) to the output log. (default false)
             framesync_options: Framesync options
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -10316,6 +10704,7 @@ class VideoStream(FilterableStream):
                 },
                 extra_options,
                 framesync_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -10374,6 +10763,7 @@ class VideoStream(FilterableStream):
         self,
         *,
         qp: String = Default(None),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -10382,6 +10772,7 @@ class VideoStream(FilterableStream):
 
         Args:
             qp: set qp expression
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -10401,6 +10792,7 @@ class VideoStream(FilterableStream):
                     "qp": qp,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -10451,6 +10843,7 @@ class VideoStream(FilterableStream):
         spw: Float = Default("0.27"),
         chp: Boolean = Default("false"),
         lp: Boolean = Default("true"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -10463,6 +10856,7 @@ class VideoStream(FilterableStream):
             spw: set ratio of width reserved for sync code detection (from 0.1 to 0.7) (default 0.27)
             chp: check and apply parity bit (default false)
             lp: lowpass line prior to processing (default true)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -10486,6 +10880,7 @@ class VideoStream(FilterableStream):
                     "lp": lp,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -10664,6 +11059,7 @@ class VideoStream(FilterableStream):
         m1: Int = Default("0"),
         m2: Int = Default("0"),
         m3: Int = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -10675,6 +11071,7 @@ class VideoStream(FilterableStream):
             m1: set mode for 2nd plane (from 0 to 24) (default 0)
             m2: set mode for 3rd plane (from 0 to 24) (default 0)
             m3: set mode for 4th plane (from 0 to 24) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -10697,6 +11094,7 @@ class VideoStream(FilterableStream):
                     "m3": m3,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -10705,6 +11103,7 @@ class VideoStream(FilterableStream):
         self,
         *,
         filename: String = Default(None),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -10713,6 +11112,7 @@ class VideoStream(FilterableStream):
 
         Args:
             filename: set bitmap filename
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -10732,6 +11132,7 @@ class VideoStream(FilterableStream):
                     "filename": filename,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -10808,6 +11209,7 @@ class VideoStream(FilterableStream):
         ah: Int = Default("0"),
         av: Int = Default("0"),
         edge: Int | Literal["smear", "wrap"] | Default = Default("smear"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -10824,6 +11226,7 @@ class VideoStream(FilterableStream):
             ah: shift alpha horizontally (from -255 to 255) (default 0)
             av: shift alpha vertically (from -255 to 255) (default 0)
             edge: set edge operation (from 0 to 1) (default smear)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -10851,6 +11254,7 @@ class VideoStream(FilterableStream):
                     "edge": edge,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -10861,6 +11265,7 @@ class VideoStream(FilterableStream):
         planes: Int = Default("15"),
         scale: Float = Default("1"),
         delta: Float = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -10871,6 +11276,7 @@ class VideoStream(FilterableStream):
             planes: set planes to filter (from 0 to 15) (default 15)
             scale: set scale (from 0 to 65535) (default 1)
             delta: set delta (from -65535 to 65535) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -10892,6 +11298,7 @@ class VideoStream(FilterableStream):
                     "delta": delta,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -10947,6 +11354,7 @@ class VideoStream(FilterableStream):
         out_h: String = Default("ih"),
         fillcolor: String = Default("black"),
         bilinear: Boolean = Default("true"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -10959,6 +11367,7 @@ class VideoStream(FilterableStream):
             out_h: set output height expression (default "ih")
             fillcolor: set background fill color (default "black")
             bilinear: use bilinear interpolation (default true)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -10982,6 +11391,7 @@ class VideoStream(FilterableStream):
                     "bilinear": bilinear,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -10995,6 +11405,7 @@ class VideoStream(FilterableStream):
         chroma_radius: Float = Default("-0.9"),
         chroma_pre_filter_radius: Float = Default("-0.9"),
         chroma_strength: Float = Default("-0.9"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -11008,6 +11419,7 @@ class VideoStream(FilterableStream):
             chroma_radius: set chroma radius (from -0.9 to 4) (default -0.9)
             chroma_pre_filter_radius: set chroma pre-filter radius (from -0.9 to 2) (default -0.9)
             chroma_strength: set chroma strength (from -0.9 to 100) (default -0.9)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -11032,6 +11444,7 @@ class VideoStream(FilterableStream):
                     "chroma_strength": chroma_strength,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -11177,6 +11590,7 @@ class VideoStream(FilterableStream):
         planes: Int = Default("15"),
         scale: Float = Default("1"),
         delta: Float = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -11187,6 +11601,7 @@ class VideoStream(FilterableStream):
             planes: set planes to filter (from 0 to 15) (default 15)
             scale: set scale (from 0 to 65535) (default 1)
             delta: set delta (from -65535 to 65535) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -11208,6 +11623,7 @@ class VideoStream(FilterableStream):
                     "delta": delta,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -11219,6 +11635,7 @@ class VideoStream(FilterableStream):
         vertical: Float = Default("0"),
         hpos: Float = Default("0"),
         vpos: Float = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -11230,6 +11647,7 @@ class VideoStream(FilterableStream):
             vertical: set the vertical scrolling speed (from -1 to 1) (default 0)
             hpos: set initial horizontal position (from 0 to 1) (default 0)
             vpos: set initial vertical position (from 0 to 1) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -11252,6 +11670,7 @@ class VideoStream(FilterableStream):
                     "vpos": vpos,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -11356,6 +11775,7 @@ class VideoStream(FilterableStream):
         neutrals: String = Default(None),
         blacks: String = Default(None),
         psfile: String = Default(None),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -11374,6 +11794,7 @@ class VideoStream(FilterableStream):
             neutrals: adjust neutral regions
             blacks: adjust black regions
             psfile: set Photoshop selectivecolor file name
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -11405,6 +11826,7 @@ class VideoStream(FilterableStream):
                     "psfile": psfile,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -11831,6 +12253,7 @@ class VideoStream(FilterableStream):
         shy: Float = Default("0"),
         fillcolor: String = Default("black"),
         interp: Int | Literal["nearest", "bilinear"] | Default = Default("bilinear"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -11842,6 +12265,7 @@ class VideoStream(FilterableStream):
             shy: set y shear factor (from -2 to 2) (default 0)
             fillcolor: set background fill color (default "black")
             interp: set interpolation (from 0 to 1) (default bilinear)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -11864,6 +12288,7 @@ class VideoStream(FilterableStream):
                     "interp": interp,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -11942,6 +12367,7 @@ class VideoStream(FilterableStream):
         self,
         *,
         mapping: String = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -11950,6 +12376,7 @@ class VideoStream(FilterableStream):
 
         Args:
             mapping: set destination indexes of input frames (default "0")
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -11971,6 +12398,7 @@ class VideoStream(FilterableStream):
                     "mapping": mapping,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -11985,6 +12413,7 @@ class VideoStream(FilterableStream):
         width: Int = Default("10"),
         height: Int = Default("10"),
         seed: Int64 = Default("-1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -11997,6 +12426,7 @@ class VideoStream(FilterableStream):
             width: set block width (from 1 to 8000) (default 10)
             height: set block height (from 1 to 8000) (default 10)
             seed: set random seed (from -1 to UINT32_MAX) (default -1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -12022,6 +12452,7 @@ class VideoStream(FilterableStream):
                     "seed": seed,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -12033,6 +12464,7 @@ class VideoStream(FilterableStream):
         map1: Int = Default("1"),
         map2: Int = Default("2"),
         map3: Int = Default("3"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -12044,6 +12476,7 @@ class VideoStream(FilterableStream):
             map1: Index of the input plane to be used as the second output plane (from 0 to 3) (default 1)
             map2: Index of the input plane to be used as the third output plane (from 0 to 3) (default 2)
             map3: Index of the input plane to be used as the fourth output plane (from 0 to 3) (default 3)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -12068,6 +12501,7 @@ class VideoStream(FilterableStream):
                     "map3": map3,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -12101,6 +12535,7 @@ class VideoStream(FilterableStream):
             "SEI_UNREGISTERED",
         ]
         | Default = Default("-1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -12110,6 +12545,7 @@ class VideoStream(FilterableStream):
         Args:
             mode: set a mode of operation (from 0 to 1) (default select)
             type: set side data type (from -1 to INT_MAX) (default -1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -12130,6 +12566,7 @@ class VideoStream(FilterableStream):
                     "type": type,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -12219,6 +12656,7 @@ class VideoStream(FilterableStream):
         chroma_radius: Float = Default("-0.9"),
         chroma_strength: Float = Default("-2"),
         chroma_threshold: Int = Default("-31"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -12232,6 +12670,7 @@ class VideoStream(FilterableStream):
             chroma_radius: set chroma radius (from -0.9 to 5) (default -0.9)
             chroma_strength: set chroma strength (from -2 to 1) (default -2)
             chroma_threshold: set chroma threshold (from -31 to 30) (default -31)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -12256,6 +12695,7 @@ class VideoStream(FilterableStream):
                     "chroma_threshold": chroma_threshold,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -12266,6 +12706,7 @@ class VideoStream(FilterableStream):
         planes: Int = Default("15"),
         scale: Float = Default("1"),
         delta: Float = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -12276,6 +12717,7 @@ class VideoStream(FilterableStream):
             planes: set planes to filter (from 0 to 15) (default 15)
             scale: set scale (from 0 to 65535) (default 1)
             delta: set delta (from -65535 to 65535) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -12297,6 +12739,7 @@ class VideoStream(FilterableStream):
                     "delta": delta,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -12474,6 +12917,7 @@ class VideoStream(FilterableStream):
         qp: Int = Default("0"),
         mode: Int | Literal["hard", "soft"] | Default = Default("hard"),
         use_bframe_qp: Boolean = Default("false"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -12485,6 +12929,7 @@ class VideoStream(FilterableStream):
             qp: force a constant quantizer parameter (from 0 to 63) (default 0)
             mode: set thresholding mode (from 0 to 1) (default hard)
             use_bframe_qp: use B-frames' QP (default false)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -12507,6 +12952,7 @@ class VideoStream(FilterableStream):
                     "use_bframe_qp": use_bframe_qp,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -12564,6 +13010,7 @@ class VideoStream(FilterableStream):
         *,
         stats_file: String = Default(None),
         framesync_options: FFMpegFrameSyncOption | None = None,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -12573,6 +13020,7 @@ class VideoStream(FilterableStream):
         Args:
             stats_file: Set file where to store per-frame difference information
             framesync_options: Framesync options
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -12594,6 +13042,7 @@ class VideoStream(FilterableStream):
                 },
                 extra_options,
                 framesync_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -12792,6 +13241,7 @@ class VideoStream(FilterableStream):
         y1: String = Default("h/2"),
         x2: String = Default("0"),
         y2: String = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -12805,6 +13255,7 @@ class VideoStream(FilterableStream):
             y1: set 1st rect y top left coordinate (default "h/2")
             x2: set 2nd rect x top left coordinate (default "0")
             y2: set 2nd rect y top left coordinate (default "0")
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -12829,12 +13280,14 @@ class VideoStream(FilterableStream):
                     "y2": y2,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
 
     def swapuv(
         self,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -12842,6 +13295,7 @@ class VideoStream(FilterableStream):
         Swap U and V components.
 
         Args:
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -12859,6 +13313,7 @@ class VideoStream(FilterableStream):
             **merge(
                 {},
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -13106,6 +13561,7 @@ class VideoStream(FilterableStream):
         c2_opacity: Double = Default("1"),
         c3_opacity: Double = Default("1"),
         all_opacity: Double = Default("1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -13128,6 +13584,7 @@ class VideoStream(FilterableStream):
             c2_opacity: set color component #2 opacity (from 0 to 1) (default 1)
             c3_opacity: set color component #3 opacity (from 0 to 1) (default 1)
             all_opacity: set opacity for all color components (from 0 to 1) (default 1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -13161,6 +13618,7 @@ class VideoStream(FilterableStream):
                     "all_opacity": all_opacity,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -13274,6 +13732,7 @@ class VideoStream(FilterableStream):
         _max: VideoStream,
         *,
         planes: Int = Default("15"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -13282,6 +13741,7 @@ class VideoStream(FilterableStream):
 
         Args:
             planes: set planes to filter (from 0 to 15) (default 15)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -13306,6 +13766,7 @@ class VideoStream(FilterableStream):
                     "planes": planes,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -13315,6 +13776,7 @@ class VideoStream(FilterableStream):
         *,
         n: Int = Default("100"),
         log: Int | Literal["quiet", "info", "verbose"] | Default = Default("info"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -13324,6 +13786,7 @@ class VideoStream(FilterableStream):
         Args:
             n: set the frames batch size (from 2 to INT_MAX) (default 100)
             log: force stats logging level (from INT_MIN to INT_MAX) (default info)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -13344,6 +13807,7 @@ class VideoStream(FilterableStream):
                     "log": log,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -13454,6 +13918,7 @@ class VideoStream(FilterableStream):
         c1: String = Default("x"),
         c2: String = Default("x"),
         c3: String = Default("x"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -13465,6 +13930,7 @@ class VideoStream(FilterableStream):
             c1: set component #1 expression (default "x")
             c2: set component #2 expression (default "x")
             c3: set component #3 expression (default "x")
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -13487,6 +13953,7 @@ class VideoStream(FilterableStream):
                     "c3": c3,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -13497,6 +13964,7 @@ class VideoStream(FilterableStream):
         radius: Int = Default("1"),
         planes: Int = Default("15"),
         percentile: Float = Default("0.5"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -13507,6 +13975,7 @@ class VideoStream(FilterableStream):
             radius: set median filter radius (from 1 to 127) (default 1)
             planes: set planes to filter (from 0 to 15) (default 15)
             percentile: set percentile (from 0 to 1) (default 0.5)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -13528,6 +13997,7 @@ class VideoStream(FilterableStream):
                     "percentile": percentile,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -13538,6 +14008,7 @@ class VideoStream(FilterableStream):
         radius: Int = Default("5"),
         sigma: Float = Default("0.5"),
         planes: Int = Default("15"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -13548,6 +14019,7 @@ class VideoStream(FilterableStream):
             radius: set radius (from 1 to 127) (default 5)
             sigma: set sigma (from 0 to 1) (default 0.5)
             planes: set planes (from 0 to 15) (default 15)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -13571,6 +14043,7 @@ class VideoStream(FilterableStream):
                     "planes": planes,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -13582,6 +14055,7 @@ class VideoStream(FilterableStream):
         weights: String = Default("1 1 1"),
         scale: Float = Default("0"),
         planes: Flags = Default("F"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -13593,6 +14067,7 @@ class VideoStream(FilterableStream):
             weights: set weight for each frame (default "1 1 1")
             scale: set scale (from 0 to 32767) (default 0)
             planes: set what planes to filter (default F)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -13615,6 +14090,7 @@ class VideoStream(FilterableStream):
                     "planes": planes,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -13981,6 +14457,7 @@ class VideoStream(FilterableStream):
         alpha_msize_x: Int = Default("5"),
         alpha_msize_y: Int = Default("5"),
         alpha_amount: Float = Default("0"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -13997,6 +14474,7 @@ class VideoStream(FilterableStream):
             alpha_msize_x: set alpha matrix horizontal size (from 3 to 23) (default 5)
             alpha_msize_y: set alpha matrix vertical size (from 3 to 23) (default 5)
             alpha_amount: set alpha effect strength (from -2 to 5) (default 0)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -14024,6 +14502,7 @@ class VideoStream(FilterableStream):
                     "alpha_amount": alpha_amount,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -14122,6 +14601,7 @@ class VideoStream(FilterableStream):
         qp: Int = Default("0"),
         use_bframe_qp: Boolean = Default("false"),
         codec: String = Default("snow"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -14133,6 +14613,7 @@ class VideoStream(FilterableStream):
             qp: force a constant quantizer parameter (from 0 to 63) (default 0)
             use_bframe_qp: use B-frames' QP (default false)
             codec: Codec name (default "snow")
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -14155,6 +14636,7 @@ class VideoStream(FilterableStream):
                     "codec": codec,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -14390,6 +14872,7 @@ class VideoStream(FilterableStream):
         percent: Float = Default("85"),
         planes: Int = Default("15"),
         type: Int | Literal["universal", "bayes"] | Default = Default("universal"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -14403,6 +14886,7 @@ class VideoStream(FilterableStream):
             percent: set percent of full denoising (from 0 to 100) (default 85)
             planes: set planes to filter (from 0 to 15) (default 15)
             type: set threshold type (from 0 to 1) (default universal)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -14429,6 +14913,7 @@ class VideoStream(FilterableStream):
                     "type": type,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -14441,6 +14926,7 @@ class VideoStream(FilterableStream):
         max_r: Int = Default("8"),
         planes: Int = Default("15"),
         framesync_options: FFMpegFrameSyncOption | None = None,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -14452,6 +14938,7 @@ class VideoStream(FilterableStream):
             max_r: set max blur radius (from 1 to 255) (default 8)
             planes: set planes to filter (from 0 to 15) (default 15)
             framesync_options: Framesync options
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -14477,6 +14964,7 @@ class VideoStream(FilterableStream):
                 },
                 extra_options,
                 framesync_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -14563,6 +15051,7 @@ class VideoStream(FilterableStream):
 
     def vflip(
         self,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -14570,6 +15059,7 @@ class VideoStream(FilterableStream):
         Flip the input video vertically.
 
         Args:
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -14587,6 +15077,7 @@ class VideoStream(FilterableStream):
             **merge(
                 {},
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -14662,6 +15153,7 @@ class VideoStream(FilterableStream):
         glum: Float = Default("0.715158"),
         blum: Float = Default("0.212656"),
         alternate: Boolean = Default("false"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -14677,6 +15169,7 @@ class VideoStream(FilterableStream):
             glum: set the green luma coefficient (from 0 to 1) (default 0.715158)
             blum: set the blue luma coefficient (from 0 to 1) (default 0.212656)
             alternate: use alternate colors (default false)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -14703,6 +15196,7 @@ class VideoStream(FilterableStream):
                     "alternate": alternate,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -14844,6 +15338,7 @@ class VideoStream(FilterableStream):
         self,
         _reference: VideoStream,
         framesync_options: FFMpegFrameSyncOption | None = None,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -14852,6 +15347,7 @@ class VideoStream(FilterableStream):
 
         Args:
             framesync_options: Framesync options
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -14867,7 +15363,12 @@ class VideoStream(FilterableStream):
             ),
             self,
             _reference,
-            **merge({}, extra_options, framesync_options),
+            **merge(
+                {},
+                extra_options,
+                framesync_options,
+                timeline_options,
+            ),
         )
         return filter_node.video(0)
 
@@ -14881,6 +15382,7 @@ class VideoStream(FilterableStream):
         eval: Int | Literal["init", "frame"] | Default = Default("init"),
         dither: Boolean = Default("true"),
         aspect: Rational = Default("1/1"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -14895,6 +15397,7 @@ class VideoStream(FilterableStream):
             eval: specify when to evaluate expressions (from 0 to 1) (default init)
             dither: set dithering (default true)
             aspect: set aspect ratio (from 0 to DBL_MAX) (default 1/1)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -14920,6 +15423,7 @@ class VideoStream(FilterableStream):
                     "aspect": aspect,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -14966,6 +15470,7 @@ class VideoStream(FilterableStream):
         mode: Int | Literal["frame", "field"] | Default = Default("field"),
         parity: Int | Literal["tff", "bff", "auto"] | Default = Default("auto"),
         deint: Int | Literal["all", "interlaced"] | Default = Default("all"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -14977,6 +15482,7 @@ class VideoStream(FilterableStream):
             mode: specify the interlacing mode (from 0 to 1) (default field)
             parity: specify the assumed picture field parity (from -1 to 1) (default auto)
             deint: specify which frames to deinterlace (from 0 to 1) (default all)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -14999,6 +15505,7 @@ class VideoStream(FilterableStream):
                     "deint": deint,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -15174,6 +15681,7 @@ class VideoStream(FilterableStream):
         planes: Int = Default("7"),
         secondary: Int | Literal["first", "all"] | Default = Default("all"),
         framesync_options: FFMpegFrameSyncOption | None = None,
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -15184,6 +15692,7 @@ class VideoStream(FilterableStream):
             planes: set planes to cross-correlate (from 0 to 15) (default 7)
             secondary: when to process secondary frame (from 0 to 1) (default all)
             framesync_options: Framesync options
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -15208,6 +15717,7 @@ class VideoStream(FilterableStream):
                 },
                 extra_options,
                 framesync_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -15396,6 +15906,7 @@ class VideoStream(FilterableStream):
         | Default = Default("send_frame"),
         parity: Int | Literal["tff", "bff", "auto"] | Default = Default("auto"),
         deint: Int | Literal["all", "interlaced"] | Default = Default("all"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -15406,6 +15917,7 @@ class VideoStream(FilterableStream):
             mode: specify the interlacing mode (from 0 to 3) (default send_frame)
             parity: specify the assumed picture field parity (from -1 to 1) (default auto)
             deint: specify which frames to deinterlace (from 0 to 1) (default all)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -15427,6 +15939,7 @@ class VideoStream(FilterableStream):
                     "deint": deint,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)
@@ -15437,6 +15950,7 @@ class VideoStream(FilterableStream):
         radius: Int = Default("3"),
         planes: Int = Default("1"),
         sigma: Int = Default("128"),
+        timeline_options: FFMpegTimelineOption | None = None,
         extra_options: dict[str, Any] | None = None,
     ) -> VideoStream:
         """
@@ -15447,6 +15961,7 @@ class VideoStream(FilterableStream):
             radius: set window radius (from 0 to INT_MAX) (default 3)
             planes: set planes to filter (from 0 to 15) (default 1)
             sigma: set blur strength (from 1 to INT_MAX) (default 128)
+            timeline_options: Timeline options
             extra_options: Extra options for the filter
 
         Returns:
@@ -15468,6 +15983,7 @@ class VideoStream(FilterableStream):
                     "sigma": sigma,
                 },
                 extra_options,
+                timeline_options,
             ),
         )
         return filter_node.video(0)

--- a/src/ffmpeg/tests/__snapshots__/test_base/test_filter_node_with_timeline.json
+++ b/src/ffmpeg/tests/__snapshots__/test_base/test_filter_node_with_timeline.json
@@ -1,0 +1,10 @@
+[
+  "ffmpeg",
+  "-i",
+  "input1",
+  "-filter_complex",
+  "[0]smartblur=enable=between(t\\,10\\,3*60)[s0]",
+  "-map",
+  "[s0]",
+  "out.mp4"
+]

--- a/src/ffmpeg/tests/test_base.py
+++ b/src/ffmpeg/tests/test_base.py
@@ -2,12 +2,15 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 from syrupy.extensions.json import JSONSnapshotExtension
 
+from ..options import timeline
+from .. import expressions
+
 from .. import formats
 from ..base import input, merge_outputs, output, vfilter
 from ..codecs.decoders import h264
 from ..codecs.encoders import h263
 from ..filters import blend, concat, join
-from ..options import framesync
+from ..options import framesync, timeline
 from ..schema import StreamType
 from ..sources import color
 from ..streams.video import VideoStream
@@ -74,7 +77,14 @@ def test_filter_node_with_framesync(snapshot: SnapshotAssertion) -> None:
         .compile()
     )
 
+def test_filter_node_with_timeline(snapshot: SnapshotAssertion) -> None:
+    input1 = input("input1")
 
+    assert snapshot(extension_class=JSONSnapshotExtension) == (
+        input1.smartblur(timeline_options=timeline(enable=expressions.between(expressions.Expression("t"), 10, "3*60")))
+        .output(filename="out.mp4")
+        .compile()
+    )
 def test_compile(snapshot: SnapshotAssertion) -> None:
     # ['ffmpeg', '-i', 'input.mp4', '-i', 'overlay.png', '-filter_complex', '[0]trim=end_frame=20:start_frame=10[s0];[0]trim=end_frame=40:start_frame=30[s1];[s0][s1]concat=n=2[s2];[1]hflip[s3];[s2][s3]overlay=eof_action=repeat[s4];[s4]drawbox=50:50:120:120:red:t=5[s5]', '-map', '[s5]', 'out.mp4']
     in_file = input("input.mp4")

--- a/src/ffmpeg/tests/test_base.py
+++ b/src/ffmpeg/tests/test_base.py
@@ -2,10 +2,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 from syrupy.extensions.json import JSONSnapshotExtension
 
-from ..options import timeline
-from .. import expressions
-
-from .. import formats
+from .. import expressions, formats
 from ..base import input, merge_outputs, output, vfilter
 from ..codecs.decoders import h264
 from ..codecs.encoders import h263
@@ -77,14 +74,21 @@ def test_filter_node_with_framesync(snapshot: SnapshotAssertion) -> None:
         .compile()
     )
 
+
 def test_filter_node_with_timeline(snapshot: SnapshotAssertion) -> None:
     input1 = input("input1")
 
     assert snapshot(extension_class=JSONSnapshotExtension) == (
-        input1.smartblur(timeline_options=timeline(enable=expressions.between(expressions.Expression("t"), 10, "3*60")))
+        input1.smartblur(
+            timeline_options=timeline(
+                enable=expressions.between(expressions.Expression("t"), 10, "3*60")
+            )
+        )
         .output(filename="out.mp4")
         .compile()
     )
+
+
 def test_compile(snapshot: SnapshotAssertion) -> None:
     # ['ffmpeg', '-i', 'input.mp4', '-i', 'overlay.png', '-filter_complex', '[0]trim=end_frame=20:start_frame=10[s0];[0]trim=end_frame=40:start_frame=30[s1];[s0][s1]concat=n=2[s2];[1]hflip[s3];[s2][s3]overlay=eof_action=repeat[s4];[s4]drawbox=50:50:120:120:red:t=5[s5]', '-map', '[s5]', 'out.mp4']
     in_file = input("input.mp4")

--- a/src/scripts/code_gen/templates/_components.jinja
+++ b/src/scripts/code_gen/templates/_components.jinja
@@ -59,6 +59,9 @@ Args:
 {%- if f.is_support_framesync %}
     framesync_options: Framesync options
 {%- endif %}
+{%- if f.is_support_timeline %}
+    timeline_options: Timeline options
+{%- endif %}
     extra_options: Extra options for the filter
 
 Returns:
@@ -119,7 +122,10 @@ filter_node = filter_node_factory(
     },
     extra_options,
     {% if f.is_support_framesync %}
-    framesync_options
+    framesync_options,
+    {% endif %}
+    {% if f.is_support_timeline %}
+    timeline_options,
     {% endif %}
     )
 )
@@ -149,6 +155,9 @@ return (
     {% if f.is_support_framesync %}
     framesync_options: FFMpegFrameSyncOption | None = None,
     {% endif %}
+    {% if f.is_support_timeline %}
+    timeline_options: FFMpegTimelineOption | None = None,
+    {% endif %}
     extra_options: dict[str, Any] | None = None,
     ) {{- return_stream_typings(f) }}
         """
@@ -165,6 +174,9 @@ def {{f.name}}(
     {{ f | filter_option_typings }}
     {% if f.is_support_framesync %}
     framesync_options: FFMpegFrameSyncOption | None = None,
+    {% endif %}
+    {% if f.is_support_timeline %}
+    timeline_options: FFMpegTimelineOption | None = None,
     {% endif %}
     extra_options: dict[str, Any] | None = None,
 ) {{- return_stream_typings(f) }}
@@ -186,6 +198,7 @@ from {{get_relative_path(f, template_path)}} import Binary, Boolean, Color, Dict
 {{get_relative_import("schema", template_path, "Default, StreamType, Auto")}}
 {{get_relative_import("common.schema", template_path, "FFMpegFilterDef")}}
 {{get_relative_import("options.framesync", template_path, "FFMpegFrameSyncOption")}}
+{{get_relative_import("options.timeline", template_path, "FFMpegTimelineOption")}}
 {{get_relative_import("streams.av", template_path, "AVStream")}}
 {{get_relative_import("streams.channel_layout", template_path, "CHANNEL_LAYOUT")}}
 {{get_relative_import("codecs.schema", template_path, "FFMpegEncoderOption, FFMpegDecoderOption")}}

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[_input.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[_input.py].raw
@@ -16,6 +16,7 @@ from ...utils.typing import override
 from ...schema import Default, StreamType, Auto
 from ...common.schema import FFMpegFilterDef
 from ...options.framesync import FFMpegFrameSyncOption
+from ...options.timeline import FFMpegTimelineOption
 from ...streams.av import AVStream
 from ...streams.channel_layout import CHANNEL_LAYOUT
 from ...codecs.schema import FFMpegEncoderOption, FFMpegDecoderOption

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[_output.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[_output.py].raw
@@ -15,6 +15,7 @@ from ...utils.typing import override
 from ...schema import Default, StreamType, Auto
 from ...common.schema import FFMpegFilterDef
 from ...options.framesync import FFMpegFrameSyncOption
+from ...options.timeline import FFMpegTimelineOption
 from ...streams.av import AVStream
 from ...streams.channel_layout import CHANNEL_LAYOUT
 from ...codecs.schema import FFMpegEncoderOption, FFMpegDecoderOption

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[audio.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[audio.py].raw
@@ -17,6 +17,7 @@ from ..utils.typing import override
 from ..schema import Default, StreamType, Auto
 from ..common.schema import FFMpegFilterDef
 from ..options.framesync import FFMpegFrameSyncOption
+from ..options.timeline import FFMpegTimelineOption
 from .av import AVStream
 from .channel_layout import CHANNEL_LAYOUT
 from ..codecs.schema import FFMpegEncoderOption, FFMpegDecoderOption
@@ -60,6 +61,7 @@ class AudioStream(FilterableStream):
     *,
     order: Int = Default(None),projection: Int = Default(None),
     
+    
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
@@ -102,6 +104,7 @@ References:
                 
             },
             extra_options,
+            
             
             )
         )

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[decoders.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[decoders.py].raw
@@ -15,6 +15,7 @@ from ..utils.typing import override
 from ..schema import Default, StreamType, Auto
 from ..common.schema import FFMpegFilterDef
 from ..options.framesync import FFMpegFrameSyncOption
+from ..options.timeline import FFMpegTimelineOption
 from ..streams.av import AVStream
 from ..streams.channel_layout import CHANNEL_LAYOUT
 from .schema import FFMpegEncoderOption, FFMpegDecoderOption

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[demuxers.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[demuxers.py].raw
@@ -15,6 +15,7 @@ from ..utils.typing import override
 from ..schema import Default, StreamType, Auto
 from ..common.schema import FFMpegFilterDef
 from ..options.framesync import FFMpegFrameSyncOption
+from ..options.timeline import FFMpegTimelineOption
 from ..streams.av import AVStream
 from ..streams.channel_layout import CHANNEL_LAYOUT
 from ..codecs.schema import FFMpegEncoderOption, FFMpegDecoderOption

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[encoders.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[encoders.py].raw
@@ -15,6 +15,7 @@ from ..utils.typing import override
 from ..schema import Default, StreamType, Auto
 from ..common.schema import FFMpegFilterDef
 from ..options.framesync import FFMpegFrameSyncOption
+from ..options.timeline import FFMpegTimelineOption
 from ..streams.av import AVStream
 from ..streams.channel_layout import CHANNEL_LAYOUT
 from .schema import FFMpegEncoderOption, FFMpegDecoderOption

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[filters.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[filters.py].raw
@@ -15,6 +15,7 @@ from .utils.typing import override
 from .schema import Default, StreamType, Auto
 from .common.schema import FFMpegFilterDef
 from .options.framesync import FFMpegFrameSyncOption
+from .options.timeline import FFMpegTimelineOption
 from .streams.av import AVStream
 from .streams.channel_layout import CHANNEL_LAYOUT
 from .codecs.schema import FFMpegEncoderOption, FFMpegDecoderOption
@@ -52,6 +53,7 @@ def aap(
 
     *,
     order: Int = Default(None),projection: Int = Default(None),
+    
     
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
@@ -94,6 +96,7 @@ References:
             
         },
         extra_options,
+        
         
         )
     )

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[global_args.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[global_args.py].raw
@@ -18,6 +18,7 @@ from ...utils.typing import override
 from ...schema import Default, StreamType, Auto
 from ...common.schema import FFMpegFilterDef
 from ...options.framesync import FFMpegFrameSyncOption
+from ...options.timeline import FFMpegTimelineOption
 from ...streams.av import AVStream
 from ...streams.channel_layout import CHANNEL_LAYOUT
 from ...codecs.schema import FFMpegEncoderOption, FFMpegDecoderOption

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[muxers.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[muxers.py].raw
@@ -15,6 +15,7 @@ from ..utils.typing import override
 from ..schema import Default, StreamType, Auto
 from ..common.schema import FFMpegFilterDef
 from ..options.framesync import FFMpegFrameSyncOption
+from ..options.timeline import FFMpegTimelineOption
 from ..streams.av import AVStream
 from ..streams.channel_layout import CHANNEL_LAYOUT
 from ..codecs.schema import FFMpegEncoderOption, FFMpegDecoderOption

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[output_args.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[output_args.py].raw
@@ -19,6 +19,7 @@ from ...utils.typing import override
 from ...schema import Default, StreamType, Auto
 from ...common.schema import FFMpegFilterDef
 from ...options.framesync import FFMpegFrameSyncOption
+from ...options.timeline import FFMpegTimelineOption
 from ...streams.av import AVStream
 from ...streams.channel_layout import CHANNEL_LAYOUT
 from ...codecs.schema import FFMpegEncoderOption, FFMpegDecoderOption

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[sources.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[sources.py].raw
@@ -14,6 +14,7 @@ from .utils.typing import override
 from .schema import Default, StreamType, Auto
 from .common.schema import FFMpegFilterDef
 from .options.framesync import FFMpegFrameSyncOption
+from .options.timeline import FFMpegTimelineOption
 from .streams.av import AVStream
 from .streams.channel_layout import CHANNEL_LAYOUT
 from .codecs.schema import FFMpegEncoderOption, FFMpegDecoderOption

--- a/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[video.py].raw
+++ b/src/scripts/code_gen/tests/__snapshots__/test_gen/test_render[video.py].raw
@@ -17,6 +17,7 @@ from ..utils.typing import override
 from ..schema import Default, StreamType, Auto
 from ..common.schema import FFMpegFilterDef
 from ..options.framesync import FFMpegFrameSyncOption
+from ..options.timeline import FFMpegTimelineOption
 from .av import AVStream
 from .channel_layout import CHANNEL_LAYOUT
 from ..codecs.schema import FFMpegEncoderOption, FFMpegDecoderOption


### PR DESCRIPTION
- fix #729

This pull request updates the type annotations for several mathematical and logical functions in `src/ffmpeg/expressions.py`. The changes expand the type of function parameters from `str` to `Any`, improving flexibility and compatibility with diverse input types.

### Type Annotation Updates:
* Updated parameter types for mathematical functions such as `abs`, `acos`, `asin`, `atan`, `atan2`, and others to accept `Any` instead of `str`. This change allows these functions to handle a broader range of input types. [[1]](diffhunk://#diff-aa10f4e5ee2eaa5dd4a83485e576300abcb7c08c030da791f0cc2688962e0ddaL122-R122) [[2]](diffhunk://#diff-aa10f4e5ee2eaa5dd4a83485e576300abcb7c08c030da791f0cc2688962e0ddaL136-R136) [[3]](diffhunk://#diff-aa10f4e5ee2eaa5dd4a83485e576300abcb7c08c030da791f0cc2688962e0ddaL150-R150) [[4]](diffhunk://#diff-aa10f4e5ee2eaa5dd4a83485e576300abcb7c08c030da791f0cc2688962e0ddaL164-R164) [[5]](diffhunk://#diff-aa10f4e5ee2eaa5dd4a83485e576300abcb7c08c030da791f0cc2688962e0ddaL178-R178)
* Updated logical and comparison functions like `eq`, `gt`, `gte`, `lt`, and `lte` to accept `Any` type parameters, enhancing their usability across different data types. [[1]](diffhunk://#diff-aa10f4e5ee2eaa5dd4a83485e576300abcb7c08c030da791f0cc2688962e0ddaL296-R296) [[2]](diffhunk://#diff-aa10f4e5ee2eaa5dd4a83485e576300abcb7c08c030da791f0cc2688962e0ddaL368-R368) [[3]](diffhunk://#diff-aa10f4e5ee2eaa5dd4a83485e576300abcb7c08c030da791f0cc2688962e0ddaL383-R383) [[4]](diffhunk://#diff-aa10f4e5ee2eaa5dd4a83485e576300abcb7c08c030da791f0cc2688962e0ddaL398-R398) [[5]](diffhunk://#diff-aa10f4e5ee2eaa5dd4a83485e576300abcb7c08c030da791f0cc2688962e0ddaL538-R538)
* Adjusted utility functions like `clip`, `lerp`, `random`, and `print` to accommodate `Any` type inputs, ensuring broader compatibility. [[1]](diffhunk://#diff-aa10f4e5ee2eaa5dd4a83485e576300abcb7c08c030da791f0cc2688962e0ddaL252-R252) [[2]](diffhunk://#diff-aa10f4e5ee2eaa5dd4a83485e576300abcb7c08c030da791f0cc2688962e0ddaL509-R509) [[3]](diffhunk://#diff-aa10f4e5ee2eaa5dd4a83485e576300abcb7c08c030da791f0cc2688962e0ddaL659-R659) [[4]](diffhunk://#diff-aa10f4e5ee2eaa5dd4a83485e576300abcb7c08c030da791f0cc2688962e0ddaL645-R645)