### PR TITLE
fix: deploy docs on release tags instead of main

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,8 +2,8 @@ name: Deploy Documentation
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - '[0-9]*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Docs were rebuilding on every push to `main`, publishing potentially unreleased/incomplete API reference
- Changed trigger from `push: branches: [main]` to `push: tags: ['[0-9]*']` so docs only deploy on version releases (e.g. `3.11.1`)
- `workflow_dispatch` retained for manual deploys

## Why

The 3.11 hotfix highlighted the issue: docs built from `main` diverged from what users actually install from PyPI. Docs should always match the released package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)