### PR TITLE
Fix typos in blog.md and docs/faq.md

### DIFF
--- a/blog.md
+++ b/blog.md
@@ -1,10 +1,10 @@
-- the originoal idea is start after GPT-3 is released, but I don't have time to work on it.
+- the original idea is start after GPT-3 is released, but I don't have time to work on it.
 - The ffmpeg document is not easy to read, so I want to make a simple document for it.
-- At beginning, I want to do an End to End genrator, given ffmpeg document than generate python code,
+- At beginning, I want to do an End to End generator, given ffmpeg document then generate python code,
 - However since there are too many filters need to be implemented, and always have some little glitch I decide to do it step by step.
 - I did some POC about use ChatGPT to generate Python code, it works
 - Some bug include generate not complete JSON code
-- The docstring format is not consistence each time I used it.
+- The docstring format is not consistency each time I used it.
 - most of the filters I never used,
 
 I hate code gen, it is hard to maintain, but I think it is a good way to learn about ffmpeg and GPT.
@@ -13,4 +13,4 @@ I hate code gen, it is hard to maintain, but I think it is a good way to learn a
 
 Future Work
 - generate python code from ffmpeg code instead of document, maybe it is easier to do it.
-- findout some way to test the genereate code, so the GPT can learn from the test result and generate better code. improve itself
+- find out some way to test the generated code, so the GPT can learn from the test result and generate better code. improve itself

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,8 +4,8 @@
 
 typed-ffmpeg support ffmpeg source filters:
 
-- How to use predefined video/audio source filter can be find [Complex Filters](./usage/complex-filtering.ipynb)
-- How to customized video/audio source filter can be find [Customizing Filters](./usage/customizing-filters.ipynb)
+- How to use predefined video/audio source filter can be found [Complex Filters](./usage/complex-filtering.ipynb)
+- How to customize video/audio source filter can be found [Customizing Filters](./usage/customizing-filters.ipynb)
 
 
 ## Differences Between ffmpeg-python and typed-ffmpeg


### PR DESCRIPTION
## Summary
- Fix 6 typos in `blog.md`: `originoal` → `original`, `genrator` → `generator`, `than` → `then`, `consistence` → `consistency`, `findout` → `find out`, `genereate` → `generated`
- Fix 3 issues in `docs/faq.md`: `can be find` → `can be found`, `customized` → `customize`

## Test plan
- [ ] Verify markdown renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)