### PR TITLE
ci: add regenerate-bindings workflow

### DIFF
--- a/.github/workflows/regenerate-bindings.yml
+++ b/.github/workflows/regenerate-bindings.yml
@@ -1,4 +1,4 @@
-name: Regenerate Bindings
+name: Regenerate FFmpeg Bindings
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Adds workflow_dispatch workflow to regenerate FFmpeg bindings using jrottenberg/ffmpeg Docker images and open a PR against v4.