### PR TITLE
fix: update broken CI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## typed-ffmpeg
 
-[![CI Package](https://github.com/livingbio/typed-ffmpeg/actions/workflows/ci-package.yml/badge.svg)](https://github.com/livingbio/typed-ffmpeg/actions?query=workflow%3Aci-package)
+[![CI Package](https://github.com/livingbio/typed-ffmpeg/actions/workflows/ci-package-test.yml/badge.svg)](https://github.com/livingbio/typed-ffmpeg/actions/workflows/ci-package-test.yml)
 [![Documentation](https://img.shields.io/badge/docs-mkdocs%20material-blue.svg?style=flat)](https://livingbio.github.io/typed-ffmpeg/)
 [![PyPI Version](https://img.shields.io/pypi/v/typed-ffmpeg.svg)](https://pypi.org/project/typed-ffmpeg/)
 [![codecov](https://codecov.io/gh/livingbio/typed-ffmpeg/graph/badge.svg?token=B95PR629LP)](https://codecov.io/gh/livingbio/typed-ffmpeg)


### PR DESCRIPTION
## Summary

- `ci-package.yml` no longer exists — it was split into `ci-package-lint.yml` and `ci-package-test.yml` during the monorepo refactor
- The README badge was pointing to the old workflow, causing a broken badge image
- Updated to `ci-package-test.yml`

## Test plan

- [ ] Verify badge renders correctly on the repo homepage after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)