### PR TITLE
fix: exclude src/scripts from mkdocs code reference (3.11 hotfix)

### DIFF
--- a/scripts/gen_ref_pages.py
+++ b/scripts/gen_ref_pages.py
@@ -20,6 +20,7 @@ for path in sorted(src.rglob("*.py")):
         "tests" in path.parts
         or "migrations" in path.parts
         or "management" in path.parts
+        or "scripts" in path.parts
     ):
         continue
 


### PR DESCRIPTION
## Summary

- `gen_ref_pages.py` scanned all of `src/` via `rglob("*.py")`, picking up `src/scripts/**` (internal codegen tooling) alongside `src/ffmpeg/**`
- This caused the Code Reference section to be empty or broken — `scripts.*` modules either polluted the docs or failed to import under mkdocstrings strict mode, aborting the build
- Fix: add `"scripts" in path.parts` to the exclusion filter so only `src/ffmpeg/` is documented

## Test plan

- [ ] Trigger `Deploy Documentation` workflow manually on this branch via `workflow_dispatch`
- [ ] Verify the Code Reference section shows only `ffmpeg.*` modules

> **Note:** This is a hotfix branched from tag `3.11`. The base branch is `main` but the intent is to patch the 3.11 release docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)