### PR TITLE
fix: resolve lint failures in CI pipeline

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,8 +30,8 @@ repos:
         exclude: '__snapshots__/|.eslintrc.json'
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version - updated for pref compatibility
-    rev: v0.9.6
+    # Ruff version - keep in sync with pyproject.toml and uv.lock
+    rev: v0.12.2
     hooks:
       # Run the formatter.
       - id: ruff-format

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -33,7 +33,7 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "syrupy>=5.0",
-    "ruff>=0.9.6",
+    "ruff==0.12.2",
     "mypy>=1.0",
 ]
 

--- a/packages/latest/pyproject.toml
+++ b/packages/latest/pyproject.toml
@@ -41,7 +41,7 @@ typed-ffmpeg-v8 = { workspace = true }
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
-    "ruff>=0.9.6",
+    "ruff==0.12.2",
 ]
 
 [build-system]

--- a/packages/tests-shared/compile/cases.py
+++ b/packages/tests-shared/compile/cases.py
@@ -100,8 +100,7 @@ def global_args() -> Stream:
 def global_args_2() -> Stream:
     input1 = input("input1.mp4")
     graph = (
-        input1.video
-        .output(filename="tmp.mp4")
+        input1.video.output(filename="tmp.mp4")
         .global_args(loglevel="info")
         .global_args(loglevel="warning")
     )

--- a/packages/tests-shared/compile/cases.py
+++ b/packages/tests-shared/compile/cases.py
@@ -100,7 +100,8 @@ def global_args() -> Stream:
 def global_args_2() -> Stream:
     input1 = input("input1.mp4")
     graph = (
-        input1.video.output(filename="tmp.mp4")
+        input1.video
+        .output(filename="tmp.mp4")
         .global_args(loglevel="info")
         .global_args(loglevel="warning")
     )

--- a/packages/tests-shared/utils/test_view.py
+++ b/packages/tests-shared/utils/test_view.py
@@ -67,8 +67,7 @@ def test_view_with_filter_chain() -> None:
         import graphviz  # type: ignore # noqa: F401
 
         output = (
-            ffmpeg
-            .input("input.mp4")
+            ffmpeg.input("input.mp4")
             .video.scale(w=1280, h=720)
             .fps(fps=30)
             .output(filename="output.mp4")

--- a/packages/tests-shared/utils/test_view.py
+++ b/packages/tests-shared/utils/test_view.py
@@ -67,7 +67,8 @@ def test_view_with_filter_chain() -> None:
         import graphviz  # type: ignore # noqa: F401
 
         output = (
-            ffmpeg.input("input.mp4")
+            ffmpeg
+            .input("input.mp4")
             .video.scale(w=1280, h=720)
             .fps(fps=30)
             .output(filename="output.mp4")

--- a/packages/v5/pyproject.toml
+++ b/packages/v5/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = ["ffmpeg-core>=1.0.0a1,<2.0"]
 ffmpeg-core = { workspace = true }
 
 [project.optional-dependencies]
-dev = ["pytest>=7.0", "pytest-cov>=4.0", "syrupy>=5.0", "ruff>=0.9.6"]
+dev = ["pytest>=7.0", "pytest-cov>=4.0", "syrupy>=5.0", "ruff==0.12.2"]
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/packages/v5/src/ffmpeg/codecs/decoders.py
+++ b/packages/v5/src/ffmpeg/codecs/decoders.py
@@ -438,293 +438,293 @@ from ..streams.audio import AudioStream
 
 
 def _012v(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed 4:2:2 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def _4xm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     4X Movie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def _8bps(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QuickTime 8BPS video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def aasc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Autodesk RLE
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def agm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Amuse Graphics Movie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def aic(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Apple Intermediate Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def alias_pix(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Alias/Wavefront PIX image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def amv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AMV Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def anm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Deluxe Paint Animation
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ansi(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ASCII/ANSI art
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def apng(
-    
+
 ) -> FFMpegDecoderOption:
     """
     APNG (Animated Portable Network Graphics) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def arbc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Gryphon's Anim Compressor
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def argo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Argonaut Games Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def asv1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ASUS V1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def asv2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ASUS V2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def aura(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Auravision AURA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def aura2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Auravision Aura 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def libdav1d(
-    
+
     tilethreads: int | None = None,
-    
+
     framethreads: int | None = None,
-    
+
     filmgrain: bool | None = None,
-    
+
     oppoint: int | None = None,
-    
+
     alllayers: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     dav1d AV1 decoder by VideoLAN (codec av1)
-    
+
     Args:
         tilethreads: Tile threads (from 0 to 256) (default 0)
         framethreads: Frame threads (from 0 to 256) (default 0)
@@ -736,29 +736,29 @@ def libdav1d(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "tilethreads": tilethreads,
-        
+
         "framethreads": framethreads,
-        
+
         "filmgrain": filmgrain,
-        
+
         "oppoint": oppoint,
-        
+
         "alllayers": alllayers,
-        
+
     }))
 
 
 
 def av1(
-    
+
     operating_point: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Alliance for Open Media AV1
-    
+
     Args:
         operating_point: Select an operating point of the scalable bitstream (from 0 to 31) (default 0)
 
@@ -766,667 +766,667 @@ def av1(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "operating_point": operating_point,
-        
+
     }))
 
 
 
 def avrn(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Avid AVI Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def avrp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Avid 1:1 10-bit RGB Packer
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def avs(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AVS (Audio Video Standard) video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def avui(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Avid Meridien Uncompressed
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ayuv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed packed MS 4:4:4:4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bethsoftvid(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bethesda VID video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bfi(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Brute Force & Ignorance
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def binkvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bink video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bintext(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Binary text
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bitpacked(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bitpacked
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bmp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     BMP (Windows and OS/2 bitmap)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bmv_video(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Discworld II BMV video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def brender_pix(
-    
+
 ) -> FFMpegDecoderOption:
     """
     BRender PIX image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def c93(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Interplay C93
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cavs(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Chinese AVS (Audio Video Standard) (AVS1-P2, JiZhun profile)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cdgraphics(
-    
+
 ) -> FFMpegDecoderOption:
     """
     CD Graphics video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cdtoons(
-    
+
 ) -> FFMpegDecoderOption:
     """
     CDToons video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cdxl(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Commodore CDXL video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cfhd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     GoPro CineForm HD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cinepak(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Cinepak
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def clearvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Iterated Systems ClearVideo
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cljr(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Cirrus Logic AccuPak
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cllc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Canopus Lossless Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def eacmv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Electronic Arts CMV video (codec cmv)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cpia(
-    
+
 ) -> FFMpegDecoderOption:
     """
     CPiA video format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cri(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Cintel RAW
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def camstudio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     CamStudio (codec cscd)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cyuv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Creative YUV (CYUV)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dds(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DirectDraw Surface image decoder
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dfa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Chronomaster DFA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dirac(
-    
+
 ) -> FFMpegDecoderOption:
     """
     BBC Dirac VC-2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dnxhd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     VC3/DNxHD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dpx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPX (Digital Picture Exchange) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dsicinvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Delphine Software International CIN video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dvvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DV (Digital Video)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dxa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Feeble Files/ScummVM DXA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dxtory(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Dxtory
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dxv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Resolume DXV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def escape124(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Escape 124
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def escape130(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Escape 130
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def exr(
-    
+
     layer: str | None = None,
-    
+
     part: int | None = None,
-    
+
     gamma: float | None = None,
-    
+
     apply_trc: int | None| Literal["bt709", "gamma", "gamma22", "gamma28", "smpte170m", "smpte240m", "linear", "log", "log_sqrt", "iec61966_2_4", "bt1361", "iec61966_2_1", "bt2020_10bit", "bt2020_12bit", "smpte2084", "smpte428_1"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     OpenEXR image
-    
+
     Args:
         layer: Set the decoding layer (default "")
         part: Set the decoding part (from 0 to INT_MAX) (default 0)
@@ -1437,59 +1437,59 @@ def exr(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "layer": layer,
-        
+
         "part": part,
-        
+
         "gamma": gamma,
-        
+
         "apply_trc": apply_trc,
-        
+
     }))
 
 
 
 def ffv1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     FFmpeg video codec #1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ffvhuff(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Huffyuv FFmpeg variant
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def fic(
-    
+
     skip_cursor: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Mirillis FIC
-    
+
     Args:
         skip_cursor: skip the cursor (default false)
 
@@ -1497,21 +1497,21 @@ def fic(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "skip_cursor": skip_cursor,
-        
+
     }))
 
 
 
 def fits(
-    
+
     blank_value: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Flexible Image Transport System
-    
+
     Args:
         blank_value: value that is used to replace BLANK pixels in data array (from 0 to 65535) (default 0)
 
@@ -1519,117 +1519,117 @@ def fits(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "blank_value": blank_value,
-        
+
     }))
 
 
 
 def flashsv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Flash Screen Video v1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def flashsv2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Flash Screen Video v2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def flic(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Autodesk Animator Flic video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def flv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     FLV / Sorenson Spark / Sorenson H.263 (Flash Video) (codec flv1)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def fmvc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     FM Screen Capture Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def fraps(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Fraps
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def frwu(
-    
+
     change_field_order: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Forward Uncompressed
-    
+
     Args:
         change_field_order: Change field order (default false)
 
@@ -1637,69 +1637,69 @@ def frwu(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "change_field_order": change_field_order,
-        
+
     }))
 
 
 
 def g2m(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Go2Meeting
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def gdv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Gremlin Digital Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def gem(
-    
+
 ) -> FFMpegDecoderOption:
     """
     GEM Raster image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def gif(
-    
+
     trans_color: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     GIF (Graphics Interchange Format)
-    
+
     Args:
         trans_color: color value (ARGB) that is used instead of transparent color (from 0 to UINT32_MAX) (default 16777215)
 
@@ -1707,55 +1707,55 @@ def gif(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "trans_color": trans_color,
-        
+
     }))
 
 
 
 def h261(
-    
+
 ) -> FFMpegDecoderOption:
     """
     H.261
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def h263(
-    
+
 ) -> FFMpegDecoderOption:
     """
     H.263 / H.263-1996, H.263+ / H.263-1998 / H.263 version 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def h263_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem H.263 decoder wrapper (codec h263)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 6 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 20 to INT_MAX) (default 20)
@@ -1764,61 +1764,61 @@ def h263_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def h263i(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Intel H.263
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def h263p(
-    
+
 ) -> FFMpegDecoderOption:
     """
     H.263 / H.263-1996, H.263+ / H.263-1998 / H.263 version 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def h264(
-    
+
     is_avc: bool | None = None,
-    
+
     nal_length_size: int | None = None,
-    
+
     enable_er: bool | None = None,
-    
+
     x264_build: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10
-    
+
     Args:
         is_avc: is avc (default false)
         nal_length_size: nal_length_size (from 0 to 4) (default 0)
@@ -1829,29 +1829,29 @@ def h264(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "is_avc": is_avc,
-        
+
         "nal_length_size": nal_length_size,
-        
+
         "enable_er": enable_er,
-        
+
         "x264_build": x264_build,
-        
+
     }))
 
 
 
 def h264_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem H.264 decoder wrapper (codec h264)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 6 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 20 to INT_MAX) (default 20)
@@ -1860,41 +1860,41 @@ def h264_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def hap(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Vidvox Hap
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hevc(
-    
+
     apply_defdispwin: bool | None = None,
-    
+
     strict_displaywin: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     HEVC (High Efficiency Video Coding)
-    
+
     Args:
         apply_defdispwin: Apply default display window from VUI (default false)
         strict_displaywin: stricly apply default display window size (default false)
@@ -1903,25 +1903,25 @@ def hevc(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "apply_defdispwin": apply_defdispwin,
-        
+
         "strict-displaywin": strict_displaywin,
-        
+
     }))
 
 
 
 def hevc_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem HEVC decoder wrapper (codec hevc)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 6 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 20 to INT_MAX) (default 20)
@@ -1930,279 +1930,279 @@ def hevc_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def hnm4video(
-    
+
 ) -> FFMpegDecoderOption:
     """
     HNM 4 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hq_hqa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Canopus HQ/HQA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hqx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Canopus HQX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def huffyuv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Huffyuv / HuffYUV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hymt(
-    
+
 ) -> FFMpegDecoderOption:
     """
     HuffYUV MT
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def idcinvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     id Quake II CIN video (codec idcin)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def idf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     iCEDraw text
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def iff(
-    
+
 ) -> FFMpegDecoderOption:
     """
     IFF ACBM/ANIM/DEEP/ILBM/PBM/RGB8/RGBN (codec iff_ilbm)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def imm4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Infinity IMM4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def imm5(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Infinity IMM5
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def indeo2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Intel Indeo 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def indeo3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Intel Indeo 3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def indeo4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Intel Indeo Video Interactive 4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def indeo5(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Intel Indeo Video Interactive 5
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def interplayvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Interplay MVE video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ipu(
-    
+
 ) -> FFMpegDecoderOption:
     """
     IPU Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def jpeg2000(
-    
+
     lowres: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     JPEG 2000
-    
+
     Args:
         lowres: Lower the decoding resolution by a power of two (from 0 to 33) (default 0)
 
@@ -2210,21 +2210,21 @@ def jpeg2000(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "lowres": lowres,
-        
+
     }))
 
 
 
 def libopenjpeg(
-    
+
     lowqual: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     OpenJPEG JPEG 2000 (codec jpeg2000)
-    
+
     Args:
         lowqual: Limit the number of layers used for decoding (from 0 to INT_MAX) (default 0)
 
@@ -2232,213 +2232,213 @@ def libopenjpeg(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "lowqual": lowqual,
-        
+
     }))
 
 
 
 def jpegls(
-    
+
 ) -> FFMpegDecoderOption:
     """
     JPEG-LS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def jv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bitmap Brothers JV video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def kgv1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Kega Game Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def kmvc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Karl Morton's video codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def lagarith(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Lagarith lossless
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def loco(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LOCO
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def lscr(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LEAD Screen Capture
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def m101(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Matrox Uncompressed SD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def eamad(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Electronic Arts Madcow Video (codec mad)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def magicyuv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MagicYUV video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mdec(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sony PlayStation MDEC (Motion DECoder)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mimic(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Mimic
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mjpeg(
-    
+
     extern_huff: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     MJPEG (Motion JPEG)
-    
+
     Args:
         extern_huff: Use external huffman table. (default false)
 
@@ -2446,103 +2446,103 @@ def mjpeg(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "extern_huff": extern_huff,
-        
+
     }))
 
 
 
 def mjpegb(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Apple MJPEG-B
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mmvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     American Laser Games MM Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mobiclip(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MobiClip Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def motionpixels(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Motion Pixels video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpeg1video(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-1 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpeg1_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem MPEG1 decoder wrapper (codec mpeg1video)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 6 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 20 to INT_MAX) (default 20)
@@ -2551,57 +2551,57 @@ def mpeg1_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def mpeg2video(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-2 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpegvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-1 video (codec mpeg2video)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpeg2_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem MPEG2 decoder wrapper (codec mpeg2video)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 6 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 20 to INT_MAX) (default 20)
@@ -2610,41 +2610,41 @@ def mpeg2_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def mpeg4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-4 part 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpeg4_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem MPEG4 decoder wrapper (codec mpeg4)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 6 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 20 to INT_MAX) (default 20)
@@ -2653,503 +2653,503 @@ def mpeg4_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def msa1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MS ATC Screen
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mscc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Mandsoft Screen Capture Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msmpeg4v1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-4 part 2 Microsoft variant version 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msmpeg4v2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-4 part 2 Microsoft variant version 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msmpeg4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-4 part 2 Microsoft variant version 3 (codec msmpeg4v3)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msp2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Microsoft Paint (MSP) version 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msrle(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Microsoft RLE
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mss1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MS Screen 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mss2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MS Windows Media Video V9 Screen
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msvideo1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Microsoft Video 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mszh(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LCL (LossLess Codec Library) MSZH
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mts2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MS Expression Encoder Screen
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mv30(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MidiVid 3.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mvc1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Silicon Graphics Motion Video Compressor 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mvc2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Silicon Graphics Motion Video Compressor 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mvdv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MidiVid VQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mvha(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MidiVid Archive Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mwsc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MatchWare Screen Capture Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mxpeg(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Mobotix MxPEG video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def notchlc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     NotchLC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def nuv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     NuppelVideo/RTJPEG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def paf_video(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Amazing Studio Packed Animation File Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pam(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PAM (Portable AnyMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pbm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PBM (Portable BitMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PC Paintbrush PCX image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pfm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PFM (Portable FloatMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pgm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PGM (Portable GrayMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pgmyuv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PGMYUV (Portable GrayMap YUV) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pgx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PGX (JPEG2000 Test Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def phm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PHM (Portable HalfFloatMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def photocd(
-    
+
     lowres: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Kodak Photo CD
-    
+
     Args:
         lowres: Lower the decoding resolution by a power of two (from 0 to 4) (default 0)
 
@@ -3157,245 +3157,245 @@ def photocd(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "lowres": lowres,
-        
+
     }))
 
 
 
 def pictor(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Pictor/PC Paint
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pixlet(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Apple Pixlet
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def png(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PNG (Portable Network Graphics) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ppm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PPM (Portable PixelMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def prores(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Apple ProRes (iCodec Pro)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def prosumer(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Brooktree ProSumer Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def psd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Photoshop PSD file
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ptx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     V.Flash PTX image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qdraw(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Apple QuickDraw
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qoi(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QOI (Quite OK Image format) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qpeg(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Q-team QPEG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qtrle(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QuickTime Animation (RLE) video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def r10k(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AJA Kona 10-bit RGB Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def r210(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed RGB 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rasc(
-    
+
     skip_cursor: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     RemotelyAnywhere Screen Capture
-    
+
     Args:
         skip_cursor: skip the cursor (default false)
 
@@ -3403,21 +3403,21 @@ def rasc(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "skip_cursor": skip_cursor,
-        
+
     }))
 
 
 
 def rawvideo(
-    
+
     top: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     raw video
-    
+
     Args:
         top: top field first (default auto)
 
@@ -3425,569 +3425,569 @@ def rawvideo(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "top": top,
-        
+
     }))
 
 
 
 def rl2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RL2 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def roqvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     id RoQ video (codec roq)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rpza(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QuickTime video (RPZA)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rscc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     innoHeim/Rsupport Screen Capture Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rv10(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealVideo 1.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rv20(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealVideo 2.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rv30(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealVideo 3.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rv40(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealVideo 4.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sanm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LucasArts SANM/Smush video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def scpr(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ScreenPressor
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def screenpresso(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Screenpresso
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sga(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Digital Pictures SGA Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sgi(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SGI image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sgirle(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Silicon Graphics RLE 8-bit video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sheervideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     BitJazz SheerVideo
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def simbiosis_imx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Simbiosis Interactive IMX Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def smackvid(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Smacker video (codec smackvideo)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def smc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QuickTime Graphics (SMC)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def smvjpeg(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SMV JPEG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def snow(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Snow
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sp5x(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sunplus JPEG (SP5X)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def speedhq(
-    
+
 ) -> FFMpegDecoderOption:
     """
     NewTek SpeedHQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def srgc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Screen Recorder Gold Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sunrast(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sun Rasterfile image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def svq1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sorenson Vector Quantizer 1 / Sorenson Video 1 / SVQ1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def svq3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sorenson Vector Quantizer 3 / Sorenson Video 3 / SVQ3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def targa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Truevision Targa image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def targa_y216(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Pinnacle TARGA CineWave YUV16
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def tdsc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     TDSC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def eatgq(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Electronic Arts TGQ video (codec tgq)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def eatgv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Electronic Arts TGV video (codec tgv)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def theora(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Theora
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def thp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Nintendo Gamecube THP video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def tiertexseqvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Tiertex Limited SEQ video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def tiff(
-    
+
     subimage: bool | None = None,
-    
+
     thumbnail: bool | None = None,
-    
+
     page: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     TIFF image
-    
+
     Args:
         subimage: decode subimage instead if available (default false)
         thumbnail: decode embedded thumbnail subimage instead if available (default false)
@@ -3997,185 +3997,185 @@ def tiff(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "subimage": subimage,
-        
+
         "thumbnail": thumbnail,
-        
+
         "page": page,
-        
+
     }))
 
 
 
 def tmv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     8088flex TMV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def eatqi(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Electronic Arts TQI Video (codec tqi)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def truemotion1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Duck TrueMotion 1.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def truemotion2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Duck TrueMotion 2.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def truemotion2rt(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Duck TrueMotion 2.0 Real Time
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def camtasia(
-    
+
 ) -> FFMpegDecoderOption:
     """
     TechSmith Screen Capture Codec (codec tscc)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def tscc2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     TechSmith Screen Codec 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def txd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Renderware TXD (TeXture Dictionary) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ultimotion(
-    
+
 ) -> FFMpegDecoderOption:
     """
     IBM UltiMotion (codec ulti)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def utvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Ut Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def v210(
-    
+
     custom_stride: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed 4:2:2 10-bit
-    
+
     Args:
         custom_stride: Custom V210 stride (from -1 to INT_MAX) (default 0)
 
@@ -4183,151 +4183,151 @@ def v210(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "custom_stride": custom_stride,
-        
+
     }))
 
 
 
 def v210x(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed 4:2:2 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def v308(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed packed 4:4:4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def v408(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed packed QT 4:4:4:4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def v410(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed 4:4:4 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vb(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Beam Software VB
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vble(
-    
+
 ) -> FFMpegDecoderOption:
     """
     VBLE Lossless Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vbn(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Vizrt Binary Image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vc1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SMPTE VC-1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vc1_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem VC1 decoder wrapper (codec vc1)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 6 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 20 to INT_MAX) (default 20)
@@ -4336,233 +4336,233 @@ def vc1_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def vc1image(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Video 9 Image v2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vcr1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATI VCR1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xl(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Miro VideoXL (codec vixl)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vmdvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sierra VMD video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vmnc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     VMware Screen Codec / VMware Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp5(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP5
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp6(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP6
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp6a(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP6 (Flash version, with alpha channel)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp6f(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP6 (Flash version)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp7(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP7
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp8(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP8
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp8_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem VP8 decoder wrapper (codec vp8)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 6 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 20 to INT_MAX) (default 20)
@@ -4571,57 +4571,57 @@ def vp8_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def libvpx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     libvpx VP8 (codec vp8)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp9(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Google VP9
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp9_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem VP9 decoder wrapper (codec vp9)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 6 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 20 to INT_MAX) (default 20)
@@ -4630,425 +4630,425 @@ def vp9_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def wcmv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     WinCAM Motion Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def webp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     WebP image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmv1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Video 7
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmv2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Video 8
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmv3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Video 9
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmv3image(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Video 9 Image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wnv1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Winnov WNV1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wrapped_avframe(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AVPacket to AVFrame passthrough
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vqavideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Westwood Studios VQA (Vector Quantized Animation) video (codec ws_vqa)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xan_wc3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Wing Commander III / Xan
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xan_wc4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Wing Commander IV / Xxan
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xbin(
-    
+
 ) -> FFMpegDecoderOption:
     """
     eXtended BINary text
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xbm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     XBM (X BitMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xface(
-    
+
 ) -> FFMpegDecoderOption:
     """
     X-face image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xpm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     XPM (X PixMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xwd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     XWD (X Window Dump) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def y41p(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed YUV 4:1:1 12-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ylc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     YUY2 Lossless Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def yop(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Psygnosis YOP Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def yuv4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed packed 4:2:0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def zerocodec(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ZeroCodec Lossless Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def zlib(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LCL (LossLess Codec Library) ZLIB
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def zmbv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Zip Motion Blocks Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def _8svx_exp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     8SVX exponential
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def _8svx_fib(
-    
+
 ) -> FFMpegDecoderOption:
     """
     8SVX fibonacci
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def aac(
-    
+
     dual_mono_mode: int | None| Literal["auto", "main", "sub", "both"] = None,
-    
+
     channel_order: int | None| Literal["default", "coded"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     AAC (Advanced Audio Coding)
-    
+
     Args:
         dual_mono_mode: Select the channel to decode for dual mono (from -1 to 2) (default auto)
         channel_order: Order in which the channels are to be exported (from 0 to 1) (default default)
@@ -5057,63 +5057,63 @@ def aac(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "dual_mono_mode": dual_mono_mode,
-        
+
         "channel_order": channel_order,
-        
+
     }))
 
 
 
 def aac_fixed(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AAC (Advanced Audio Coding) (codec aac)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def aac_latm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AAC LATM (Advanced Audio Coding LATM syntax)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ac3(
-    
+
     cons_noisegen: bool | None = None,
-    
+
     drc_scale: float | None = None,
-    
+
     heavy_compr: bool | None = None,
-    
+
     target_level: int | None = None,
-    
+
     downmix: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATSC A/52A (AC-3)
-    
+
     Args:
         cons_noisegen: enable consistent noise generation (default false)
         drc_scale: percentage of dynamic range compression to apply (from 0 to 6) (default 1)
@@ -5125,35 +5125,35 @@ def ac3(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "cons_noisegen": cons_noisegen,
-        
+
         "drc_scale": drc_scale,
-        
+
         "heavy_compr": heavy_compr,
-        
+
         "target_level": target_level,
-        
+
         "downmix": downmix,
-        
+
     }))
 
 
 
 def ac3_fixed(
-    
+
     cons_noisegen: bool | None = None,
-    
+
     drc_scale: float | None = None,
-    
+
     heavy_compr: bool | None = None,
-    
+
     downmix: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATSC A/52A (AC-3) (codec ac3)
-    
+
     Args:
         cons_noisegen: enable consistent noise generation (default false)
         drc_scale: percentage of dynamic range compression to apply (from 0 to 6) (default 1)
@@ -5164,251 +5164,251 @@ def ac3_fixed(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "cons_noisegen": cons_noisegen,
-        
+
         "drc_scale": drc_scale,
-        
+
         "heavy_compr": heavy_compr,
-        
+
         "downmix": downmix,
-        
+
     }))
 
 
 
 def adpcm_4xm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM 4X Movie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_adx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SEGA CRI ADX ADPCM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_afc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Nintendo Gamecube AFC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_agm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM AmuseGraphics Movie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_aica(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Yamaha AICA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_argo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Argonaut Games
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ct(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Creative Technology
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_dtk(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Nintendo Gamecube DTK
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ea(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Electronic Arts
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ea_maxis_xa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Electronic Arts Maxis CDROM XA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ea_r1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Electronic Arts R1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ea_r2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Electronic Arts R2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ea_r3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Electronic Arts R3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ea_xas(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Electronic Arts XAS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def g722(
-    
+
     bits_per_codeword: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     G.722 ADPCM (codec adpcm_g722)
-    
+
     Args:
         bits_per_codeword: Bits per G722 codeword (from 6 to 8) (default 8)
 
@@ -5416,597 +5416,597 @@ def g722(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "bits_per_codeword": bits_per_codeword,
-        
+
     }))
 
 
 
 def g726(
-    
+
 ) -> FFMpegDecoderOption:
     """
     G.726 ADPCM (codec adpcm_g726)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def g726le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     G.726 ADPCM little-endian (codec adpcm_g726le)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_acorn(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Acorn Replay
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_alp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA High Voltage Software ALP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_amv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA AMV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_apc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA CRYO APC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_apm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Ubisoft APM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_cunning(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Cunning Developments
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_dat4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Eurocom DAT4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_dk3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Duck DK3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_dk4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Duck DK4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_ea_eacs(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Electronic Arts EACS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_ea_sead(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Electronic Arts SEAD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_iss(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Funcom ISS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_moflex(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA MobiClip MOFLEX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_mtf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Capcom's MT Framework
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_oki(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Dialogic OKI
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_qt(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA QuickTime
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_rad(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Radical
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_smjpeg(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Loki SDL MJPEG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_ssi(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Simon & Schuster Interactive
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_wav(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA WAV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_ws(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Westwood
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ms(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Microsoft
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_mtaf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM MTAF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_psx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Playstation
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_sbpro_2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Sound Blaster Pro 2-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_sbpro_3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Sound Blaster Pro 2.6-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_sbpro_4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Sound Blaster Pro 4-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_swf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Shockwave Flash
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_thp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Nintendo THP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_thp_le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Nintendo THP (little-endian)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_vima(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LucasArts VIMA audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_xa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM CDROM XA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_yamaha(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Yamaha
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_zork(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Zork
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def alac(
-    
+
     extra_bits_bug: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     ALAC (Apple Lossless Audio Codec)
-    
+
     Args:
         extra_bits_bug: Force non-standard decoding process (default false)
 
@@ -6014,85 +6014,85 @@ def alac(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "extra_bits_bug": extra_bits_bug,
-        
+
     }))
 
 
 
 def amrnb(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AMR-NB (Adaptive Multi-Rate NarrowBand) (codec amr_nb)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def libopencore_amrnb(
-    
+
 ) -> FFMpegDecoderOption:
     """
     OpenCORE AMR-NB (Adaptive Multi-Rate Narrow-Band) (codec amr_nb)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def amrwb(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AMR-WB (Adaptive Multi-Rate WideBand) (codec amr_wb)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def libopencore_amrwb(
-    
+
 ) -> FFMpegDecoderOption:
     """
     OpenCORE AMR-WB (Adaptive Multi-Rate Wide-Band) (codec amr_wb)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ape(
-    
+
     max_samples: int | None| Literal["all"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Monkey's Audio
-    
+
     Args:
         max_samples: maximum number of samples decoded per call (from 1 to INT_MAX) (default 4608)
 
@@ -6100,277 +6100,277 @@ def ape(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "max_samples": max_samples,
-        
+
     }))
 
 
 
 def aptx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     aptX (Audio Processing Technology for Bluetooth)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def aptx_hd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     aptX HD (Audio Processing Technology for Bluetooth)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def atrac1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATRAC1 (Adaptive TRansform Acoustic Coding)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def atrac3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATRAC3 (Adaptive TRansform Acoustic Coding 3)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def atrac3al(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATRAC3 AL (Adaptive TRansform Acoustic Coding 3 Advanced Lossless)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def atrac3plus(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATRAC3+ (Adaptive TRansform Acoustic Coding 3+) (codec atrac3p)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def atrac3plusal(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATRAC3+ AL (Adaptive TRansform Acoustic Coding 3+ Advanced Lossless) (codec atrac3pal)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def atrac9(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATRAC9 (Adaptive TRansform Acoustic Coding 9)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def on2avc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 Audio for Video Codec (codec avc)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def binkaudio_dct(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bink Audio (DCT)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def binkaudio_rdft(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bink Audio (RDFT)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bmv_audio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Discworld II BMV audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def comfortnoise(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RFC 3389 comfort noise generator
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cook(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Cook / Cooker / Gecko (RealAudio G2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def derf_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Xilam DERF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dfpwm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DFPWM1a audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dolby_e(
-    
+
     channel_order: int | None| Literal["default", "coded"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Dolby E
-    
+
     Args:
         channel_order: Order in which the channels are to be exported (from 0 to 1) (default default)
 
@@ -6378,137 +6378,137 @@ def dolby_e(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "channel_order": channel_order,
-        
+
     }))
 
 
 
 def dsd_lsbf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DSD (Direct Stream Digital), least significant bit first
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dsd_lsbf_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DSD (Direct Stream Digital), least significant bit first, planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dsd_msbf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DSD (Direct Stream Digital), most significant bit first
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dsd_msbf_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DSD (Direct Stream Digital), most significant bit first, planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dsicinaudio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Delphine Software International CIN audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dss_sp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Digital Speech Standard - Standard Play mode (DSS SP)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dst(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DST (Digital Stream Transfer)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dca(
-    
+
     core_only: bool | None = None,
-    
+
     channel_order: int | None| Literal["default", "coded"] = None,
-    
+
     downmix: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     DCA (DTS Coherent Acoustics) (codec dts)
-    
+
     Args:
         core_only: Decode core only without extensions (default false)
         channel_order: Order in which the channels are to be exported (from 0 to 1) (default default)
@@ -6518,49 +6518,49 @@ def dca(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "core_only": core_only,
-        
+
         "channel_order": channel_order,
-        
+
         "downmix": downmix,
-        
+
     }))
 
 
 
 def dvaudio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Ulead DV Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def eac3(
-    
+
     cons_noisegen: bool | None = None,
-    
+
     drc_scale: float | None = None,
-    
+
     heavy_compr: bool | None = None,
-    
+
     target_level: int | None = None,
-    
+
     downmix: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATSC A/52B (AC-3, E-AC-3)
-    
+
     Args:
         cons_noisegen: enable consistent noise generation (default false)
         drc_scale: percentage of dynamic range compression to apply (from 0 to 6) (default 1)
@@ -6572,29 +6572,29 @@ def eac3(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "cons_noisegen": cons_noisegen,
-        
+
         "drc_scale": drc_scale,
-        
+
         "heavy_compr": heavy_compr,
-        
+
         "target_level": target_level,
-        
+
         "downmix": downmix,
-        
+
     }))
 
 
 
 def evrc(
-    
+
     postfilter: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     EVRC (Enhanced Variable Rate Codec)
-    
+
     Args:
         postfilter: enable postfilter (default true)
 
@@ -6602,37 +6602,37 @@ def evrc(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "postfilter": postfilter,
-        
+
     }))
 
 
 
 def fastaudio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MobiClip FastAudio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def flac(
-    
+
     use_buggy_lpc: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     FLAC (Free Lossless Audio Codec)
-    
+
     Args:
         use_buggy_lpc: emulate old buggy lavc behavior (default false)
 
@@ -6640,21 +6640,21 @@ def flac(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "use_buggy_lpc": use_buggy_lpc,
-        
+
     }))
 
 
 
 def g723_1(
-    
+
     postfilter: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     G.723.1
-    
+
     Args:
         postfilter: enable postfilter (default true)
 
@@ -6662,245 +6662,245 @@ def g723_1(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "postfilter": postfilter,
-        
+
     }))
 
 
 
 def g729(
-    
+
 ) -> FFMpegDecoderOption:
     """
     G.729
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def gremlin_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Gremlin
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def gsm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     GSM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def gsm_ms(
-    
+
 ) -> FFMpegDecoderOption:
     """
     GSM Microsoft variant
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hca(
-    
+
 ) -> FFMpegDecoderOption:
     """
     CRI HCA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hcom(
-    
+
 ) -> FFMpegDecoderOption:
     """
     HCOM Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def iac(
-    
+
 ) -> FFMpegDecoderOption:
     """
     IAC (Indeo Audio Coder)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ilbc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     iLBC (Internet Low Bitrate Codec)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def imc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     IMC (Intel Music Coder)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def interplay_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Interplay
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def interplayacm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Interplay ACM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mace3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MACE (Macintosh Audio Compression/Expansion) 3:1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mace6(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MACE (Macintosh Audio Compression/Expansion) 6:1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def metasound(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Voxware MetaSound
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mlp(
-    
+
     downmix: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     MLP (Meridian Lossless Packing)
-    
+
     Args:
         downmix: Request a specific channel layout from the decoder
 
@@ -6908,261 +6908,261 @@ def mlp(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "downmix": downmix,
-        
+
     }))
 
 
 
 def mp1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP1 (MPEG audio layer 1)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp1float(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP1 (MPEG audio layer 1) (codec mp1)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP2 (MPEG audio layer 2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp2float(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP2 (MPEG audio layer 2) (codec mp2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp3float(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP3 (MPEG audio layer 3) (codec mp3)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP3 (MPEG audio layer 3)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp3adufloat(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADU (Application Data Unit) MP3 (MPEG audio layer 3) (codec mp3adu)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp3adu(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADU (Application Data Unit) MP3 (MPEG audio layer 3)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp3on4float(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP3onMP4 (codec mp3on4)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp3on4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP3onMP4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def als(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-4 Audio Lossless Coding (ALS) (codec mp4als)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msnsiren(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MSN Siren
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpc7(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Musepack SV7 (codec musepack7)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpc8(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Musepack SV8 (codec musepack8)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def nellymoser(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Nellymoser Asao
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def opus(
-    
+
     apply_phase_inv: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Opus
-    
+
     Args:
         apply_phase_inv: Apply intensity stereo phase inversion (default true)
 
@@ -7170,21 +7170,21 @@ def opus(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "apply_phase_inv": apply_phase_inv,
-        
+
     }))
 
 
 
 def libopus(
-    
+
     apply_phase_inv: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     libopus Opus (codec opus)
-    
+
     Args:
         apply_phase_inv: Apply intensity stereo phase inversion (default true)
 
@@ -7192,709 +7192,709 @@ def libopus(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "apply_phase_inv": apply_phase_inv,
-        
+
     }))
 
 
 
 def paf_audio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Amazing Studio Packed Animation File Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_alaw(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM A-law / G.711 A-law
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_bluray(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 16|20|24-bit big-endian for Blu-ray media
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_dvd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 16|20|24-bit big-endian for DVD media
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f16le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM 16.8 floating point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f24le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM 24.0 floating point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f32be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM 32-bit floating point big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f32le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM 32-bit floating point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f64be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM 64-bit floating point big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f64le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM 64-bit floating point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_lxf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 20-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_mulaw(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM mu-law / G.711 mu-law
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 16-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16be_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 16-bit big-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 16-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16le_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 16-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 24-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24daud(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM D-Cinema audio signed 24-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 24-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24le_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 24-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s32be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 32-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s32le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 32-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s32le_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 32-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s64be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 64-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s64le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 64-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s8(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 8-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s8_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 8-bit planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_sga(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM SGA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u16be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 16-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u16le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 16-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u24be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 24-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u24le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 24-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u32be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 32-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u32le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 32-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u8(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 8-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_vidc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM Archimedes VIDC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qcelp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QCELP / PureVoice
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qdm2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QDesign Music Codec 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qdmc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QDesign Music Codec 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def real_144(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealAudio 1.0 (14.4K) (codec ra_144)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def real_288(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealAudio 2.0 (28.8K) (codec ra_288)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ralf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealAudio Lossless
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def roq_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM id RoQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def s302m(
-    
+
     non_pcm_mode: int | None| Literal["copy", "drop", "decode_copy", "decode_drop"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     SMPTE 302M
-    
+
     Args:
         non_pcm_mode: Chooses what to do with NON-PCM (from 0 to 3) (default decode_drop)
 
@@ -7902,181 +7902,181 @@ def s302m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "non_pcm_mode": non_pcm_mode,
-        
+
     }))
 
 
 
 def sbc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SBC (low-complexity subband codec)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sdx2_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Squareroot-Delta-Exact
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def shorten(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Shorten
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sipr(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealAudio SIPR / ACELP.NET
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def siren(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Siren
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def smackaud(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Smacker audio (codec smackaudio)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sol_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Sol
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sonic(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sonic
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def speex(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Speex
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def tak(
-    
+
 ) -> FFMpegDecoderOption:
     """
     TAK (Tom's lossless Audio Kompressor)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def truehd(
-    
+
     downmix: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     TrueHD
-    
+
     Args:
         downmix: Request a specific channel layout from the decoder
 
@@ -8084,37 +8084,37 @@ def truehd(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "downmix": downmix,
-        
+
     }))
 
 
 
 def truespeech(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DSP Group TrueSpeech
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def tta(
-    
+
     password: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     TTA (True Audio)
-    
+
     Args:
         password: Set decoding password
 
@@ -8122,297 +8122,297 @@ def tta(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "password": password,
-        
+
     }))
 
 
 
 def twinvq(
-    
+
 ) -> FFMpegDecoderOption:
     """
     VQF TwinVQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vmdaudio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sierra VMD audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vorbis(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Vorbis
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def libvorbis(
-    
+
 ) -> FFMpegDecoderOption:
     """
     libvorbis (codec vorbis)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wavesynth(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Wave synthesis pseudo-codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wavpack(
-    
+
 ) -> FFMpegDecoderOption:
     """
     WavPack
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ws_snd1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Westwood Audio (SND1) (codec westwood_snd1)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmalossless(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Audio Lossless
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmapro(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Audio 9 Professional
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmav1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Audio 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmav2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Audio 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmavoice(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Audio Voice
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xan_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Xan
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xma1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Xbox Media Audio 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xma2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Xbox Media Audio 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ssa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ASS (Advanced SubStation Alpha) subtitle (codec ass)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ass(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ASS (Advanced SubStation Alpha) subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dvbsub(
-    
+
     compute_edt: bool | None = None,
-    
+
     compute_clut: bool | None = None,
-    
+
     dvb_substream: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     DVB subtitles (codec dvb_subtitle)
-    
+
     Args:
         compute_edt: compute end of time using pts or timeout (default false)
         compute_clut: compute clut when not available(-1) or only once (-2) or always(1) or never(0) (default auto)
@@ -8422,29 +8422,29 @@ def dvbsub(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "compute_edt": compute_edt,
-        
+
         "compute_clut": compute_clut,
-        
+
         "dvb_substream": dvb_substream,
-        
+
     }))
 
 
 
 def dvdsub(
-    
+
     palette: str | None = None,
-    
+
     ifo_palette: str | None = None,
-    
+
     forced_subs_only: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     DVD subtitles (codec dvd_subtitle)
-    
+
     Args:
         palette: set the global palette
         ifo_palette: obtain the global palette from .IFO file
@@ -8454,29 +8454,29 @@ def dvdsub(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "palette": palette,
-        
+
         "ifo_palette": ifo_palette,
-        
+
         "forced_subs_only": forced_subs_only,
-        
+
     }))
 
 
 
 def cc_dec(
-    
+
     real_time: bool | None = None,
-    
+
     real_time_latency_msec: int | None = None,
-    
+
     data_field: int | None| Literal["auto", "first", "second"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Closed Caption (EIA-608 / CEA-708) (codec eia_608)
-    
+
     Args:
         real_time: emit subtitle events as they are decoded for real-time display (default false)
         real_time_latency_msec: minimum elapsed time between emitting real-time subtitle events (from 0 to 500) (default 200)
@@ -8486,25 +8486,25 @@ def cc_dec(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "real_time": real_time,
-        
+
         "real_time_latency_msec": real_time_latency_msec,
-        
+
         "data_field": data_field,
-        
+
     }))
 
 
 
 def pgssub(
-    
+
     forced_subs_only: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     HDMV Presentation Graphic Stream subtitles (codec hdmv_pgs_subtitle)
-    
+
     Args:
         forced_subs_only: Only show forced subtitles (default false)
 
@@ -8512,55 +8512,55 @@ def pgssub(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "forced_subs_only": forced_subs_only,
-        
+
     }))
 
 
 
 def jacosub(
-    
+
 ) -> FFMpegDecoderOption:
     """
     JACOsub subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def microdvd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MicroDVD subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mov_text(
-    
+
     width: int | None = None,
-    
+
     height: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     3GPP Timed Text subtitle
-    
+
     Args:
         width: Frame width, usually video width (from 0 to INT_MAX) (default 0)
         height: Frame height, usually video height (from 0 to INT_MAX) (default 0)
@@ -8569,39 +8569,39 @@ def mov_text(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "width": width,
-        
+
         "height": height,
-        
+
     }))
 
 
 
 def mpl2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPL2 subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pjs(
-    
+
     keep_ass_markup: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     PJS subtitle
-    
+
     Args:
         keep_ass_markup: Set if ASS tags must be escaped (default false)
 
@@ -8609,53 +8609,53 @@ def pjs(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "keep_ass_markup": keep_ass_markup,
-        
+
     }))
 
 
 
 def realtext(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealText subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sami(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SAMI subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def stl(
-    
+
     keep_ass_markup: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Spruce subtitle format
-    
+
     Args:
         keep_ass_markup: Set if ASS tags must be escaped (default false)
 
@@ -8663,69 +8663,69 @@ def stl(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "keep_ass_markup": keep_ass_markup,
-        
+
     }))
 
 
 
 def srt(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SubRip subtitle (codec subrip)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def subrip(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SubRip subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def subviewer(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SubViewer subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def subviewer1(
-    
+
     keep_ass_markup: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     SubViewer1 subtitle
-    
+
     Args:
         keep_ass_markup: Set if ASS tags must be escaped (default false)
 
@@ -8733,21 +8733,21 @@ def subviewer1(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "keep_ass_markup": keep_ass_markup,
-        
+
     }))
 
 
 
 def text(
-    
+
     keep_ass_markup: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Raw text subtitle
-    
+
     Args:
         keep_ass_markup: Set if ASS tags must be escaped (default false)
 
@@ -8755,21 +8755,21 @@ def text(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "keep_ass_markup": keep_ass_markup,
-        
+
     }))
 
 
 
 def vplayer(
-    
+
     keep_ass_markup: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     VPlayer subtitle
-    
+
     Args:
         keep_ass_markup: Set if ASS tags must be escaped (default false)
 
@@ -8777,40 +8777,39 @@ def vplayer(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "keep_ass_markup": keep_ass_markup,
-        
+
     }))
 
 
 
 def webvtt(
-    
+
 ) -> FFMpegDecoderOption:
     """
     WebVTT subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xsub(
-    
+
 ) -> FFMpegDecoderOption:
     """
     XSUB
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
-    }))
 
+    }))

--- a/packages/v5/src/ffmpeg/codecs/encoders.py
+++ b/packages/v5/src/ffmpeg/codecs/encoders.py
@@ -44,105 +44,105 @@ from ..streams.audio import AudioStream
 
 
 def a64multi(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Multicolor charset for Commodore 64 (codec a64_multi)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def a64multi5(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Multicolor charset for Commodore 64, extended with 5th color (colram) (codec a64_multi5)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def alias_pix(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Alias/Wavefront PIX image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def amv(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     huffman: int | None| Literal["default", "optimal"] = None,
-    
+
     force_duplicated_matrix: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     AMV Video
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -172,69 +172,69 @@ def amv(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "huffman": huffman,
-        
+
         "force_duplicated_matrix": force_duplicated_matrix,
-        
+
     }))
 
 
 
 def apng(
-    
+
     dpi: int | None = None,
-    
+
     dpm: int | None = None,
-    
+
     pred: int | None| Literal["none", "sub", "up", "avg", "paeth", "mixed"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     APNG (Animated Portable Network Graphics) image
-    
+
     Args:
         dpi: Set image resolution (in dots per inch) (from 0 to 65536) (default 0)
         dpm: Set image resolution (in dots per meter) (from 0 to 65536) (default 0)
@@ -244,137 +244,137 @@ def apng(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "dpi": dpi,
-        
+
         "dpm": dpm,
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def asv1(
-    
+
 ) -> FFMpegEncoderOption:
     """
     ASUS V1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def asv2(
-    
+
 ) -> FFMpegEncoderOption:
     """
     ASUS V2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def avrp(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Avid 1:1 10-bit RGB Packer
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def avui(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Avid Meridien Uncompressed
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def ayuv(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed packed MS 4:4:4:4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def bitpacked(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Bitpacked
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def bmp(
-    
+
 ) -> FFMpegEncoderOption:
     """
     BMP (Windows and OS/2 bitmap)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def cfhd(
-    
+
     quality: int | None| Literal["film3+", "film3", "film2+", "film2", "film1.5", "film1+", "film1", "high+", "high", "medium+", "medium", "low+", "low"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     GoPro CineForm HD
-    
+
     Args:
         quality: set quality (from 0 to 12) (default film3+)
 
@@ -382,29 +382,29 @@ def cfhd(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "quality": quality,
-        
+
     }))
 
 
 
 def cinepak(
-    
+
     max_extra_cb_iterations: int | None = None,
-    
+
     skip_empty_cb: bool | None = None,
-    
+
     max_strips: int | None = None,
-    
+
     min_strips: int | None = None,
-    
+
     strip_number_adaptivity: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Cinepak
-    
+
     Args:
         max_extra_cb_iterations: Max extra codebook recalculation passes, more is better and slower (from 0 to INT_MAX) (default 2)
         skip_empty_cb: Avoid wasting bytes, ignore vintage MacOS decoder (default false)
@@ -416,29 +416,29 @@ def cinepak(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "max_extra_cb_iterations": max_extra_cb_iterations,
-        
+
         "skip_empty_cb": skip_empty_cb,
-        
+
         "max_strips": max_strips,
-        
+
         "min_strips": min_strips,
-        
+
         "strip_number_adaptivity": strip_number_adaptivity,
-        
+
     }))
 
 
 
 def cljr(
-    
+
     dither_type: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Cirrus Logic AccuPak
-    
+
     Args:
         dither_type: Dither type (from 0 to 2) (default 1)
 
@@ -446,31 +446,31 @@ def cljr(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "dither_type": dither_type,
-        
+
     }))
 
 
 
 def vc2(
-    
+
     tolerance: float | None = None,
-    
+
     slice_width: int | None = None,
-    
+
     slice_height: int | None = None,
-    
+
     wavelet_depth: int | None = None,
-    
+
     wavelet_type: int | None| Literal["9_7", "5_3", "haar", "haar_noshift"] = None,
-    
+
     qm: int | None| Literal["default", "color", "flat"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     SMPTE VC-2 (codec dirac)
-    
+
     Args:
         tolerance: Max undershoot in percent (from 0 to 45) (default 5)
         slice_width: Slice width (from 32 to 1024) (default 32)
@@ -483,35 +483,35 @@ def vc2(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "tolerance": tolerance,
-        
+
         "slice_width": slice_width,
-        
+
         "slice_height": slice_height,
-        
+
         "wavelet_depth": wavelet_depth,
-        
+
         "wavelet_type": wavelet_type,
-        
+
         "qm": qm,
-        
+
     }))
 
 
 
 def dnxhd(
-    
+
     nitris_compat: bool | None = None,
-    
+
     ibias: int | None = None,
-    
+
     profile: int | None| Literal["dnxhd", "dnxhr_444", "dnxhr_hqx", "dnxhr_hq", "dnxhr_sq", "dnxhr_lb"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     VC3/DNxHD
-    
+
     Args:
         nitris_compat: encode with Avid Nitris compatibility (default false)
         ibias: intra quant bias (from INT_MIN to INT_MAX) (default 0)
@@ -521,41 +521,41 @@ def dnxhd(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "nitris_compat": nitris_compat,
-        
+
         "ibias": ibias,
-        
+
         "profile": profile,
-        
+
     }))
 
 
 
 def dpx(
-    
+
 ) -> FFMpegEncoderOption:
     """
     DPX (Digital Picture Exchange) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def dvvideo(
-    
+
     quant_deadzone: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     DV (Digital Video)
-    
+
     Args:
         quant_deadzone: Quantizer dead zone (from 0 to 1024) (default 7)
 
@@ -563,25 +563,25 @@ def dvvideo(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "quant_deadzone": quant_deadzone,
-        
+
     }))
 
 
 
 def exr(
-    
+
     compression: int | None| Literal["none", "rle", "zip1", "zip16"] = None,
-    
+
     format: int | None| Literal["half", "float"] = None,
-    
+
     gamma: float | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     OpenEXR image
-    
+
     Args:
         compression: set compression type (from 0 to 3) (default none)
         format: set pixel type (from 1 to 2) (default float)
@@ -591,29 +591,29 @@ def exr(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "compression": compression,
-        
+
         "format": format,
-        
+
         "gamma": gamma,
-        
+
     }))
 
 
 
 def ffv1(
-    
+
     slicecrc: bool | None = None,
-    
+
     coder: int | None| Literal["rice", "range_def", "range_tab", "ac"] = None,
-    
+
     context: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     FFmpeg video codec #1
-    
+
     Args:
         slicecrc: Protect slices with CRCs (default auto)
         coder: Coder type (from -2 to 2) (default rice)
@@ -623,29 +623,29 @@ def ffv1(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "slicecrc": slicecrc,
-        
+
         "coder": coder,
-        
+
         "context": context,
-        
+
     }))
 
 
 
 def ffvhuff(
-    
+
     non_deterministic: bool | None = None,
-    
+
     pred: int | None| Literal["left", "plane", "median"] = None,
-    
+
     context: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Huffyuv FFmpeg variant
-    
+
     Args:
         non_deterministic: Allow multithreading for e.g. context=1 at the expense of determinism (default false)
         pred: Prediction method (from 0 to 2) (default left)
@@ -655,121 +655,121 @@ def ffvhuff(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "non_deterministic": non_deterministic,
-        
+
         "pred": pred,
-        
+
         "context": context,
-        
+
     }))
 
 
 
 def fits(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Flexible Image Transport System
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def flashsv(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Flash Screen Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def flashsv2(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Flash Screen Video Version 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def flv(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     FLV / Sorenson Spark / Sorenson H.263 (Flash Video) (codec flv1)
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -801,73 +801,73 @@ def flv(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def gif(
-    
+
     gifflags: str | None = None,
-    
+
     gifimage: bool | None = None,
-    
+
     global_palette: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     GIF (Graphics Interchange Format)
-    
+
     Args:
         gifflags: set GIF flags (default offsetting+transdiff)
         gifimage: enable encoding only images per frame (default false)
@@ -877,73 +877,73 @@ def gif(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "gifflags": gifflags,
-        
+
         "gifimage": gifimage,
-        
+
         "global_palette": global_palette,
-        
+
     }))
 
 
 
 def h261(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     H.261
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -975,121 +975,121 @@ def h261(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def h263(
-    
+
     obmc: bool | None = None,
-    
+
     mb_info: int | None = None,
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     H.263 / H.263-1996
-    
+
     Args:
         obmc: use overlapped block motion compensation. (default false)
         mb_info: emit macroblock info for RFC 2190 packetization, the parameter value is the maximum payload size (from 0 to INT_MAX) (default 0)
@@ -1123,75 +1123,75 @@ def h263(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "obmc": obmc,
-        
+
         "mb_info": mb_info,
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def h263_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     V4L2 mem2mem H.263 encoder wrapper (codec h263)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 6 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 4 to INT_MAX) (default 4)
@@ -1200,79 +1200,79 @@ def h263_v4l2m2m(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def h263p(
-    
+
     umv: bool | None = None,
-    
+
     aiv: bool | None = None,
-    
+
     obmc: bool | None = None,
-    
+
     structured_slices: bool | None = None,
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     H.263+ / H.263-1998 / H.263 version 2
-    
+
     Args:
         umv: Use unlimited motion vectors. (default false)
         aiv: Use alternative inter VLC. (default false)
@@ -1308,167 +1308,167 @@ def h263p(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "umv": umv,
-        
+
         "aiv": aiv,
-        
+
         "obmc": obmc,
-        
+
         "structured_slices": structured_slices,
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def libx264(
-    
+
     preset: str | None = None,
-    
+
     tune: str | None = None,
-    
+
     profile: str | None = None,
-    
+
     fastfirstpass: bool | None = None,
-    
+
     level: str | None = None,
-    
+
     passlogfile: str | None = None,
-    
+
     wpredp: str | None = None,
-    
+
     a53cc: bool | None = None,
-    
+
     x264opts: str | None = None,
-    
+
     crf: float | None = None,
-    
+
     crf_max: float | None = None,
-    
+
     qp: int | None = None,
-    
+
     aq_mode: int | None| Literal["none", "variance", "autovariance", "autovariance-biased"] = None,
-    
+
     aq_strength: float | None = None,
-    
+
     psy: bool | None = None,
-    
+
     psy_rd: str | None = None,
-    
+
     rc_lookahead: int | None = None,
-    
+
     weightb: bool | None = None,
-    
+
     weightp: int | None| Literal["none", "simple", "smart"] = None,
-    
+
     ssim: bool | None = None,
-    
+
     intra_refresh: bool | None = None,
-    
+
     bluray_compat: bool | None = None,
-    
+
     b_bias: int | None = None,
-    
+
     b_pyramid: int | None| Literal["none", "strict", "normal"] = None,
-    
+
     mixed_refs: bool | None = None,
-    
+
     _8x8dct: bool | None = None,
-    
+
     fast_pskip: bool | None = None,
-    
+
     aud: bool | None = None,
-    
+
     mbtree: bool | None = None,
-    
+
     deblock: str | None = None,
-    
+
     cplxblur: float | None = None,
-    
+
     partitions: str | None = None,
-    
+
     direct_pred: int | None| Literal["none", "spatial", "temporal", "auto"] = None,
-    
+
     slice_max_size: int | None = None,
-    
+
     stats: str | None = None,
-    
+
     nal_hrd: int | None| Literal["none", "vbr", "cbr"] = None,
-    
+
     avcintra_class: int | None = None,
-    
+
     me_method: int | None| Literal["dia", "hex", "umh", "esa", "tesa"] = None,
-    
+
     forced_idr: bool | None = None,
-    
+
     coder: int | None| Literal["default", "cavlc", "cabac", "vlc", "ac"] = None,
-    
+
     b_strategy: int | None = None,
-    
+
     chromaoffset: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     udu_sei: bool | None = None,
-    
+
     x264_params: str | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libx264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 (codec h264)
-    
+
     Args:
         preset: Set the encoding preset (cf. x264 --fullhelp) (default "medium")
         tune: Tune the encoding params (cf. x264 --fullhelp)
@@ -1521,201 +1521,201 @@ def libx264(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "preset": preset,
-        
+
         "tune": tune,
-        
+
         "profile": profile,
-        
+
         "fastfirstpass": fastfirstpass,
-        
+
         "level": level,
-        
+
         "passlogfile": passlogfile,
-        
+
         "wpredp": wpredp,
-        
+
         "a53cc": a53cc,
-        
+
         "x264opts": x264opts,
-        
+
         "crf": crf,
-        
+
         "crf_max": crf_max,
-        
+
         "qp": qp,
-        
+
         "aq-mode": aq_mode,
-        
+
         "aq-strength": aq_strength,
-        
+
         "psy": psy,
-        
+
         "psy-rd": psy_rd,
-        
+
         "rc-lookahead": rc_lookahead,
-        
+
         "weightb": weightb,
-        
+
         "weightp": weightp,
-        
+
         "ssim": ssim,
-        
+
         "intra-refresh": intra_refresh,
-        
+
         "bluray-compat": bluray_compat,
-        
+
         "b-bias": b_bias,
-        
+
         "b-pyramid": b_pyramid,
-        
+
         "mixed-refs": mixed_refs,
-        
+
         "8x8dct": _8x8dct,
-        
+
         "fast-pskip": fast_pskip,
-        
+
         "aud": aud,
-        
+
         "mbtree": mbtree,
-        
+
         "deblock": deblock,
-        
+
         "cplxblur": cplxblur,
-        
+
         "partitions": partitions,
-        
+
         "direct-pred": direct_pred,
-        
+
         "slice-max-size": slice_max_size,
-        
+
         "stats": stats,
-        
+
         "nal-hrd": nal_hrd,
-        
+
         "avcintra-class": avcintra_class,
-        
+
         "me_method": me_method,
-        
+
         "forced-idr": forced_idr,
-        
+
         "coder": coder,
-        
+
         "b_strategy": b_strategy,
-        
+
         "chromaoffset": chromaoffset,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "udu_sei": udu_sei,
-        
+
         "x264-params": x264_params,
-        
+
     }))
 
 
 
 def libx264rgb(
-    
+
     preset: str | None = None,
-    
+
     tune: str | None = None,
-    
+
     profile: str | None = None,
-    
+
     fastfirstpass: bool | None = None,
-    
+
     level: str | None = None,
-    
+
     passlogfile: str | None = None,
-    
+
     wpredp: str | None = None,
-    
+
     a53cc: bool | None = None,
-    
+
     x264opts: str | None = None,
-    
+
     crf: float | None = None,
-    
+
     crf_max: float | None = None,
-    
+
     qp: int | None = None,
-    
+
     aq_mode: int | None| Literal["none", "variance", "autovariance", "autovariance-biased"] = None,
-    
+
     aq_strength: float | None = None,
-    
+
     psy: bool | None = None,
-    
+
     psy_rd: str | None = None,
-    
+
     rc_lookahead: int | None = None,
-    
+
     weightb: bool | None = None,
-    
+
     weightp: int | None| Literal["none", "simple", "smart"] = None,
-    
+
     ssim: bool | None = None,
-    
+
     intra_refresh: bool | None = None,
-    
+
     bluray_compat: bool | None = None,
-    
+
     b_bias: int | None = None,
-    
+
     b_pyramid: int | None| Literal["none", "strict", "normal"] = None,
-    
+
     mixed_refs: bool | None = None,
-    
+
     _8x8dct: bool | None = None,
-    
+
     fast_pskip: bool | None = None,
-    
+
     aud: bool | None = None,
-    
+
     mbtree: bool | None = None,
-    
+
     deblock: str | None = None,
-    
+
     cplxblur: float | None = None,
-    
+
     partitions: str | None = None,
-    
+
     direct_pred: int | None| Literal["none", "spatial", "temporal", "auto"] = None,
-    
+
     slice_max_size: int | None = None,
-    
+
     stats: str | None = None,
-    
+
     nal_hrd: int | None| Literal["none", "vbr", "cbr"] = None,
-    
+
     avcintra_class: int | None = None,
-    
+
     me_method: int | None| Literal["dia", "hex", "umh", "esa", "tesa"] = None,
-    
+
     forced_idr: bool | None = None,
-    
+
     coder: int | None| Literal["default", "cavlc", "cabac", "vlc", "ac"] = None,
-    
+
     b_strategy: int | None = None,
-    
+
     chromaoffset: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     udu_sei: bool | None = None,
-    
+
     x264_params: str | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libx264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 RGB (codec h264)
-    
+
     Args:
         preset: Set the encoding preset (cf. x264 --fullhelp) (default "medium")
         tune: Tune the encoding params (cf. x264 --fullhelp)
@@ -1768,113 +1768,113 @@ def libx264rgb(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "preset": preset,
-        
+
         "tune": tune,
-        
+
         "profile": profile,
-        
+
         "fastfirstpass": fastfirstpass,
-        
+
         "level": level,
-        
+
         "passlogfile": passlogfile,
-        
+
         "wpredp": wpredp,
-        
+
         "a53cc": a53cc,
-        
+
         "x264opts": x264opts,
-        
+
         "crf": crf,
-        
+
         "crf_max": crf_max,
-        
+
         "qp": qp,
-        
+
         "aq-mode": aq_mode,
-        
+
         "aq-strength": aq_strength,
-        
+
         "psy": psy,
-        
+
         "psy-rd": psy_rd,
-        
+
         "rc-lookahead": rc_lookahead,
-        
+
         "weightb": weightb,
-        
+
         "weightp": weightp,
-        
+
         "ssim": ssim,
-        
+
         "intra-refresh": intra_refresh,
-        
+
         "bluray-compat": bluray_compat,
-        
+
         "b-bias": b_bias,
-        
+
         "b-pyramid": b_pyramid,
-        
+
         "mixed-refs": mixed_refs,
-        
+
         "8x8dct": _8x8dct,
-        
+
         "fast-pskip": fast_pskip,
-        
+
         "aud": aud,
-        
+
         "mbtree": mbtree,
-        
+
         "deblock": deblock,
-        
+
         "cplxblur": cplxblur,
-        
+
         "partitions": partitions,
-        
+
         "direct-pred": direct_pred,
-        
+
         "slice-max-size": slice_max_size,
-        
+
         "stats": stats,
-        
+
         "nal-hrd": nal_hrd,
-        
+
         "avcintra-class": avcintra_class,
-        
+
         "me_method": me_method,
-        
+
         "forced-idr": forced_idr,
-        
+
         "coder": coder,
-        
+
         "b_strategy": b_strategy,
-        
+
         "chromaoffset": chromaoffset,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "udu_sei": udu_sei,
-        
+
         "x264-params": x264_params,
-        
+
     }))
 
 
 
 def h264_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     V4L2 mem2mem H.264 encoder wrapper (codec h264)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 6 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 4 to INT_MAX) (default 4)
@@ -1883,47 +1883,47 @@ def h264_v4l2m2m(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def h264_vaapi(
-    
+
     low_power: bool | None = None,
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     rc_mode: int | None| Literal["auto", "CQP", "CBR", "VBR", "ICQ", "QVBR", "AVBR"] = None,
-    
+
     qp: int | None = None,
-    
+
     quality: int | None = None,
-    
+
     coder: int | None| Literal["cavlc", "cabac", "vlc", "ac"] = None,
-    
+
     aud: bool | None = None,
-    
+
     sei: str | None = None,
-    
+
     profile: int | None| Literal["constrained_baseline", "main", "high"] = None,
-    
+
     level: int | None| Literal["1", "1.1", "1.2", "1.3", "2", "2.1", "2.2", "3", "3.1", "3.2", "4", "4.1", "4.2", "5", "5.1", "5.2", "6", "6.1", "6.2"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     H.264/AVC (VAAPI) (codec h264)
-    
+
     Args:
         low_power: Use low-power encoding mode (only available on some platforms; may not support all encoding features) (default false)
         idr_interval: Distance (in I-frames) between IDR frames (from 0 to INT_MAX) (default 0)
@@ -1943,59 +1943,59 @@ def h264_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "low_power": low_power,
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "rc_mode": rc_mode,
-        
+
         "qp": qp,
-        
+
         "quality": quality,
-        
+
         "coder": coder,
-        
+
         "aud": aud,
-        
+
         "sei": sei,
-        
+
         "profile": profile,
-        
+
         "level": level,
-        
+
     }))
 
 
 
 def libx265(
-    
+
     crf: float | None = None,
-    
+
     qp: int | None = None,
-    
+
     forced_idr: bool | None = None,
-    
+
     preset: str | None = None,
-    
+
     tune: str | None = None,
-    
+
     profile: str | None = None,
-    
+
     udu_sei: bool | None = None,
-    
+
     x265_params: str | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libx265 H.265 / HEVC (codec hevc)
-    
+
     Args:
         crf: set the x265 crf (from -1 to FLT_MAX) (default -1)
         qp: set the x265 qp (from -1 to INT_MAX) (default -1)
@@ -2010,37 +2010,37 @@ def libx265(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "crf": crf,
-        
+
         "qp": qp,
-        
+
         "forced-idr": forced_idr,
-        
+
         "preset": preset,
-        
+
         "tune": tune,
-        
+
         "profile": profile,
-        
+
         "udu_sei": udu_sei,
-        
+
         "x265-params": x265_params,
-        
+
     }))
 
 
 
 def hevc_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     V4L2 mem2mem HEVC encoder wrapper (codec hevc)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 6 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 4 to INT_MAX) (default 4)
@@ -2049,47 +2049,47 @@ def hevc_v4l2m2m(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def hevc_vaapi(
-    
+
     low_power: bool | None = None,
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     rc_mode: int | None| Literal["auto", "CQP", "CBR", "VBR", "ICQ", "QVBR", "AVBR"] = None,
-    
+
     qp: int | None = None,
-    
+
     aud: bool | None = None,
-    
+
     profile: int | None| Literal["main", "main10", "rext"] = None,
-    
+
     tier: int | None| Literal["main", "high"] = None,
-    
+
     level: int | None| Literal["1", "2", "2.1", "3", "3.1", "4", "4.1", "5", "5.1", "5.2", "6", "6.1", "6.2"] = None,
-    
+
     sei: str | None = None,
-    
+
     tiles: str | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     H.265/HEVC (VAAPI) (codec hevc)
-    
+
     Args:
         low_power: Use low-power encoding mode (only available on some platforms; may not support all encoding features) (default false)
         idr_interval: Distance (in I-frames) between IDR frames (from 0 to INT_MAX) (default 0)
@@ -2109,47 +2109,47 @@ def hevc_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "low_power": low_power,
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "rc_mode": rc_mode,
-        
+
         "qp": qp,
-        
+
         "aud": aud,
-        
+
         "profile": profile,
-        
+
         "tier": tier,
-        
+
         "level": level,
-        
+
         "sei": sei,
-        
+
         "tiles": tiles,
-        
+
     }))
 
 
 
 def huffyuv(
-    
+
     non_deterministic: bool | None = None,
-    
+
     pred: int | None| Literal["left", "plane", "median"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Huffyuv / HuffYUV
-    
+
     Args:
         non_deterministic: Allow multithreading for e.g. context=1 at the expense of determinism (default false)
         pred: Prediction method (from 0 to 2) (default left)
@@ -2158,37 +2158,37 @@ def huffyuv(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "non_deterministic": non_deterministic,
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def jpeg2000(
-    
+
     format: int | None| Literal["j2k", "jp2"] = None,
-    
+
     tile_width: int | None = None,
-    
+
     tile_height: int | None = None,
-    
+
     pred: int | None| Literal["dwt97int", "dwt53"] = None,
-    
+
     sop: int | None = None,
-    
+
     eph: int | None = None,
-    
+
     prog: int | None| Literal["lrcp", "rlcp", "rpcl", "pcrl", "cprl"] = None,
-    
+
     layer_rates: str | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     JPEG 2000
-    
+
     Args:
         format: Codec Format (from 0 to 1) (default jp2)
         tile_width: Tile Width (from 1 to 1.07374e+09) (default 256)
@@ -2203,49 +2203,49 @@ def jpeg2000(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "format": format,
-        
+
         "tile_width": tile_width,
-        
+
         "tile_height": tile_height,
-        
+
         "pred": pred,
-        
+
         "sop": sop,
-        
+
         "eph": eph,
-        
+
         "prog": prog,
-        
+
         "layer_rates": layer_rates,
-        
+
     }))
 
 
 
 def libopenjpeg(
-    
+
     format: int | None| Literal["j2k", "jp2"] = None,
-    
+
     profile: int | None| Literal["jpeg2000", "cinema2k", "cinema4k"] = None,
-    
+
     cinema_mode: int | None| Literal["off", "2k_24", "2k_48", "4k_24"] = None,
-    
+
     prog_order: int | None| Literal["lrcp", "rlcp", "rpcl", "pcrl", "cprl"] = None,
-    
+
     numresolution: int | None = None,
-    
+
     irreversible: int | None = None,
-    
+
     disto_alloc: int | None = None,
-    
+
     fixed_quality: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     OpenJPEG JPEG 2000 (codec jpeg2000)
-    
+
     Args:
         format: Codec Format (from 0 to 2) (default jp2)
         profile: (from 0 to 4) (default jpeg2000)
@@ -2260,35 +2260,35 @@ def libopenjpeg(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "format": format,
-        
+
         "profile": profile,
-        
+
         "cinema_mode": cinema_mode,
-        
+
         "prog_order": prog_order,
-        
+
         "numresolution": numresolution,
-        
+
         "irreversible": irreversible,
-        
+
         "disto_alloc": disto_alloc,
-        
+
         "fixed_quality": fixed_quality,
-        
+
     }))
 
 
 
 def jpegls(
-    
+
     pred: int | None| Literal["left", "plane", "median"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     JPEG-LS
-    
+
     Args:
         pred: Prediction method (from 0 to 2) (default left)
 
@@ -2296,21 +2296,21 @@ def jpegls(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def ljpeg(
-    
+
     pred: int | None| Literal["left", "plane", "median"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Lossless JPEG
-    
+
     Args:
         pred: Prediction method (from 1 to 3) (default left)
 
@@ -2318,21 +2318,21 @@ def ljpeg(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def magicyuv(
-    
+
     pred: int | None| Literal["left", "gradient", "median"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MagicYUV video
-    
+
     Args:
         pred: Prediction method (from 1 to 3) (default left)
 
@@ -2340,65 +2340,65 @@ def magicyuv(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def mjpeg(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     huffman: int | None| Literal["default", "optimal"] = None,
-    
+
     force_duplicated_matrix: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MJPEG (Motion JPEG)
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -2428,77 +2428,77 @@ def mjpeg(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "huffman": huffman,
-        
+
         "force_duplicated_matrix": force_duplicated_matrix,
-        
+
     }))
 
 
 
 def mjpeg_vaapi(
-    
+
     low_power: bool | None = None,
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     jfif: bool | None = None,
-    
+
     huffman: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MJPEG (VAAPI) (codec mjpeg)
-    
+
     Args:
         low_power: Use low-power encoding mode (only available on some platforms; may not support all encoding features) (default false)
         idr_interval: Distance (in I-frames) between IDR frames (from 0 to INT_MAX) (default 0)
@@ -2512,95 +2512,95 @@ def mjpeg_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "low_power": low_power,
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "jfif": jfif,
-        
+
         "huffman": huffman,
-        
+
     }))
 
 
 
 def mpeg1video(
-    
+
     gop_timecode: str | None = None,
-    
+
     drop_frame_timecode: bool | None = None,
-    
+
     scan_offset: bool | None = None,
-    
+
     timecode_frame_start: int | None = None,
-    
+
     b_strategy: int | None = None,
-    
+
     b_sensitivity: int | None = None,
-    
+
     brd_scale: int | None = None,
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MPEG-1 video
-    
+
     Args:
         gop_timecode: MPEG GOP Timecode in hh:mm:ss[:;.]ff format. Overrides timecode_frame_start.
         drop_frame_timecode: Timecode is in drop frame format. (default false)
@@ -2639,157 +2639,157 @@ def mpeg1video(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "gop_timecode": gop_timecode,
-        
+
         "drop_frame_timecode": drop_frame_timecode,
-        
+
         "scan_offset": scan_offset,
-        
+
         "timecode_frame_start": timecode_frame_start,
-        
+
         "b_strategy": b_strategy,
-        
+
         "b_sensitivity": b_sensitivity,
-        
+
         "brd_scale": brd_scale,
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def mpeg2video(
-    
+
     gop_timecode: str | None = None,
-    
+
     drop_frame_timecode: bool | None = None,
-    
+
     scan_offset: bool | None = None,
-    
+
     timecode_frame_start: int | None = None,
-    
+
     b_strategy: int | None = None,
-    
+
     b_sensitivity: int | None = None,
-    
+
     brd_scale: int | None = None,
-    
+
     intra_vlc: bool | None = None,
-    
+
     non_linear_quant: bool | None = None,
-    
+
     alternate_scan: bool | None = None,
-    
+
     a53cc: bool | None = None,
-    
+
     seq_disp_ext: int | None| Literal["auto", "never", "always"] = None,
-    
+
     video_format: int | None| Literal["component", "pal", "ntsc", "secam", "mac", "unspecified"] = None,
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MPEG-2 video
-    
+
     Args:
         gop_timecode: MPEG GOP Timecode in hh:mm:ss[:;.]ff format. Overrides timecode_frame_start.
         drop_frame_timecode: Timecode is in drop frame format. (default false)
@@ -2834,109 +2834,109 @@ def mpeg2video(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "gop_timecode": gop_timecode,
-        
+
         "drop_frame_timecode": drop_frame_timecode,
-        
+
         "scan_offset": scan_offset,
-        
+
         "timecode_frame_start": timecode_frame_start,
-        
+
         "b_strategy": b_strategy,
-        
+
         "b_sensitivity": b_sensitivity,
-        
+
         "brd_scale": brd_scale,
-        
+
         "intra_vlc": intra_vlc,
-        
+
         "non_linear_quant": non_linear_quant,
-        
+
         "alternate_scan": alternate_scan,
-        
+
         "a53cc": a53cc,
-        
+
         "seq_disp_ext": seq_disp_ext,
-        
+
         "video_format": video_format,
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def mpeg2_vaapi(
-    
+
     low_power: bool | None = None,
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     rc_mode: int | None| Literal["auto", "CQP", "CBR", "VBR", "ICQ", "QVBR", "AVBR"] = None,
-    
+
     profile: int | None| Literal["simple", "main"] = None,
-    
+
     level: int | None| Literal["low", "main", "high_1440", "high"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MPEG-2 (VAAPI) (codec mpeg2video)
-    
+
     Args:
         low_power: Use low-power encoding mode (only available on some platforms; may not support all encoding features) (default false)
         idr_interval: Distance (in I-frames) between IDR frames (from 0 to INT_MAX) (default 0)
@@ -2951,95 +2951,95 @@ def mpeg2_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "low_power": low_power,
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "rc_mode": rc_mode,
-        
+
         "profile": profile,
-        
+
         "level": level,
-        
+
     }))
 
 
 
 def mpeg4(
-    
+
     data_partitioning: bool | None = None,
-    
+
     alternate_scan: bool | None = None,
-    
+
     mpeg_quant: int | None = None,
-    
+
     b_strategy: int | None = None,
-    
+
     b_sensitivity: int | None = None,
-    
+
     brd_scale: int | None = None,
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MPEG-4 part 2
-    
+
     Args:
         data_partitioning: Use data partitioning. (default false)
         alternate_scan: Enable alternate scantable. (default false)
@@ -3077,93 +3077,93 @@ def mpeg4(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "data_partitioning": data_partitioning,
-        
+
         "alternate_scan": alternate_scan,
-        
+
         "mpeg_quant": mpeg_quant,
-        
+
         "b_strategy": b_strategy,
-        
+
         "b_sensitivity": b_sensitivity,
-        
+
         "brd_scale": brd_scale,
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def libxvid(
-    
+
     lumi_aq: int | None = None,
-    
+
     variance_aq: int | None = None,
-    
+
     ssim: int | None| Literal["off", "avg", "frame"] = None,
-    
+
     ssim_acc: int | None = None,
-    
+
     gmc: int | None = None,
-    
+
     me_quality: int | None = None,
-    
+
     mpeg_quant: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libxvidcore MPEG-4 part 2 (codec mpeg4)
-    
+
     Args:
         lumi_aq: Luminance masking AQ (from 0 to 1) (default 0)
         variance_aq: Variance AQ (from 0 to 1) (default 0)
@@ -3177,35 +3177,35 @@ def libxvid(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "lumi_aq": lumi_aq,
-        
+
         "variance_aq": variance_aq,
-        
+
         "ssim": ssim,
-        
+
         "ssim_acc": ssim_acc,
-        
+
         "gmc": gmc,
-        
+
         "me_quality": me_quality,
-        
+
         "mpeg_quant": mpeg_quant,
-        
+
     }))
 
 
 
 def mpeg4_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     V4L2 mem2mem MPEG4 encoder wrapper (codec mpeg4)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 6 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 4 to INT_MAX) (default 4)
@@ -3214,71 +3214,71 @@ def mpeg4_v4l2m2m(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def msmpeg4v2(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MPEG-4 part 2 Microsoft variant version 2
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -3310,117 +3310,117 @@ def msmpeg4v2(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def msmpeg4(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MPEG-4 part 2 Microsoft variant version 3 (codec msmpeg4v3)
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -3452,201 +3452,201 @@ def msmpeg4(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def msvideo1(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Microsoft Video-1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pam(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PAM (Portable AnyMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pbm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PBM (Portable BitMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcx(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PC Paintbrush PCX image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pfm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PFM (Portable FloatMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pgm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PGM (Portable GrayMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pgmyuv(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PGMYUV (Portable GrayMap YUV) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def phm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PHM (Portable HalfFloatMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def png(
-    
+
     dpi: int | None = None,
-    
+
     dpm: int | None = None,
-    
+
     pred: int | None| Literal["none", "sub", "up", "avg", "paeth", "mixed"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     PNG (Portable Network Graphics) image
-    
+
     Args:
         dpi: Set image resolution (in dots per inch) (from 0 to 65536) (default 0)
         dpm: Set image resolution (in dots per meter) (from 0 to 65536) (default 0)
@@ -3656,41 +3656,41 @@ def png(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "dpi": dpi,
-        
+
         "dpm": dpm,
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def ppm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PPM (Portable PixelMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def prores(
-    
+
     vendor: str | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Apple ProRes
-    
+
     Args:
         vendor: vendor ID (default "fmpg")
 
@@ -3698,21 +3698,21 @@ def prores(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "vendor": vendor,
-        
+
     }))
 
 
 
 def prores_aw(
-    
+
     vendor: str | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Apple ProRes (codec prores)
-    
+
     Args:
         vendor: vendor ID (default "fmpg")
 
@@ -3720,31 +3720,31 @@ def prores_aw(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "vendor": vendor,
-        
+
     }))
 
 
 
 def prores_ks(
-    
+
     mbs_per_slice: int | None = None,
-    
+
     profile: int | None| Literal["auto", "proxy", "lt", "standard", "hq", "4444", "4444xq"] = None,
-    
+
     vendor: str | None = None,
-    
+
     bits_per_mb: int | None = None,
-    
+
     quant_mat: int | None| Literal["auto", "proxy", "lt", "standard", "hq", "default"] = None,
-    
+
     alpha_bits: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Apple ProRes (iCodec Pro) (codec prores)
-    
+
     Args:
         mbs_per_slice: macroblocks per slice (from 1 to 8) (default 8)
         profile: (from -1 to 5) (default auto)
@@ -3757,111 +3757,111 @@ def prores_ks(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mbs_per_slice": mbs_per_slice,
-        
+
         "profile": profile,
-        
+
         "vendor": vendor,
-        
+
         "bits_per_mb": bits_per_mb,
-        
+
         "quant_mat": quant_mat,
-        
+
         "alpha_bits": alpha_bits,
-        
+
     }))
 
 
 
 def qoi(
-    
+
 ) -> FFMpegEncoderOption:
     """
     QOI (Quite OK Image format) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def qtrle(
-    
+
 ) -> FFMpegEncoderOption:
     """
     QuickTime Animation (RLE) video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def r10k(
-    
+
 ) -> FFMpegEncoderOption:
     """
     AJA Kona 10-bit RGB Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def r210(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed RGB 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def rawvideo(
-    
+
 ) -> FFMpegEncoderOption:
     """
     raw video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def roqvideo(
-    
+
     quake3_compat: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     id RoQ video (codec roq)
-    
+
     Args:
         quake3_compat: Whether to respect known limitations in Quake 3 decoder (default true)
 
@@ -3869,25 +3869,25 @@ def roqvideo(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "quake3_compat": quake3_compat,
-        
+
     }))
 
 
 
 def rpza(
-    
+
     skip_frame_thresh: int | None = None,
-    
+
     continue_one_color_thresh: int | None = None,
-    
+
     sixteen_color_thresh: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     QuickTime video (RPZA)
-    
+
     Args:
         skip_frame_thresh: (from 0 to 24) (default 1)
         continue_one_color_thresh: (from 0 to 24) (default 0)
@@ -3897,73 +3897,73 @@ def rpza(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "skip_frame_thresh": skip_frame_thresh,
-        
+
         "continue_one_color_thresh": continue_one_color_thresh,
-        
+
         "sixteen_color_thresh": sixteen_color_thresh,
-        
+
     }))
 
 
 
 def rv10(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     RealVideo 1.0
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -3995,117 +3995,117 @@ def rv10(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def rv20(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     RealVideo 2.0
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -4137,69 +4137,69 @@ def rv20(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def sgi(
-    
+
     rle: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     SGI image
-    
+
     Args:
         rle: Use run-length compression (from 0 to 1) (default 1)
 
@@ -4207,51 +4207,51 @@ def sgi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "rle": rle,
-        
+
     }))
 
 
 
 def smc(
-    
+
 ) -> FFMpegEncoderOption:
     """
     QuickTime Graphics (SMC)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def snow(
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone", "iter"] = None,
-    
+
     memc_only: bool | None = None,
-    
+
     no_bitstream: bool | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
     iterative_dia_size: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     pred: int | None| Literal["dwt97", "dwt53"] = None,
-    
+
     rc_eq: str | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Snow
-    
+
     Args:
         motion_est: motion estimation algorithm (from 0 to 3) (default epzs)
         memc_only: Only do ME/MC (I frames -> ref, P frame -> ME+MC). (default false)
@@ -4266,83 +4266,83 @@ def snow(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "motion_est": motion_est,
-        
+
         "memc_only": memc_only,
-        
+
         "no_bitstream": no_bitstream,
-        
+
         "intra_penalty": intra_penalty,
-        
+
         "iterative_dia_size": iterative_dia_size,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "pred": pred,
-        
+
         "rc_eq": rc_eq,
-        
+
     }))
 
 
 
 def speedhq(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     NewTek SpeedHQ
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -4374,69 +4374,69 @@ def speedhq(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def sunrast(
-    
+
     rle: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Sun Rasterfile image
-    
+
     Args:
         rle: Use run-length compression (from 0 to 1) (default 1)
 
@@ -4444,21 +4444,21 @@ def sunrast(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "rle": rle,
-        
+
     }))
 
 
 
 def svq1(
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Sorenson Vector Quantizer 1 / Sorenson Video 1 / SVQ1
-    
+
     Args:
         motion_est: Motion estimation algorithm (from 0 to 2) (default epzs)
 
@@ -4466,21 +4466,21 @@ def svq1(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "motion-est": motion_est,
-        
+
     }))
 
 
 
 def targa(
-    
+
     rle: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Truevision Targa image
-    
+
     Args:
         rle: Use run-length compression (from 0 to 1) (default 1)
 
@@ -4488,39 +4488,39 @@ def targa(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "rle": rle,
-        
+
     }))
 
 
 
 def libtheora(
-    
+
 ) -> FFMpegEncoderOption:
     """
     libtheora Theora (codec theora)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def tiff(
-    
+
     dpi: int | None = None,
-    
+
     compression_algo: int | None| Literal["packbits", "raw", "lzw", "deflate"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     TIFF image
-    
+
     Args:
         dpi: set the image resolution (in dpi) (from 1 to 65536) (default 72)
         compression_algo: (from 1 to 32946) (default packbits)
@@ -4529,23 +4529,23 @@ def tiff(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "dpi": dpi,
-        
+
         "compression_algo": compression_algo,
-        
+
     }))
 
 
 
 def utvideo(
-    
+
     pred: int | None| Literal["none", "left", "gradient", "median"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Ut Video
-    
+
     Args:
         pred: Prediction method (from 0 to 3) (default left)
 
@@ -4553,85 +4553,85 @@ def utvideo(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def v210(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed 4:2:2 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def v308(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed packed 4:4:4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def v408(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed packed QT 4:4:4:4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def v410(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed 4:4:4 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def vbn(
-    
+
     format: int | None| Literal["raw", "dxt1", "dxt5"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Vizrt Binary Image
-    
+
     Args:
         format: Texture format (from 0 to 3) (default dxt5)
 
@@ -4639,65 +4639,65 @@ def vbn(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "format": format,
-        
+
     }))
 
 
 
 def libvpx(
-    
+
     lag_in_frames: int | None = None,
-    
+
     arnr_maxframes: int | None = None,
-    
+
     arnr_strength: int | None = None,
-    
+
     arnr_type: int | None| Literal["backward", "forward", "centered"] = None,
-    
+
     tune: int | None| Literal["psnr", "ssim"] = None,
-    
+
     deadline: int | None| Literal["best", "good", "realtime"] = None,
-    
+
     error_resilient: str | None = None,
-    
+
     max_intra_rate: int | None = None,
-    
+
     crf: int | None = None,
-    
+
     static_thresh: int | None = None,
-    
+
     drop_threshold: int | None = None,
-    
+
     noise_sensitivity: int | None = None,
-    
+
     undershoot_pct: int | None = None,
-    
+
     overshoot_pct: int | None = None,
-    
+
     ts_parameters: str | None = None,
-    
+
     auto_alt_ref: int | None = None,
-    
+
     cpu_used: int | None = None,
-    
+
     speed: int | None = None,
-    
+
     quality: int | None| Literal["best", "good", "realtime"] = None,
-    
+
     vp8flags: str | None = None,
-    
+
     arnr_max_frames: int | None = None,
-    
+
     rc_lookahead: int | None = None,
-    
+
     sharpness: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libvpx VP8 (codec vp8)
-    
+
     Args:
         lag_in_frames: Number of frames to look ahead for alternate reference frame selection (from -1 to INT_MAX) (default -1)
         arnr_maxframes: altref noise reduction max frame count (from -1 to INT_MAX) (default -1)
@@ -4727,67 +4727,67 @@ def libvpx(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "lag-in-frames": lag_in_frames,
-        
+
         "arnr-maxframes": arnr_maxframes,
-        
+
         "arnr-strength": arnr_strength,
-        
+
         "arnr-type": arnr_type,
-        
+
         "tune": tune,
-        
+
         "deadline": deadline,
-        
+
         "error-resilient": error_resilient,
-        
+
         "max-intra-rate": max_intra_rate,
-        
+
         "crf": crf,
-        
+
         "static-thresh": static_thresh,
-        
+
         "drop-threshold": drop_threshold,
-        
+
         "noise-sensitivity": noise_sensitivity,
-        
+
         "undershoot-pct": undershoot_pct,
-        
+
         "overshoot-pct": overshoot_pct,
-        
+
         "ts-parameters": ts_parameters,
-        
+
         "auto-alt-ref": auto_alt_ref,
-        
+
         "cpu-used": cpu_used,
-        
+
         "speed": speed,
-        
+
         "quality": quality,
-        
+
         "vp8flags": vp8flags,
-        
+
         "arnr_max_frames": arnr_max_frames,
-        
+
         "rc_lookahead": rc_lookahead,
-        
+
         "sharpness": sharpness,
-        
+
     }))
 
 
 
 def vp8_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     V4L2 mem2mem VP8 encoder wrapper (codec vp8)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 6 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 4 to INT_MAX) (default 4)
@@ -4796,37 +4796,37 @@ def vp8_v4l2m2m(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def vp8_vaapi(
-    
+
     low_power: bool | None = None,
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     rc_mode: int | None| Literal["auto", "CQP", "CBR", "VBR", "ICQ", "QVBR", "AVBR"] = None,
-    
+
     loop_filter_level: int | None = None,
-    
+
     loop_filter_sharpness: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     VP8 (VAAPI) (codec vp8)
-    
+
     Args:
         low_power: Use low-power encoding mode (only available on some platforms; may not support all encoding features) (default false)
         idr_interval: Distance (in I-frames) between IDR frames (from 0 to INT_MAX) (default 0)
@@ -4841,49 +4841,49 @@ def vp8_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "low_power": low_power,
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "rc_mode": rc_mode,
-        
+
         "loop_filter_level": loop_filter_level,
-        
+
         "loop_filter_sharpness": loop_filter_sharpness,
-        
+
     }))
 
 
 
 def vp9_vaapi(
-    
+
     low_power: bool | None = None,
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     rc_mode: int | None| Literal["auto", "CQP", "CBR", "VBR", "ICQ", "QVBR", "AVBR"] = None,
-    
+
     loop_filter_level: int | None = None,
-    
+
     loop_filter_sharpness: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     VP9 (VAAPI) (codec vp9)
-    
+
     Args:
         low_power: Use low-power encoding mode (only available on some platforms; may not support all encoding features) (default false)
         idr_interval: Distance (in I-frames) between IDR frames (from 0 to INT_MAX) (default 0)
@@ -4898,43 +4898,43 @@ def vp9_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "low_power": low_power,
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "rc_mode": rc_mode,
-        
+
         "loop_filter_level": loop_filter_level,
-        
+
         "loop_filter_sharpness": loop_filter_sharpness,
-        
+
     }))
 
 
 
 def libwebp_anim(
-    
+
     lossless: int | None = None,
-    
+
     preset: int | None| Literal["none", "default", "picture", "photo", "drawing", "icon", "text"] = None,
-    
+
     cr_threshold: int | None = None,
-    
+
     cr_size: int | None = None,
-    
+
     quality: float | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libwebp WebP image (codec webp)
-    
+
     Args:
         lossless: Use lossless mode (from 0 to 1) (default 0)
         preset: Configuration preset (from -1 to 5) (default none)
@@ -4946,37 +4946,37 @@ def libwebp_anim(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "lossless": lossless,
-        
+
         "preset": preset,
-        
+
         "cr_threshold": cr_threshold,
-        
+
         "cr_size": cr_size,
-        
+
         "quality": quality,
-        
+
     }))
 
 
 
 def libwebp(
-    
+
     lossless: int | None = None,
-    
+
     preset: int | None| Literal["none", "default", "picture", "photo", "drawing", "icon", "text"] = None,
-    
+
     cr_threshold: int | None = None,
-    
+
     cr_size: int | None = None,
-    
+
     quality: float | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libwebp WebP image (codec webp)
-    
+
     Args:
         lossless: Use lossless mode (from 0 to 1) (default 0)
         preset: Configuration preset (from -1 to 5) (default none)
@@ -4988,77 +4988,77 @@ def libwebp(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "lossless": lossless,
-        
+
         "preset": preset,
-        
+
         "cr_threshold": cr_threshold,
-        
+
         "cr_size": cr_size,
-        
+
         "quality": quality,
-        
+
     }))
 
 
 
 def wmv1(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Windows Media Video 7
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -5090,117 +5090,117 @@ def wmv1(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def wmv2(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Windows Media Video 8
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -5232,211 +5232,211 @@ def wmv2(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def wrapped_avframe(
-    
+
 ) -> FFMpegEncoderOption:
     """
     AVFrame to AVPacket passthrough
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def xbm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     XBM (X BitMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def xface(
-    
+
 ) -> FFMpegEncoderOption:
     """
     X-face image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def xwd(
-    
+
 ) -> FFMpegEncoderOption:
     """
     XWD (X Window Dump) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def y41p(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed YUV 4:1:1 12-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def yuv4(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed packed 4:2:0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def zlib(
-    
+
 ) -> FFMpegEncoderOption:
     """
     LCL (LossLess Codec Library) ZLIB
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def zmbv(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Zip Motion Blocks Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def aac(
-    
+
     aac_coder: int | None| Literal["anmr", "twoloop", "fast"] = None,
-    
+
     aac_ms: bool | None = None,
-    
+
     aac_is: bool | None = None,
-    
+
     aac_pns: bool | None = None,
-    
+
     aac_tns: bool | None = None,
-    
+
     aac_ltp: bool | None = None,
-    
+
     aac_pred: bool | None = None,
-    
+
     aac_pce: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     AAC (Advanced Audio Coding)
-    
+
     Args:
         aac_coder: Coding algorithm (from 0 to 2) (default twoloop)
         aac_ms: Force M/S stereo coding (default auto)
@@ -5451,73 +5451,73 @@ def aac(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "aac_coder": aac_coder,
-        
+
         "aac_ms": aac_ms,
-        
+
         "aac_is": aac_is,
-        
+
         "aac_pns": aac_pns,
-        
+
         "aac_tns": aac_tns,
-        
+
         "aac_ltp": aac_ltp,
-        
+
         "aac_pred": aac_pred,
-        
+
         "aac_pce": aac_pce,
-        
+
     }))
 
 
 
 def ac3(
-    
+
     center_mixlev: float | None = None,
-    
+
     surround_mixlev: float | None = None,
-    
+
     mixing_level: int | None = None,
-    
+
     room_type: int | None| Literal["notindicated", "large", "small"] = None,
-    
+
     per_frame_metadata: bool | None = None,
-    
+
     copyright: int | None = None,
-    
+
     dialnorm: int | None = None,
-    
+
     dsur_mode: int | None| Literal["notindicated", "on", "off"] = None,
-    
+
     original: int | None = None,
-    
+
     dmix_mode: int | None| Literal["notindicated", "ltrt", "loro", "dplii"] = None,
-    
+
     ltrt_cmixlev: float | None = None,
-    
+
     ltrt_surmixlev: float | None = None,
-    
+
     loro_cmixlev: float | None = None,
-    
+
     loro_surmixlev: float | None = None,
-    
+
     dsurex_mode: int | None| Literal["notindicated", "on", "off", "dpliiz"] = None,
-    
+
     dheadphone_mode: int | None| Literal["notindicated", "on", "off"] = None,
-    
+
     ad_conv_type: int | None| Literal["standard", "hdcd"] = None,
-    
+
     stereo_rematrixing: bool | None = None,
-    
+
     channel_coupling: int | None| Literal["auto"] = None,
-    
+
     cpl_start_band: int | None| Literal["auto"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ATSC A/52A (AC-3)
-    
+
     Args:
         center_mixlev: Center Mix Level (from 0 to 1) (default 0.594604)
         surround_mixlev: Surround Mix Level (from 0 to 1) (default 0.5)
@@ -5544,97 +5544,97 @@ def ac3(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "center_mixlev": center_mixlev,
-        
+
         "surround_mixlev": surround_mixlev,
-        
+
         "mixing_level": mixing_level,
-        
+
         "room_type": room_type,
-        
+
         "per_frame_metadata": per_frame_metadata,
-        
+
         "copyright": copyright,
-        
+
         "dialnorm": dialnorm,
-        
+
         "dsur_mode": dsur_mode,
-        
+
         "original": original,
-        
+
         "dmix_mode": dmix_mode,
-        
+
         "ltrt_cmixlev": ltrt_cmixlev,
-        
+
         "ltrt_surmixlev": ltrt_surmixlev,
-        
+
         "loro_cmixlev": loro_cmixlev,
-        
+
         "loro_surmixlev": loro_surmixlev,
-        
+
         "dsurex_mode": dsurex_mode,
-        
+
         "dheadphone_mode": dheadphone_mode,
-        
+
         "ad_conv_type": ad_conv_type,
-        
+
         "stereo_rematrixing": stereo_rematrixing,
-        
+
         "channel_coupling": channel_coupling,
-        
+
         "cpl_start_band": cpl_start_band,
-        
+
     }))
 
 
 
 def ac3_fixed(
-    
+
     center_mixlev: float | None = None,
-    
+
     surround_mixlev: float | None = None,
-    
+
     mixing_level: int | None = None,
-    
+
     room_type: int | None| Literal["notindicated", "large", "small"] = None,
-    
+
     per_frame_metadata: bool | None = None,
-    
+
     copyright: int | None = None,
-    
+
     dialnorm: int | None = None,
-    
+
     dsur_mode: int | None| Literal["notindicated", "on", "off"] = None,
-    
+
     original: int | None = None,
-    
+
     dmix_mode: int | None| Literal["notindicated", "ltrt", "loro", "dplii"] = None,
-    
+
     ltrt_cmixlev: float | None = None,
-    
+
     ltrt_surmixlev: float | None = None,
-    
+
     loro_cmixlev: float | None = None,
-    
+
     loro_surmixlev: float | None = None,
-    
+
     dsurex_mode: int | None| Literal["notindicated", "on", "off", "dpliiz"] = None,
-    
+
     dheadphone_mode: int | None| Literal["notindicated", "on", "off"] = None,
-    
+
     ad_conv_type: int | None| Literal["standard", "hdcd"] = None,
-    
+
     stereo_rematrixing: bool | None = None,
-    
+
     channel_coupling: int | None| Literal["auto"] = None,
-    
+
     cpl_start_band: int | None| Literal["auto"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ATSC A/52A (AC-3) (codec ac3)
-    
+
     Args:
         center_mixlev: Center Mix Level (from 0 to 1) (default 0.594604)
         surround_mixlev: Surround Mix Level (from 0 to 1) (default 0.5)
@@ -5661,75 +5661,75 @@ def ac3_fixed(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "center_mixlev": center_mixlev,
-        
+
         "surround_mixlev": surround_mixlev,
-        
+
         "mixing_level": mixing_level,
-        
+
         "room_type": room_type,
-        
+
         "per_frame_metadata": per_frame_metadata,
-        
+
         "copyright": copyright,
-        
+
         "dialnorm": dialnorm,
-        
+
         "dsur_mode": dsur_mode,
-        
+
         "original": original,
-        
+
         "dmix_mode": dmix_mode,
-        
+
         "ltrt_cmixlev": ltrt_cmixlev,
-        
+
         "ltrt_surmixlev": ltrt_surmixlev,
-        
+
         "loro_cmixlev": loro_cmixlev,
-        
+
         "loro_surmixlev": loro_surmixlev,
-        
+
         "dsurex_mode": dsurex_mode,
-        
+
         "dheadphone_mode": dheadphone_mode,
-        
+
         "ad_conv_type": ad_conv_type,
-        
+
         "stereo_rematrixing": stereo_rematrixing,
-        
+
         "channel_coupling": channel_coupling,
-        
+
         "cpl_start_band": cpl_start_band,
-        
+
     }))
 
 
 
 def adpcm_adx(
-    
+
 ) -> FFMpegEncoderOption:
     """
     SEGA CRI ADX ADPCM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_argo(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM Argonaut Games
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -5737,37 +5737,37 @@ def adpcm_argo(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def g722(
-    
+
 ) -> FFMpegEncoderOption:
     """
     G.722 ADPCM (codec adpcm_g722)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def g726(
-    
+
     code_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     G.726 ADPCM (codec adpcm_g726)
-    
+
     Args:
         code_size: Bits per code (from 2 to 5) (default 4)
 
@@ -5775,21 +5775,21 @@ def g726(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "code_size": code_size,
-        
+
     }))
 
 
 
 def g726le(
-    
+
     code_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     G.726 little endian ADPCM ("right-justified") (codec adpcm_g726le)
-    
+
     Args:
         code_size: Bits per code (from 2 to 5) (default 4)
 
@@ -5797,21 +5797,21 @@ def g726le(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "code_size": code_size,
-        
+
     }))
 
 
 
 def adpcm_ima_alp(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA High Voltage Software ALP
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -5819,21 +5819,21 @@ def adpcm_ima_alp(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ima_amv(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA AMV
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -5841,21 +5841,21 @@ def adpcm_ima_amv(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ima_apm(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA Ubisoft APM
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -5863,21 +5863,21 @@ def adpcm_ima_apm(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ima_qt(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA QuickTime
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -5885,21 +5885,21 @@ def adpcm_ima_qt(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ima_ssi(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA Simon & Schuster Interactive
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -5907,21 +5907,21 @@ def adpcm_ima_ssi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ima_wav(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA WAV
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -5929,21 +5929,21 @@ def adpcm_ima_wav(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ima_ws(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA Westwood
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -5951,21 +5951,21 @@ def adpcm_ima_ws(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ms(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM Microsoft
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -5973,21 +5973,21 @@ def adpcm_ms(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_swf(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM Shockwave Flash
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -5995,21 +5995,21 @@ def adpcm_swf(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_yamaha(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM Yamaha
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6017,23 +6017,23 @@ def adpcm_yamaha(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def alac(
-    
+
     min_prediction_order: int | None = None,
-    
+
     max_prediction_order: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ALAC (Apple Lossless Audio Codec)
-    
+
     Args:
         min_prediction_order: (from 1 to 30) (default 4)
         max_prediction_order: (from 1 to 30) (default 6)
@@ -6042,23 +6042,23 @@ def alac(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "min_prediction_order": min_prediction_order,
-        
+
         "max_prediction_order": max_prediction_order,
-        
+
     }))
 
 
 
 def libopencore_amrnb(
-    
+
     dtx: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     OpenCORE AMR-NB (Adaptive Multi-Rate Narrow-Band) (codec amr_nb)
-    
+
     Args:
         dtx: Allow DTX (generate comfort noise) (from 0 to 1) (default 0)
 
@@ -6066,85 +6066,85 @@ def libopencore_amrnb(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "dtx": dtx,
-        
+
     }))
 
 
 
 def aptx(
-    
+
 ) -> FFMpegEncoderOption:
     """
     aptX (Audio Processing Technology for Bluetooth)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def aptx_hd(
-    
+
 ) -> FFMpegEncoderOption:
     """
     aptX HD (Audio Processing Technology for Bluetooth)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def comfortnoise(
-    
+
 ) -> FFMpegEncoderOption:
     """
     RFC 3389 comfort noise generator
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def dfpwm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     DFPWM1a audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def dca(
-    
+
     dca_adpcm: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     DCA (DTS Coherent Acoustics) (codec dts)
-    
+
     Args:
         dca_adpcm: Use ADPCM encoding (default false)
 
@@ -6152,55 +6152,55 @@ def dca(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "dca_adpcm": dca_adpcm,
-        
+
     }))
 
 
 
 def eac3(
-    
+
     mixing_level: int | None = None,
-    
+
     room_type: int | None| Literal["notindicated", "large", "small"] = None,
-    
+
     per_frame_metadata: bool | None = None,
-    
+
     copyright: int | None = None,
-    
+
     dialnorm: int | None = None,
-    
+
     dsur_mode: int | None| Literal["notindicated", "on", "off"] = None,
-    
+
     original: int | None = None,
-    
+
     dmix_mode: int | None| Literal["notindicated", "ltrt", "loro", "dplii"] = None,
-    
+
     ltrt_cmixlev: float | None = None,
-    
+
     ltrt_surmixlev: float | None = None,
-    
+
     loro_cmixlev: float | None = None,
-    
+
     loro_surmixlev: float | None = None,
-    
+
     dsurex_mode: int | None| Literal["notindicated", "on", "off", "dpliiz"] = None,
-    
+
     dheadphone_mode: int | None| Literal["notindicated", "on", "off"] = None,
-    
+
     ad_conv_type: int | None| Literal["standard", "hdcd"] = None,
-    
+
     stereo_rematrixing: bool | None = None,
-    
+
     channel_coupling: int | None| Literal["auto"] = None,
-    
+
     cpl_start_band: int | None| Literal["auto"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ATSC A/52 E-AC-3
-    
+
     Args:
         mixing_level: Mixing Level (from -1 to 111) (default -1)
         room_type: Room Type (from -1 to 2) (default -1)
@@ -6225,71 +6225,71 @@ def eac3(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mixing_level": mixing_level,
-        
+
         "room_type": room_type,
-        
+
         "per_frame_metadata": per_frame_metadata,
-        
+
         "copyright": copyright,
-        
+
         "dialnorm": dialnorm,
-        
+
         "dsur_mode": dsur_mode,
-        
+
         "original": original,
-        
+
         "dmix_mode": dmix_mode,
-        
+
         "ltrt_cmixlev": ltrt_cmixlev,
-        
+
         "ltrt_surmixlev": ltrt_surmixlev,
-        
+
         "loro_cmixlev": loro_cmixlev,
-        
+
         "loro_surmixlev": loro_surmixlev,
-        
+
         "dsurex_mode": dsurex_mode,
-        
+
         "dheadphone_mode": dheadphone_mode,
-        
+
         "ad_conv_type": ad_conv_type,
-        
+
         "stereo_rematrixing": stereo_rematrixing,
-        
+
         "channel_coupling": channel_coupling,
-        
+
         "cpl_start_band": cpl_start_band,
-        
+
     }))
 
 
 
 def flac(
-    
+
     lpc_coeff_precision: int | None = None,
-    
+
     lpc_type: int | None| Literal["none", "fixed", "levinson", "cholesky"] = None,
-    
+
     lpc_passes: int | None = None,
-    
+
     min_partition_order: int | None = None,
-    
+
     prediction_order_method: int | None| Literal["estimation", "2level", "4level", "8level", "search", "log"] = None,
-    
+
     ch_mode: int | None| Literal["auto", "indep", "left_side", "right_side", "mid_side"] = None,
-    
+
     exact_rice_parameters: bool | None = None,
-    
+
     multi_dim_quant: bool | None = None,
-    
+
     min_prediction_order: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     FLAC (Free Lossless Audio Codec)
-    
+
     Args:
         lpc_coeff_precision: LPC coefficient precision (from 0 to 15) (default 15)
         lpc_type: LPC algorithm (from -1 to 3) (default -1)
@@ -6305,105 +6305,105 @@ def flac(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "lpc_coeff_precision": lpc_coeff_precision,
-        
+
         "lpc_type": lpc_type,
-        
+
         "lpc_passes": lpc_passes,
-        
+
         "min_partition_order": min_partition_order,
-        
+
         "prediction_order_method": prediction_order_method,
-        
+
         "ch_mode": ch_mode,
-        
+
         "exact_rice_parameters": exact_rice_parameters,
-        
+
         "multi_dim_quant": multi_dim_quant,
-        
+
         "min_prediction_order": min_prediction_order,
-        
+
     }))
 
 
 
 def g723_1(
-    
+
 ) -> FFMpegEncoderOption:
     """
     G.723.1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def mlp(
-    
+
 ) -> FFMpegEncoderOption:
     """
     MLP (Meridian Lossless Packing)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def mp2(
-    
+
 ) -> FFMpegEncoderOption:
     """
     MP2 (MPEG audio layer 2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def mp2fixed(
-    
+
 ) -> FFMpegEncoderOption:
     """
     MP2 fixed point (MPEG audio layer 2) (codec mp2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def libmp3lame(
-    
+
     reservoir: bool | None = None,
-    
+
     joint_stereo: bool | None = None,
-    
+
     abr: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libmp3lame MP3 (MPEG audio layer 3) (codec mp3)
-    
+
     Args:
         reservoir: use bit reservoir (default true)
         joint_stereo: use joint stereo (default true)
@@ -6413,43 +6413,43 @@ def libmp3lame(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "reservoir": reservoir,
-        
+
         "joint_stereo": joint_stereo,
-        
+
         "abr": abr,
-        
+
     }))
 
 
 
 def nellymoser(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Nellymoser Asao
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def opus(
-    
+
     opus_delay: float | None = None,
-    
+
     apply_phase_inv: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Opus
-    
+
     Args:
         opus_delay: Maximum delay in milliseconds (from 2.5 to 360) (default 360)
         apply_phase_inv: Apply intensity stereo phase inversion (default true)
@@ -6458,35 +6458,35 @@ def opus(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "opus_delay": opus_delay,
-        
+
         "apply_phase_inv": apply_phase_inv,
-        
+
     }))
 
 
 
 def libopus(
-    
+
     application: int | None| Literal["voip", "audio", "lowdelay"] = None,
-    
+
     frame_duration: float | None = None,
-    
+
     packet_loss: int | None = None,
-    
+
     fec: bool | None = None,
-    
+
     vbr: int | None| Literal["off", "on", "constrained"] = None,
-    
+
     mapping_family: int | None = None,
-    
+
     apply_phase_inv: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libopus Opus (codec opus)
-    
+
     Args:
         application: Intended application type (from 2048 to 2051) (default audio)
         frame_duration: Duration of a frame in milliseconds (from 2.5 to 120) (default 20)
@@ -6500,579 +6500,579 @@ def libopus(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "application": application,
-        
+
         "frame_duration": frame_duration,
-        
+
         "packet_loss": packet_loss,
-        
+
         "fec": fec,
-        
+
         "vbr": vbr,
-        
+
         "mapping_family": mapping_family,
-        
+
         "apply_phase_inv": apply_phase_inv,
-        
+
     }))
 
 
 
 def pcm_alaw(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM A-law / G.711 A-law
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_bluray(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 16|20|24-bit big-endian for Blu-ray media
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_dvd(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 16|20|24-bit big-endian for DVD media
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f32be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM 32-bit floating point big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f32le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM 32-bit floating point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f64be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM 64-bit floating point big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f64le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM 64-bit floating point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_mulaw(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM mu-law / G.711 mu-law
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 16-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16be_planar(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 16-bit big-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 16-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16le_planar(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 16-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 24-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24daud(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM D-Cinema audio signed 24-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 24-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24le_planar(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 24-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s32be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 32-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s32le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 32-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s32le_planar(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 32-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s64be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 64-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s64le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 64-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s8(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 8-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s8_planar(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 8-bit planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u16be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 16-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u16le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 16-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u24be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 24-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u24le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 24-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u32be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 32-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u32le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 32-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u8(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 8-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_vidc(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM Archimedes VIDC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def real_144(
-    
+
 ) -> FFMpegEncoderOption:
     """
     RealAudio 1.0 (14.4K) (codec ra_144)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def roq_dpcm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     id RoQ DPCM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def s302m(
-    
+
 ) -> FFMpegEncoderOption:
     """
     SMPTE 302M
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def sbc(
-    
+
     sbc_delay: str | None = None,
-    
+
     msbc: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     SBC (low-complexity subband codec)
-    
+
     Args:
         sbc_delay: set maximum algorithmic latency (default 0.013)
         msbc: use mSBC mode (wideband speech mono SBC) (default false)
@@ -7081,103 +7081,103 @@ def sbc(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "sbc_delay": sbc_delay,
-        
+
         "msbc": msbc,
-        
+
     }))
 
 
 
 def sonic(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Sonic
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def sonicls(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Sonic lossless
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def truehd(
-    
+
 ) -> FFMpegEncoderOption:
     """
     TrueHD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def tta(
-    
+
 ) -> FFMpegEncoderOption:
     """
     TTA (True Audio)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def vorbis(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Vorbis
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def libvorbis(
-    
+
     iblock: float | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libvorbis (codec vorbis)
-    
+
     Args:
         iblock: Sets the impulse block bias (from -15 to 0) (default 0)
 
@@ -7185,23 +7185,23 @@ def libvorbis(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "iblock": iblock,
-        
+
     }))
 
 
 
 def wavpack(
-    
+
     joint_stereo: bool | None = None,
-    
+
     optimize_mono: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     WavPack
-    
+
     Args:
         joint_stereo: (default auto)
         optimize_mono: (default false)
@@ -7210,105 +7210,105 @@ def wavpack(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "joint_stereo": joint_stereo,
-        
+
         "optimize_mono": optimize_mono,
-        
+
     }))
 
 
 
 def wmav1(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Windows Media Audio 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def wmav2(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Windows Media Audio 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def ssa(
-    
+
 ) -> FFMpegEncoderOption:
     """
     ASS (Advanced SubStation Alpha) subtitle (codec ass)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def ass(
-    
+
 ) -> FFMpegEncoderOption:
     """
     ASS (Advanced SubStation Alpha) subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def dvbsub(
-    
+
 ) -> FFMpegEncoderOption:
     """
     DVB subtitles (codec dvb_subtitle)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def dvdsub(
-    
+
     palette: str | None = None,
-    
+
     even_rows_fix: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     DVD subtitles (codec dvd_subtitle)
-    
+
     Args:
         palette: set the global palette
         even_rows_fix: Make number of rows even (workaround for some players) (default false)
@@ -7317,23 +7317,23 @@ def dvdsub(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "palette": palette,
-        
+
         "even_rows_fix": even_rows_fix,
-        
+
     }))
 
 
 
 def mov_text(
-    
+
     height: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     3GPP Timed Text subtitle
-    
+
     Args:
         height: Frame height, usually video height (from 0 to INT_MAX) (default 0)
 
@@ -7341,1084 +7341,103 @@ def mov_text(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "height": height,
-        
+
     }))
 
 
 
 def srt(
-    
+
 ) -> FFMpegEncoderOption:
     """
     SubRip subtitle (codec subrip)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def subrip(
-    
+
 ) -> FFMpegEncoderOption:
     """
     SubRip subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def text(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Raw text subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def ttml(
-    
+
 ) -> FFMpegEncoderOption:
     """
     TTML subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def webvtt(
-    
+
 ) -> FFMpegEncoderOption:
     """
     WebVTT subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def xsub(
-    
+
 ) -> FFMpegEncoderOption:
     """
     DivX subtitles (XSUB)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/packages/v5/src/ffmpeg/dag/global_runnable/global_args.py
+++ b/packages/v5/src/ffmpeg/dag/global_runnable/global_args.py
@@ -96,237 +96,237 @@ class GlobalArgs(ABC):
 
         return self._global_node(**merge(
             {
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "loglevel": loglevel,
-                
+
                 "v": v,
-                
+
                 "report": report,
-                
+
                 "max_alloc": max_alloc,
-                
+
                 "cpuflags": cpuflags,
-                
+
                 "cpucount": cpucount,
-                
+
                 "hide_banner": hide_banner,
-                
-                
-                
-                
+
+
+
+
                 "y": y,
-                
+
                 "n": n,
-                
+
                 "ignore_unknown": ignore_unknown,
-                
+
                 "copy_unknown": copy_unknown,
-                
+
                 "recast_media": recast_media,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "benchmark": benchmark,
-                
+
                 "benchmark_all": benchmark_all,
-                
+
                 "progress": progress,
-                
+
                 "stdin": stdin,
-                
+
                 "timelimit": timelimit,
-                
+
                 "dump": dump,
-                
+
                 "hex": hex,
-                
-                
-                
-                
+
+
+
+
                 "vsync": vsync,
-                
+
                 "frame_drop_threshold": frame_drop_threshold,
-                
+
                 "async": _async,
-                
+
                 "adrift_threshold": adrift_threshold,
-                
+
                 "copyts": copyts,
-                
+
                 "start_at_zero": start_at_zero,
-                
+
                 "copytb": copytb,
-                
-                
-                
-                
+
+
+
+
                 "dts_delta_threshold": dts_delta_threshold,
-                
+
                 "dts_error_threshold": dts_error_threshold,
-                
+
                 "xerror": xerror,
-                
+
                 "abort_on": abort_on,
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
                 "filter_threads": filter_threads,
-                
-                
-                
+
+
+
                 "filter_complex": filter_complex,
-                
+
                 "filter_complex_threads": filter_complex_threads,
-                
+
                 "lavfi": lavfi,
-                
+
                 "filter_complex_script": filter_complex_script,
-                
+
                 "auto_conversion_filters": auto_conversion_filters,
-                
+
                 "stats": stats,
-                
+
                 "stats_period": stats_period,
-                
-                
-                
-                
+
+
+
+
                 "debug_ts": debug_ts,
-                
+
                 "max_error_rate": max_error_rate,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "psnr": psnr,
-                
+
                 "vstats": vstats,
-                
+
                 "vstats_file": vstats_file,
-                
+
                 "vstats_version": vstats_version,
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
                 "qphist": qphist,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "vol": vol,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "vaapi_device": vaapi_device,
-                
+
                 "init_hw_device": init_hw_device,
-                
+
                 "filter_hw_device": filter_hw_device,
-                
-                
+
+
             }, extra_options)
         ).stream()

--- a/packages/v5/src/ffmpeg/dag/io/_input.py
+++ b/packages/v5/src/ffmpeg/dag/io/_input.py
@@ -121,236 +121,236 @@ def input(
     return InputNode(
         filename=str(filename),
         kwargs=merge({
-            
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "f": f,
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 "c": c,
-                
+
                 "codec": codec,
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 "t": t,
-                
+
                 "to": to,
-                
-                
+
+
                 "ss": ss,
-                
+
                 "sseof": sseof,
-                
+
                 "seek_timestamp": seek_timestamp,
-                
+
                 "accurate_seek": accurate_seek,
-                
+
                 "isync": isync,
-                
+
                 "itsoffset": itsoffset,
-                
+
                 "itsscale": itsscale,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
                 "re": re,
-                
+
                 "readrate": readrate,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
                 "bitexact": bitexact,
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
                 "tag": tag,
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
                 "reinit_filter": reinit_filter,
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
                 "dump_attachment": dump_attachment,
-                
+
                 "stream_loop": stream_loop,
-                
-                
-                
+
+
+
                 "discard": discard,
-                
-                
+
+
                 "thread_queue_size": thread_queue_size,
-                
+
                 "find_stream_info": find_stream_info,
-                
-                
-                
+
+
+
                 "r": r,
-                
-                
+
+
                 "s": s,
-                
-                
+
+
                 "pix_fmt": pix_fmt,
-                
+
                 "vn": vn,
-                
-                
+
+
                 "vcodec": vcodec,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
                 "top": top,
-                
+
                 "vtag": vtag,
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
                 "hwaccel": hwaccel,
-                
+
                 "hwaccel_device": hwaccel_device,
-                
+
                 "hwaccel_output_format": hwaccel_output_format,
-                
-                
+
+
                 "autorotate": autorotate,
-                
-                
-                
-                
+
+
+
+
                 "ar": ar,
-                
+
                 "ac": ac,
-                
+
                 "an": an,
-                
+
                 "acodec": acodec,
-                
-                
-                
+
+
+
                 "sample_fmt": sample_fmt,
-                
+
                 "channel_layout": channel_layout,
-                
+
                 "ch_layout": ch_layout,
-                
-                
+
+
                 "guess_layout_max": guess_layout_max,
-                
+
                 "sn": sn,
-                
+
                 "scodec": scodec,
-                
-                
+
+
                 "fix_sub_duration": fix_sub_duration,
-                
+
                 "canvas_size": canvas_size,
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 "bsf": bsf,
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
                 "dcodec": dcodec,
-                
+
                 "dn": dn,
-                
-                
-                
-                
-                
+
+
+
+
+
         }, decoder_options, demuxer_options, format_options, codec_options, extra_options )
     ).stream()

--- a/packages/v5/src/ffmpeg/dag/io/_output.py
+++ b/packages/v5/src/ffmpeg/dag/io/_output.py
@@ -156,275 +156,275 @@ def output(
         inputs=streams,
         filename=str(filename),
         kwargs=merge({
-            
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "f": f,
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 "c": c,
-                
+
                 "codec": codec,
-                
+
                 "pre": pre,
-                
+
                 "map": map,
-                
+
                 "map_channel": map_channel,
-                
+
                 "map_metadata": map_metadata,
-                
+
                 "map_chapters": map_chapters,
-                
+
                 "t": t,
-                
+
                 "to": to,
-                
+
                 "fs": fs,
-                
+
                 "ss": ss,
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
                 "timestamp": timestamp,
-                
+
                 "metadata": metadata,
-                
+
                 "program": program,
-                
+
                 "dframes": dframes,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
                 "target": target,
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
                 "shortest": shortest,
-                
+
                 "bitexact": bitexact,
-                
+
                 "apad": apad,
-                
-                
-                
-                
-                
+
+
+
+
+
                 "copyinkf": copyinkf,
-                
+
                 "copypriorss": copypriorss,
-                
+
                 "frames": frames,
-                
+
                 "tag": tag,
-                
+
                 "q": q,
-                
+
                 "qscale": qscale,
-                
+
                 "profile": profile,
-                
+
                 "filter": filter,
-                
-                
+
+
                 "filter_script": filter_script,
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
                 "attach": attach,
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 "disposition": disposition,
-                
-                
-                
+
+
+
                 "bits_per_raw_sample": bits_per_raw_sample,
-                
+
                 "vframes": vframes,
-                
+
                 "r": r,
-                
+
                 "fpsmax": fpsmax,
-                
+
                 "s": s,
-                
+
                 "aspect": aspect,
-                
+
                 "pix_fmt": pix_fmt,
-                
+
                 "vn": vn,
-                
+
                 "rc_override": rc_override,
-                
+
                 "vcodec": vcodec,
-                
+
                 "timecode": timecode,
-                
+
                 "pass": _pass,
-                
+
                 "passlogfile": passlogfile,
-                
-                
-                
-                
-                
+
+
+
+
+
                 "vf": vf,
-                
+
                 "intra_matrix": intra_matrix,
-                
+
                 "inter_matrix": inter_matrix,
-                
+
                 "chroma_intra_matrix": chroma_intra_matrix,
-                
+
                 "top": top,
-                
+
                 "vtag": vtag,
-                
-                
+
+
                 "fps_mode": fps_mode,
-                
+
                 "force_fps": force_fps,
-                
+
                 "streamid": streamid,
-                
+
                 "force_key_frames": force_key_frames,
-                
+
                 "ab": ab,
-                
+
                 "b": b,
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 "autoscale": autoscale,
-                
+
                 "aframes": aframes,
-                
+
                 "aq": aq,
-                
+
                 "ar": ar,
-                
+
                 "ac": ac,
-                
+
                 "an": an,
-                
+
                 "acodec": acodec,
-                
+
                 "atag": atag,
-                
-                
+
+
                 "sample_fmt": sample_fmt,
-                
+
                 "channel_layout": channel_layout,
-                
+
                 "ch_layout": ch_layout,
-                
+
                 "af": af,
-                
-                
+
+
                 "sn": sn,
-                
+
                 "scodec": scodec,
-                
+
                 "stag": stag,
-                
-                
-                
+
+
+
                 "muxdelay": muxdelay,
-                
+
                 "muxpreload": muxpreload,
-                
+
                 "sdp_file": sdp_file,
-                
+
                 "time_base": time_base,
-                
+
                 "enc_time_base": enc_time_base,
-                
+
                 "bsf": bsf,
-                
+
                 "absf": absf,
-                
+
                 "vbsf": vbsf,
-                
+
                 "apre": apre,
-                
+
                 "vpre": vpre,
-                
+
                 "spre": spre,
-                
+
                 "fpre": fpre,
-                
+
                 "max_muxing_queue_size": max_muxing_queue_size,
-                
+
                 "muxing_queue_data_threshold": muxing_queue_data_threshold,
-                
+
                 "dcodec": dcodec,
-                
+
                 "dn": dn,
-                
-                
-                
-                
-                
+
+
+
+
+
         }, encoder_options, muxer_options, format_options, codec_options, extra_options )
     ).stream()

--- a/packages/v5/src/ffmpeg/dag/io/output_args.py
+++ b/packages/v5/src/ffmpeg/dag/io/output_args.py
@@ -166,274 +166,274 @@ class OutputArgs(ABC):
         """
 
         return self._output_node(*streams, filename=filename, **merge({
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
             "f": f,
-                
-            
-            
-            
-            
-            
+
+
+
+
+
+
             "c": c,
-                
+
             "codec": codec,
-                
+
             "pre": pre,
-                
+
             "map": map,
-                
+
             "map_channel": map_channel,
-                
+
             "map_metadata": map_metadata,
-                
+
             "map_chapters": map_chapters,
-                
+
             "t": t,
-                
+
             "to": to,
-                
+
             "fs": fs,
-                
+
             "ss": ss,
-                
-            
-            
-            
-            
-            
-            
+
+
+
+
+
+
+
             "timestamp": timestamp,
-                
+
             "metadata": metadata,
-                
+
             "program": program,
-                
+
             "dframes": dframes,
-                
-            
-            
-            
-            
-            
-            
-            
-            
-            
+
+
+
+
+
+
+
+
+
+
             "target": target,
-                
-            
-            
-            
-            
-            
-            
-            
+
+
+
+
+
+
+
+
             "shortest": shortest,
-                
+
             "bitexact": bitexact,
-                
+
             "apad": apad,
-                
-            
-            
-            
-            
+
+
+
+
+
             "copyinkf": copyinkf,
-                
+
             "copypriorss": copypriorss,
-                
+
             "frames": frames,
-                
+
             "tag": tag,
-                
+
             "q": q,
-                
+
             "qscale": qscale,
-                
+
             "profile": profile,
-                
+
             "filter": filter,
-                
-            
+
+
             "filter_script": filter_script,
-                
-            
-            
-            
-            
-            
-            
-            
-            
+
+
+
+
+
+
+
+
+
             "attach": attach,
-                
-            
-            
-            
-            
-            
+
+
+
+
+
+
             "disposition": disposition,
-                
-            
-            
+
+
+
             "bits_per_raw_sample": bits_per_raw_sample,
-                
+
             "vframes": vframes,
-                
+
             "r": r,
-                
+
             "fpsmax": fpsmax,
-                
+
             "s": s,
-                
+
             "aspect": aspect,
-                
+
             "pix_fmt": pix_fmt,
-                
+
             "vn": vn,
-                
+
             "rc_override": rc_override,
-                
+
             "vcodec": vcodec,
-                
+
             "timecode": timecode,
-                
+
             "pass": _pass,
-                
+
             "passlogfile": passlogfile,
-                
-            
-            
-            
-            
+
+
+
+
+
             "vf": vf,
-                
+
             "intra_matrix": intra_matrix,
-                
+
             "inter_matrix": inter_matrix,
-                
+
             "chroma_intra_matrix": chroma_intra_matrix,
-                
+
             "top": top,
-                
+
             "vtag": vtag,
-                
-            
+
+
             "fps_mode": fps_mode,
-                
+
             "force_fps": force_fps,
-                
+
             "streamid": streamid,
-                
+
             "force_key_frames": force_key_frames,
-                
+
             "ab": ab,
-                
+
             "b": b,
-                
-            
-            
-            
-            
-            
+
+
+
+
+
+
             "autoscale": autoscale,
-                
+
             "aframes": aframes,
-                
+
             "aq": aq,
-                
+
             "ar": ar,
-                
+
             "ac": ac,
-                
+
             "an": an,
-                
+
             "acodec": acodec,
-                
+
             "atag": atag,
-                
-            
+
+
             "sample_fmt": sample_fmt,
-                
+
             "channel_layout": channel_layout,
-                
+
             "ch_layout": ch_layout,
-                
+
             "af": af,
-                
-            
+
+
             "sn": sn,
-                
+
             "scodec": scodec,
-                
+
             "stag": stag,
-                
-            
-            
+
+
+
             "muxdelay": muxdelay,
-                
+
             "muxpreload": muxpreload,
-                
+
             "sdp_file": sdp_file,
-                
+
             "time_base": time_base,
-                
+
             "enc_time_base": enc_time_base,
-                
+
             "bsf": bsf,
-                
+
             "absf": absf,
-                
+
             "vbsf": vbsf,
-                
+
             "apre": apre,
-                
+
             "vpre": vpre,
-                
+
             "spre": spre,
-                
+
             "fpre": fpre,
-                
+
             "max_muxing_queue_size": max_muxing_queue_size,
-                
+
             "muxing_queue_data_threshold": muxing_queue_data_threshold,
-                
+
             "dcodec": dcodec,
-                
+
             "dn": dn,
-                
-            
-            
-            
-            
+
+
+
+
+
         }, encoder_options, muxer_options, format_options, codec_options, extra_options)).stream()

--- a/packages/v5/src/ffmpeg/filters.py
+++ b/packages/v5/src/ffmpeg/filters.py
@@ -45,45 +45,45 @@ import re
 
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
 def acrossfade(
-    
 
-    
-        
+
+
+
         _crossfade0: AudioStream,
-        
-    
-        
+
+
+
         _crossfade1: AudioStream,
-        
-    
+
+
 
 
     *,
     nb_samples: Int = Default('44100'),duration: Duration = Default('0'),overlap: Boolean = Default('true'),curve1: Int| Literal["nofade","tri","qsin","esin","hsin","log","ipar","qua","cub","squ","cbr","par","exp","iqsin","ihsin","dese","desi","losi","sinc","isinc"] | Default = Default('tri'),curve2: Int| Literal["nofade","tri","qsin","esin","hsin","log","ipar","qua","cub","squ","cbr","par","exp","iqsin","ihsin","dese","desi","losi","sinc","isinc"] | Default = Default('tri'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Apply cross fade from one input audio stream to another input audio stream.
 The cross fade is applied for specified duration near the end of first stream.
 
@@ -105,128 +105,128 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acrossfade)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='acrossfade', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _crossfade0,
-            
-        
-            
+
+
+
             _crossfade1,
-            
-        
+
+
 
 
         **merge({
-            
+
             "nb_samples": nb_samples,
-            
+
             "duration": duration,
-            
+
             "overlap": overlap,
-            
+
             "curve1": curve1,
-            
+
             "curve2": curve2,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def ainterleave(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     nb_inputs: Int = Auto('len(streams)'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Temporally interleave frames from several inputs.
 
 interleave works with video inputs, ainterleave with audio.
@@ -265,82 +265,82 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#interleave)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='ainterleave', typings_input='[StreamType.audio] * int(nb_inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "nb_inputs": nb_inputs,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
 def alphamerge(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _alpha: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Add or replace the alpha component of the primary input with the
 grayscale value of a second input. This is intended for use with
 alphaextract to allow the transmission or storage of frame
@@ -366,7 +366,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#alphamerge)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -377,55 +377,55 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='alphamerge', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _alpha,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def amerge(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Merge two or more audio streams into a single multi-channel stream.
 
 The filter accepts the following options:
@@ -442,54 +442,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amerge)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='amerge', typings_input='[StreamType.audio] * int(inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def amix(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),dropout_transition: Float = Default('2'),weights: String = Default('1 1'),normalize: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Mixes multiple audio inputs into a single output.
 
 Note that this filter only supports float samples (the amerge
@@ -522,70 +522,70 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amix)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='amix', typings_input='[StreamType.audio] * int(inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "duration": duration,
-            
+
             "dropout_transition": dropout_transition,
-            
+
             "weights": weights,
-            
+
             "normalize": normalize,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def amultiply(
-    
 
-    
-        
+
+
+
         _multiply0: AudioStream,
-        
-    
-        
+
+
+
         _multiply1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Multiply first audio stream with second audio stream and store result
 in output audio stream. Multiplication is done by multiplying each
 sample from first stream with sample at same position from second stream.
@@ -604,69 +604,69 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amultiply)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='amultiply', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _multiply0,
-            
-        
-            
+
+
+
             _multiply1,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def anlmf(
-    
 
-    
-        
+
+
+
         _input: AudioStream,
-        
-    
-        
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('256'),mu: Float = Default('0.75'),eps: Float = Default('1'),leakage: Float = Default('0'),out_mode: Int| Literal["i","d","o","n"] | Default = Default('o'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Apply Normalized Least-Mean-(Squares|Fourth) algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to mimic a desired filter by finding the filter coefficients that
@@ -692,7 +692,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anlmf)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -700,72 +700,72 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='anlmf', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _input,
-            
-        
-            
+
+
+
             _desired,
-            
-        
+
+
 
 
         **merge({
-            
+
             "order": order,
-            
+
             "mu": mu,
-            
+
             "eps": eps,
-            
+
             "leakage": leakage,
-            
+
             "out_mode": out_mode,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
+
+
+
 def anlms(
-    
 
-    
-        
+
+
+
         _input: AudioStream,
-        
-    
-        
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('256'),mu: Float = Default('0.75'),eps: Float = Default('1'),leakage: Float = Default('0'),out_mode: Int| Literal["i","d","o","n"] | Default = Default('o'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Apply Normalized Least-Mean-(Squares|Fourth) algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to mimic a desired filter by finding the filter coefficients that
@@ -791,7 +791,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anlmf)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -799,99 +799,99 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='anlms', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _input,
-            
-        
-            
+
+
+
             _desired,
-            
-        
+
+
 
 
         **merge({
-            
+
             "order": order,
-            
+
             "mu": mu,
-            
+
             "eps": eps,
-            
+
             "leakage": leakage,
-            
+
             "out_mode": out_mode,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def asdr(
-    
 
-    
-        
+
+
+
         _input0: AudioStream,
-        
-    
-        
+
+
+
         _input1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Measure Audio Signal-to-Distortion Ratio.
 
 This filter takes two audio streams for input, and outputs first
@@ -909,84 +909,84 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asdr)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='asdr', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _input0,
-            
-        
-            
+
+
+
             _input1,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def astreamselect(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),map: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Select video or audio streams.
 
 The filter accepts the following options:
@@ -1005,87 +1005,87 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#streamselect)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='astreamselect', typings_input='[StreamType.audio] * int(inputs)', typings_output="[StreamType.audio] * len(re.findall(r'\\d+', str(map)))"),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "map": map,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def axcorrelate(
-    
 
-    
-        
+
+
+
         _axcorrelate0: AudioStream,
-        
-    
-        
+
+
+
         _axcorrelate1: AudioStream,
-        
-    
+
+
 
 
     *,
     size: Int = Default('256'),algo: Int| Literal["slow","fast"] | Default = Default('slow'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Calculate normalized windowed cross-correlation between two input audio streams.
 
 Resulted samples are always between -1 and 1 inclusive.
@@ -1109,96 +1109,96 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#axcorrelate)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='axcorrelate', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _axcorrelate0,
-            
-        
-            
+
+
+
             _axcorrelate1,
-            
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "algo": algo,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def blend(
-    
 
-    
-        
+
+
+
         _top: VideoStream,
-        
-    
-        
+
+
+
         _bottom: VideoStream,
-        
-    
+
+
 
 
     *,
     c0_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c1_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c2_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c3_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),all_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('-1'),c0_expr: String = Default(None),c1_expr: String = Default(None),c2_expr: String = Default(None),c3_expr: String = Default(None),all_expr: String = Default(None),c0_opacity: Double = Default('1'),c1_opacity: Double = Default('1'),c2_opacity: Double = Default('1'),c3_opacity: Double = Default('1'),all_opacity: Double = Default('1'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Blend two video frames into each other.
 
 The blend filter takes two input streams and outputs one
@@ -1239,7 +1239,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blend)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -1250,92 +1250,92 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='blend', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _top,
-            
-        
-            
+
+
+
             _bottom,
-            
-        
+
+
 
 
         **merge({
-            
+
             "c0_mode": c0_mode,
-            
+
             "c1_mode": c1_mode,
-            
+
             "c2_mode": c2_mode,
-            
+
             "c3_mode": c3_mode,
-            
+
             "all_mode": all_mode,
-            
+
             "c0_expr": c0_expr,
-            
+
             "c1_expr": c1_expr,
-            
+
             "c2_expr": c2_expr,
-            
+
             "c3_expr": c3_expr,
-            
+
             "all_expr": all_expr,
-            
+
             "c0_opacity": c0_opacity,
-            
+
             "c1_opacity": c1_opacity,
-            
+
             "c2_opacity": c2_opacity,
-            
+
             "c3_opacity": c3_opacity,
-            
+
             "all_opacity": all_opacity,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def bm3d(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     sigma: Float = Default('1'),block: Int = Default('4'),bstep: Int = Default('4'),group: Int = Default('1'),range: Int = Default('9'),mstep: Int = Default('1'),thmse: Float = Default('0'),hdthr: Float = Default('2.7'),estim: Int| Literal["basic","final"] | Default = Default('basic'),ref: Boolean = Default('false'),planes: Int = Default('7'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Denoise frames using Block-Matching 3D algorithm.
 
 The filter accepts the following options.
@@ -1363,7 +1363,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bm3d)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -1371,136 +1371,136 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='bm3d', typings_input='[StreamType.video] + [StreamType.video] if ref else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "sigma": sigma,
-            
+
             "block": block,
-            
+
             "bstep": bstep,
-            
+
             "group": group,
-            
+
             "range": range,
-            
+
             "mstep": mstep,
-            
+
             "thmse": thmse,
-            
+
             "hdthr": hdthr,
-            
+
             "estim": estim,
-            
+
             "ref": ref,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def colormap(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _target: VideoStream,
-        
-    
+
+
 
 
     *,
     patch_size: Image_size = Default('64x64'),nb_patches: Int = Default('0'),type: Int| Literal["relative","absolute"] | Default = Default('absolute'),kernel: Int| Literal["euclidean","weuclidean"] | Default = Default('euclidean'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply custom color maps to video stream.
 
 This filter needs three input video streams.
@@ -1526,7 +1526,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colormap)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -1534,77 +1534,77 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='colormap', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _target,
-            
-        
+
+
 
 
         **merge({
-            
+
             "patch_size": patch_size,
-            
+
             "nb_patches": nb_patches,
-            
+
             "type": type,
-            
+
             "kernel": kernel,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
 def concat(
-    
 
-    
+
+
     *streams: FilterableStream,
-    
 
 
-    
+
+
     n: Int = Auto('len(streams) // (int(v) + int(a))'),v: Int = Default('1'),a: Int = Default('0'),unsafe: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Concatenate audio and video streams, joining them together one after the
 other.
 
@@ -1630,77 +1630,77 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#concat)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='concat', typings_input='([StreamType.video]*int(v) + [StreamType.audio]*int(a))*int(n)', typings_output='[StreamType.video]*int(v) + [StreamType.audio]*int(a)'),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "n": n,
-            
+
             "v": v,
-            
+
             "a": a,
-            
+
             "unsafe": unsafe,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def convolve(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _impulse: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('7'),impulse: Int| Literal["first","all"] | Default = Default('all'),noise: Float = Default('1e-07'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply 2D convolution of video stream in frequency domain using second stream
 as impulse.
 
@@ -1722,7 +1722,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#convolve)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -1733,89 +1733,89 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='convolve', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _impulse,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "impulse": impulse,
-            
+
             "noise": noise,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def decimate(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     cycle: Int = Default('5'),dupthresh: Double = Default('1.1'),scthresh: Double = Default('15'),blockx: Int = Default('32'),blocky: Int = Default('32'),ppsrc: Boolean = Default('false'),chroma: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Drop duplicated frames at regular intervals.
 
 The filter accepts the following options:
@@ -1838,78 +1838,78 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#decimate)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='decimate', typings_input='[StreamType.video] + ([StreamType.video] if ppsrc else [])', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "cycle": cycle,
-            
+
             "dupthresh": dupthresh,
-            
+
             "scthresh": scthresh,
-            
+
             "blockx": blockx,
-            
+
             "blocky": blocky,
-            
+
             "ppsrc": ppsrc,
-            
+
             "chroma": chroma,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def deconvolve(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _impulse: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('7'),impulse: Int| Literal["first","all"] | Default = Default('all'),noise: Float = Default('1e-07'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply 2D deconvolution of video stream in frequency domain using second stream
 as impulse.
 
@@ -1931,7 +1931,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deconvolve)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -1942,106 +1942,106 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='deconvolve', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _impulse,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "impulse": impulse,
-            
+
             "noise": noise,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def displace(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _xmap: VideoStream,
-        
-    
-        
+
+
+
         _ymap: VideoStream,
-        
-    
+
+
 
 
     *,
     edge: Int| Literal["blank","smear","wrap","mirror"] | Default = Default('smear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Displace pixels as indicated by second and third input stream.
 
 It takes three input streams and outputs one stream, the first input is the
@@ -2070,7 +2070,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#displace)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -2078,125 +2078,125 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='displace', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _xmap,
-            
-        
-            
+
+
+
             _ymap,
-            
-        
+
+
 
 
         **merge({
-            
+
             "edge": edge,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def feedback(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _feedin: VideoStream,
-        
-    
+
+
 
 
     *,
     x: Int = Default('0'),w: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> tuple[
-    
-        
+
+
             VideoStream,
-        
-    
-        
+
+
+
             VideoStream,
-        
-    
+
+
 ]:
     """
-    
+
 Apply feedback video filter.
 
 This filter pass cropped input frames to 2nd output.
@@ -2223,79 +2223,79 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#feedback)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='feedback', typings_input=('video', 'video'), typings_output=('video', 'video')),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _feedin,
-            
-        
+
+
 
 
         **merge({
-            
+
             "x": x,
-            
+
             "w": w,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return (
-        
-            
+
+
                 filter_node.video(0),
-            
-        
-            
+
+
+
                 filter_node.video(1),
-            
-        
+
+
     )
 
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def fieldmatch(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     order: Int| Literal["auto","bff","tff"] | Default = Default('auto'),mode: Int| Literal["pc","pc_n","pc_u","pc_n_ub","pcn","pcn_ub"] | Default = Default('pc_n'),ppsrc: Boolean = Default('false'),field: Int| Literal["auto","bottom","top"] | Default = Default('auto'),mchroma: Boolean = Default('true'),y0: Int = Default('0'),scthresh: Double = Default('12'),combmatch: Int| Literal["none","sc","full"] | Default = Default('sc'),combdbg: Int| Literal["none","pcn","pcnub"] | Default = Default('none'),cthresh: Int = Default('9'),chroma: Boolean = Default('false'),blockx: Int = Default('16'),blocky: Int = Default('16'),combpel: Int = Default('80'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Field matching filter for inverse telecine. It is meant to reconstruct the
 progressive frames from a telecined stream. The filter does not drop duplicated
 frames, so to achieve a complete inverse telecine fieldmatch needs to be
@@ -2353,102 +2353,102 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fieldmatch)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='fieldmatch', typings_input='[StreamType.video] + [StreamType.video] if ppsrc else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "order": order,
-            
+
             "mode": mode,
-            
+
             "ppsrc": ppsrc,
-            
+
             "field": field,
-            
+
             "mchroma": mchroma,
-            
+
             "y0": y0,
-            
+
             "scthresh": scthresh,
-            
+
             "combmatch": combmatch,
-            
+
             "combdbg": combdbg,
-            
+
             "cthresh": cthresh,
-            
+
             "chroma": chroma,
-            
+
             "blockx": blockx,
-            
+
             "blocky": blocky,
-            
+
             "combpel": combpel,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
 def framepack(
-    
 
-    
-        
+
+
+
         _left: VideoStream,
-        
-    
-        
+
+
+
         _right: VideoStream,
-        
-    
+
+
 
 
     *,
     format: Int| Literal["sbs","tab","frameseq","lines","columns"] | Default = Default('sbs'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Pack two different video streams into a stereoscopic video, setting proper
 metadata on supported codecs. The two views should have the same size and
 framerate and processing will stop when the shorter video ends. Please note
@@ -2469,70 +2469,70 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#framepack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='framepack', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _left,
-            
-        
-            
+
+
+
             _right,
-            
-        
+
+
 
 
         **merge({
-            
+
             "format": format,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def freezeframes(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _replace: VideoStream,
-        
-    
+
+
 
 
     *,
     first: Int64 = Default('0'),last: Int64 = Default('0'),replace: Int64 = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Freeze video frames.
 
 This filter freezes video frames using frame from 2nd input.
@@ -2553,81 +2553,81 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#freezeframes)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='freezeframes', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _replace,
-            
-        
+
+
 
 
         **merge({
-            
+
             "first": first,
-            
+
             "last": last,
-            
+
             "replace": replace,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
 def guided(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     radius: Int = Default('3'),eps: Float = Default('0.01'),mode: Int| Literal["basic","fast"] | Default = Default('basic'),sub: Int = Default('4'),guidance: Int| Literal["off","on"] | Default = Default('off'),planes: Int = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply guided filter for edge-preserving smoothing, dehazing and so on.
 
 The filter accepts the following options:
@@ -2650,7 +2650,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#guided)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -2658,75 +2658,75 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='guided', typings_input='[StreamType.video] + [StreamType.video] if guidance else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "radius": radius,
-            
+
             "eps": eps,
-            
+
             "mode": mode,
-            
+
             "sub": sub,
-            
+
             "guidance": guidance,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def haldclut(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _clut: VideoStream,
-        
-    
+
+
 
 
     *,
     clut: Int| Literal["first","all"] | Default = Default('all'),interp: Int| Literal["nearest","trilinear","tetrahedral","pyramid","prism"] | Default = Default('tetrahedral'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply a Hald CLUT to a video stream.
 
 First input is the video stream to process, and second one is the Hald CLUT.
@@ -2749,7 +2749,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#haldclut)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -2760,63 +2760,63 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='haldclut', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _clut,
-            
-        
+
+
 
 
         **merge({
-            
+
             "clut": clut,
-            
+
             "interp": interp,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def headphone(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     map: String = Default(None),gain: Float = Default('0'),lfe: Float = Default('0'),type: Int| Literal["time","freq"] | Default = Default('freq'),size: Int = Default('1024'),hrir: Int| Literal["stereo","multich"] | Default = Default('stereo'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Apply head-related transfer functions (HRTFs) to create virtual
 loudspeakers around the user for binaural listening via headphones.
 The HRIRs are provided via additional streams, for each channel
@@ -2841,78 +2841,78 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#headphone)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='headphone', typings_input="[StreamType.audio] + [StreamType.audio] * (len(str(map).split('|')) - 1) if int(hrir) == 1 else []", typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "map": map,
-            
+
             "gain": gain,
-            
+
             "lfe": lfe,
-            
+
             "type": type,
-            
+
             "size": size,
-            
+
             "hrir": hrir,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
 def hstack(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),shortest: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos horizontally.
 
 All streams must be of same pixel format and of same height.
@@ -2935,82 +2935,82 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hstack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='hstack', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
 def hysteresis(
-    
 
-    
-        
+
+
+
         _base: VideoStream,
-        
-    
-        
+
+
+
         _alt: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),threshold: Int = Default('0'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Grow first stream into second stream by connecting components.
 This makes it possible to build more robust edge masks.
 
@@ -3031,7 +3031,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hysteresis)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -3042,73 +3042,73 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='hysteresis', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _base,
-            
-        
-            
+
+
+
             _alt,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "threshold": threshold,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def identity(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Obtain the identity score between two input videos.
 
 This filter takes two input videos.
@@ -3142,7 +3142,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#identity)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -3153,63 +3153,63 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='identity', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def interleave(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     nb_inputs: Int = Auto('len(streams)'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Temporally interleave frames from several inputs.
 
 interleave works with video inputs, ainterleave with audio.
@@ -3248,54 +3248,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#interleave)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='interleave', typings_input='[StreamType.video] * int(nb_inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "nb_inputs": nb_inputs,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def join(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),channel_layout: String = Default('stereo'),map: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Join multiple input streams into one multi-channel stream.
 
 It accepts the following parameters:
@@ -3314,71 +3314,71 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#join)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='join', typings_input='[StreamType.audio] * int(inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "channel_layout": channel_layout,
-            
+
             "map": map,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
 def limitdiff(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     threshold: Float = Default('0.00392157'),elasticity: Float = Default('2'),reference: Boolean = Default('false'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply limited difference filter using second and optionally third video stream.
 
 The filter accepts the following options:
@@ -3399,7 +3399,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#limitdiff)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -3407,85 +3407,85 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='limitdiff', typings_input='[StreamType.video, StreamType.video] + ([StreamType.video] if reference else [])', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "threshold": threshold,
-            
+
             "elasticity": elasticity,
-            
+
             "reference": reference,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
 def lut2(
-    
 
-    
-        
+
+
+
         _srcx: VideoStream,
-        
-    
-        
+
+
+
         _srcy: VideoStream,
-        
-    
+
+
 
 
     *,
     c0: String = Default('x'),c1: String = Default('x'),c2: String = Default('x'),c3: String = Default('x'),d: Int = Default('0'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The lut2 filter takes two input streams and outputs one
 stream.
 
@@ -3512,7 +3512,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut2)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -3523,86 +3523,86 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='lut2', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _srcx,
-            
-        
-            
+
+
+
             _srcy,
-            
-        
+
+
 
 
         **merge({
-            
+
             "c0": c0,
-            
+
             "c1": c1,
-            
+
             "c2": c2,
-            
+
             "c3": c3,
-            
+
             "d": d,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def maskedclamp(
-    
 
-    
-        
+
+
+
         _base: VideoStream,
-        
-    
-        
+
+
+
         _dark: VideoStream,
-        
-    
-        
+
+
+
         _bright: VideoStream,
-        
-    
+
+
 
 
     *,
     undershoot: Int = Default('0'),overshoot: Int = Default('0'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Clamp the first input stream with the second input and third input stream.
 
 Returns the value of first stream to be between second input
@@ -3625,7 +3625,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedclamp)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -3633,76 +3633,76 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='maskedclamp', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _base,
-            
-        
-            
+
+
+
             _dark,
-            
-        
-            
+
+
+
             _bright,
-            
-        
+
+
 
 
         **merge({
-            
+
             "undershoot": undershoot,
-            
+
             "overshoot": overshoot,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def maskedmax(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _filter1: VideoStream,
-        
-    
-        
+
+
+
         _filter2: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Merge the second and third input stream into output stream using absolute differences
 between second input stream and first input stream and absolute difference between
 third input stream and first input stream. The picked value will be from second input
@@ -3724,7 +3724,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedmax)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -3732,72 +3732,72 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='maskedmax', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _filter1,
-            
-        
-            
+
+
+
             _filter2,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def maskedmerge(
-    
 
-    
-        
+
+
+
         _base: VideoStream,
-        
-    
-        
+
+
+
         _overlay: VideoStream,
-        
-    
-        
+
+
+
         _mask: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Merge the first input stream with the second input stream using per pixel
 weights in the third input stream.
 
@@ -3822,7 +3822,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedmerge)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -3830,72 +3830,72 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='maskedmerge', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _base,
-            
-        
-            
+
+
+
             _overlay,
-            
-        
-            
+
+
+
             _mask,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def maskedmin(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _filter1: VideoStream,
-        
-    
-        
+
+
+
         _filter2: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Merge the second and third input stream into output stream using absolute differences
 between second input stream and first input stream and absolute difference between
 third input stream and first input stream. The picked value will be from second input
@@ -3917,7 +3917,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedmin)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -3925,68 +3925,68 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='maskedmin', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _filter1,
-            
-        
-            
+
+
+
             _filter2,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def maskedthreshold(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     threshold: Int = Default('1'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Pick pixels comparing absolute difference of two video streams with fixed
 threshold.
 
@@ -4011,7 +4011,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedthreshold)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4019,63 +4019,63 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='maskedthreshold', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
             "threshold": threshold,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def mergeplanes(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     mapping: Int = Default('-1'),format: Pix_fmt = Default('yuva444p'),map0s: Int = Default('0'),map0p: Int = Default('0'),map1s: Int = Default('0'),map1p: Int = Default('0'),map2s: Int = Default('0'),map2p: Int = Default('0'),map3s: Int = Default('0'),map3p: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Merge color channel components from several video streams.
 
 The filter accepts up to 4 input streams, and merge selected input
@@ -4104,83 +4104,83 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mergeplanes)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='mergeplanes', typings_input='[StreamType.video] * int(max(hex(int(mapping))[2::2]))', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "mapping": mapping,
-            
+
             "format": format,
-            
+
             "map0s": map0s,
-            
+
             "map0p": map0p,
-            
+
             "map1s": map1s,
-            
+
             "map1p": map1p,
-            
+
             "map2s": map2s,
-            
+
             "map2p": map2p,
-            
+
             "map3s": map3s,
-            
+
             "map3p": map3p,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def midequalizer(
-    
 
-    
-        
+
+
+
         _in0: VideoStream,
-        
-    
-        
+
+
+
         _in1: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply Midway Image Equalization effect using two video streams.
 
 Midway Image Equalization adjusts a pair of images to have the same
@@ -4206,7 +4206,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#midequalizer)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4214,60 +4214,60 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='midequalizer', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _in0,
-            
-        
-            
+
+
+
             _in1,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def mix(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),weights: String = Default('1 1'),scale: Float = Default('0'),planes: Flags = Default('F'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Mix several video input streams into one video stream.
 
 A description of the accepted options follows.
@@ -4289,7 +4289,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mix)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4297,73 +4297,73 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='mix', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "weights": weights,
-            
+
             "scale": scale,
-            
+
             "planes": planes,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def morpho(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _structure: VideoStream,
-        
-    
+
+
 
 
     *,
     mode: Int| Literal["erode","dilate","open","close","gradient","tophat","blackhat"] | Default = Default('erode'),planes: Int = Default('7'),structure: Int| Literal["first","all"] | Default = Default('all'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 This filter allows to apply main morphological grayscale transforms,
 erode and dilate with arbitrary structures set in second input stream.
 
@@ -4389,7 +4389,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#morpho)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -4400,81 +4400,81 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='morpho', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _structure,
-            
-        
+
+
 
 
         **merge({
-            
+
             "mode": mode,
-            
+
             "planes": planes,
-            
+
             "structure": structure,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def msad(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Obtain the MSAD (Mean Sum of Absolute Differences) between two input videos.
 
 This filter takes two input videos.
@@ -4508,7 +4508,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#msad)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -4519,64 +4519,64 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='msad', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def multiply(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _factor: VideoStream,
-        
-    
+
+
 
 
     *,
     scale: Float = Default('1'),offset: Float = Default('0.5'),planes: Flags = Default('F'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Multiply first video stream pixels values with second video stream pixels values.
 
 The filter accepts the following options:
@@ -4596,7 +4596,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#multiply)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4604,97 +4604,97 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='multiply', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _factor,
-            
-        
+
+
 
 
         **merge({
-            
+
             "scale": scale,
-            
+
             "offset": offset,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def overlay(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _overlay: VideoStream,
-        
-    
+
+
 
 
     *,
     x: String = Default('0'),y: String = Default('0'),eof_action: Int| Literal["repeat","endall","pass"] | Default = Default('repeat'),eval: Int| Literal["init","frame"] | Default = Default('frame'),shortest: Boolean = Default('false'),format: Int| Literal["yuv420","yuv420p10","yuv422","yuv422p10","yuv444","rgb","gbrp","auto"] | Default = Default('yuv420'),repeatlast: Boolean = Default('true'),alpha: Int| Literal["straight","premultiplied"] | Default = Default('straight'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
-    
-    
-    
-    
-    
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Overlay one video on top of another.
 
 It takes two inputs and has one output. The first input is the "main"
@@ -4725,7 +4725,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4733,77 +4733,77 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='overlay', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _overlay,
-            
-        
+
+
 
 
         **merge({
-            
+
             "x": x,
-            
+
             "y": y,
-            
+
             "eof_action": eof_action,
-            
+
             "eval": eval,
-            
+
             "shortest": shortest,
-            
+
             "format": format,
-            
+
             "repeatlast": repeatlast,
-            
+
             "alpha": alpha,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def overlay_opencl(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _overlay: VideoStream,
-        
-    
+
+
 
 
     *,
     x: Int = Default('0'),y: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Overlay one video on top of another.
 
 It takes two inputs and has one output. The first input is the "main" video on which the second input is overlaid.
@@ -4824,66 +4824,66 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay_opencl)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='overlay_opencl', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _overlay,
-            
-        
+
+
 
 
         **merge({
-            
+
             "x": x,
-            
+
             "y": y,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def overlay_vaapi(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _overlay: VideoStream,
-        
-    
+
+
 
 
     *,
     x: Int = Default('0'),y: Int = Default('0'),w: Int = Default('0'),h: Int = Default('0'),alpha: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Overlay one video on the top of another.
 
 It takes two inputs and has one output. The first input is the "main" video on which the second input is overlaid.
@@ -4907,84 +4907,84 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay_vaapi)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='overlay_vaapi', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _overlay,
-            
-        
+
+
 
 
         **merge({
-            
+
             "x": x,
-            
+
             "y": y,
-            
+
             "w": w,
-            
+
             "h": h,
-            
+
             "alpha": alpha,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
 def paletteuse(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _palette: VideoStream,
-        
-    
+
+
 
 
     *,
     dither: Int| Literal["bayer","heckbert","floyd_steinberg","sierra2","sierra2_4a"] | Default = Default('sierra2_4a'),bayer_scale: Int = Default('2'),diff_mode: Int| Literal["rectangle"] | Default = Default('0'),new: Boolean = Default('false'),alpha_threshold: Int = Default('128'),use_alpha: Boolean = Default('false'),debug_kdtree: String = Default(None),color_search: Int| Literal["nns_iterative","nns_recursive","bruteforce"] | Default = Default('nns_iterative'),mean_err: Boolean = Default('false'),debug_accuracy: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Use a palette to downsample an input video stream.
 
 The filter takes two inputs: one video stream and a palette. The palette must
@@ -5013,99 +5013,99 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#paletteuse)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='paletteuse', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _palette,
-            
-        
+
+
 
 
         **merge({
-            
+
             "dither": dither,
-            
+
             "bayer_scale": bayer_scale,
-            
+
             "diff_mode": diff_mode,
-            
+
             "new": new,
-            
+
             "alpha_threshold": alpha_threshold,
-            
+
             "use_alpha": use_alpha,
-            
+
             "debug_kdtree": debug_kdtree,
-            
+
             "color_search": color_search,
-            
+
             "mean_err": mean_err,
-            
+
             "debug_accuracy": debug_accuracy,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
 def premultiply(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     planes: Int = Default('15'),inplace: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply alpha premultiply effect to input video stream using first plane
 of second stream as alpha.
 
@@ -5127,7 +5127,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#premultiply)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -5135,62 +5135,62 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='premultiply', typings_input='[StreamType.video] + [StreamType.video] if inplace else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "inplace": inplace,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def program_opencl(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     source: String = Default(None),kernel: String = Default(None),inputs: Int = Default('1'),size: Image_size = Default(None),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Filter video using an OpenCL program.
 
 
@@ -5209,7 +5209,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#program_opencl)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -5217,71 +5217,71 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='program_opencl', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "source": source,
-            
+
             "kernel": kernel,
-            
+
             "inputs": inputs,
-            
+
             "size": size,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def psnr(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),stats_version: Int = Default('1'),output_max: Boolean = Default('false'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Obtain the average, maximum and minimum PSNR (Peak Signal to Noise
 Ratio) between two input videos.
 
@@ -5325,7 +5325,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#psnr)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -5336,83 +5336,83 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='psnr', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
             "stats_file": stats_file,
-            
+
             "stats_version": stats_version,
-            
+
             "output_max": output_max,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
 def remap(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _xmap: VideoStream,
-        
-    
-        
+
+
+
         _ymap: VideoStream,
-        
-    
+
+
 
 
     *,
     format: Int| Literal["color","gray"] | Default = Default('color'),fill: Color = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Remap pixels using 2nd: Xmap and 3rd: Ymap input video stream.
 
 Destination pixel at position (X, Y) will be picked from source (x, y) position
@@ -5436,74 +5436,74 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#remap)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='remap', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _xmap,
-            
-        
-            
+
+
+
             _ymap,
-            
-        
+
+
 
 
         **merge({
-            
+
             "format": format,
-            
+
             "fill": fill,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def remap_opencl(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _xmap: VideoStream,
-        
-    
-        
+
+
+
         _ymap: VideoStream,
-        
-    
+
+
 
 
     *,
     interp: Int| Literal["near","linear"] | Default = Default('linear'),fill: Color = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Remap pixels using 2nd: Xmap and 3rd: Ymap input video stream.
 
 Destination pixel at position (X, Y) will be picked from source (x, y) position
@@ -5527,104 +5527,104 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#remap_opencl)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='remap_opencl', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _xmap,
-            
-        
-            
+
+
+
             _ymap,
-            
-        
+
+
 
 
         **merge({
-            
+
             "interp": interp,
-            
+
             "fill": fill,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def scale2ref(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _ref: VideoStream,
-        
-    
+
+
 
 
     *,
     w: String = Default(None),h: String = Default(None),flags: String = Default(''),interl: Boolean = Default('false'),in_color_matrix: String| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default('auto'),out_color_matrix: String| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default(None),in_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),out_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),in_v_chr_pos: Int = Default('-513'),in_h_chr_pos: Int = Default('-513'),out_v_chr_pos: Int = Default('-513'),out_h_chr_pos: Int = Default('-513'),force_original_aspect_ratio: Int| Literal["disable","decrease","increase"] | Default = Default('disable'),force_divisible_by: Int = Default('1'),param0: Double = Default('123456'),param1: Double = Default('123456'),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> tuple[
-    
-        
+
+
             VideoStream,
-        
-    
-        
+
+
+
             VideoStream,
-        
-    
+
+
 ]:
     """
-    
+
 Scale (resize) the input video, based on a reference video.
 
 See the scale filter for available options, scale2ref supports the same but
@@ -5661,169 +5661,169 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#scale2ref)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='scale2ref', typings_input=('video', 'video'), typings_output=('video', 'video')),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _ref,
-            
-        
+
+
 
 
         **merge({
-            
+
             "w": w,
-            
+
             "h": h,
-            
+
             "flags": flags,
-            
+
             "interl": interl,
-            
+
             "in_color_matrix": in_color_matrix,
-            
+
             "out_color_matrix": out_color_matrix,
-            
+
             "in_range": in_range,
-            
+
             "out_range": out_range,
-            
+
             "in_v_chr_pos": in_v_chr_pos,
-            
+
             "in_h_chr_pos": in_h_chr_pos,
-            
+
             "out_v_chr_pos": out_v_chr_pos,
-            
+
             "out_h_chr_pos": out_h_chr_pos,
-            
+
             "force_original_aspect_ratio": force_original_aspect_ratio,
-            
+
             "force_divisible_by": force_divisible_by,
-            
+
             "param0": param0,
-            
+
             "param1": param1,
-            
+
             "eval": eval,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return (
-        
-            
+
+
                 filter_node.video(0),
-            
-        
-            
+
+
+
                 filter_node.video(1),
-            
-        
+
+
     )
 
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def sidechaincompress(
-    
 
-    
-        
+
+
+
         _main: AudioStream,
-        
-    
-        
+
+
+
         _sidechain: AudioStream,
-        
-    
+
+
 
 
     *,
     level_in: Double = Default('1'),mode: Int| Literal["downward","upward"] | Default = Default('downward'),threshold: Double = Default('0.125'),ratio: Double = Default('2'),attack: Double = Default('20'),release: Double = Default('250'),makeup: Double = Default('1'),knee: Double = Default('2.82843'),link: Int| Literal["average","maximum"] | Default = Default('average'),detection: Int| Literal["peak","rms"] | Default = Default('rms'),level_sc: Double = Default('1'),mix: Double = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 This filter acts like normal compressor but has the ability to compress
 detected signal using second input signal.
 It needs two input streams and returns one output stream.
@@ -5856,89 +5856,89 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sidechaincompress)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='sidechaincompress', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _sidechain,
-            
-        
+
+
 
 
         **merge({
-            
+
             "level_in": level_in,
-            
+
             "mode": mode,
-            
+
             "threshold": threshold,
-            
+
             "ratio": ratio,
-            
+
             "attack": attack,
-            
+
             "release": release,
-            
+
             "makeup": makeup,
-            
+
             "knee": knee,
-            
+
             "link": link,
-            
+
             "detection": detection,
-            
+
             "level_sc": level_sc,
-            
+
             "mix": mix,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
+
+
+
 def sidechaingate(
-    
 
-    
-        
+
+
+
         _main: AudioStream,
-        
-    
-        
+
+
+
         _sidechain: AudioStream,
-        
-    
+
+
 
 
     *,
     level_in: Double = Default('1'),mode: Int| Literal["downward","upward"] | Default = Default('downward'),range: Double = Default('0.06125'),threshold: Double = Default('0.125'),ratio: Double = Default('2'),attack: Double = Default('20'),release: Double = Default('250'),makeup: Double = Default('1'),knee: Double = Default('2.82843'),detection: Int| Literal["peak","rms"] | Default = Default('rms'),link: Int| Literal["average","maximum"] | Default = Default('average'),level_sc: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 A sidechain gate acts like a normal (wideband) gate but has the ability to
 filter the detected signal before sending it to the gain reduction stage.
 Normally a gate uses the full range signal to detect a level above the
@@ -5977,7 +5977,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sidechaingate)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -5985,83 +5985,83 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='sidechaingate', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _sidechain,
-            
-        
+
+
 
 
         **merge({
-            
+
             "level_in": level_in,
-            
+
             "mode": mode,
-            
+
             "range": range,
-            
+
             "threshold": threshold,
-            
+
             "ratio": ratio,
-            
+
             "attack": attack,
-            
+
             "release": release,
-            
+
             "makeup": makeup,
-            
+
             "knee": knee,
-            
+
             "detection": detection,
-            
+
             "link": link,
-            
+
             "level_sc": level_sc,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def signature(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     detectmode: Int| Literal["off","full","fast"] | Default = Default('off'),nb_inputs: Int = Auto('len(streams)'),filename: String = Default(''),format: Int| Literal["binary","xml"] | Default = Default('binary'),th_d: Int = Default('9000'),th_dc: Int = Default('60000'),th_xh: Int = Default('116'),th_di: Int = Default('0'),th_it: Double = Default('0.5'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Calculates the MPEG-7 Video Signature. The filter can handle more than one
 input. In this case the matching between the inputs can be calculated additionally.
 The filter always passes through the first input. The signature of each stream can
@@ -6089,94 +6089,94 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#signature)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='signature', typings_input='[StreamType.video] * int(nb_inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "detectmode": detectmode,
-            
+
             "nb_inputs": nb_inputs,
-            
+
             "filename": filename,
-            
+
             "format": format,
-            
+
             "th_d": th_d,
-            
+
             "th_dc": th_dc,
-            
+
             "th_xh": th_xh,
-            
+
             "th_di": th_di,
-            
+
             "th_it": th_it,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
 def spectrumsynth(
-    
 
-    
-        
+
+
+
         _magnitude: VideoStream,
-        
-    
-        
+
+
+
         _phase: VideoStream,
-        
-    
+
+
 
 
     *,
     sample_rate: Int = Default('44100'),channels: Int = Default('1'),scale: Int| Literal["lin","log"] | Default = Default('log'),slide: Int| Literal["replace","scroll","fullframe","rscroll"] | Default = Default('fullframe'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman"] | Default = Default('rect'),overlap: Float = Default('1'),orientation: Int| Literal["vertical","horizontal"] | Default = Default('vertical'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Synthesize audio from 2 input video spectrums, first input stream represents
 magnitude across time and second represents phase across time.
 The filter will transform from frequency domain as displayed in videos back
@@ -6213,92 +6213,92 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#spectrumsynth)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='spectrumsynth', typings_input=('video', 'video'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _magnitude,
-            
-        
-            
+
+
+
             _phase,
-            
-        
+
+
 
 
         **merge({
-            
+
             "sample_rate": sample_rate,
-            
+
             "channels": channels,
-            
+
             "scale": scale,
-            
+
             "slide": slide,
-            
+
             "win_func": win_func,
-            
+
             "overlap": overlap,
-            
+
             "orientation": orientation,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def ssim(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Obtain the SSIM (Structural SImilarity Metric) between two input videos.
 
 This filter takes in input two input videos, the first input is
@@ -6328,7 +6328,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ssim)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -6339,63 +6339,63 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='ssim', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
             "stats_file": stats_file,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def streamselect(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),map: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Select video or audio streams.
 
 The filter accepts the following options:
@@ -6414,94 +6414,94 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#streamselect)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='streamselect', typings_input='[StreamType.video] * int(inputs)', typings_output="[StreamType.video] * len(re.findall(r'\\d+', str(map)))"),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "map": map,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def threshold(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _threshold: VideoStream,
-        
-    
-        
+
+
+
         _min: VideoStream,
-        
-    
-        
+
+
+
         _max: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply threshold effect to video stream.
 
 This filter needs four video streams to perform thresholding.
@@ -6524,7 +6524,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#threshold)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -6532,102 +6532,102 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='threshold', typings_input=('video', 'video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _threshold,
-            
-        
-            
+
+
+
             _min,
-            
-        
-            
+
+
+
             _max,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def unpremultiply(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     planes: Int = Default('15'),inplace: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply alpha unpremultiply effect to input video stream using first plane
 of second stream as alpha.
 
@@ -6649,7 +6649,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#unpremultiply)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -6657,75 +6657,75 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='unpremultiply', typings_input='[StreamType.video] + ([StreamType.video] if inplace else [])', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "inplace": inplace,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
 def varblur(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _radius: VideoStream,
-        
-    
+
+
 
 
     *,
     min_r: Int = Default('0'),max_r: Int = Default('8'),planes: Int = Default('15'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply variable blur filter by using 2nd video stream to set blur radius.
 The 2nd stream must have the same dimensions.
 
@@ -6747,7 +6747,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#varblur)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -6758,84 +6758,84 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='varblur', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _radius,
-            
-        
+
+
 
 
         **merge({
-            
+
             "min_r": min_r,
-            
+
             "max_r": max_r,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
 def vif(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Obtain the average VIF (Visual Information Fidelity) between two input videos.
 
 This filter takes two input videos.
@@ -6869,7 +6869,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vif)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -6877,63 +6877,63 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='vif', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
 def vstack(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),shortest: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos vertically.
 
 All streams must be of same pixel format and of same width.
@@ -6956,76 +6956,76 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vstack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='vstack', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def xcorrelate(
-    
 
-    
-        
+
+
+
         _primary: VideoStream,
-        
-    
-        
+
+
+
         _secondary: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('7'),secondary: Int| Literal["first","all"] | Default = Default('all'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply normalized cross-correlation between first and second input video stream.
 
 Second input video stream dimensions must be lower than first input video stream.
@@ -7047,7 +7047,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xcorrelate)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -7058,65 +7058,65 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xcorrelate', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _primary,
-            
-        
-            
+
+
+
             _secondary,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "secondary": secondary,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xfade(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _xfade: VideoStream,
-        
-    
+
+
 
 
     *,
     transition: Int| Literal["custom","fade","wipeleft","wiperight","wipeup","wipedown","slideleft","slideright","slideup","slidedown","circlecrop","rectcrop","distance","fadeblack","fadewhite","radial","smoothleft","smoothright","smoothup","smoothdown","circleopen","circleclose","vertopen","vertclose","horzopen","horzclose","dissolve","pixelize","diagtl","diagtr","diagbl","diagbr","hlslice","hrslice","vuslice","vdslice","hblur","fadegrays","wipetl","wipetr","wipebl","wipebr","squeezeh","squeezev","zoomin","fadefast","fadeslow"] | Default = Default('fade'),duration: Duration = Default('1'),offset: Duration = Default('0'),expr: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply cross fade from one input video stream to another input video stream.
 The cross fade is applied for specified duration.
 
@@ -7140,70 +7140,70 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xfade)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xfade', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _xfade,
-            
-        
+
+
 
 
         **merge({
-            
+
             "transition": transition,
-            
+
             "duration": duration,
-            
+
             "offset": offset,
-            
+
             "expr": expr,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xfade_opencl(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _xfade: VideoStream,
-        
-    
+
+
 
 
     *,
     transition: Int| Literal["custom","fade","wipeleft","wiperight","wipeup","wipedown","slideleft","slideright","slideup","slidedown"] | Default = Default('fade'),source: String = Default(None),kernel: String = Default(None),duration: Duration = Default('1'),offset: Duration = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Cross fade two videos with custom transition effect by using OpenCL.
 
 It accepts the following options:
@@ -7224,74 +7224,74 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xfade_opencl)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xfade_opencl', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _xfade,
-            
-        
+
+
 
 
         **merge({
-            
+
             "transition": transition,
-            
+
             "source": source,
-            
+
             "kernel": kernel,
-            
+
             "duration": duration,
-            
+
             "offset": offset,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xmedian(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),planes: Int = Default('15'),percentile: Float = Default('0.5'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Pick median pixels from several input videos.
 
 The filter accepts the following options:
@@ -7312,7 +7312,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xmedian)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -7323,55 +7323,55 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xmedian', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "planes": planes,
-            
+
             "percentile": percentile,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xstack(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),layout: String = Default(None),grid: Image_size = Default(None),shortest: Boolean = Default('false'),fill: String = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack video inputs into custom layout.
 
 All streams must be of same pixel format.
@@ -7394,49 +7394,34 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xstack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xstack', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "layout": layout,
-            
+
             "grid": grid,
-            
+
             "shortest": shortest,
-            
+
             "fill": fill,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
-
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    

--- a/packages/v5/src/ffmpeg/formats/demuxers.py
+++ b/packages/v5/src/ffmpeg/formats/demuxers.py
@@ -392,45 +392,45 @@ from ..streams.audio import AudioStream
 
 
 def _3dostr(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     3DO STR
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def _4xm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     4X Technologies
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def aa(
-    
+
     aa_fixed_key: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Audible AA format files
-    
+
     Args:
         aa_fixed_key: Fixed key used for handling Audible AA files
 
@@ -438,53 +438,53 @@ def aa(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "aa_fixed_key": aa_fixed_key,
-        
+
     }))
 
 
 
 def aac(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw ADTS AAC (Advanced Audio Coding)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def aax(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CRI AAX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ac3(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw AC-3
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -492,37 +492,37 @@ def ac3(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def ace(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     tri-Ace Audio Container
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def acm(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Interplay ACM
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -530,41 +530,41 @@ def acm(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def act(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     ACT Voice file format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def adf(
-    
+
     linespeed: int | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Artworx Data Format
-    
+
     Args:
         linespeed: set simulated line speed (bytes per second) (from 1 to INT_MAX) (default 6000)
         video_size: set video size, such as 640x480 or hd720.
@@ -574,185 +574,185 @@ def adf(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "linespeed": linespeed,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def adp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     ADP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ads(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony PS2 ADS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def adx(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CRI ADX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def aea(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MD STUDIO audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def afc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AFC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def aiff(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Audio IFF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def aix(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CRI AIX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def alaw(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM A-law
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def alias_pix(
-    
+
     pattern_type: int | None| Literal["glob_sequence", "glob", "sequence", "none"] = None,
-    
+
     start_number: int | None = None,
-    
+
     start_number_range: int | None = None,
-    
+
     ts_from_file: int | None| Literal["none", "sec", "ns"] = None,
-    
+
     export_path_metadata: bool | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Alias/Wavefront PIX image
-    
+
     Args:
         pattern_type: set pattern type (from 0 to INT_MAX) (default 4)
         start_number: set first number in the sequence (from INT_MIN to INT_MAX) (default 0)
@@ -768,53 +768,53 @@ def alias_pix(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "pattern_type": pattern_type,
-        
+
         "start_number": start_number,
-        
+
         "start_number_range": start_number_range,
-        
+
         "ts_from_file": ts_from_file,
-        
+
         "export_path_metadata": export_path_metadata,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def alp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     LEGO Racers ALP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def amr(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     3GPP AMR
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -822,21 +822,21 @@ def amr(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def amrnb(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw AMR-NB
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -844,21 +844,21 @@ def amrnb(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def amrwb(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw AMR-WB
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -866,89 +866,89 @@ def amrwb(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def anm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Deluxe Paint Animation
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def apc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CRYO APC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ape(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Monkey's Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def apm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Ubisoft Rayman 2 APM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def apng(
-    
+
     ignore_loop: bool | None = None,
-    
+
     max_fps: int | None = None,
-    
+
     default_fps: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Animated Portable Network Graphics
-    
+
     Args:
         ignore_loop: ignore loop setting (default true)
         max_fps: maximum framerate (0 is no limit) (from 0 to INT_MAX) (default 0)
@@ -958,25 +958,25 @@ def apng(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "ignore_loop": ignore_loop,
-        
+
         "max_fps": max_fps,
-        
+
         "default_fps": default_fps,
-        
+
     }))
 
 
 
 def aptx(
-    
+
     sample_rate: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw aptX
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 48000)
 
@@ -984,21 +984,21 @@ def aptx(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
     }))
 
 
 
 def aptx_hd(
-    
+
     sample_rate: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw aptX HD
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 48000)
 
@@ -1006,21 +1006,21 @@ def aptx_hd(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
     }))
 
 
 
 def aqtitle(
-    
+
     subfps: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AQTitle subtitles
-    
+
     Args:
         subfps: set the movie frame rate (from 0 to INT_MAX) (default 25/1)
 
@@ -1028,71 +1028,71 @@ def aqtitle(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "subfps": subfps,
-        
+
     }))
 
 
 
 def argo_asf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Argonaut Games ASF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def argo_brp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Argonaut Games BRP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def argo_cvg(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Argonaut Games CVG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def asf(
-    
+
     no_resync_search: bool | None = None,
-    
+
     export_xmp: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     ASF (Advanced / Active Streaming Format)
-    
+
     Args:
         no_resync_search: Don't try to resynchronize by looking for a certain optional start code (default false)
         export_xmp: Export full XMP metadata (default false)
@@ -1101,87 +1101,87 @@ def asf(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "no_resync_search": no_resync_search,
-        
+
         "export_xmp": export_xmp,
-        
+
     }))
 
 
 
 def asf_o(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     ASF (Advanced / Active Streaming Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ass(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SSA (SubStation Alpha) subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ast(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AST (Audio Stream)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def au(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sun AU
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def av1(
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AV1 Annex B
-    
+
     Args:
         framerate: (default "25")
 
@@ -1189,21 +1189,21 @@ def av1(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def avi(
-    
+
     use_odml: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AVI (Audio Video Interleaved)
-    
+
     Args:
         use_odml: use odml index (default true)
 
@@ -1211,55 +1211,55 @@ def avi(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "use_odml": use_odml,
-        
+
     }))
 
 
 
 def avr(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AVR (Audio Visual Research)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def avs(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Argonaut Games Creature Shock
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def avs2(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw AVS2-P2/IEEE1857.4
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -1268,25 +1268,25 @@ def avs2(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def avs3(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw AVS3-P2/IEEE1857.10
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -1295,75 +1295,75 @@ def avs3(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def bethsoftvid(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Bethesda Softworks VID
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def bfi(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Brute Force & Ignorance
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def bfstm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     BFSTM (Binary Cafe Stream)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def bin(
-    
+
     linespeed: int | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Binary text
-    
+
     Args:
         linespeed: set simulated line speed (bytes per second) (from 1 to INT_MAX) (default 6000)
         video_size: set video size, such as 640x480 or hd720.
@@ -1373,77 +1373,77 @@ def bin(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "linespeed": linespeed,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def bink(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Bink
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def binka(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Bink Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def bit(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     G.729 BIT file format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def bitpacked(
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Bitpacked
-    
+
     Args:
         pixel_format: set pixel format (default "yuv420p")
         video_size: set frame size
@@ -1453,33 +1453,33 @@ def bitpacked(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def bmp_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped bmp sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -1491,77 +1491,77 @@ def bmp_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def bmv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Discworld II BMV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def boa(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Black Ops Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def brender_pix(
-    
+
     pattern_type: int | None| Literal["glob_sequence", "glob", "sequence", "none"] = None,
-    
+
     start_number: int | None = None,
-    
+
     start_number_range: int | None = None,
-    
+
     ts_from_file: int | None| Literal["none", "sec", "ns"] = None,
-    
+
     export_path_metadata: bool | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     BRender PIX image
-    
+
     Args:
         pattern_type: set pattern type (from 0 to INT_MAX) (default 4)
         start_number: set first number in the sequence (from INT_MIN to INT_MAX) (default 0)
@@ -1577,87 +1577,87 @@ def brender_pix(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "pattern_type": pattern_type,
-        
+
         "start_number": start_number,
-        
+
         "start_number_range": start_number_range,
-        
+
         "ts_from_file": ts_from_file,
-        
+
         "export_path_metadata": export_path_metadata,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def brstm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     BRSTM (Binary Revolution Stream)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def c93(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Interplay C93
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def caf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Apple CAF (Core Audio Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def cavsvideo(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw Chinese AVS (Audio Video Standard)
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -1666,41 +1666,41 @@ def cavsvideo(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def cdg(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CD Graphics
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def cdxl(
-    
+
     sample_rate: int | None = None,
-    
+
     frame_rate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Commodore CDXL video
-    
+
     Args:
         sample_rate: (from 8000 to INT_MAX) (default 11025)
         frame_rate: (default "15")
@@ -1709,39 +1709,39 @@ def cdxl(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "frame_rate": frame_rate,
-        
+
     }))
 
 
 
 def cine(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Phantom Cine
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def codec2(
-    
+
     frames_per_packet: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     codec2 .c2 demuxer
-    
+
     Args:
         frames_per_packet: Number of frames to read at a time. Higher = faster decoding, lower granularity (from 1 to INT_MAX) (default 1)
 
@@ -1749,23 +1749,23 @@ def codec2(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frames_per_packet": frames_per_packet,
-        
+
     }))
 
 
 
 def codec2raw(
-    
+
     mode: int | None| Literal["3200", "2400", "1600", "1400", "1300", "1200", "700", "700B", "700C"] = None,
-    
+
     frames_per_packet: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw codec2 demuxer
-    
+
     Args:
         mode: codec2 mode [mandatory] (from -1 to 8) (default -1)
         frames_per_packet: Number of frames to read at a time. Higher = faster decoding, lower granularity (from 1 to INT_MAX) (default 1)
@@ -1774,27 +1774,27 @@ def codec2raw(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "mode": mode,
-        
+
         "frames_per_packet": frames_per_packet,
-        
+
     }))
 
 
 
 def concat(
-    
+
     safe: bool | None = None,
-    
+
     auto_convert: bool | None = None,
-    
+
     segment_time_metadata: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Virtual concatenation script
-    
+
     Args:
         safe: enable safe mode (default true)
         auto_convert: automatically convert bitstream format (default true)
@@ -1804,33 +1804,33 @@ def concat(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "safe": safe,
-        
+
         "auto_convert": auto_convert,
-        
+
         "segment_time_metadata": segment_time_metadata,
-        
+
     }))
 
 
 
 def cri_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped cri sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -1842,29 +1842,29 @@ def cri_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def data(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw data
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -1872,61 +1872,61 @@ def data(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def daud(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     D-Cinema audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dcstr(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sega DC STR
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dds_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped dds sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -1938,111 +1938,111 @@ def dds_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def derf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Xilam DERF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dfa(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Chronomaster DFA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dfpwm(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw DFPWM1a
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 48000)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def dhav(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Video DAV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dirac(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw Dirac
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -2051,25 +2051,25 @@ def dirac(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def dnxhd(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw DNxHD (SMPTE VC-3)
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -2078,31 +2078,31 @@ def dnxhd(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def dpx_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped dpx sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -2114,77 +2114,77 @@ def dpx_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def dsf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     DSD Stream File (DSF)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dsicin(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Delphine Software International CIN
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dss(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Digital Speech Standard (DSS)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dts(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw DTS
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -2192,53 +2192,53 @@ def dts(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def dtshd(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw DTS-HD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     DV (Digital Video)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dvbsub(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw dvbsub
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -2246,21 +2246,21 @@ def dvbsub(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def dvbtxt(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     dvbtxt
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -2268,69 +2268,69 @@ def dvbtxt(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def dxa(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     DXA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ea(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Electronic Arts Multimedia
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ea_cdata(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Electronic Arts cdata
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def eac3(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw E-AC-3
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -2338,45 +2338,45 @@ def eac3(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def epaf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Ensoniq Paris Audio File
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def exr_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped exr sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -2388,157 +2388,157 @@ def exr_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def f32be(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM 32-bit floating-point big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def f32le(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM 32-bit floating-point little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def f64be(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM 64-bit floating-point big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def f64le(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM 64-bit floating-point little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def fbdev(
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Linux framebuffer
-    
+
     Args:
         framerate: (default "25")
 
@@ -2546,69 +2546,69 @@ def fbdev(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def ffmetadata(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     FFmpeg metadata in text
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def film_cpk(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sega FILM / CPK
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def filmstrip(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Adobe Filmstrip
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def fits(
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Flexible Image Transport System
-    
+
     Args:
         framerate: set the framerate (default "1")
 
@@ -2616,21 +2616,21 @@ def fits(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def flac(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw FLAC
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -2638,43 +2638,43 @@ def flac(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def flic(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     FLI/FLC/FLX animation
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def flv(
-    
+
     flv_metadata: bool | None = None,
-    
+
     flv_full_metadata: bool | None = None,
-    
+
     flv_ignore_prevtag: bool | None = None,
-    
+
     missing_streams: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     FLV (Flash Video)
-    
+
     Args:
         flv_metadata: Allocate streams according to the onMetaData array (default false)
         flv_full_metadata: Dump full metadata of the onMetadata (default false)
@@ -2685,75 +2685,75 @@ def flv(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "flv_metadata": flv_metadata,
-        
+
         "flv_full_metadata": flv_full_metadata,
-        
+
         "flv_ignore_prevtag": flv_ignore_prevtag,
-        
+
         "missing_streams": missing_streams,
-        
+
     }))
 
 
 
 def frm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Megalux Frame
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def fsb(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     FMOD Sample Bank
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def fwse(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Capcom's MT Framework sound
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def g722(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw G.722
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -2761,39 +2761,39 @@ def g722(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def g723_1(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     G.723.1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def g726(
-    
+
     code_size: int | None = None,
-    
+
     sample_rate: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw big-endian G.726 ("left aligned")
-    
+
     Args:
         code_size: Bits per G.726 code (from 2 to 5) (default 4)
         sample_rate: (from 0 to INT_MAX) (default 8000)
@@ -2802,25 +2802,25 @@ def g726(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "code_size": code_size,
-        
+
         "sample_rate": sample_rate,
-        
+
     }))
 
 
 
 def g726le(
-    
+
     code_size: int | None = None,
-    
+
     sample_rate: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw little-endian G.726 ("right aligned")
-    
+
     Args:
         code_size: Bits per G.726 code (from 2 to 5) (default 4)
         sample_rate: (from 0 to INT_MAX) (default 8000)
@@ -2829,23 +2829,23 @@ def g726le(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "code_size": code_size,
-        
+
         "sample_rate": sample_rate,
-        
+
     }))
 
 
 
 def g729(
-    
+
     bit_rate: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     G.729 raw format demuxer
-    
+
     Args:
         bit_rate: (from 0 to INT_MAX) (default 8000)
 
@@ -2853,45 +2853,45 @@ def g729(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "bit_rate": bit_rate,
-        
+
     }))
 
 
 
 def gdv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Gremlin Digital Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def gem_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped gem sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -2903,51 +2903,51 @@ def gem_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def genh(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     GENeric Header
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def gif(
-    
+
     min_delay: int | None = None,
-    
+
     max_gif_delay: int | None = None,
-    
+
     default_delay: int | None = None,
-    
+
     ignore_loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CompuServe Graphics Interchange Format (GIF)
-    
+
     Args:
         min_delay: minimum valid delay between frames (in hundredths of second) (from 0 to 6000) (default 2)
         max_gif_delay: maximum valid delay between frames (in hundredths of seconds) (from 0 to 65535) (default 65535)
@@ -2958,35 +2958,35 @@ def gif(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "min_delay": min_delay,
-        
+
         "max_gif_delay": max_gif_delay,
-        
+
         "default_delay": default_delay,
-        
+
         "ignore_loop": ignore_loop,
-        
+
     }))
 
 
 
 def gif_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped gif sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -2998,29 +2998,29 @@ def gif_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def gsm(
-    
+
     sample_rate: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw GSM
-    
+
     Args:
         sample_rate: (from 1 to 6.50753e+07) (default 8000)
 
@@ -3028,39 +3028,39 @@ def gsm(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
     }))
 
 
 
 def gxf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     GXF (General eXchange Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def h261(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw H.261
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -3069,25 +3069,25 @@ def h261(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def h263(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw H.263
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -3096,25 +3096,25 @@ def h263(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def h264(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw H.264 video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -3123,57 +3123,57 @@ def h264(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def hca(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CRI HCA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def hcom(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Macintosh HCOM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def hevc(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw HEVC video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -3182,43 +3182,43 @@ def hevc(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def hls(
-    
+
     live_start_index: int | None = None,
-    
+
     prefer_x_start: bool | None = None,
-    
+
     allowed_extensions: str | None = None,
-    
+
     allowed_segment_extensions: str | None = None,
-    
+
     extension_picky: bool | None = None,
-    
+
     max_reload: int | None = None,
-    
+
     m3u8_hold_counters: int | None = None,
-    
+
     http_persistent: bool | None = None,
-    
+
     http_multiple: bool | None = None,
-    
+
     http_seekable: bool | None = None,
-    
+
     seg_format_options: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Apple HTTP Live Streaming
-    
+
     Args:
         live_start_index: segment index to start live streams at (negative values are from the end) (from INT_MIN to INT_MAX) (default -3)
         prefer_x_start: prefer to use #EXT-X-START if it's in playlist instead of live_start_index (default false)
@@ -3236,93 +3236,93 @@ def hls(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "live_start_index": live_start_index,
-        
+
         "prefer_x_start": prefer_x_start,
-        
+
         "allowed_extensions": allowed_extensions,
-        
+
         "allowed_segment_extensions": allowed_segment_extensions,
-        
+
         "extension_picky": extension_picky,
-        
+
         "max_reload": max_reload,
-        
+
         "m3u8_hold_counters": m3u8_hold_counters,
-        
+
         "http_persistent": http_persistent,
-        
+
         "http_multiple": http_multiple,
-        
+
         "http_seekable": http_seekable,
-        
+
         "seg_format_options": seg_format_options,
-        
+
     }))
 
 
 
 def hnm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Cryo HNM v4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ico(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Microsoft Windows ICO
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def idcin(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     id Cinematic
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def idf(
-    
+
     linespeed: int | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     iCE Draw File
-    
+
     Args:
         linespeed: set simulated line speed (bytes per second) (from 1 to INT_MAX) (default 6000)
         video_size: set video size, such as 640x480 or hd720.
@@ -3332,89 +3332,89 @@ def idf(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "linespeed": linespeed,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def iff(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     IFF (Interchange File Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ifv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     IFV CCTV DVR
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ilbc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     iLBC storage
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def image2(
-    
+
     pattern_type: int | None| Literal["glob_sequence", "glob", "sequence", "none"] = None,
-    
+
     start_number: int | None = None,
-    
+
     start_number_range: int | None = None,
-    
+
     ts_from_file: int | None| Literal["none", "sec", "ns"] = None,
-    
+
     export_path_metadata: bool | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     image2 sequence
-    
+
     Args:
         pattern_type: set pattern type (from 0 to INT_MAX) (default 4)
         start_number: set first number in the sequence (from INT_MIN to INT_MAX) (default 0)
@@ -3430,45 +3430,45 @@ def image2(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "pattern_type": pattern_type,
-        
+
         "start_number": start_number,
-        
+
         "start_number_range": start_number_range,
-        
+
         "ts_from_file": ts_from_file,
-        
+
         "export_path_metadata": export_path_metadata,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def image2pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped image2 sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3480,31 +3480,31 @@ def image2pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def ingenient(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw Ingenient MJPEG
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -3513,39 +3513,39 @@ def ingenient(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def ipmovie(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Interplay MVE
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ipu(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw IPU Video
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -3553,109 +3553,109 @@ def ipu(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def ircam(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Berkeley/IRCAM/CARL Sound Format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def iss(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Funcom ISS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def iv8(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     IndigoVision 8000 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ivf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     On2 IVF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ivr(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     IVR (Internet Video Recording)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def j2k_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped j2k sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3667,53 +3667,53 @@ def j2k_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def jacosub(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     JACOsub subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def jpeg_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped jpeg sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3725,37 +3725,37 @@ def jpeg_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def jpegls_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped jpegls sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3767,37 +3767,37 @@ def jpegls_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def jpegxl_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped jpegxl sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3809,51 +3809,51 @@ def jpegxl_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def jv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Bitmap Brothers JV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def kux(
-    
+
     flv_metadata: bool | None = None,
-    
+
     flv_full_metadata: bool | None = None,
-    
+
     flv_ignore_prevtag: bool | None = None,
-    
+
     missing_streams: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     KUX (YouKu)
-    
+
     Args:
         flv_metadata: Allocate streams according to the onMetaData array (default false)
         flv_full_metadata: Dump full metadata of the onMetadata (default false)
@@ -3864,47 +3864,47 @@ def kux(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "flv_metadata": flv_metadata,
-        
+
         "flv_full_metadata": flv_full_metadata,
-        
+
         "flv_ignore_prevtag": flv_ignore_prevtag,
-        
+
         "missing_streams": missing_streams,
-        
+
     }))
 
 
 
 def kvag(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Simon & Schuster Interactive VAG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def lavfi(
-    
+
     graph: str | None = None,
-    
+
     graph_file: str | None = None,
-    
+
     dumpgraph: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Libavfilter virtual input device
-    
+
     Args:
         graph: set libavfilter graph
         graph_file: set libavfilter graph filename
@@ -3914,31 +3914,31 @@ def lavfi(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "graph": graph,
-        
+
         "graph_file": graph_file,
-        
+
         "dumpgraph": dumpgraph,
-        
+
     }))
 
 
 
 def live_flv(
-    
+
     flv_metadata: bool | None = None,
-    
+
     flv_full_metadata: bool | None = None,
-    
+
     flv_ignore_prevtag: bool | None = None,
-    
+
     missing_streams: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     live RTMP FLV (Flash Video)
-    
+
     Args:
         flv_metadata: Allocate streams according to the onMetaData array (default false)
         flv_full_metadata: Dump full metadata of the onMetadata (default false)
@@ -3949,43 +3949,43 @@ def live_flv(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "flv_metadata": flv_metadata,
-        
+
         "flv_full_metadata": flv_full_metadata,
-        
+
         "flv_ignore_prevtag": flv_ignore_prevtag,
-        
+
         "missing_streams": missing_streams,
-        
+
     }))
 
 
 
 def lmlm4(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw lmlm4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def loas(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     LOAS AudioSyncStream
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -3993,87 +3993,87 @@ def loas(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def lrc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     LRC lyrics
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def luodat(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Video CCTV DAT
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def lvf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     LVF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def lxf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     VR native stream (LXF)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def m4v(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw MPEG-4 video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -4082,71 +4082,71 @@ def m4v(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def mca(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MCA Audio Format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mcc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MacCaption
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mgsts(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Metal Gear Solid: The Twin Snakes
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def microdvd(
-    
+
     subfps: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MicroDVD subtitle format
-    
+
     Args:
         subfps: set the movie frame rate fallback (from 0 to INT_MAX) (default 0/1)
 
@@ -4154,23 +4154,23 @@ def microdvd(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "subfps": subfps,
-        
+
     }))
 
 
 
 def mjpeg(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw MJPEG video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -4179,25 +4179,25 @@ def mjpeg(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def mjpeg_2000(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw MJPEG 2000 video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -4206,23 +4206,23 @@ def mjpeg_2000(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def mlp(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw MLP
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -4230,101 +4230,101 @@ def mlp(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def mlv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Magic Lantern Video (MLV)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     American Laser Games MM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mmf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Yamaha SMAF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mods(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MobiClip MODS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def moflex(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MobiClip MOFLEX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mp3(
-    
+
     usetoc: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MP2/3 (MPEG audio layer 2/3)
-    
+
     Args:
         usetoc: use table of contents (default false)
 
@@ -4332,81 +4332,81 @@ def mp3(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "usetoc": usetoc,
-        
+
     }))
 
 
 
 def mpc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Musepack
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mpc8(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Musepack SV8
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mpeg(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MPEG-PS (MPEG-2 Program Stream)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mpegts(
-    
+
     resync_size: int | None = None,
-    
+
     fix_teletext_pts: bool | None = None,
-    
+
     ts_packetsize: int | None = None,
-    
+
     scan_all_pmts: bool | None = None,
-    
+
     skip_unknown_pmt: bool | None = None,
-    
+
     merge_pmt_versions: bool | None = None,
-    
+
     max_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MPEG-TS (MPEG-2 Transport Stream)
-    
+
     Args:
         resync_size: set size limit for looking up a new synchronization (from 0 to INT_MAX) (default 65536)
         fix_teletext_pts: try to fix pts values of dvb teletext streams (default true)
@@ -4420,37 +4420,37 @@ def mpegts(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "resync_size": resync_size,
-        
+
         "fix_teletext_pts": fix_teletext_pts,
-        
+
         "ts_packetsize": ts_packetsize,
-        
+
         "scan_all_pmts": scan_all_pmts,
-        
+
         "skip_unknown_pmt": skip_unknown_pmt,
-        
+
         "merge_pmt_versions": merge_pmt_versions,
-        
+
         "max_packet_size": max_packet_size,
-        
+
     }))
 
 
 
 def mpegtsraw(
-    
+
     resync_size: int | None = None,
-    
+
     compute_pcr: bool | None = None,
-    
+
     ts_packetsize: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw MPEG-TS (MPEG-2 Transport Stream)
-    
+
     Args:
         resync_size: set size limit for looking up a new synchronization (from 0 to INT_MAX) (default 65536)
         compute_pcr: compute exact PCR for each transport stream packet (default false)
@@ -4460,27 +4460,27 @@ def mpegtsraw(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "resync_size": resync_size,
-        
+
         "compute_pcr": compute_pcr,
-        
+
         "ts_packetsize": ts_packetsize,
-        
+
     }))
 
 
 
 def mpegvideo(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw MPEG video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -4489,23 +4489,23 @@ def mpegvideo(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def mpjpeg(
-    
+
     strict_mime_boundary: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MIME multipart JPEG
-    
+
     Args:
         strict_mime_boundary: require MIME boundaries match (default false)
 
@@ -4513,213 +4513,213 @@ def mpjpeg(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "strict_mime_boundary": strict_mime_boundary,
-        
+
     }))
 
 
 
 def mpl2(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MPL2 subtitles
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mpsub(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MPlayer subtitles
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def msf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony PS3 MSF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def msnwctcp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MSN TCP Webcam stream
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def msp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Microsoft Paint (MSP))
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mtaf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Konami PS2 MTAF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mtv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MTV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mulaw(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM mu-law
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def musx(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Eurocom MUSX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Silicon Graphics Movie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mvi(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Motion Pixels MVI
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mxf(
-    
+
     eia608_extract: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MXF (Material eXchange Format)
-    
+
     Args:
         eia608_extract: extract eia 608 captions from s436m track (default false)
 
@@ -4727,133 +4727,133 @@ def mxf(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "eia608_extract": eia608_extract,
-        
+
     }))
 
 
 
 def mxg(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MxPEG clip
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def nc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     NC camera feed
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def nistsphere(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     NIST SPeech HEader REsources
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def nsp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Computerized Speech Lab NSP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def nsv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Nullsoft Streaming Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def nut(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     NUT
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def nuv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     NuppelVideo
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def obu(
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AV1 low overhead OBU
-    
+
     Args:
         framerate: (default "25")
 
@@ -4861,55 +4861,55 @@ def obu(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def ogg(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Ogg
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def oma(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony OpenMG audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def oss(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     OSS (Open Sound System) capture
-    
+
     Args:
         sample_rate: (from 1 to INT_MAX) (default 48000)
         channels: (from 1 to INT_MAX) (default 2)
@@ -4918,47 +4918,47 @@ def oss(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
     }))
 
 
 
 def paf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Amazing Studio Packed Animation File
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def pam_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pam sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -4970,37 +4970,37 @@ def pam_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pbm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pbm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5012,37 +5012,37 @@ def pbm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pcx_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pcx sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5054,37 +5054,37 @@ def pcx_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pfm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pfm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5096,37 +5096,37 @@ def pfm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pgm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pgm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5138,37 +5138,37 @@ def pgm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pgmyuv_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pgmyuv sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5180,37 +5180,37 @@ def pgmyuv_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pgx_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pgx sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5222,37 +5222,37 @@ def pgx_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def phm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped phm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5264,37 +5264,37 @@ def phm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def photocd_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped photocd sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5306,37 +5306,37 @@ def photocd_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pictor_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pictor sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5348,69 +5348,69 @@ def pictor_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pjs(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PJS (Phoenix Japanimation Society) subtitles
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def pmp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Playstation Portable PMP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def png_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped png sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5422,53 +5422,53 @@ def png_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pp_bnk(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Pro Pinball Series Soundbank
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ppm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped ppm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5480,37 +5480,37 @@ def ppm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def psd_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped psd sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5522,101 +5522,101 @@ def psd_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def psxstr(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony Playstation STR
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def pva(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     TechnoTrend PVA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def pvf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PVF (Portable Voice Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def qcp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     QCP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def qdraw_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped qdraw sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5628,37 +5628,37 @@ def qdraw_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def qoi_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped qoi sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5670,49 +5670,49 @@ def qoi_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def r3d(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     REDCODE R3D
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rawvideo(
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw video
-    
+
     Args:
         pixel_format: set pixel format (default "yuv420p")
         video_size: set frame size
@@ -5722,163 +5722,163 @@ def rawvideo(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def realtext(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RealText subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def redspark(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RedSpark
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rl2(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RL2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RealMedia
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def roq(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     id RoQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rpl(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RPL / ARMovie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rsd(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     GameCube RSD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rso(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Lego Mindstorms RSO
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rtp(
-    
+
     rtp_flags: str | None = None,
-    
+
     listen_timeout: str | None = None,
-    
+
     localaddr: str | None = None,
-    
+
     allowed_media_types: str | None = None,
-    
+
     reorder_queue_size: int | None = None,
-    
+
     buffer_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RTP input
-    
+
     Args:
         rtp_flags: set RTP flags (default 0)
         listen_timeout: set maximum timeout (in seconds) to wait for incoming connections (default 10)
@@ -5891,51 +5891,51 @@ def rtp(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "rtp_flags": rtp_flags,
-        
+
         "listen_timeout": listen_timeout,
-        
+
         "localaddr": localaddr,
-        
+
         "allowed_media_types": allowed_media_types,
-        
+
         "reorder_queue_size": reorder_queue_size,
-        
+
         "buffer_size": buffer_size,
-        
+
     }))
 
 
 
 def rtsp(
-    
+
     initial_pause: bool | None = None,
-    
+
     rtsp_transport: str | None = None,
-    
+
     rtsp_flags: str | None = None,
-    
+
     allowed_media_types: str | None = None,
-    
+
     min_port: int | None = None,
-    
+
     max_port: int | None = None,
-    
+
     listen_timeout: int | None = None,
-    
+
     timeout: int | None = None,
-    
+
     reorder_queue_size: int | None = None,
-    
+
     buffer_size: int | None = None,
-    
+
     user_agent: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RTSP input
-    
+
     Args:
         initial_pause: do not start playing the stream immediately (default false)
         rtsp_transport: set RTSP transport protocols (default 0)
@@ -5953,313 +5953,313 @@ def rtsp(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "initial_pause": initial_pause,
-        
+
         "rtsp_transport": rtsp_transport,
-        
+
         "rtsp_flags": rtsp_flags,
-        
+
         "allowed_media_types": allowed_media_types,
-        
+
         "min_port": min_port,
-        
+
         "max_port": max_port,
-        
+
         "listen_timeout": listen_timeout,
-        
+
         "timeout": timeout,
-        
+
         "reorder_queue_size": reorder_queue_size,
-        
+
         "buffer_size": buffer_size,
-        
+
         "user_agent": user_agent,
-        
+
     }))
 
 
 
 def s16be(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 16-bit big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def s16le(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 16-bit little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def s24be(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 24-bit big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def s24le(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 24-bit little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def s32be(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 32-bit big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def s32le(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 32-bit little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def s337m(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SMPTE 337M
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def s8(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 8-bit
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def sami(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SAMI subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sap(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SAP input
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sbc(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw SBC (low-complexity subband codec)
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -6267,23 +6267,23 @@ def sbc(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def sbg(
-    
+
     sample_rate: int | None = None,
-    
+
     max_file_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SBaGen binaural beats script
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 0)
         max_file_size: (from 0 to INT_MAX) (default 5000000)
@@ -6292,65 +6292,65 @@ def sbg(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "max_file_size": max_file_size,
-        
+
     }))
 
 
 
 def scc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Scenarist Closed Captions
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def scd(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Square Enix SCD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sdp(
-    
+
     sdp_flags: str | None = None,
-    
+
     listen_timeout: str | None = None,
-    
+
     localaddr: str | None = None,
-    
+
     allowed_media_types: str | None = None,
-    
+
     reorder_queue_size: int | None = None,
-    
+
     buffer_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SDP
-    
+
     Args:
         sdp_flags: SDP flags (default 0)
         listen_timeout: set maximum timeout (in seconds) to wait for incoming connections (default 10)
@@ -6363,79 +6363,79 @@ def sdp(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sdp_flags": sdp_flags,
-        
+
         "listen_timeout": listen_timeout,
-        
+
         "localaddr": localaddr,
-        
+
         "allowed_media_types": allowed_media_types,
-        
+
         "reorder_queue_size": reorder_queue_size,
-        
+
         "buffer_size": buffer_size,
-        
+
     }))
 
 
 
 def sdr2(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SDR2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sds(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MIDI Sample Dump Standard
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sdx(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sample Dump eXchange
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ser(
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SER (Simple uncompressed video format for astronomical capturing)
-    
+
     Args:
         framerate: set frame rate (default "25")
 
@@ -6443,45 +6443,45 @@ def ser(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def sga(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Digital Pictures SGA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sgi_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped sgi sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -6493,29 +6493,29 @@ def sgi_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def shn(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw Shorten
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -6523,253 +6523,253 @@ def shn(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def siff(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Beam Software SIFF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def simbiosis_imx(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Simbiosis Interactive IMX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sln(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Asterisk raw pcm
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 8000)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def smjpeg(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Loki SDL MJPEG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def smk(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Smacker
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def smush(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     LucasArts Smush
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sol(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sierra SOL
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sox(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SoX native
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def spdif(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     IEC 61937 (compressed data in S/PDIF)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def srt(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SubRip subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def stl(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Spruce subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def subviewer(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SubViewer subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def subviewer1(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SubViewer v1 subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sunrast_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped sunrast sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -6781,69 +6781,69 @@ def sunrast_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def sup(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw HDMV Presentation Graphic Stream subtitles
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def svag(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Konami PS2 SVAG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def svg_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped svg sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -6855,61 +6855,61 @@ def svg_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def svs(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Square SVS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def swf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SWF (ShockWave Flash)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def tak(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw TAK
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -6917,21 +6917,21 @@ def tak(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def tedcaptions(
-    
+
     start_time: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     TED Talks captions
-    
+
     Args:
         start_time: set the start time (offset) of the subtitles, in ms (from I64_MIN to I64_MAX) (default 15000)
 
@@ -6939,61 +6939,61 @@ def tedcaptions(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "start_time": start_time,
-        
+
     }))
 
 
 
 def thp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     THP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def tiertexseq(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Tiertex Limited SEQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def tiff_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped tiff sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -7005,45 +7005,45 @@ def tiff_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def tmv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     8088flex TMV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def truehd(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw TrueHD
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -7051,41 +7051,41 @@ def truehd(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def tta(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     TTA (True Audio)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def tty(
-    
+
     chars_per_frame: int | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Tele-typewriter
-    
+
     Args:
         chars_per_frame: (from 1 to INT_MAX) (default 6000)
         video_size: A string describing frame size, such as 640x480 or hd720.
@@ -7095,283 +7095,283 @@ def tty(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "chars_per_frame": chars_per_frame,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def txd(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Renderware TeXture Dictionary
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ty(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     TiVo TY Stream
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def u16be(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 16-bit big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def u16le(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 16-bit little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def u24be(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 24-bit big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def u24le(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 24-bit little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def u32be(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 32-bit big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def u32le(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 32-bit little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def u8(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 8-bit
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def v210(
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Uncompressed 4:2:2 10-bit
-    
+
     Args:
         video_size: set frame size
         framerate: set frame rate (default "25")
@@ -7380,25 +7380,25 @@ def v210(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def v210x(
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Uncompressed 4:2:2 10-bit
-    
+
     Args:
         video_size: set frame size
         framerate: set frame rate (default "25")
@@ -7407,47 +7407,47 @@ def v210x(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def vag(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony PS2 VAG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vbn_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped vbn sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -7459,31 +7459,31 @@ def vbn_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def vc1(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw VC-1
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -7492,119 +7492,119 @@ def vc1(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def vc1test(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     VC-1 test bitstream
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vidc(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM Archimedes VIDC
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def vividas(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Vividas VIV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vivo(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Vivo
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vmd(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sierra VMD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vobsub(
-    
+
     sub_name: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     VobSub subtitle format
-    
+
     Args:
         sub_name: URI for .sub file
 
@@ -7612,85 +7612,85 @@ def vobsub(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sub_name": sub_name,
-        
+
     }))
 
 
 
 def voc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Creative Voice
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vpk(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony PS2 VPK
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vplayer(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     VPlayer subtitles
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vqf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Nippon Telegraph and Telephone Corporation (NTT) TwinVQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def w64(
-    
+
     max_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony Wave64
-    
+
     Args:
         max_size: max size of single packet (from 1024 to 4.1943e+06) (default 4096)
 
@@ -7698,23 +7698,23 @@ def w64(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "max_size": max_size,
-        
+
     }))
 
 
 
 def wav(
-    
+
     ignore_length: bool | None = None,
-    
+
     max_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     WAV / WAVE (Waveform Audio)
-    
+
     Args:
         ignore_length: Ignore length (default false)
         max_size: max size of single packet (from 1024 to 4.1943e+06) (default 4096)
@@ -7723,41 +7723,41 @@ def wav(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "ignore_length": ignore_length,
-        
+
         "max_size": max_size,
-        
+
     }))
 
 
 
 def wc3movie(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Wing Commander III movie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def webm_dash_manifest(
-    
+
     live: bool | None = None,
-    
+
     bandwidth: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     WebM DASH Manifest
-    
+
     Args:
         live: flag indicating that the input is a live file that only has the headers. (default false)
         bandwidth: bandwidth of this stream to be specified in the DASH manifest. (from 0 to INT_MAX) (default 0)
@@ -7766,31 +7766,31 @@ def webm_dash_manifest(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "live": live,
-        
+
         "bandwidth": bandwidth,
-        
+
     }))
 
 
 
 def webp_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped webp sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -7802,29 +7802,29 @@ def webp_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def webvtt(
-    
+
     kind: int | None| Literal["subtitles", "captions", "descriptions", "metadata"] = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     WebVTT subtitle
-    
+
     Args:
         kind: Set kind of WebVTT track (from 0 to INT_MAX) (default subtitles)
 
@@ -7832,37 +7832,37 @@ def webvtt(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "kind": kind,
-        
+
     }))
 
 
 
 def wsaud(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Westwood Studios audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def wsd(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Wideband Single-bit Data (WSD)
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -7870,107 +7870,107 @@ def wsd(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def wsvqa(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Westwood Studios VQA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def wtv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Windows Television (WTV)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def wv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     WavPack
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def wve(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Psion 3 audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def x11grab(
-    
+
     window_id: int | None = None,
-    
+
     x: int | None = None,
-    
+
     y: int | None = None,
-    
+
     grab_x: int | None = None,
-    
+
     grab_y: int | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
     draw_mouse: int | None = None,
-    
+
     follow_mouse: int | None| Literal["centered"] = None,
-    
+
     show_region: int | None = None,
-    
+
     region_border: int | None = None,
-    
+
     select_region: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     X11 screen capture, using XCB
-    
+
     Args:
         window_id: Window to capture. (from 0 to UINT32_MAX) (default 0)
         x: Initial x coordinate. (from 0 to INT_MAX) (default 0)
@@ -7989,63 +7989,63 @@ def x11grab(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "window_id": window_id,
-        
+
         "x": x,
-        
+
         "y": y,
-        
+
         "grab_x": grab_x,
-        
+
         "grab_y": grab_y,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
         "draw_mouse": draw_mouse,
-        
+
         "follow_mouse": follow_mouse,
-        
+
         "show_region": show_region,
-        
+
         "region_border": region_border,
-        
+
         "select_region": select_region,
-        
+
     }))
 
 
 
 def xa(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Maxis XA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def xbin(
-    
+
     linespeed: int | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     eXtended BINary text (XBIN)
-    
+
     Args:
         linespeed: set simulated line speed (bytes per second) (from 1 to INT_MAX) (default 6000)
         video_size: set video size, such as 640x480 or hd720.
@@ -8055,33 +8055,33 @@ def xbin(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "linespeed": linespeed,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def xbm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped xbm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -8093,53 +8093,53 @@ def xbm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def xmv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Microsoft XMV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def xpm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped xpm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -8151,53 +8151,53 @@ def xpm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def xvag(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony PS3 XVAG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def xwd_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped xwd sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -8209,64 +8209,63 @@ def xwd_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def xwma(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Microsoft xWMA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def yop(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Psygnosis YOP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def yuv4mpegpipe(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     YUV4MPEG pipe
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
-    }))
 
+    }))

--- a/packages/v5/src/ffmpeg/formats/muxers.py
+++ b/packages/v5/src/ffmpeg/formats/muxers.py
@@ -44,61 +44,61 @@ from ..streams.audio import AudioStream
 
 
 def _3g2(
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     brand: str | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
     write_prft: int | None| Literal["wallclock", "pts"] = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     3GP2 (3GPP2 file format)
-    
+
     Args:
         movflags: MOV muxer flags (default 0)
         moov_size: maximum moov size so it can be placed at the begin (from 0 to INT_MAX) (default 0)
@@ -130,117 +130,117 @@ def _3g2(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "frag_duration": frag_duration,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "frag_size": frag_size,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "brand": brand,
-        
+
         "use_editlist": use_editlist,
-        
+
         "fragment_index": fragment_index,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_tmcd": write_tmcd,
-        
+
         "write_prft": write_prft,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "movie_timescale": movie_timescale,
-        
+
     }))
 
 
 
 def _3gp(
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     brand: str | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
     write_prft: int | None| Literal["wallclock", "pts"] = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     3GP (3GPP file format)
-    
+
     Args:
         movflags: MOV muxer flags (default 0)
         moov_size: maximum moov size so it can be placed at the begin (from 0 to INT_MAX) (default 0)
@@ -272,105 +272,105 @@ def _3gp(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "frag_duration": frag_duration,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "frag_size": frag_size,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "brand": brand,
-        
+
         "use_editlist": use_editlist,
-        
+
         "fragment_index": fragment_index,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_tmcd": write_tmcd,
-        
+
         "write_prft": write_prft,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "movie_timescale": movie_timescale,
-        
+
     }))
 
 
 
 def a64(
-    
+
 ) -> FFMpegMuxerOption:
     """
     a64 - video for Commodore 64
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ac3(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw AC-3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def adts(
-    
+
     write_id3v2: bool | None = None,
-    
+
     write_apetag: bool | None = None,
-    
+
     write_mpeg2: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     ADTS AAC (Advanced Audio Coding)
-    
+
     Args:
         write_id3v2: Enable ID3v2 tag writing (default false)
         write_apetag: Enable APE tag writing (default false)
@@ -380,43 +380,43 @@ def adts(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "write_id3v2": write_id3v2,
-        
+
         "write_apetag": write_apetag,
-        
+
         "write_mpeg2": write_mpeg2,
-        
+
     }))
 
 
 
 def adx(
-    
+
 ) -> FFMpegMuxerOption:
     """
     CRI ADX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def aiff(
-    
+
     write_id3v2: bool | None = None,
-    
+
     id3v2_version: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Audio IFF
-    
+
     Args:
         write_id3v2: Enable ID3 tags writing. (default false)
         id3v2_version: Select ID3v2 version to write. Currently 3 and 4 are supported. (from 3 to 4) (default 4)
@@ -425,39 +425,39 @@ def aiff(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "write_id3v2": write_id3v2,
-        
+
         "id3v2_version": id3v2_version,
-        
+
     }))
 
 
 
 def alaw(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM A-law
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def alp(
-    
+
     type: int | None| Literal["auto", "tun", "pcm"] = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     LEGO Racers ALP
-    
+
     Args:
         type: set file type (from 0 to 2) (default auto)
 
@@ -465,71 +465,71 @@ def alp(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "type": type,
-        
+
     }))
 
 
 
 def amr(
-    
+
 ) -> FFMpegMuxerOption:
     """
     3GPP AMR
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def amv(
-    
+
 ) -> FFMpegMuxerOption:
     """
     AMV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def apm(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Ubisoft Rayman 2 APM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def apng(
-    
+
     plays: int | None = None,
-    
+
     final_delay: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Animated Portable Network Graphics
-    
+
     Args:
         plays: Number of times to play the output: 0 - infinite loop, 1 - no loop (from 0 to 65535) (default 1)
         final_delay: Force delay after the last frame (from 0 to 65535) (default 0/1)
@@ -538,59 +538,59 @@ def apng(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "plays": plays,
-        
+
         "final_delay": final_delay,
-        
+
     }))
 
 
 
 def aptx(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw aptX (Audio Processing Technology for Bluetooth)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def aptx_hd(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw aptX HD (Audio Processing Technology for Bluetooth)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def argo_asf(
-    
+
     version_major: int | None = None,
-    
+
     version_minor: int | None = None,
-    
+
     name: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Argonaut Games ASF
-    
+
     Args:
         version_major: override file major version (from 0 to 65535) (default 2)
         version_minor: override file minor version (from 0 to 65535) (default 1)
@@ -600,25 +600,25 @@ def argo_asf(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "version_major": version_major,
-        
+
         "version_minor": version_minor,
-        
+
         "name": name,
-        
+
     }))
 
 
 
 def argo_cvg(
-    
+
     skip_rate_check: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Argonaut Games CVG
-    
+
     Args:
         skip_rate_check: skip sample rate check (default false)
 
@@ -626,21 +626,21 @@ def argo_cvg(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "skip_rate_check": skip_rate_check,
-        
+
     }))
 
 
 
 def asf(
-    
+
     packet_size: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     ASF (Advanced / Active Streaming Format)
-    
+
     Args:
         packet_size: Packet size (from 100 to 65536) (default 3200)
 
@@ -648,21 +648,21 @@ def asf(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "packet_size": packet_size,
-        
+
     }))
 
 
 
 def asf_stream(
-    
+
     packet_size: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     ASF (Advanced / Active Streaming Format)
-    
+
     Args:
         packet_size: Packet size (from 100 to 65536) (default 3200)
 
@@ -670,21 +670,21 @@ def asf_stream(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "packet_size": packet_size,
-        
+
     }))
 
 
 
 def ass(
-    
+
     ignore_readorder: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     SSA (SubStation Alpha) subtitle
-    
+
     Args:
         ignore_readorder: write events immediately, even if they're out-of-order (default false)
 
@@ -692,23 +692,23 @@ def ass(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "ignore_readorder": ignore_readorder,
-        
+
     }))
 
 
 
 def ast(
-    
+
     loopstart: int | None = None,
-    
+
     loopend: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     AST (Audio Stream)
-    
+
     Args:
         loopstart: Loopstart position in milliseconds. (from -1 to INT_MAX) (default -1)
         loopend: Loopend position in milliseconds. (from 0 to INT_MAX) (default 0)
@@ -717,43 +717,43 @@ def ast(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "loopstart": loopstart,
-        
+
         "loopend": loopend,
-        
+
     }))
 
 
 
 def au(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Sun AU
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def avi(
-    
+
     reserve_index_space: int | None = None,
-    
+
     write_channel_mask: bool | None = None,
-    
+
     flipped_raw_rgb: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     AVI (Audio Video Interleaved)
-    
+
     Args:
         reserve_index_space: reserve space (in bytes) at the beginning of the file for each stream index (from 0 to INT_MAX) (default 0)
         write_channel_mask: write channel mask into wave format header (default true)
@@ -763,255 +763,255 @@ def avi(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "reserve_index_space": reserve_index_space,
-        
+
         "write_channel_mask": write_channel_mask,
-        
+
         "flipped_raw_rgb": flipped_raw_rgb,
-        
+
     }))
 
 
 
 def avif(
-    
+
 ) -> FFMpegMuxerOption:
     """
     AVIF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def avm2(
-    
+
 ) -> FFMpegMuxerOption:
     """
     SWF (ShockWave Flash) (AVM2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def avs2(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw AVS2-P2/IEEE1857.4 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def avs3(
-    
+
 ) -> FFMpegMuxerOption:
     """
     AVS3-P2/IEEE1857.10
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def bit(
-    
+
 ) -> FFMpegMuxerOption:
     """
     G.729 BIT file format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def caf(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Apple CAF (Core Audio Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def cavsvideo(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw Chinese AVS (Audio Video Standard) video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def codec2(
-    
+
 ) -> FFMpegMuxerOption:
     """
     codec2 .c2 muxer
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def codec2raw(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw codec2 muxer
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def crc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     CRC testing
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dash(
-    
+
     adaptation_sets: str | None = None,
-    
+
     window_size: int | None = None,
-    
+
     extra_window_size: int | None = None,
-    
+
     seg_duration: str | None = None,
-    
+
     frag_duration: str | None = None,
-    
+
     frag_type: int | None| Literal["none", "every_frame", "duration", "pframes"] = None,
-    
+
     remove_at_exit: bool | None = None,
-    
+
     use_template: bool | None = None,
-    
+
     use_timeline: bool | None = None,
-    
+
     single_file: bool | None = None,
-    
+
     single_file_name: str | None = None,
-    
+
     init_seg_name: str | None = None,
-    
+
     media_seg_name: str | None = None,
-    
+
     utc_timing_url: str | None = None,
-    
+
     method: str | None = None,
-    
+
     http_user_agent: str | None = None,
-    
+
     http_persistent: bool | None = None,
-    
+
     hls_playlist: bool | None = None,
-    
+
     hls_master_name: str | None = None,
-    
+
     streaming: bool | None = None,
-    
+
     timeout: str | None = None,
-    
+
     index_correction: bool | None = None,
-    
+
     format_options: str | None = None,
-    
+
     global_sidx: bool | None = None,
-    
+
     dash_segment_type: int | None| Literal["auto", "mp4", "webm"] = None,
-    
+
     ignore_io_errors: bool | None = None,
-    
+
     lhls: bool | None = None,
-    
+
     ldash: bool | None = None,
-    
+
     master_m3u8_publish_rate: int | None = None,
-    
+
     write_prft: bool | None = None,
-    
+
     mpd_profile: str | None = None,
-    
+
     http_opts: str | None = None,
-    
+
     target_latency: str | None = None,
-    
+
     min_playback_rate: str | None = None,
-    
+
     max_playback_rate: str | None = None,
-    
+
     update_period: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     DASH Muxer
-    
+
     Args:
         adaptation_sets: Adaptation sets. Syntax: id=0,streams=0,1,2 id=1,streams=3,4 and so on
         window_size: number of segments kept in the manifest (from 0 to INT_MAX) (default 0)
@@ -1054,205 +1054,205 @@ def dash(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "adaptation_sets": adaptation_sets,
-        
+
         "window_size": window_size,
-        
+
         "extra_window_size": extra_window_size,
-        
+
         "seg_duration": seg_duration,
-        
+
         "frag_duration": frag_duration,
-        
+
         "frag_type": frag_type,
-        
+
         "remove_at_exit": remove_at_exit,
-        
+
         "use_template": use_template,
-        
+
         "use_timeline": use_timeline,
-        
+
         "single_file": single_file,
-        
+
         "single_file_name": single_file_name,
-        
+
         "init_seg_name": init_seg_name,
-        
+
         "media_seg_name": media_seg_name,
-        
+
         "utc_timing_url": utc_timing_url,
-        
+
         "method": method,
-        
+
         "http_user_agent": http_user_agent,
-        
+
         "http_persistent": http_persistent,
-        
+
         "hls_playlist": hls_playlist,
-        
+
         "hls_master_name": hls_master_name,
-        
+
         "streaming": streaming,
-        
+
         "timeout": timeout,
-        
+
         "index_correction": index_correction,
-        
+
         "format_options": format_options,
-        
+
         "global_sidx": global_sidx,
-        
+
         "dash_segment_type": dash_segment_type,
-        
+
         "ignore_io_errors": ignore_io_errors,
-        
+
         "lhls": lhls,
-        
+
         "ldash": ldash,
-        
+
         "master_m3u8_publish_rate": master_m3u8_publish_rate,
-        
+
         "write_prft": write_prft,
-        
+
         "mpd_profile": mpd_profile,
-        
+
         "http_opts": http_opts,
-        
+
         "target_latency": target_latency,
-        
+
         "min_playback_rate": min_playback_rate,
-        
+
         "max_playback_rate": max_playback_rate,
-        
+
         "update_period": update_period,
-        
+
     }))
 
 
 
 def data(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw data
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def daud(
-    
+
 ) -> FFMpegMuxerOption:
     """
     D-Cinema audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dfpwm(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw DFPWM1a
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dirac(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw Dirac
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dnxhd(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw DNxHD (SMPTE VC-3)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dts(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw DTS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dv(
-    
+
 ) -> FFMpegMuxerOption:
     """
     DV (Digital Video)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dvd(
-    
+
     muxrate: int | None = None,
-    
+
     preload: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MPEG-2 PS (DVD VOB)
-    
+
     Args:
         muxrate: (from 0 to 1.67772e+09) (default 0)
         preload: Initial demux-decode delay in microseconds. (from 0 to INT_MAX) (default 500000)
@@ -1261,119 +1261,119 @@ def dvd(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "muxrate": muxrate,
-        
+
         "preload": preload,
-        
+
     }))
 
 
 
 def eac3(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw E-AC-3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def f32be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM 32-bit floating-point big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def f32le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM 32-bit floating-point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def f4v(
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     brand: str | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
     write_prft: int | None| Literal["wallclock", "pts"] = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     F4V Adobe Flash Video
-    
+
     Args:
         movflags: MOV muxer flags (default 0)
         moov_size: maximum moov size so it can be placed at the begin (from 0 to INT_MAX) (default 0)
@@ -1405,103 +1405,103 @@ def f4v(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "frag_duration": frag_duration,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "frag_size": frag_size,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "brand": brand,
-        
+
         "use_editlist": use_editlist,
-        
+
         "fragment_index": fragment_index,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_tmcd": write_tmcd,
-        
+
         "write_prft": write_prft,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "movie_timescale": movie_timescale,
-        
+
     }))
 
 
 
 def f64be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM 64-bit floating-point big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def f64le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM 64-bit floating-point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def fbdev(
-    
+
     xoffset: int | None = None,
-    
+
     yoffset: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Linux framebuffer
-    
+
     Args:
         xoffset: set x coordinate of top left corner (from INT_MIN to INT_MAX) (default 0)
         yoffset: set y coordinate of top left corner (from INT_MIN to INT_MAX) (default 0)
@@ -1510,59 +1510,59 @@ def fbdev(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "xoffset": xoffset,
-        
+
         "yoffset": yoffset,
-        
+
     }))
 
 
 
 def ffmetadata(
-    
+
 ) -> FFMpegMuxerOption:
     """
     FFmpeg metadata in text
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def fifo(
-    
+
     fifo_format: str | None = None,
-    
+
     queue_size: int | None = None,
-    
+
     format_opts: str | None = None,
-    
+
     drop_pkts_on_overflow: bool | None = None,
-    
+
     restart_with_keyframe: bool | None = None,
-    
+
     attempt_recovery: bool | None = None,
-    
+
     max_recovery_attempts: int | None = None,
-    
+
     recovery_wait_time: str | None = None,
-    
+
     recovery_wait_streamtime: bool | None = None,
-    
+
     recover_any_error: bool | None = None,
-    
+
     timeshift: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     FIFO queue pseudo-muxer
-    
+
     Args:
         fifo_format: Target muxer
         queue_size: Size of fifo queue (from 1 to INT_MAX) (default 60)
@@ -1580,45 +1580,45 @@ def fifo(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "fifo_format": fifo_format,
-        
+
         "queue_size": queue_size,
-        
+
         "format_opts": format_opts,
-        
+
         "drop_pkts_on_overflow": drop_pkts_on_overflow,
-        
+
         "restart_with_keyframe": restart_with_keyframe,
-        
+
         "attempt_recovery": attempt_recovery,
-        
+
         "max_recovery_attempts": max_recovery_attempts,
-        
+
         "recovery_wait_time": recovery_wait_time,
-        
+
         "recovery_wait_streamtime": recovery_wait_streamtime,
-        
+
         "recover_any_error": recover_any_error,
-        
+
         "timeshift": timeshift,
-        
+
     }))
 
 
 
 def fifo_test(
-    
+
     write_header_ret: int | None = None,
-    
+
     write_trailer_ret: int | None = None,
-    
+
     print_deinit_summary: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Fifo test muxer
-    
+
     Args:
         write_header_ret: write_header() return value (from INT_MIN to INT_MAX) (default 0)
         write_trailer_ret: write_trailer() return value (from INT_MIN to INT_MAX) (default 0)
@@ -1628,73 +1628,73 @@ def fifo_test(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "write_header_ret": write_header_ret,
-        
+
         "write_trailer_ret": write_trailer_ret,
-        
+
         "print_deinit_summary": print_deinit_summary,
-        
+
     }))
 
 
 
 def film_cpk(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Sega FILM / CPK
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def filmstrip(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Adobe Filmstrip
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def fits(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Flexible Image Transport System
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def flac(
-    
+
     write_header: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw FLAC
-    
+
     Args:
         write_header: Write the file header (default true)
 
@@ -1702,21 +1702,21 @@ def flac(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "write_header": write_header,
-        
+
     }))
 
 
 
 def flv(
-    
+
     flvflags: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     FLV (Flash Video)
-    
+
     Args:
         flvflags: FLV muxer flags (default 0)
 
@@ -1724,39 +1724,39 @@ def flv(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "flvflags": flvflags,
-        
+
     }))
 
 
 
 def framecrc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     framecrc testing
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def framehash(
-    
+
     hash: str | None = None,
-    
+
     format_version: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Per-frame hash testing
-    
+
     Args:
         hash: set hash to use (default "sha256")
         format_version: file format version (from 1 to 2) (default 2)
@@ -1765,25 +1765,25 @@ def framehash(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "hash": hash,
-        
+
         "format_version": format_version,
-        
+
     }))
 
 
 
 def framemd5(
-    
+
     hash: str | None = None,
-    
+
     format_version: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Per-frame MD5 testing
-    
+
     Args:
         hash: set hash to use (default "md5")
         format_version: file format version (from 1 to 2) (default 2)
@@ -1792,89 +1792,89 @@ def framemd5(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "hash": hash,
-        
+
         "format_version": format_version,
-        
+
     }))
 
 
 
 def g722(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw G.722
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def g723_1(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw G.723.1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def g726(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw big-endian G.726 ("left-justified")
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def g726le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw little-endian G.726 ("right-justified")
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def gif(
-    
+
     loop: int | None = None,
-    
+
     final_delay: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     CompuServe Graphics Interchange Format (GIF)
-    
+
     Args:
         loop: Number of times to loop the output: -1 - no loop, 0 - infinite loop (from -1 to 65535) (default 0)
         final_delay: Force delay (in centiseconds) after the last frame (from -1 to 65535) (default -1)
@@ -1883,103 +1883,103 @@ def gif(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "loop": loop,
-        
+
         "final_delay": final_delay,
-        
+
     }))
 
 
 
 def gsm(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw GSM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def gxf(
-    
+
 ) -> FFMpegMuxerOption:
     """
     GXF (General eXchange Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def h261(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw H.261
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def h263(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw H.263
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def h264(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw H.264 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def hash(
-    
+
     hash: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Hash testing
-    
+
     Args:
         hash: set hash to use (default "sha256")
 
@@ -1987,27 +1987,27 @@ def hash(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "hash": hash,
-        
+
     }))
 
 
 
 def hds(
-    
+
     window_size: int | None = None,
-    
+
     extra_window_size: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     remove_at_exit: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     HDS Muxer
-    
+
     Args:
         window_size: number of fragments kept in the manifest (from 0 to INT_MAX) (default 0)
         extra_window_size: number of fragments kept outside of the manifest before removing from disk (from 0 to INT_MAX) (default 5)
@@ -2018,113 +2018,113 @@ def hds(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "window_size": window_size,
-        
+
         "extra_window_size": extra_window_size,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "remove_at_exit": remove_at_exit,
-        
+
     }))
 
 
 
 def hevc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw HEVC video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def hls(
-    
+
     start_number: int | None = None,
-    
+
     hls_time: str | None = None,
-    
+
     hls_init_time: str | None = None,
-    
+
     hls_list_size: int | None = None,
-    
+
     hls_delete_threshold: int | None = None,
-    
+
     hls_ts_options: str | None = None,
-    
+
     hls_vtt_options: str | None = None,
-    
+
     hls_allow_cache: int | None = None,
-    
+
     hls_base_url: str | None = None,
-    
+
     hls_segment_filename: str | None = None,
-    
+
     hls_segment_options: str | None = None,
-    
+
     hls_segment_size: int | None = None,
-    
+
     hls_key_info_file: str | None = None,
-    
+
     hls_enc: bool | None = None,
-    
+
     hls_enc_key: str | None = None,
-    
+
     hls_enc_key_url: str | None = None,
-    
+
     hls_enc_iv: str | None = None,
-    
+
     hls_subtitle_path: str | None = None,
-    
+
     hls_segment_type: int | None| Literal["mpegts", "fmp4"] = None,
-    
+
     hls_fmp4_init_filename: str | None = None,
-    
+
     hls_fmp4_init_resend: bool | None = None,
-    
+
     hls_flags: str | None = None,
-    
+
     strftime: bool | None = None,
-    
+
     strftime_mkdir: bool | None = None,
-    
+
     hls_playlist_type: int | None| Literal["event", "vod"] = None,
-    
+
     method: str | None = None,
-    
+
     hls_start_number_source: int | None| Literal["generic", "epoch", "epoch_us", "datetime"] = None,
-    
+
     http_user_agent: str | None = None,
-    
+
     var_stream_map: str | None = None,
-    
+
     cc_stream_map: str | None = None,
-    
+
     master_pl_name: str | None = None,
-    
+
     master_pl_publish_rate: int | None = None,
-    
+
     http_persistent: bool | None = None,
-    
+
     timeout: str | None = None,
-    
+
     ignore_io_errors: bool | None = None,
-    
+
     headers: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Apple HTTP Live Streaming
-    
+
     Args:
         start_number: set first number in the sequence (from 0 to I64_MAX) (default 0)
         hls_time: set segment length (default 2)
@@ -2167,133 +2167,133 @@ def hls(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "start_number": start_number,
-        
+
         "hls_time": hls_time,
-        
+
         "hls_init_time": hls_init_time,
-        
+
         "hls_list_size": hls_list_size,
-        
+
         "hls_delete_threshold": hls_delete_threshold,
-        
+
         "hls_ts_options": hls_ts_options,
-        
+
         "hls_vtt_options": hls_vtt_options,
-        
+
         "hls_allow_cache": hls_allow_cache,
-        
+
         "hls_base_url": hls_base_url,
-        
+
         "hls_segment_filename": hls_segment_filename,
-        
+
         "hls_segment_options": hls_segment_options,
-        
+
         "hls_segment_size": hls_segment_size,
-        
+
         "hls_key_info_file": hls_key_info_file,
-        
+
         "hls_enc": hls_enc,
-        
+
         "hls_enc_key": hls_enc_key,
-        
+
         "hls_enc_key_url": hls_enc_key_url,
-        
+
         "hls_enc_iv": hls_enc_iv,
-        
+
         "hls_subtitle_path": hls_subtitle_path,
-        
+
         "hls_segment_type": hls_segment_type,
-        
+
         "hls_fmp4_init_filename": hls_fmp4_init_filename,
-        
+
         "hls_fmp4_init_resend": hls_fmp4_init_resend,
-        
+
         "hls_flags": hls_flags,
-        
+
         "strftime": strftime,
-        
+
         "strftime_mkdir": strftime_mkdir,
-        
+
         "hls_playlist_type": hls_playlist_type,
-        
+
         "method": method,
-        
+
         "hls_start_number_source": hls_start_number_source,
-        
+
         "http_user_agent": http_user_agent,
-        
+
         "var_stream_map": var_stream_map,
-        
+
         "cc_stream_map": cc_stream_map,
-        
+
         "master_pl_name": master_pl_name,
-        
+
         "master_pl_publish_rate": master_pl_publish_rate,
-        
+
         "http_persistent": http_persistent,
-        
+
         "timeout": timeout,
-        
+
         "ignore_io_errors": ignore_io_errors,
-        
+
         "headers": headers,
-        
+
     }))
 
 
 
 def ico(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Microsoft Windows ICO
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ilbc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     iLBC storage
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def image2(
-    
+
     update: bool | None = None,
-    
+
     start_number: int | None = None,
-    
+
     strftime: bool | None = None,
-    
+
     frame_pts: bool | None = None,
-    
+
     atomic_writing: bool | None = None,
-    
+
     protocol_opts: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     image2 sequence
-    
+
     Args:
         update: continuously overwrite one file (default false)
         start_number: set first number in the sequence (from 0 to INT_MAX) (default 1)
@@ -2306,95 +2306,95 @@ def image2(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "update": update,
-        
+
         "start_number": start_number,
-        
+
         "strftime": strftime,
-        
+
         "frame_pts": frame_pts,
-        
+
         "atomic_writing": atomic_writing,
-        
+
         "protocol_opts": protocol_opts,
-        
+
     }))
 
 
 
 def image2pipe(
-    
+
 ) -> FFMpegMuxerOption:
     """
     piped image2 sequence
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ipod(
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     brand: str | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
     write_prft: int | None| Literal["wallclock", "pts"] = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     iPod H.264 MP4 (MPEG-4 Part 14)
-    
+
     Args:
         movflags: MOV muxer flags (default 0)
         moov_size: maximum moov size so it can be placed at the begin (from 0 to INT_MAX) (default 0)
@@ -2426,133 +2426,133 @@ def ipod(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "frag_duration": frag_duration,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "frag_size": frag_size,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "brand": brand,
-        
+
         "use_editlist": use_editlist,
-        
+
         "fragment_index": fragment_index,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_tmcd": write_tmcd,
-        
+
         "write_prft": write_prft,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "movie_timescale": movie_timescale,
-        
+
     }))
 
 
 
 def ircam(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Berkeley/IRCAM/CARL Sound Format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ismv(
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     brand: str | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
     write_prft: int | None| Literal["wallclock", "pts"] = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     ISMV/ISMA (Smooth Streaming)
-    
+
     Args:
         movflags: MOV muxer flags (default 0)
         moov_size: maximum moov size so it can be placed at the begin (from 0 to INT_MAX) (default 0)
@@ -2584,117 +2584,117 @@ def ismv(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "frag_duration": frag_duration,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "frag_size": frag_size,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "brand": brand,
-        
+
         "use_editlist": use_editlist,
-        
+
         "fragment_index": fragment_index,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_tmcd": write_tmcd,
-        
+
         "write_prft": write_prft,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "movie_timescale": movie_timescale,
-        
+
     }))
 
 
 
 def ivf(
-    
+
 ) -> FFMpegMuxerOption:
     """
     On2 IVF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def jacosub(
-    
+
 ) -> FFMpegMuxerOption:
     """
     JACOsub subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def kvag(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Simon & Schuster Interactive VAG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def latm(
-    
+
     smc_interval: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     LOAS/LATM
-    
+
     Args:
         smc_interval: StreamMuxConfig interval. (from 1 to 65535) (default 20)
 
@@ -2702,73 +2702,73 @@ def latm(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "smc-interval": smc_interval,
-        
+
     }))
 
 
 
 def lrc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     LRC lyrics
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def m4v(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw MPEG-4 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def matroska(
-    
+
     reserve_index_space: int | None = None,
-    
+
     cues_to_front: bool | None = None,
-    
+
     cluster_size_limit: int | None = None,
-    
+
     cluster_time_limit: int | None = None,
-    
+
     dash: bool | None = None,
-    
+
     dash_track_number: int | None = None,
-    
+
     live: bool | None = None,
-    
+
     allow_raw_vfw: bool | None = None,
-    
+
     flipped_raw_rgb: bool | None = None,
-    
+
     write_crc32: bool | None = None,
-    
+
     default_mode: int | None| Literal["infer", "infer_no_subs", "passthrough"] = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Matroska
-    
+
     Args:
         reserve_index_space: Reserve a given amount of space (in bytes) at the beginning of the file for the index (cues). (from 0 to INT_MAX) (default 0)
         cues_to_front: Move Cues (the index) to the front by shifting data if necessary (default false)
@@ -2786,41 +2786,41 @@ def matroska(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "reserve_index_space": reserve_index_space,
-        
+
         "cues_to_front": cues_to_front,
-        
+
         "cluster_size_limit": cluster_size_limit,
-        
+
         "cluster_time_limit": cluster_time_limit,
-        
+
         "dash": dash,
-        
+
         "dash_track_number": dash_track_number,
-        
+
         "live": live,
-        
+
         "allow_raw_vfw": allow_raw_vfw,
-        
+
         "flipped_raw_rgb": flipped_raw_rgb,
-        
+
         "write_crc32": write_crc32,
-        
+
         "default_mode": default_mode,
-        
+
     }))
 
 
 
 def md5(
-    
+
     hash: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MD5 testing
-    
+
     Args:
         hash: set hash to use (default "md5")
 
@@ -2828,149 +2828,149 @@ def md5(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "hash": hash,
-        
+
     }))
 
 
 
 def microdvd(
-    
+
 ) -> FFMpegMuxerOption:
     """
     MicroDVD subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mjpeg(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw MJPEG video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mkvtimestamp_v2(
-    
+
 ) -> FFMpegMuxerOption:
     """
     extract pts as timecode v2 format, as defined by mkvtoolnix
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mlp(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw MLP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mmf(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Yamaha SMAF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mov(
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     brand: str | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
     write_prft: int | None| Literal["wallclock", "pts"] = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     QuickTime / MOV
-    
+
     Args:
         movflags: MOV muxer flags (default 0)
         moov_size: maximum moov size so it can be placed at the begin (from 0 to INT_MAX) (default 0)
@@ -3002,89 +3002,89 @@ def mov(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "frag_duration": frag_duration,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "frag_size": frag_size,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "brand": brand,
-        
+
         "use_editlist": use_editlist,
-        
+
         "fragment_index": fragment_index,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_tmcd": write_tmcd,
-        
+
         "write_prft": write_prft,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "movie_timescale": movie_timescale,
-        
+
     }))
 
 
 
 def mp2(
-    
+
 ) -> FFMpegMuxerOption:
     """
     MP2 (MPEG audio layer 2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mp3(
-    
+
     id3v2_version: int | None = None,
-    
+
     write_id3v1: bool | None = None,
-    
+
     write_xing: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MP3 (MPEG audio layer 3)
-    
+
     Args:
         id3v2_version: Select ID3v2 version to write. Currently 3 and 4 are supported. (from 0 to 4) (default 4)
         write_id3v1: Enable ID3v1 writing. ID3v1 tags are written in UTF-8 which may not be supported by most software. (default false)
@@ -3094,73 +3094,73 @@ def mp3(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "id3v2_version": id3v2_version,
-        
+
         "write_id3v1": write_id3v1,
-        
+
         "write_xing": write_xing,
-        
+
     }))
 
 
 
 def mp4(
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     brand: str | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
     write_prft: int | None| Literal["wallclock", "pts"] = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MP4 (MPEG-4 Part 14)
-    
+
     Args:
         movflags: MOV muxer flags (default 0)
         moov_size: maximum moov size so it can be placed at the begin (from 0 to INT_MAX) (default 0)
@@ -3192,71 +3192,71 @@ def mp4(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "frag_duration": frag_duration,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "frag_size": frag_size,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "brand": brand,
-        
+
         "use_editlist": use_editlist,
-        
+
         "fragment_index": fragment_index,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_tmcd": write_tmcd,
-        
+
         "write_prft": write_prft,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "movie_timescale": movie_timescale,
-        
+
     }))
 
 
 
 def mpeg(
-    
+
     muxrate: int | None = None,
-    
+
     preload: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MPEG-1 Systems / MPEG program stream
-    
+
     Args:
         muxrate: (from 0 to 1.67772e+09) (default 0)
         preload: Initial demux-decode delay in microseconds. (from 0 to INT_MAX) (default 500000)
@@ -3265,87 +3265,87 @@ def mpeg(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "muxrate": muxrate,
-        
+
         "preload": preload,
-        
+
     }))
 
 
 
 def mpeg1video(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw MPEG-1 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mpeg2video(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw MPEG-2 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mpegts(
-    
+
     mpegts_transport_stream_id: int | None = None,
-    
+
     mpegts_original_network_id: int | None = None,
-    
+
     mpegts_service_id: int | None = None,
-    
+
     mpegts_service_type: int | None| Literal["digital_tv", "digital_radio", "teletext", "advanced_codec_digital_radio", "mpeg2_digital_hdtv", "advanced_codec_digital_sdtv", "advanced_codec_digital_hdtv", "hevc_digital_hdtv"] = None,
-    
+
     mpegts_pmt_start_pid: int | None = None,
-    
+
     mpegts_start_pid: int | None = None,
-    
+
     mpegts_m2ts_mode: bool | None = None,
-    
+
     muxrate: int | None = None,
-    
+
     pes_payload_size: int | None = None,
-    
+
     mpegts_flags: str | None = None,
-    
+
     mpegts_copyts: bool | None = None,
-    
+
     tables_version: int | None = None,
-    
+
     omit_video_pes_length: bool | None = None,
-    
+
     pcr_period: int | None = None,
-    
+
     pat_period: str | None = None,
-    
+
     sdt_period: str | None = None,
-    
+
     nit_period: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MPEG-TS (MPEG-2 Transport Stream)
-    
+
     Args:
         mpegts_transport_stream_id: Set transport_stream_id field. (from 1 to 65535) (default 1)
         mpegts_original_network_id: Set original_network_id field. (from 1 to 65535) (default 65281)
@@ -3369,53 +3369,53 @@ def mpegts(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "mpegts_transport_stream_id": mpegts_transport_stream_id,
-        
+
         "mpegts_original_network_id": mpegts_original_network_id,
-        
+
         "mpegts_service_id": mpegts_service_id,
-        
+
         "mpegts_service_type": mpegts_service_type,
-        
+
         "mpegts_pmt_start_pid": mpegts_pmt_start_pid,
-        
+
         "mpegts_start_pid": mpegts_start_pid,
-        
+
         "mpegts_m2ts_mode": mpegts_m2ts_mode,
-        
+
         "muxrate": muxrate,
-        
+
         "pes_payload_size": pes_payload_size,
-        
+
         "mpegts_flags": mpegts_flags,
-        
+
         "mpegts_copyts": mpegts_copyts,
-        
+
         "tables_version": tables_version,
-        
+
         "omit_video_pes_length": omit_video_pes_length,
-        
+
         "pcr_period": pcr_period,
-        
+
         "pat_period": pat_period,
-        
+
         "sdt_period": sdt_period,
-        
+
         "nit_period": nit_period,
-        
+
     }))
 
 
 
 def mpjpeg(
-    
+
     boundary_tag: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MIME multipart JPEG
-    
+
     Args:
         boundary_tag: Boundary tag (default "ffmpeg")
 
@@ -3423,39 +3423,39 @@ def mpjpeg(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "boundary_tag": boundary_tag,
-        
+
     }))
 
 
 
 def mulaw(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM mu-law
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mxf(
-    
+
     signal_standard: int | None| Literal["bt601", "bt1358", "smpte347m", "smpte274m", "smpte296m", "smpte349m", "smpte428"] = None,
-    
+
     store_user_comments: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MXF (Material eXchange Format)
-    
+
     Args:
         signal_standard: Force/set Signal Standard (from -1 to 7) (default -1)
         store_user_comments: (default true)
@@ -3464,27 +3464,27 @@ def mxf(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "signal_standard": signal_standard,
-        
+
         "store_user_comments": store_user_comments,
-        
+
     }))
 
 
 
 def mxf_d10(
-    
+
     d10_channelcount: int | None = None,
-    
+
     signal_standard: int | None| Literal["bt601", "bt1358", "smpte347m", "smpte274m", "smpte296m", "smpte349m", "smpte428"] = None,
-    
+
     store_user_comments: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MXF (Material eXchange Format) D-10 Mapping
-    
+
     Args:
         d10_channelcount: Force/set channelcount in generic sound essence descriptor (from -1 to 8) (default -1)
         signal_standard: Force/set Signal Standard (from -1 to 7) (default -1)
@@ -3494,29 +3494,29 @@ def mxf_d10(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "d10_channelcount": d10_channelcount,
-        
+
         "signal_standard": signal_standard,
-        
+
         "store_user_comments": store_user_comments,
-        
+
     }))
 
 
 
 def mxf_opatom(
-    
+
     mxf_audio_edit_rate: str | None = None,
-    
+
     signal_standard: int | None| Literal["bt601", "bt1358", "smpte347m", "smpte274m", "smpte296m", "smpte349m", "smpte428"] = None,
-    
+
     store_user_comments: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MXF (Material eXchange Format) Operational Pattern Atom
-    
+
     Args:
         mxf_audio_edit_rate: Audio edit rate for timecode (from 0 to INT_MAX) (default 25/1)
         signal_standard: Force/set Signal Standard (from -1 to 7) (default -1)
@@ -3526,43 +3526,43 @@ def mxf_opatom(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "mxf_audio_edit_rate": mxf_audio_edit_rate,
-        
+
         "signal_standard": signal_standard,
-        
+
         "store_user_comments": store_user_comments,
-        
+
     }))
 
 
 
 def null(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw null video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def nut(
-    
+
     syncpoints: str | None = None,
-    
+
     write_index: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     NUT
-    
+
     Args:
         syncpoints: NUT syncpoint behaviour (default 0)
         write_index: Write index (default true)
@@ -3571,45 +3571,45 @@ def nut(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "syncpoints": syncpoints,
-        
+
         "write_index": write_index,
-        
+
     }))
 
 
 
 def obu(
-    
+
 ) -> FFMpegMuxerOption:
     """
     AV1 low overhead OBU
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def oga(
-    
+
     serial_offset: int | None = None,
-    
+
     oggpagesize: int | None = None,
-    
+
     pagesize: int | None = None,
-    
+
     page_duration: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Ogg Audio
-    
+
     Args:
         serial_offset: serial number offset (from 0 to INT_MAX) (default 0)
         oggpagesize: Set preferred Ogg page size. (from 0 to 65025) (default 0)
@@ -3620,33 +3620,33 @@ def oga(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "serial_offset": serial_offset,
-        
+
         "oggpagesize": oggpagesize,
-        
+
         "pagesize": pagesize,
-        
+
         "page_duration": page_duration,
-        
+
     }))
 
 
 
 def ogg(
-    
+
     serial_offset: int | None = None,
-    
+
     oggpagesize: int | None = None,
-    
+
     pagesize: int | None = None,
-    
+
     page_duration: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Ogg
-    
+
     Args:
         serial_offset: serial number offset (from 0 to INT_MAX) (default 0)
         oggpagesize: Set preferred Ogg page size. (from 0 to 65025) (default 0)
@@ -3657,33 +3657,33 @@ def ogg(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "serial_offset": serial_offset,
-        
+
         "oggpagesize": oggpagesize,
-        
+
         "pagesize": pagesize,
-        
+
         "page_duration": page_duration,
-        
+
     }))
 
 
 
 def ogv(
-    
+
     serial_offset: int | None = None,
-    
+
     oggpagesize: int | None = None,
-    
+
     pagesize: int | None = None,
-    
+
     page_duration: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Ogg Video
-    
+
     Args:
         serial_offset: serial number offset (from 0 to INT_MAX) (default 0)
         oggpagesize: Set preferred Ogg page size. (from 0 to 65025) (default 0)
@@ -3694,49 +3694,49 @@ def ogv(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "serial_offset": serial_offset,
-        
+
         "oggpagesize": oggpagesize,
-        
+
         "pagesize": pagesize,
-        
+
         "page_duration": page_duration,
-        
+
     }))
 
 
 
 def oma(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Sony OpenMG audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def opus(
-    
+
     serial_offset: int | None = None,
-    
+
     oggpagesize: int | None = None,
-    
+
     pagesize: int | None = None,
-    
+
     page_duration: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Ogg Opus
-    
+
     Args:
         serial_offset: serial number offset (from 0 to INT_MAX) (default 0)
         oggpagesize: Set preferred Ogg page size. (from 0 to 65025) (default 0)
@@ -3747,91 +3747,91 @@ def opus(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "serial_offset": serial_offset,
-        
+
         "oggpagesize": oggpagesize,
-        
+
         "pagesize": pagesize,
-        
+
         "page_duration": page_duration,
-        
+
     }))
 
 
 
 def oss(
-    
+
 ) -> FFMpegMuxerOption:
     """
     OSS (Open Sound System) playback
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def psp(
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     brand: str | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
     write_prft: int | None| Literal["wallclock", "pts"] = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     PSP MP4 (MPEG-4 Part 14)
-    
+
     Args:
         movflags: MOV muxer flags (default 0)
         moov_size: maximum moov size so it can be placed at the begin (from 0 to INT_MAX) (default 0)
@@ -3863,141 +3863,141 @@ def psp(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "frag_duration": frag_duration,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "frag_size": frag_size,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "brand": brand,
-        
+
         "use_editlist": use_editlist,
-        
+
         "fragment_index": fragment_index,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_tmcd": write_tmcd,
-        
+
         "write_prft": write_prft,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "movie_timescale": movie_timescale,
-        
+
     }))
 
 
 
 def rawvideo(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def rm(
-    
+
 ) -> FFMpegMuxerOption:
     """
     RealMedia
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def roq(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw id RoQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def rso(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Lego Mindstorms RSO
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def rtp(
-    
+
     rtpflags: str | None = None,
-    
+
     payload_type: int | None = None,
-    
+
     ssrc: int | None = None,
-    
+
     cname: str | None = None,
-    
+
     seq: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     RTP output
-    
+
     Args:
         rtpflags: RTP muxer flags (default 0)
         payload_type: Specify RTP payload type (from -1 to 127) (default -1)
@@ -4009,31 +4009,31 @@ def rtp(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "rtpflags": rtpflags,
-        
+
         "payload_type": payload_type,
-        
+
         "ssrc": ssrc,
-        
+
         "cname": cname,
-        
+
         "seq": seq,
-        
+
     }))
 
 
 
 def rtp_mpegts(
-    
+
     mpegts_muxer_options: str | None = None,
-    
+
     rtp_muxer_options: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     RTP/mpegts output format
-    
+
     Args:
         mpegts_muxer_options: set list of options for the MPEG-TS muxer
         rtp_muxer_options: set list of options for the RTP muxer
@@ -4042,33 +4042,33 @@ def rtp_mpegts(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "mpegts_muxer_options": mpegts_muxer_options,
-        
+
         "rtp_muxer_options": rtp_muxer_options,
-        
+
     }))
 
 
 
 def rtsp(
-    
+
     rtpflags: str | None = None,
-    
+
     rtsp_transport: str | None = None,
-    
+
     min_port: int | None = None,
-    
+
     max_port: int | None = None,
-    
+
     buffer_size: int | None = None,
-    
+
     pkt_size: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     RTSP output
-    
+
     Args:
         rtpflags: RTP muxer flags (default 0)
         rtsp_transport: set RTSP transport protocols (default 0)
@@ -4081,243 +4081,243 @@ def rtsp(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "rtpflags": rtpflags,
-        
+
         "rtsp_transport": rtsp_transport,
-        
+
         "min_port": min_port,
-        
+
         "max_port": max_port,
-        
+
         "buffer_size": buffer_size,
-        
+
         "pkt_size": pkt_size,
-        
+
     }))
 
 
 
 def s16be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 16-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def s16le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 16-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def s24be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 24-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def s24le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 24-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def s32be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 32-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def s32le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 32-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def s8(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 8-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def sap(
-    
+
 ) -> FFMpegMuxerOption:
     """
     SAP output
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def sbc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw SBC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def scc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Scenarist Closed Captions
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def segment(
-    
+
     reference_stream: str | None = None,
-    
+
     segment_format: str | None = None,
-    
+
     segment_format_options: str | None = None,
-    
+
     segment_list: str | None = None,
-    
+
     segment_header_filename: str | None = None,
-    
+
     segment_list_flags: str | None = None,
-    
+
     segment_list_size: int | None = None,
-    
+
     segment_list_type: int | None| Literal["flat", "csv", "ext", "ffconcat", "m3u8", "hls"] = None,
-    
+
     segment_atclocktime: bool | None = None,
-    
+
     segment_clocktime_offset: str | None = None,
-    
+
     segment_clocktime_wrap_duration: str | None = None,
-    
+
     segment_time: str | None = None,
-    
+
     segment_time_delta: str | None = None,
-    
+
     segment_times: str | None = None,
-    
+
     segment_frames: str | None = None,
-    
+
     segment_wrap: int | None = None,
-    
+
     segment_list_entry_prefix: str | None = None,
-    
+
     segment_start_number: int | None = None,
-    
+
     segment_wrap_number: int | None = None,
-    
+
     strftime: bool | None = None,
-    
+
     increment_tc: bool | None = None,
-    
+
     break_non_keyframes: bool | None = None,
-    
+
     individual_header_trailer: bool | None = None,
-    
+
     write_header_trailer: bool | None = None,
-    
+
     reset_timestamps: bool | None = None,
-    
+
     initial_offset: str | None = None,
-    
+
     write_empty_segments: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     segment
-    
+
     Args:
         reference_stream: set reference stream (default "auto")
         segment_format: set container format used for the segments
@@ -4351,97 +4351,97 @@ def segment(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "reference_stream": reference_stream,
-        
+
         "segment_format": segment_format,
-        
+
         "segment_format_options": segment_format_options,
-        
+
         "segment_list": segment_list,
-        
+
         "segment_header_filename": segment_header_filename,
-        
+
         "segment_list_flags": segment_list_flags,
-        
+
         "segment_list_size": segment_list_size,
-        
+
         "segment_list_type": segment_list_type,
-        
+
         "segment_atclocktime": segment_atclocktime,
-        
+
         "segment_clocktime_offset": segment_clocktime_offset,
-        
+
         "segment_clocktime_wrap_duration": segment_clocktime_wrap_duration,
-        
+
         "segment_time": segment_time,
-        
+
         "segment_time_delta": segment_time_delta,
-        
+
         "segment_times": segment_times,
-        
+
         "segment_frames": segment_frames,
-        
+
         "segment_wrap": segment_wrap,
-        
+
         "segment_list_entry_prefix": segment_list_entry_prefix,
-        
+
         "segment_start_number": segment_start_number,
-        
+
         "segment_wrap_number": segment_wrap_number,
-        
+
         "strftime": strftime,
-        
+
         "increment_tc": increment_tc,
-        
+
         "break_non_keyframes": break_non_keyframes,
-        
+
         "individual_header_trailer": individual_header_trailer,
-        
+
         "write_header_trailer": write_header_trailer,
-        
+
         "reset_timestamps": reset_timestamps,
-        
+
         "initial_offset": initial_offset,
-        
+
         "write_empty_segments": write_empty_segments,
-        
+
     }))
 
 
 
 def smjpeg(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Loki SDL MJPEG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def smoothstreaming(
-    
+
     window_size: int | None = None,
-    
+
     extra_window_size: int | None = None,
-    
+
     lookahead_count: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     remove_at_exit: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Smooth Streaming Muxer
-    
+
     Args:
         window_size: number of fragments kept in the manifest (from 0 to INT_MAX) (default 0)
         extra_window_size: number of fragments kept outside of the manifest before removing from disk (from 0 to INT_MAX) (default 5)
@@ -4453,49 +4453,49 @@ def smoothstreaming(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "window_size": window_size,
-        
+
         "extra_window_size": extra_window_size,
-        
+
         "lookahead_count": lookahead_count,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "remove_at_exit": remove_at_exit,
-        
+
     }))
 
 
 
 def sox(
-    
+
 ) -> FFMpegMuxerOption:
     """
     SoX native
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def spdif(
-    
+
     spdif_flags: str | None = None,
-    
+
     dtshd_rate: int | None = None,
-    
+
     dtshd_fallback_time: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     IEC 61937 (used on S/PDIF - IEC958)
-    
+
     Args:
         spdif_flags: IEC 61937 encapsulation flags (default 0)
         dtshd_rate: mux complete DTS frames in HD mode at the specified IEC958 rate (in Hz, default 0=disabled) (from 0 to 768000) (default 0)
@@ -4505,31 +4505,31 @@ def spdif(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "spdif_flags": spdif_flags,
-        
+
         "dtshd_rate": dtshd_rate,
-        
+
         "dtshd_fallback_time": dtshd_fallback_time,
-        
+
     }))
 
 
 
 def spx(
-    
+
     serial_offset: int | None = None,
-    
+
     oggpagesize: int | None = None,
-    
+
     pagesize: int | None = None,
-    
+
     page_duration: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Ogg Speex
-    
+
     Args:
         serial_offset: serial number offset (from 0 to INT_MAX) (default 0)
         oggpagesize: Set preferred Ogg page size. (from 0 to 65025) (default 0)
@@ -4540,43 +4540,43 @@ def spx(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "serial_offset": serial_offset,
-        
+
         "oggpagesize": oggpagesize,
-        
+
         "pagesize": pagesize,
-        
+
         "page_duration": page_duration,
-        
+
     }))
 
 
 
 def srt(
-    
+
 ) -> FFMpegMuxerOption:
     """
     SubRip subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def streamhash(
-    
+
     hash: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Per-stream hash testing
-    
+
     Args:
         hash: set hash to use (default "sha256")
 
@@ -4584,39 +4584,39 @@ def streamhash(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "hash": hash,
-        
+
     }))
 
 
 
 def sup(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw HDMV Presentation Graphic Stream subtitles
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def svcd(
-    
+
     muxrate: int | None = None,
-    
+
     preload: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MPEG-2 PS (SVCD)
-    
+
     Args:
         muxrate: (from 0 to 1.67772e+09) (default 0)
         preload: Initial demux-decode delay in microseconds. (from 0 to INT_MAX) (default 500000)
@@ -4625,41 +4625,41 @@ def svcd(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "muxrate": muxrate,
-        
+
         "preload": preload,
-        
+
     }))
 
 
 
 def swf(
-    
+
 ) -> FFMpegMuxerOption:
     """
     SWF (ShockWave Flash)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def tee(
-    
+
     use_fifo: bool | None = None,
-    
+
     fifo_options: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Multiple muxer tee
-    
+
     Args:
         use_fifo: Use fifo pseudo-muxer to separate actual muxers from encoder (default false)
         fifo_options: fifo pseudo-muxer options
@@ -4668,233 +4668,233 @@ def tee(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "use_fifo": use_fifo,
-        
+
         "fifo_options": fifo_options,
-        
+
     }))
 
 
 
 def truehd(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw TrueHD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def tta(
-    
+
 ) -> FFMpegMuxerOption:
     """
     TTA (True Audio)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ttml(
-    
+
 ) -> FFMpegMuxerOption:
     """
     TTML subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u16be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 16-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u16le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 16-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u24be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 24-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u24le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 24-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u32be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 32-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u32le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 32-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u8(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 8-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def uncodedframecrc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     uncoded framecrc testing
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def vc1(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw VC-1 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def vc1test(
-    
+
 ) -> FFMpegMuxerOption:
     """
     VC-1 test bitstream
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def vcd(
-    
+
     muxrate: int | None = None,
-    
+
     preload: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MPEG-1 Systems / MPEG program stream (VCD)
-    
+
     Args:
         muxrate: (from 0 to 1.67772e+09) (default 0)
         preload: Initial demux-decode delay in microseconds. (from 0 to INT_MAX) (default 500000)
@@ -4903,41 +4903,41 @@ def vcd(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "muxrate": muxrate,
-        
+
         "preload": preload,
-        
+
     }))
 
 
 
 def vidc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM Archimedes VIDC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def vob(
-    
+
     muxrate: int | None = None,
-    
+
     preload: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MPEG-2 PS (VOB)
-    
+
     Args:
         muxrate: (from 0 to 1.67772e+09) (default 0)
         preload: Initial demux-decode delay in microseconds. (from 0 to INT_MAX) (default 500000)
@@ -4946,65 +4946,65 @@ def vob(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "muxrate": muxrate,
-        
+
         "preload": preload,
-        
+
     }))
 
 
 
 def voc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Creative Voice
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def w64(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Sony Wave64
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def wav(
-    
+
     write_bext: bool | None = None,
-    
+
     write_peak: int | None| Literal["off", "on", "only"] = None,
-    
+
     rf64: int | None| Literal["auto", "always", "never"] = None,
-    
+
     peak_block_size: int | None = None,
-    
+
     peak_format: int | None = None,
-    
+
     peak_ppv: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     WAV / WAVE (Waveform Audio)
-    
+
     Args:
         write_bext: Write BEXT chunk. (default false)
         write_peak: Write Peak Envelope chunk. (from 0 to 2) (default off)
@@ -5017,51 +5017,51 @@ def wav(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "write_bext": write_bext,
-        
+
         "write_peak": write_peak,
-        
+
         "rf64": rf64,
-        
+
         "peak_block_size": peak_block_size,
-        
+
         "peak_format": peak_format,
-        
+
         "peak_ppv": peak_ppv,
-        
+
     }))
 
 
 
 def webm(
-    
+
     reserve_index_space: int | None = None,
-    
+
     cues_to_front: bool | None = None,
-    
+
     cluster_size_limit: int | None = None,
-    
+
     cluster_time_limit: int | None = None,
-    
+
     dash: bool | None = None,
-    
+
     dash_track_number: int | None = None,
-    
+
     live: bool | None = None,
-    
+
     allow_raw_vfw: bool | None = None,
-    
+
     flipped_raw_rgb: bool | None = None,
-    
+
     write_crc32: bool | None = None,
-    
+
     default_mode: int | None| Literal["infer", "infer_no_subs", "passthrough"] = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     WebM
-    
+
     Args:
         reserve_index_space: Reserve a given amount of space (in bytes) at the beginning of the file for the index (cues). (from 0 to INT_MAX) (default 0)
         cues_to_front: Move Cues (the index) to the front by shifting data if necessary (default false)
@@ -5079,47 +5079,47 @@ def webm(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "reserve_index_space": reserve_index_space,
-        
+
         "cues_to_front": cues_to_front,
-        
+
         "cluster_size_limit": cluster_size_limit,
-        
+
         "cluster_time_limit": cluster_time_limit,
-        
+
         "dash": dash,
-        
+
         "dash_track_number": dash_track_number,
-        
+
         "live": live,
-        
+
         "allow_raw_vfw": allow_raw_vfw,
-        
+
         "flipped_raw_rgb": flipped_raw_rgb,
-        
+
         "write_crc32": write_crc32,
-        
+
         "default_mode": default_mode,
-        
+
     }))
 
 
 
 def webm_chunk(
-    
+
     chunk_start_index: int | None = None,
-    
+
     header: str | None = None,
-    
+
     audio_chunk_duration: int | None = None,
-    
+
     method: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     WebM Chunk Muxer
-    
+
     Args:
         chunk_start_index: start index of the chunk (from 0 to INT_MAX) (default 0)
         header: filename of the header where the initialization data will be written
@@ -5130,39 +5130,39 @@ def webm_chunk(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "chunk_start_index": chunk_start_index,
-        
+
         "header": header,
-        
+
         "audio_chunk_duration": audio_chunk_duration,
-        
+
         "method": method,
-        
+
     }))
 
 
 
 def webm_dash_manifest(
-    
+
     adaptation_sets: str | None = None,
-    
+
     live: bool | None = None,
-    
+
     chunk_start_index: int | None = None,
-    
+
     chunk_duration_ms: int | None = None,
-    
+
     utc_timing_url: str | None = None,
-    
+
     time_shift_buffer_depth: float | None = None,
-    
+
     minimum_update_period: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     WebM DASH Manifest
-    
+
     Args:
         adaptation_sets: Adaptation sets. Syntax: id=0,streams=0,1,2 id=1,streams=3,4 and so on
         live: create a live stream manifest (default false)
@@ -5176,33 +5176,33 @@ def webm_dash_manifest(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "adaptation_sets": adaptation_sets,
-        
+
         "live": live,
-        
+
         "chunk_start_index": chunk_start_index,
-        
+
         "chunk_duration_ms": chunk_duration_ms,
-        
+
         "utc_timing_url": utc_timing_url,
-        
+
         "time_shift_buffer_depth": time_shift_buffer_depth,
-        
+
         "minimum_update_period": minimum_update_period,
-        
+
     }))
 
 
 
 def webp(
-    
+
     loop: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     WebP
-    
+
     Args:
         loop: Number of times to loop the output: 0 - infinite loop (from 0 to 65535) (default 1)
 
@@ -5210,760 +5210,87 @@ def webp(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def webvtt(
-    
+
 ) -> FFMpegMuxerOption:
     """
     WebVTT subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def wsaud(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Westwood Studios audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def wtv(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Windows Television (WTV)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def wv(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw WavPack
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def yuv4mpegpipe(
-    
+
 ) -> FFMpegMuxerOption:
     """
     YUV4MPEG pipe
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/packages/v5/src/ffmpeg/sources.py
+++ b/packages/v5/src/ffmpeg/sources.py
@@ -43,27 +43,27 @@ from .streams.audio import AudioStream
 import re
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def abuffer(
-    
 
-    
+
+
 
 
     *,
     time_base: Rational = Default('0/1'),sample_rate: Int = Default('0'),sample_fmt: Sample_fmt = Default('none'),channel_layout: String = Default(None),channels: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Buffer audio frames, and make them available to the filter chain.
 
 This source is mainly intended for a programmatic use, in particular
@@ -87,98 +87,98 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#abuffer)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='abuffer', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "time_base": time_base,
-            
+
             "sample_rate": sample_rate,
-            
+
             "sample_fmt": sample_fmt,
-            
+
             "channel_layout": channel_layout,
-            
+
             "channels": channels,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def aevalsrc(
-    
 
-    
+
+
 
 
     *,
     exprs: String = Default(None),nb_samples: Int = Default('1024'),sample_rate: String = Default('44100'),duration: Duration = Default('-0.000001'),channel_layout: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate an audio signal specified by an expression.
 
 This source accepts in input one or more expressions (one for each
@@ -203,66 +203,66 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aevalsrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='aevalsrc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "exprs": exprs,
-            
+
             "nb_samples": nb_samples,
-            
+
             "sample_rate": sample_rate,
-            
+
             "duration": duration,
-            
+
             "channel_layout": channel_layout,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
 def afirsrc(
-    
 
-    
+
+
 
 
     *,
     taps: Int = Default('1025'),frequency: String = Default('0 1'),magnitude: String = Default('1 1'),phase: String = Default('0 0'),sample_rate: Int = Default('44100'),nb_samples: Int = Default('1024'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman"] | Default = Default('blackman'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate a FIR coefficients using frequency sampling method.
 
 The resulting stream can be used with afir filter for filtering the audio signal.
@@ -287,78 +287,78 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afirsrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='afirsrc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "taps": taps,
-            
+
             "frequency": frequency,
-            
+
             "magnitude": magnitude,
-            
+
             "phase": phase,
-            
+
             "sample_rate": sample_rate,
-            
+
             "nb_samples": nb_samples,
-            
+
             "win_func": win_func,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
 def ainterleave(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     nb_inputs: Int = Auto('len(streams)'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Temporally interleave frames from several inputs.
 
 interleave works with video inputs, ainterleave with audio.
@@ -397,58 +397,58 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#interleave)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='ainterleave', typings_input='[StreamType.audio] * int(nb_inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "nb_inputs": nb_inputs,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def allrgb(
-    
 
-    
+
+
 
 
     *,
     rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -509,52 +509,52 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='allrgb', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def allyuv(
-    
 
-    
+
+
 
 
     *,
     rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -615,60 +615,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='allyuv', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def amerge(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Merge two or more audio streams into a single multi-channel stream.
 
 The filter accepts the following options:
@@ -685,54 +685,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amerge)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='amerge', typings_input='[StreamType.audio] * int(inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def amix(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),dropout_transition: Float = Default('2'),weights: String = Default('1 1'),normalize: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Mixes multiple audio inputs into a single output.
 
 Note that this filter only supports float samples (the amerge
@@ -765,64 +765,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amix)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='amix', typings_input='[StreamType.audio] * int(inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "duration": duration,
-            
+
             "dropout_transition": dropout_transition,
-            
+
             "weights": weights,
-            
+
             "normalize": normalize,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
+
+
+
 def amovie(
-    
 
-    
+
+
 
 
     *,
     filename: String = Default(None),format_name: String = Default(None),stream_index: Int = Default('-1'),seek_point: Double = Default('0'),streams: String = Default(None),loop: Int = Default('1'),discontinuity: Duration = Default('0'),dec_threads: Int = Default('0'),format_opts: Dictionary = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 This is the same as movie source, except it selects an audio
 stream by default.
 
 
 Args:
-    filename: 
+    filename:
     format_name: set format name
     stream_index: set stream index (from -1 to INT_MAX) (default -1)
     seek_point: set seekpoint (seconds) (from 0 to 9.22337e+12) (default 0)
@@ -841,77 +841,77 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amovie)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='amovie', typings_input="[StreamType.audio] * len(streams.split('+'))", typings_output="[StreamType.audio] * len(streams.split('+'))"),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "filename": filename,
-            
+
             "format_name": format_name,
-            
+
             "stream_index": stream_index,
-            
+
             "seek_point": seek_point,
-            
+
             "streams": streams,
-            
+
             "loop": loop,
-            
+
             "discontinuity": discontinuity,
-            
+
             "dec_threads": dec_threads,
-            
+
             "format_opts": format_opts,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
 def anoisesrc(
-    
 
-    
+
+
 
 
     *,
     sample_rate: Int = Default('48000'),amplitude: Double = Default('1'),duration: Duration = Default('0'),color: Int| Literal["white","pink","brown","blue","violet","velvet"] | Default = Default('white'),seed: Int64 = Default('-1'),nb_samples: Int = Default('1024'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate a noise audio signal.
 
 The filter accepts the following options:
@@ -933,62 +933,62 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anoisesrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='anoisesrc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "sample_rate": sample_rate,
-            
+
             "amplitude": amplitude,
-            
+
             "duration": duration,
-            
+
             "color": color,
-            
+
             "seed": seed,
-            
+
             "nb_samples": nb_samples,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def anullsrc(
-    
 
-    
+
+
 
 
     *,
     channel_layout: String = Default('stereo'),sample_rate: String = Default('44100'),nb_samples: Int = Default('1024'),duration: Duration = Default('-0.000001'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 The null audio source, return unprocessed audio frames. It is mainly useful
 as a template and to be employed in analysis / debugging tools, or as
 the source for filters which ignore the input data (for example the sox
@@ -1011,108 +1011,108 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anullsrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='anullsrc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "channel_layout": channel_layout,
-            
+
             "sample_rate": sample_rate,
-            
+
             "nb_samples": nb_samples,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def astreamselect(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),map: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Select video or audio streams.
 
 The filter accepts the following options:
@@ -1131,87 +1131,87 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#streamselect)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='astreamselect', typings_input='[StreamType.audio] * int(inputs)', typings_output="[StreamType.audio] * len(re.findall(r'\\d+', str(map)))"),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "map": map,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def avsynctest(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('hd720'),framerate: Video_rate = Default('30'),samplerate: Int = Default('44100'),amplitude: Float = Default('0.7'),period: Int = Default('3'),delay: Int = Default('0'),cycle: Boolean = Default('false'),duration: Duration = Default('0'),fg: Color = Default('white'),bg: Color = Default('black'),ag: Color = Default('gray'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> tuple[
-    
-        
+
+
             AudioStream,
-        
-    
-        
+
+
+
             VideoStream,
-        
-    
+
+
 ]:
     """
-    
+
 Generate an Audio/Video Sync Test.
 
 Generated stream periodically shows flash video frame and emits beep in audio.
@@ -1242,114 +1242,114 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#avsynctest)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='avsynctest', typings_input=(), typings_output=('audio', 'video')),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "framerate": framerate,
-            
+
             "samplerate": samplerate,
-            
+
             "amplitude": amplitude,
-            
+
             "period": period,
-            
+
             "delay": delay,
-            
+
             "cycle": cycle,
-            
+
             "duration": duration,
-            
+
             "fg": fg,
-            
+
             "bg": bg,
-            
+
             "ag": ag,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return (
-        
-            
+
+
                 filter_node.audio(0),
-            
-        
-            
+
+
+
                 filter_node.video(0),
-            
-        
+
+
     )
 
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def bm3d(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     sigma: Float = Default('1'),block: Int = Default('4'),bstep: Int = Default('4'),group: Int = Default('1'),range: Int = Default('9'),mstep: Int = Default('1'),thmse: Float = Default('0'),hdthr: Float = Default('2.7'),estim: Int| Literal["basic","final"] | Default = Default('basic'),ref: Boolean = Default('false'),planes: Int = Default('7'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Denoise frames using Block-Matching 3D algorithm.
 
 The filter accepts the following options.
@@ -1377,7 +1377,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bm3d)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -1385,71 +1385,71 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='bm3d', typings_input='[StreamType.video] + [StreamType.video] if ref else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "sigma": sigma,
-            
+
             "block": block,
-            
+
             "bstep": bstep,
-            
+
             "group": group,
-            
+
             "range": range,
-            
+
             "mstep": mstep,
-            
+
             "thmse": thmse,
-            
+
             "hdthr": hdthr,
-            
+
             "estim": estim,
-            
+
             "ref": ref,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def buffer(
-    
 
-    
+
+
 
 
     *,
     width: Int = Default('0'),video_size: Image_size = Default(None),height: Int = Default('0'),pix_fmt: Pix_fmt = Default('none'),sar: Rational = Default('0/1'),time_base: Rational = Default('0/1'),sws_param: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Buffer video frames, and make them available to the filter chain.
 
 This source is mainly intended for a programmatic use, in particular
@@ -1475,66 +1475,66 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#buffer)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='buffer', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "width": width,
-            
+
             "video_size": video_size,
-            
+
             "height": height,
-            
+
             "pix_fmt": pix_fmt,
-            
+
             "sar": sar,
-            
+
             "time_base": time_base,
-            
+
             "sws_param": sws_param,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def cellauto(
-    
 
-    
+
+
 
 
     *,
     filename: String = Default(None),pattern: String = Default(None),rate: Video_rate = Default('25'),size: Image_size = Default(None),rule: Int = Default('110'),random_fill_ratio: Double = Default('0.618034'),random_seed: Int64 = Default('-1'),scroll: Boolean = Default('true'),start_full: Boolean = Default('false'),full: Boolean = Default('true'),stitch: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Create a pattern generated by an elementary cellular automaton.
 
 The initial state of the cellular automaton can be defined through the
@@ -1569,86 +1569,86 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#cellauto)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='cellauto', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "filename": filename,
-            
+
             "pattern": pattern,
-            
+
             "rate": rate,
-            
+
             "size": size,
-            
+
             "rule": rule,
-            
+
             "random_fill_ratio": random_fill_ratio,
-            
+
             "random_seed": random_seed,
-            
+
             "scroll": scroll,
-            
+
             "start_full": start_full,
-            
+
             "full": full,
-            
+
             "stitch": stitch,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
 def color(
-    
 
-    
+
+
 
 
     *,
     color: Color = Default('black'),size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -1711,60 +1711,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='color', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "color": color,
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def colorchart(
-    
 
-    
+
+
 
 
     *,
     rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),patch_size: Image_size = Default('64x64'),preset: Int| Literal["reference","skintones"] | Default = Default('reference'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -1827,76 +1827,76 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='colorchart', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
             "patch_size": patch_size,
-            
+
             "preset": preset,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
 def colorspectrum(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),type: Int| Literal["black","white","all"] | Default = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -1959,64 +1959,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='colorspectrum', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
             "type": type,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def concat(
-    
 
-    
+
+
     *streams: FilterableStream,
-    
 
 
-    
+
+
     n: Int = Auto('len(streams) // (int(v) + int(a))'),v: Int = Default('1'),a: Int = Default('0'),unsafe: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Concatenate audio and video streams, joining them together one after the
 other.
 
@@ -2042,93 +2042,93 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#concat)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='concat', typings_input='([StreamType.video]*int(v) + [StreamType.audio]*int(a))*int(n)', typings_output='[StreamType.video]*int(v) + [StreamType.audio]*int(a)'),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "n": n,
-            
+
             "v": v,
-            
+
             "a": a,
-            
+
             "unsafe": unsafe,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def decimate(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     cycle: Int = Default('5'),dupthresh: Double = Default('1.1'),scthresh: Double = Default('15'),blockx: Int = Default('32'),blocky: Int = Default('32'),ppsrc: Boolean = Default('false'),chroma: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Drop duplicated frames at regular intervals.
 
 The filter accepts the following options:
@@ -2151,160 +2151,160 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#decimate)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='decimate', typings_input='[StreamType.video] + ([StreamType.video] if ppsrc else [])', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "cycle": cycle,
-            
+
             "dupthresh": dupthresh,
-            
+
             "scthresh": scthresh,
-            
+
             "blockx": blockx,
-            
+
             "blocky": blocky,
-            
+
             "ppsrc": ppsrc,
-            
+
             "chroma": chroma,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def fieldmatch(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     order: Int| Literal["auto","bff","tff"] | Default = Default('auto'),mode: Int| Literal["pc","pc_n","pc_u","pc_n_ub","pcn","pcn_ub"] | Default = Default('pc_n'),ppsrc: Boolean = Default('false'),field: Int| Literal["auto","bottom","top"] | Default = Default('auto'),mchroma: Boolean = Default('true'),y0: Int = Default('0'),scthresh: Double = Default('12'),combmatch: Int| Literal["none","sc","full"] | Default = Default('sc'),combdbg: Int| Literal["none","pcn","pcnub"] | Default = Default('none'),cthresh: Int = Default('9'),chroma: Boolean = Default('false'),blockx: Int = Default('16'),blocky: Int = Default('16'),combpel: Int = Default('80'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Field matching filter for inverse telecine. It is meant to reconstruct the
 progressive frames from a telecined stream. The filter does not drop duplicated
 frames, so to achieve a complete inverse telecine fieldmatch needs to be
@@ -2362,112 +2362,112 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fieldmatch)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='fieldmatch', typings_input='[StreamType.video] + [StreamType.video] if ppsrc else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "order": order,
-            
+
             "mode": mode,
-            
+
             "ppsrc": ppsrc,
-            
+
             "field": field,
-            
+
             "mchroma": mchroma,
-            
+
             "y0": y0,
-            
+
             "scthresh": scthresh,
-            
+
             "combmatch": combmatch,
-            
+
             "combdbg": combdbg,
-            
+
             "cthresh": cthresh,
-            
+
             "chroma": chroma,
-            
+
             "blockx": blockx,
-            
+
             "blocky": blocky,
-            
+
             "combpel": combpel,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def gradients(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('640x480'),rate: Video_rate = Default('25'),c0: Color = Default('random'),c1: Color = Default('random'),c2: Color = Default('random'),c3: Color = Default('random'),c4: Color = Default('random'),c5: Color = Default('random'),c6: Color = Default('random'),c7: Color = Default('random'),x0: Int = Default('-1'),y0: Int = Default('-1'),x1: Int = Default('-1'),y1: Int = Default('-1'),nb_colors: Int = Default('2'),seed: Int64 = Default('-1'),duration: Duration = Default('-0.000001'),speed: Float = Default('0.01'),type: Int| Literal["linear","radial","circular","spiral"] | Default = Default('linear'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate several gradients.
 
 
@@ -2500,95 +2500,95 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#gradients)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='gradients', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "c0": c0,
-            
+
             "c1": c1,
-            
+
             "c2": c2,
-            
+
             "c3": c3,
-            
+
             "c4": c4,
-            
+
             "c5": c5,
-            
+
             "c6": c6,
-            
+
             "c7": c7,
-            
+
             "x0": x0,
-            
+
             "y0": y0,
-            
+
             "x1": x1,
-            
+
             "y1": y1,
-            
+
             "nb_colors": nb_colors,
-            
+
             "seed": seed,
-            
+
             "duration": duration,
-            
+
             "speed": speed,
-            
+
             "type": type,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def guided(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     radius: Int = Default('3'),eps: Float = Default('0.01'),mode: Int| Literal["basic","fast"] | Default = Default('basic'),sub: Int = Default('4'),guidance: Int| Literal["off","on"] | Default = Default('off'),planes: Int = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply guided filter for edge-preserving smoothing, dehazing and so on.
 
 The filter accepts the following options:
@@ -2611,7 +2611,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#guided)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -2619,61 +2619,61 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='guided', typings_input='[StreamType.video] + [StreamType.video] if guidance else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "radius": radius,
-            
+
             "eps": eps,
-            
+
             "mode": mode,
-            
+
             "sub": sub,
-            
+
             "guidance": guidance,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def haldclutsrc(
-    
 
-    
+
+
 
 
     *,
     level: Int = Default('6'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -2735,58 +2735,58 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='haldclutsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "level": level,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def headphone(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     map: String = Default(None),gain: Float = Default('0'),lfe: Float = Default('0'),type: Int| Literal["time","freq"] | Default = Default('freq'),size: Int = Default('1024'),hrir: Int| Literal["stereo","multich"] | Default = Default('stereo'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Apply head-related transfer functions (HRTFs) to create virtual
 loudspeakers around the user for binaural listening via headphones.
 The HRIRs are provided via additional streams, for each channel
@@ -2811,66 +2811,66 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#headphone)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='headphone', typings_input="[StreamType.audio] + [StreamType.audio] * (len(str(map).split('|')) - 1) if int(hrir) == 1 else []", typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "map": map,
-            
+
             "gain": gain,
-            
+
             "lfe": lfe,
-            
+
             "type": type,
-            
+
             "size": size,
-            
+
             "hrir": hrir,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def hilbert(
-    
 
-    
+
+
 
 
     *,
     sample_rate: Int = Default('44100'),taps: Int = Default('22051'),nb_samples: Int = Default('1024'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman"] | Default = Default('blackman'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate odd-tap Hilbert transform FIR coefficients.
 
 The resulting stream can be used with afir filter for phase-shifting
@@ -2896,64 +2896,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hilbert)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='hilbert', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "sample_rate": sample_rate,
-            
+
             "taps": taps,
-            
+
             "nb_samples": nb_samples,
-            
+
             "win_func": win_func,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def hstack(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),shortest: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos horizontally.
 
 All streams must be of same pixel format and of same height.
@@ -2976,80 +2976,80 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hstack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='hstack', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def interleave(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     nb_inputs: Int = Auto('len(streams)'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Temporally interleave frames from several inputs.
 
 interleave works with video inputs, ainterleave with audio.
@@ -3088,54 +3088,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#interleave)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='interleave', typings_input='[StreamType.video] * int(nb_inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "nb_inputs": nb_inputs,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def join(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),channel_layout: String = Default('stereo'),map: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Join multiple input streams into one multi-channel stream.
 
 It accepts the following parameters:
@@ -3154,64 +3154,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#join)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='join', typings_input='[StreamType.audio] * int(inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "channel_layout": channel_layout,
-            
+
             "map": map,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
 def life(
-    
 
-    
+
+
 
 
     *,
     filename: String = Default(None),size: Image_size = Default(None),rate: Video_rate = Default('25'),rule: String = Default('B3/S23'),random_fill_ratio: Double = Default('0.618034'),random_seed: Int64 = Default('-1'),stitch: Boolean = Default('true'),mold: Int = Default('0'),life_color: Color = Default('white'),death_color: Color = Default('black'),mold_color: Color = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate a life pattern.
 
 This source is based on a generalization of John Conway's life game.
@@ -3250,73 +3250,73 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#life)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='life', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "filename": filename,
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "rule": rule,
-            
+
             "random_fill_ratio": random_fill_ratio,
-            
+
             "random_seed": random_seed,
-            
+
             "stitch": stitch,
-            
+
             "mold": mold,
-            
+
             "life_color": life_color,
-            
+
             "death_color": death_color,
-            
+
             "mold_color": mold_color,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def limitdiff(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     threshold: Float = Default('0.00392157'),elasticity: Float = Default('2'),reference: Boolean = Default('false'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply limited difference filter using second and optionally third video stream.
 
 The filter accepts the following options:
@@ -3337,7 +3337,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#limitdiff)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -3345,77 +3345,77 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='limitdiff', typings_input='[StreamType.video, StreamType.video] + ([StreamType.video] if reference else [])', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "threshold": threshold,
-            
+
             "elasticity": elasticity,
-            
+
             "reference": reference,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def mandelbrot(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('640x480'),rate: Video_rate = Default('25'),maxiter: Int = Default('7189'),start_x: Double = Default('-0.743644'),start_y: Double = Default('-0.131826'),start_scale: Double = Default('3'),end_scale: Double = Default('0.3'),end_pts: Double = Default('400'),bailout: Double = Default('10'),morphxf: Double = Default('0.01'),morphyf: Double = Default('0.0123'),morphamp: Double = Default('0'),outer: Int| Literal["iteration_count","normalized_iteration_count","white","outz"] | Default = Default('normalized_iteration_count'),inner: Int| Literal["black","period","convergence","mincol"] | Default = Default('mincol'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate a Mandelbrot set fractal, and progressively zoom towards the
 point specified with start_x and start_y.
 
@@ -3446,92 +3446,92 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mandelbrot)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='mandelbrot', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "maxiter": maxiter,
-            
+
             "start_x": start_x,
-            
+
             "start_y": start_y,
-            
+
             "start_scale": start_scale,
-            
+
             "end_scale": end_scale,
-            
+
             "end_pts": end_pts,
-            
+
             "bailout": bailout,
-            
+
             "morphxf": morphxf,
-            
+
             "morphyf": morphyf,
-            
+
             "morphamp": morphamp,
-            
+
             "outer": outer,
-            
+
             "inner": inner,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
 def mergeplanes(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     mapping: Int = Default('-1'),format: Pix_fmt = Default('yuva444p'),map0s: Int = Default('0'),map0p: Int = Default('0'),map1s: Int = Default('0'),map1p: Int = Default('0'),map2s: Int = Default('0'),map2p: Int = Default('0'),map3s: Int = Default('0'),map3p: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Merge color channel components from several video streams.
 
 The filter accepts up to 4 input streams, and merge selected input
@@ -3560,81 +3560,81 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mergeplanes)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='mergeplanes', typings_input='[StreamType.video] * int(max(hex(int(mapping))[2::2]))', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "mapping": mapping,
-            
+
             "format": format,
-            
+
             "map0s": map0s,
-            
+
             "map0p": map0p,
-            
+
             "map1s": map1s,
-            
+
             "map1p": map1p,
-            
+
             "map2s": map2s,
-            
+
             "map2p": map2p,
-            
+
             "map3s": map3s,
-            
+
             "map3p": map3p,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def mix(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),weights: String = Default('1 1'),scale: Float = Default('0'),planes: Flags = Default('F'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Mix several video input streams into one video stream.
 
 A description of the accepted options follows.
@@ -3656,7 +3656,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mix)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -3664,59 +3664,59 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='mix', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "weights": weights,
-            
+
             "scale": scale,
-            
+
             "planes": planes,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def movie(
-    
 
-    
+
+
 
 
     *,
     filename: String = Default(None),format_name: String = Default(None),stream_index: Int = Default('-1'),seek_point: Double = Default('0'),streams: String = Default(None),loop: Int = Default('1'),discontinuity: Duration = Default('0'),dec_threads: Int = Default('0'),format_opts: Dictionary = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Read audio and/or video stream(s) from a movie container.
 
 It accepts the following parameters:
@@ -3742,67 +3742,67 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#movie)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='movie', typings_input="[StreamType.video] * len(streams.split('+'))", typings_output="[StreamType.video] * len(streams.split('+'))"),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "filename": filename,
-            
+
             "format_name": format_name,
-            
+
             "stream_index": stream_index,
-            
+
             "seek_point": seek_point,
-            
+
             "streams": streams,
-            
+
             "loop": loop,
-            
+
             "discontinuity": discontinuity,
-            
+
             "dec_threads": dec_threads,
-            
+
             "format_opts": format_opts,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def mptestsrc(
-    
 
-    
+
+
 
 
     *,
     rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),test: Int| Literal["dc_luma","dc_chroma","freq_luma","freq_chroma","amp_luma","amp_chroma","cbp","mv","ring1","ring2","all"] | Default = Default('all'),max_frames: Int64 = Default('30'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate various test patterns, as generated by the MPlayer test filter.
 
 The size of the generated video is fixed, and is 256x256.
@@ -3825,76 +3825,76 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mptestsrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='mptestsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "test": test,
-            
+
             "max_frames": max_frames,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def nullsrc(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -3956,54 +3956,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='nullsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def openclsrc(
-    
 
-    
+
+
 
 
     *,
     source: String = Default(None),kernel: String = Default(None),size: Image_size = Default(None),format: Pix_fmt = Default('none'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate video using an OpenCL program.
 
 
@@ -4022,70 +4022,70 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#openclsrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='openclsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "source": source,
-            
+
             "kernel": kernel,
-            
+
             "size": size,
-            
+
             "format": format,
-            
+
             "rate": rate,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
 def pal100bars(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -4147,54 +4147,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='pal100bars', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def pal75bars(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -4256,83 +4256,83 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='pal75bars', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def premultiply(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     planes: Int = Default('15'),inplace: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply alpha premultiply effect to input video stream using first plane
 of second stream as alpha.
 
@@ -4354,7 +4354,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#premultiply)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4362,62 +4362,62 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='premultiply', typings_input='[StreamType.video] + [StreamType.video] if inplace else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "inplace": inplace,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def program_opencl(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     source: String = Default(None),kernel: String = Default(None),inputs: Int = Default('1'),size: Image_size = Default(None),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Filter video using an OpenCL program.
 
 
@@ -4436,7 +4436,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#program_opencl)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -4444,85 +4444,85 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='program_opencl', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "source": source,
-            
+
             "kernel": kernel,
-            
+
             "inputs": inputs,
-            
+
             "size": size,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def rgbtestsrc(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),complement: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -4585,136 +4585,136 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='rgbtestsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
             "complement": complement,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def sierpinski(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('640x480'),rate: Video_rate = Default('25'),seed: Int64 = Default('-1'),jump: Int = Default('100'),type: Int| Literal["carpet","triangle"] | Default = Default('carpet'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate a Sierpinski carpet/triangle fractal, and randomly pan around.
 
 This source accepts the following options:
@@ -4735,60 +4735,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sierpinski)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='sierpinski', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "seed": seed,
-            
+
             "jump": jump,
-            
+
             "type": type,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def signature(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     detectmode: Int| Literal["off","full","fast"] | Default = Default('off'),nb_inputs: Int = Auto('len(streams)'),filename: String = Default(''),format: Int| Literal["binary","xml"] | Default = Default('binary'),th_d: Int = Default('9000'),th_dc: Int = Default('60000'),th_xh: Int = Default('116'),th_di: Int = Default('0'),th_it: Double = Default('0.5'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Calculates the MPEG-7 Video Signature. The filter can handle more than one
 input. In this case the matching between the inputs can be calculated additionally.
 The filter always passes through the first input. The signature of each stream can
@@ -4816,70 +4816,70 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#signature)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='signature', typings_input='[StreamType.video] * int(nb_inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "detectmode": detectmode,
-            
+
             "nb_inputs": nb_inputs,
-            
+
             "filename": filename,
-            
+
             "format": format,
-            
+
             "th_d": th_d,
-            
+
             "th_dc": th_dc,
-            
+
             "th_xh": th_xh,
-            
+
             "th_di": th_di,
-            
+
             "th_it": th_it,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def sinc(
-    
 
-    
+
+
 
 
     *,
     sample_rate: Int = Default('44100'),nb_samples: Int = Default('1024'),hp: Float = Default('0'),lp: Float = Default('0'),phase: Float = Default('50'),beta: Float = Default('-1'),att: Float = Default('120'),round: Boolean = Default('false'),hptaps: Int = Default('0'),lptaps: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate a sinc kaiser-windowed low-pass, high-pass, band-pass, or band-reject FIR coefficients.
 
 The resulting stream can be used with afir filter for filtering the audio signal.
@@ -4907,66 +4907,66 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sinc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='sinc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "sample_rate": sample_rate,
-            
+
             "nb_samples": nb_samples,
-            
+
             "hp": hp,
-            
+
             "lp": lp,
-            
+
             "phase": phase,
-            
+
             "beta": beta,
-            
+
             "att": att,
-            
+
             "round": round,
-            
+
             "hptaps": hptaps,
-            
+
             "lptaps": lptaps,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
+
+
+
 def sine(
-    
 
-    
+
+
 
 
     *,
     frequency: Double = Default('440'),beep_factor: Double = Default('0'),sample_rate: Int = Default('44100'),duration: Duration = Default('0'),samples_per_frame: String = Default('1024'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate an audio signal made of a sine wave with amplitude 1/8.
 
 The audio signal is bit-exact.
@@ -4989,60 +4989,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sine)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='sine', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "frequency": frequency,
-            
+
             "beep_factor": beep_factor,
-            
+
             "sample_rate": sample_rate,
-            
+
             "duration": duration,
-            
+
             "samples_per_frame": samples_per_frame,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def smptebars(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -5104,54 +5104,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='smptebars', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def smptehdbars(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -5213,78 +5213,78 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='smptehdbars', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def streamselect(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),map: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Select video or audio streams.
 
 The filter accepts the following options:
@@ -5303,69 +5303,69 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#streamselect)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='streamselect', typings_input='[StreamType.video] * int(inputs)', typings_output="[StreamType.video] * len(re.findall(r'\\d+', str(map)))"),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "map": map,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
 def testsrc(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),decimals: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -5428,56 +5428,56 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='testsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
             "decimals": decimals,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def testsrc2(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),alpha: Int = Default('255'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -5540,101 +5540,101 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='testsrc2', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
             "alpha": alpha,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def unpremultiply(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     planes: Int = Default('15'),inplace: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply alpha unpremultiply effect to input video stream using first plane
 of second stream as alpha.
 
@@ -5656,7 +5656,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#unpremultiply)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -5664,89 +5664,89 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='unpremultiply', typings_input='[StreamType.video] + ([StreamType.video] if inplace else [])', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "inplace": inplace,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def vstack(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),shortest: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos vertically.
 
 All streams must be of same pixel format and of same width.
@@ -5769,76 +5769,76 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vstack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='vstack', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
 def xmedian(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),planes: Int = Default('15'),percentile: Float = Default('0.5'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Pick median pixels from several input videos.
 
 The filter accepts the following options:
@@ -5859,7 +5859,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xmedian)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -5870,55 +5870,55 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xmedian', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "planes": planes,
-            
+
             "percentile": percentile,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xstack(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),layout: String = Default(None),grid: Image_size = Default(None),shortest: Boolean = Default('false'),fill: String = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack video inputs into custom layout.
 
 All streams must be of same pixel format.
@@ -5941,62 +5941,62 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xstack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xstack', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "layout": layout,
-            
+
             "grid": grid,
-            
+
             "shortest": shortest,
-            
+
             "fill": fill,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def yuvtestsrc(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -6058,39 +6058,30 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='yuvtestsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
-
-
-    
-
-    
-
-    
-
-    

--- a/packages/v5/src/ffmpeg/streams/audio.py
+++ b/packages/v5/src/ffmpeg/streams/audio.py
@@ -48,12 +48,12 @@ class AudioStream(FilterableStream):
     Audio stream.
     """
 
-    
-        
-    
-    
+
+
+
+
     def abench(
-    
+
     self,
 
 
@@ -61,12 +61,12 @@ class AudioStream(FilterableStream):
 
     *,
     action: Int| Literal["start","stop"] | Default = Default('start'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Benchmark part of a filtergraph.
 
 The filter accepts the following options:
@@ -83,37 +83,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bench)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='abench', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "action": action,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def abitscope(
-    
+
     self,
 
 
@@ -121,12 +121,12 @@ References:
 
     *,
     rate: Video_rate = Default('25'),size: Image_size = Default('1024x256'),colors: String = Default('red|green|blue|yellow|orange|lime|pink|magenta|brown'),mode: Int| Literal["bars","trace"] | Default = Default('bars'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a video output, displaying the audio bit scope.
 
 The filter accepts the following options:
@@ -146,47 +146,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#abitscope)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='abitscope', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rate": rate,
-                
+
                 "size": size,
-                
+
                 "colors": colors,
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def acompressor(
-    
+
     self,
 
 
@@ -194,12 +194,12 @@ References:
 
     *,
     level_in: Double = Default('1'),mode: Int| Literal["downward","upward"] | Default = Default('downward'),threshold: Double = Default('0.125'),ratio: Double = Default('2'),attack: Double = Default('20'),release: Double = Default('250'),makeup: Double = Default('1'),knee: Double = Default('2.82843'),link: Int| Literal["average","maximum"] | Default = Default('average'),detection: Int| Literal["peak","rms"] | Default = Default('rms'),level_sc: Double = Default('1'),mix: Double = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 A compressor is mainly used to reduce the dynamic range of a signal.
 Especially modern music is mostly compressed at a high ratio to
 improve the overall loudness. It's done to get the highest attention
@@ -252,59 +252,59 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acompressor)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acompressor', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "mode": mode,
-                
+
                 "threshold": threshold,
-                
+
                 "ratio": ratio,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "makeup": makeup,
-                
+
                 "knee": knee,
-                
+
                 "link": link,
-                
+
                 "detection": detection,
-                
+
                 "level_sc": level_sc,
-                
+
                 "mix": mix,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def acontrast(
-    
+
     self,
 
 
@@ -312,12 +312,12 @@ References:
 
     *,
     contrast: Float = Default('33'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Simple audio dynamic range compression/expansion filter.
 
 The filter accepts the following options:
@@ -334,50 +334,50 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acontrast)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acontrast', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "contrast": contrast,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def acopy(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Copy the input audio source unchanged to the output. This is mainly useful for
 testing purposes.
 
@@ -392,56 +392,56 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acopy)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acopy', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def acrossfade(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _crossfade1: AudioStream,
-        
-    
+
+
 
 
     *,
     nb_samples: Int = Default('44100'),duration: Duration = Default('0'),overlap: Boolean = Default('true'),curve1: Int| Literal["nofade","tri","qsin","esin","hsin","log","ipar","qua","cub","squ","cbr","par","exp","iqsin","ihsin","dese","desi","losi","sinc","isinc"] | Default = Default('tri'),curve2: Int| Literal["nofade","tri","qsin","esin","hsin","log","ipar","qua","cub","squ","cbr","par","exp","iqsin","ihsin","dese","desi","losi","sinc","isinc"] | Default = Default('tri'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply cross fade from one input audio stream to another input audio stream.
 The cross fade is applied for specified duration near the end of first stream.
 
@@ -463,53 +463,53 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acrossfade)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acrossfade', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _crossfade1,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "nb_samples": nb_samples,
-                
+
                 "duration": duration,
-                
+
                 "overlap": overlap,
-                
+
                 "curve1": curve1,
-                
+
                 "curve2": curve2,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def acrossover(
-    
+
     self,
 
 
@@ -517,12 +517,12 @@ References:
 
     *,
     split: String = Default('500'),order: Int| Literal["2nd","4th","6th","8th","10th","12th","14th","16th","18th","20th"] | Default = Default('4th'),level: Float = Default('1'),gain: String = Default('1.f'),precision: Int| Literal["auto","float","double"] | Default = Default('auto'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Split audio stream into several bands.
 
 This filter splits audio stream into two or more frequency ranges.
@@ -547,46 +547,46 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acrossover)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acrossover', typings_input=('audio',), typings_output="[StreamType.audio] * len(re.split(r'[ |]+', str(split)))"),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "split": split,
-                
+
                 "order": order,
-                
+
                 "level": level,
-                
+
                 "gain": gain,
-                
+
                 "precision": precision,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def acrusher(
-    
+
     self,
 
 
@@ -594,15 +594,15 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),bits: Double = Default('8'),mix: Double = Default('0.5'),mode: Int| Literal["lin","log"] | Default = Default('lin'),dc: Double = Default('1'),aa: Double = Default('0.5'),samples: Double = Default('1'),lfo: Boolean = Default('false'),lforange: Double = Default('20'),lforate: Double = Default('0.3'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Reduce audio bit resolution.
 
 This filter is bit crusher with enhanced functionality. A bit crusher
@@ -647,7 +647,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acrusher)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -655,54 +655,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acrusher', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "bits": bits,
-                
+
                 "mix": mix,
-                
+
                 "mode": mode,
-                
+
                 "dc": dc,
-                
+
                 "aa": aa,
-                
+
                 "samples": samples,
-                
+
                 "lfo": lfo,
-                
+
                 "lforange": lforange,
-                
+
                 "lforate": lforate,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def acue(
-    
+
     self,
 
 
@@ -710,12 +710,12 @@ References:
 
     *,
     cue: Int64 = Default('0'),preroll: Duration = Default('0'),buffer: Duration = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Delay audio filtering until a given wallclock timestamp. See the cue
 filter.
 
@@ -733,43 +733,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acue)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acue', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cue": cue,
-                
+
                 "preroll": preroll,
-                
+
                 "buffer": buffer,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def adeclick(
-    
+
     self,
 
 
@@ -777,15 +777,15 @@ References:
 
     *,
     window: Double = Default('55'),overlap: Double = Default('75'),arorder: Double = Default('2'),threshold: Double = Default('2'),burst: Double = Default('2'),method: Int| Literal["add","a","save","s"] | Default = Default('add'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Remove impulsive noise from input audio.
 
 Samples detected as impulsive noise are replaced by interpolated samples using
@@ -809,7 +809,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adeclick)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -817,44 +817,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adeclick', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "window": window,
-                
+
                 "overlap": overlap,
-                
+
                 "arorder": arorder,
-                
+
                 "threshold": threshold,
-                
+
                 "burst": burst,
-                
+
                 "method": method,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adeclip(
-    
+
     self,
 
 
@@ -862,15 +862,15 @@ References:
 
     *,
     window: Double = Default('55'),overlap: Double = Default('75'),arorder: Double = Default('8'),threshold: Double = Default('10'),hsize: Int = Default('1000'),method: Int| Literal["add","a","save","s"] | Default = Default('add'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Remove clipped samples from input audio.
 
 Samples detected as clipped are replaced by interpolated samples using
@@ -894,7 +894,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adeclip)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -902,44 +902,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adeclip', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "window": window,
-                
+
                 "overlap": overlap,
-                
+
                 "arorder": arorder,
-                
+
                 "threshold": threshold,
-                
+
                 "hsize": hsize,
-                
+
                 "method": method,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adecorrelate(
-    
+
     self,
 
 
@@ -947,15 +947,15 @@ References:
 
     *,
     stages: Int = Default('6'),seed: Int64 = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply decorrelation to input audio stream.
 
 The filter accepts the following options:
@@ -974,7 +974,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adecorrelate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -982,36 +982,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adecorrelate', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "stages": stages,
-                
+
                 "seed": seed,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adelay(
-    
+
     self,
 
 
@@ -1019,15 +1019,15 @@ References:
 
     *,
     delays: String = Default(None),all: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Delay one or more audio channels.
 
 Samples in delayed channel are filled with silence.
@@ -1048,7 +1048,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adelay)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1056,36 +1056,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adelay', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "delays": delays,
-                
+
                 "all": all,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adenorm(
-    
+
     self,
 
 
@@ -1093,15 +1093,15 @@ References:
 
     *,
     level: Double = Default('-351'),type: Int| Literal["dc","ac","square","pulse"] | Default = Default('dc'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Remedy denormals in audio by adding extremely low-level noise.
 
 This filter shall be placed before any filter that can produce denormals.
@@ -1122,7 +1122,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adenorm)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1130,52 +1130,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adenorm', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level": level,
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aderivative(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Compute derivative/integral of audio stream.
 
 Applying both filters one after another produces original audio.
@@ -1192,7 +1192,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aderivative)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1200,32 +1200,32 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aderivative', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adrawgraph(
-    
+
     self,
 
 
@@ -1233,12 +1233,12 @@ References:
 
     *,
     m1: String = Default(''),fg1: String = Default('0xffff0000'),m2: String = Default(''),fg2: String = Default('0xff00ff00'),m3: String = Default(''),fg3: String = Default('0xffff00ff'),m4: String = Default(''),fg4: String = Default('0xffffff00'),bg: Color = Default('white'),min: Float = Default('-1'),max: Float = Default('1'),mode: Int| Literal["bar","dot","line"] | Default = Default('line'),slide: Int| Literal["frame","replace","scroll","rscroll","picture"] | Default = Default('frame'),size: Image_size = Default('900x256'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw a graph using input audio metadata.
 
 See drawgraph
@@ -1269,65 +1269,65 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adrawgraph)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adrawgraph', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "m1": m1,
-                
+
                 "fg1": fg1,
-                
+
                 "m2": m2,
-                
+
                 "fg2": fg2,
-                
+
                 "m3": m3,
-                
+
                 "fg3": fg3,
-                
+
                 "m4": m4,
-                
+
                 "fg4": fg4,
-                
+
                 "bg": bg,
-                
+
                 "min": min,
-                
+
                 "max": max,
-                
+
                 "mode": mode,
-                
+
                 "slide": slide,
-                
+
                 "size": size,
-                
+
                 "rate": rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adynamicequalizer(
-    
+
     self,
 
 
@@ -1335,15 +1335,15 @@ References:
 
     *,
     threshold: Double = Default('0'),dfrequency: Double = Default('1000'),dqfactor: Double = Default('1'),tfrequency: Double = Default('1000'),tqfactor: Double = Default('1'),attack: Double = Default('20'),release: Double = Default('200'),knee: Double = Default('1'),ratio: Double = Default('1'),makeup: Double = Default('0'),range: Double = Default('0'),slew: Double = Default('1'),mode: Int| Literal["listen","cut","boost"] | Default = Default('cut'),tftype: Int| Literal["bell","lowshelf","highshelf"] | Default = Default('bell'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply dynamic equalization to input audio stream.
 
 A description of the accepted options follows.
@@ -1374,7 +1374,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adynamicequalizer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1382,60 +1382,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adynamicequalizer', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold": threshold,
-                
+
                 "dfrequency": dfrequency,
-                
+
                 "dqfactor": dqfactor,
-                
+
                 "tfrequency": tfrequency,
-                
+
                 "tqfactor": tqfactor,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "knee": knee,
-                
+
                 "ratio": ratio,
-                
+
                 "makeup": makeup,
-                
+
                 "range": range,
-                
+
                 "slew": slew,
-                
+
                 "mode": mode,
-                
+
                 "tftype": tftype,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adynamicsmooth(
-    
+
     self,
 
 
@@ -1443,15 +1443,15 @@ References:
 
     *,
     sensitivity: Double = Default('2'),basefreq: Double = Default('22050'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply dynamic smoothing to input audio stream.
 
 A description of the accepted options follows.
@@ -1470,7 +1470,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adynamicsmooth)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1478,36 +1478,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adynamicsmooth', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sensitivity": sensitivity,
-                
+
                 "basefreq": basefreq,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aecho(
-    
+
     self,
 
 
@@ -1515,12 +1515,12 @@ References:
 
     *,
     in_gain: Float = Default('0.6'),out_gain: Float = Default('0.3'),delays: String = Default('1000'),decays: String = Default('0.5'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply echoing to the input audio.
 
 Echoes are reflected sound and can occur naturally amongst mountains
@@ -1548,43 +1548,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aecho)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aecho', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "in_gain": in_gain,
-                
+
                 "out_gain": out_gain,
-                
+
                 "delays": delays,
-                
+
                 "decays": decays,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aemphasis(
-    
+
     self,
 
 
@@ -1592,15 +1592,15 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),mode: Int| Literal["reproduction","production"] | Default = Default('reproduction'),type: Int| Literal["col","emi","bsi","riaa","cd","50fm","75fm","50kf","75kf"] | Default = Default('cd'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Audio emphasis filter creates or restores material directly taken from LPs or
 emphased CDs with different filter curves. E.g. to store music on vinyl the
 signal has to be altered by a filter first to even out the disadvantages of
@@ -1626,7 +1626,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aemphasis)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1634,40 +1634,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aemphasis', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "mode": mode,
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aeval(
-    
+
     self,
 
 
@@ -1675,15 +1675,15 @@ References:
 
     *,
     exprs: String = Default(None),channel_layout: String = Default(None),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Modify an audio signal according to the specified expressions.
 
 This filter accepts one or more expressions (one for each channel),
@@ -1705,7 +1705,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aeval)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1713,38 +1713,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aeval', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "exprs": exprs,
-                
+
                 "channel_layout": channel_layout,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def aexciter(
-    
+
     self,
 
 
@@ -1752,15 +1752,15 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),amount: Double = Default('1'),drive: Double = Default('8.5'),blend: Double = Default('0'),freq: Double = Default('7500'),ceil: Double = Default('9999'),listen: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 An exciter is used to produce high sound that is not present in the
 original signal. This is done by creating harmonic distortions of the
 signal which are restricted in range and added to the original signal.
@@ -1790,7 +1790,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aexciter)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1798,48 +1798,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aexciter', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "amount": amount,
-                
+
                 "drive": drive,
-                
+
                 "blend": blend,
-                
+
                 "freq": freq,
-                
+
                 "ceil": ceil,
-                
+
                 "listen": listen,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def afade(
-    
+
     self,
 
 
@@ -1847,15 +1847,15 @@ References:
 
     *,
     type: Int| Literal["in","out"] | Default = Default('in'),start_sample: Int64 = Default('0'),nb_samples: Int64 = Default('44100'),start_time: Duration = Default('0'),duration: Duration = Default('0'),curve: Int| Literal["nofade","tri","qsin","esin","hsin","log","ipar","qua","cub","squ","cbr","par","exp","iqsin","ihsin","dese","desi","losi","sinc","isinc"] | Default = Default('tri'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply fade-in/out effect to input audio.
 
 A description of the accepted parameters follows.
@@ -1878,7 +1878,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afade)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1886,44 +1886,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='afade', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "type": type,
-                
+
                 "start_sample": start_sample,
-                
+
                 "nb_samples": nb_samples,
-                
+
                 "start_time": start_time,
-                
+
                 "duration": duration,
-                
+
                 "curve": curve,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def afftdn(
-    
+
     self,
 
 
@@ -1931,15 +1931,15 @@ References:
 
     *,
     noise_reduction: Float = Default('12'),noise_floor: Float = Default('-50'),noise_type: Int| Literal["white","w","vinyl","v","shellac","s","custom","c"] | Default = Default('white'),band_noise: String = Default(None),residual_floor: Float = Default('-38'),track_noise: Boolean = Default('false'),track_residual: Boolean = Default('false'),output_mode: Int| Literal["input","i","output","o","noise","n"] | Default = Default('output'),adaptivity: Float = Default('0.5'),floor_offset: Float = Default('1'),noise_link: Int| Literal["none","min","max","average"] | Default = Default('min'),band_multiplier: Float = Default('1.25'),sample_noise: Int| Literal["none","start","begin","stop","end"] | Default = Default('none'),gain_smooth: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Denoise audio samples with FFT.
 
 A description of the accepted parameters follows.
@@ -1970,7 +1970,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afftdn)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1978,60 +1978,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='afftdn', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "noise_reduction": noise_reduction,
-                
+
                 "noise_floor": noise_floor,
-                
+
                 "noise_type": noise_type,
-                
+
                 "band_noise": band_noise,
-                
+
                 "residual_floor": residual_floor,
-                
+
                 "track_noise": track_noise,
-                
+
                 "track_residual": track_residual,
-                
+
                 "output_mode": output_mode,
-                
+
                 "adaptivity": adaptivity,
-                
+
                 "floor_offset": floor_offset,
-                
+
                 "noise_link": noise_link,
-                
+
                 "band_multiplier": band_multiplier,
-                
+
                 "sample_noise": sample_noise,
-                
+
                 "gain_smooth": gain_smooth,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def afftfilt(
-    
+
     self,
 
 
@@ -2039,15 +2039,15 @@ References:
 
     *,
     real: String = Default('re'),imag: String = Default('im'),win_size: Int = Default('4096'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman"] | Default = Default('hann'),overlap: Float = Default('0.75'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply arbitrary expressions to samples in frequency domain.
 
 
@@ -2067,7 +2067,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afftfilt)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2075,55 +2075,55 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='afftfilt', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "real": real,
-                
+
                 "imag": imag,
-                
+
                 "win_size": win_size,
-                
+
                 "win_func": win_func,
-                
+
                 "overlap": overlap,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def afifo(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Buffer input images and send them when they are requested.
 
 It is mainly useful when auto-inserted by the libavfilter
@@ -2142,37 +2142,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fifo)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='afifo', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def aformat(
-    
+
     self,
 
 
@@ -2180,12 +2180,12 @@ References:
 
     *,
     sample_fmts: String = Default(None),sample_rates: String = Default(None),channel_layouts: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Set output format constraints for the input audio. The framework will
 negotiate the most appropriate format to minimize conversions.
 
@@ -2205,41 +2205,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aformat)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aformat', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sample_fmts": sample_fmts,
-                
+
                 "sample_rates": sample_rates,
-                
+
                 "channel_layouts": channel_layouts,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def afreqshift(
-    
+
     self,
 
 
@@ -2247,15 +2247,15 @@ References:
 
     *,
     shift: Double = Default('0'),level: Double = Default('1'),order: Int = Default('8'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply frequency shift to input audio samples.
 
 The filter accepts the following options:
@@ -2275,7 +2275,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afreqshift)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2283,38 +2283,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='afreqshift', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "shift": shift,
-                
+
                 "level": level,
-                
+
                 "order": order,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def afwtdn(
-    
+
     self,
 
 
@@ -2322,15 +2322,15 @@ References:
 
     *,
     sigma: Double = Default('0'),levels: Int = Default('10'),wavet: Int| Literal["sym2","sym4","rbior68","deb10","sym10","coif5","bl3"] | Default = Default('sym10'),percent: Double = Default('85'),profile: Boolean = Default('false'),adaptive: Boolean = Default('false'),samples: Int = Default('8192'),softness: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Reduce broadband noise from input samples using Wavelets.
 
 A description of the accepted options follows.
@@ -2355,7 +2355,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afwtdn)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2363,48 +2363,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='afwtdn', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sigma": sigma,
-                
+
                 "levels": levels,
-                
+
                 "wavet": wavet,
-                
+
                 "percent": percent,
-                
+
                 "profile": profile,
-                
+
                 "adaptive": adaptive,
-                
+
                 "samples": samples,
-                
+
                 "softness": softness,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def agate(
-    
+
     self,
 
 
@@ -2412,15 +2412,15 @@ References:
 
     *,
     level_in: Double = Default('1'),mode: Int| Literal["downward","upward"] | Default = Default('downward'),range: Double = Default('0.06125'),threshold: Double = Default('0.125'),ratio: Double = Default('2'),attack: Double = Default('20'),release: Double = Default('250'),makeup: Double = Default('1'),knee: Double = Default('2.82843'),detection: Int| Literal["peak","rms"] | Default = Default('rms'),link: Int| Literal["average","maximum"] | Default = Default('average'),level_sc: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 A gate is mainly used to reduce lower parts of a signal. This kind of signal
 processing reduces disturbing noise between useful signals.
 
@@ -2459,7 +2459,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#agate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2467,56 +2467,56 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='agate', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "mode": mode,
-                
+
                 "range": range,
-                
+
                 "threshold": threshold,
-                
+
                 "ratio": ratio,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "makeup": makeup,
-                
+
                 "knee": knee,
-                
+
                 "detection": detection,
-                
+
                 "link": link,
-                
+
                 "level_sc": level_sc,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def agraphmonitor(
-    
+
     self,
 
 
@@ -2524,12 +2524,12 @@ References:
 
     *,
     size: Image_size = Default('hd720'),opacity: Float = Default('0.9'),mode: Int| Literal["full","compact"] | Default = Default('full'),flags: Flags| Literal["queue","frame_count_in","frame_count_out","frame_count_delta","pts","pts_delta","time","time_delta","timebase","format","size","rate","eof","sample_count_in","sample_count_out","sample_count_delta"] | Default = Default('queue'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 See graphmonitor.
 
 
@@ -2548,45 +2548,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#agraphmonitor)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='agraphmonitor', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "opacity": opacity,
-                
+
                 "mode": mode,
-                
+
                 "flags": flags,
-                
+
                 "rate": rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ahistogram(
-    
+
     self,
 
 
@@ -2594,12 +2594,12 @@ References:
 
     *,
     dmode: Int| Literal["single","separate"] | Default = Default('single'),rate: Video_rate = Default('25'),size: Image_size = Default('hd720'),scale: Int| Literal["log","sqrt","cbrt","lin","rlog"] | Default = Default('log'),ascale: Int| Literal["log","lin"] | Default = Default('log'),acount: Int = Default('1'),rheight: Float = Default('0.1'),slide: Int| Literal["replace","scroll"] | Default = Default('replace'),hmode: Int| Literal["abs","sign"] | Default = Default('abs'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a video output, displaying the volume histogram.
 
 The filter accepts the following options:
@@ -2624,53 +2624,53 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ahistogram)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ahistogram', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dmode": dmode,
-                
+
                 "rate": rate,
-                
+
                 "size": size,
-                
+
                 "scale": scale,
-                
+
                 "ascale": ascale,
-                
+
                 "acount": acount,
-                
+
                 "rheight": rheight,
-                
+
                 "slide": slide,
-                
+
                 "hmode": hmode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aiir(
-    
+
     self,
 
 
@@ -2678,12 +2678,12 @@ References:
 
     *,
     zeros: String = Default('1+0i 1-0i'),poles: String = Default('1+0i 1-0i'),gains: String = Default('1|1'),dry: Double = Default('1'),wet: Double = Default('1'),format: Int| Literal["ll","sf","tf","zp","pr","pd","sp"] | Default = Default('zp'),process: Int| Literal["d","s","p"] | Default = Default('s'),precision: Int| Literal["dbl","flt","i32","i16"] | Default = Default('dbl'),e: Int| Literal["dbl","flt","i32","i16"] | Default = Default('dbl'),normalize: Boolean = Default('true'),mix: Double = Default('1'),response: Boolean = Default('false'),channel: Int = Default('0'),size: Image_size = Default('hd720'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Apply an arbitrary Infinite Impulse Response filter.
 
 It accepts the following parameters:
@@ -2715,82 +2715,82 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aiir)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aiir', typings_input=('audio',), typings_output='[StreamType.audio] + [StreamType.video] if response else []'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "zeros": zeros,
-                
+
                 "poles": poles,
-                
+
                 "gains": gains,
-                
+
                 "dry": dry,
-                
+
                 "wet": wet,
-                
+
                 "format": format,
-                
+
                 "process": process,
-                
+
                 "precision": precision,
-                
+
                 "e": e,
-                
+
                 "normalize": normalize,
-                
+
                 "mix": mix,
-                
+
                 "response": response,
-                
+
                 "channel": channel,
-                
+
                 "size": size,
-                
+
                 "rate": rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aintegral(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Compute derivative/integral of audio stream.
 
 Applying both filters one after another produces original audio.
@@ -2807,7 +2807,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aderivative)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2815,50 +2815,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aintegral', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def alatency(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Measure filtering latency.
 
 Report previous filter filtering latency, delay in number of audio samples for audio filters
@@ -2879,7 +2879,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#latency)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2887,32 +2887,32 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='alatency', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def alimiter(
-    
+
     self,
 
 
@@ -2920,15 +2920,15 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),limit: Double = Default('1'),attack: Double = Default('5'),release: Double = Default('50'),asc: Boolean = Default('false'),asc_level: Double = Default('0.5'),level: Boolean = Default('true'),latency: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 The limiter prevents an input signal from rising over a desired threshold.
 This limiter uses lookahead technology to prevent your signal from distorting.
 It means that there is a small delay after the signal is processed. Keep in mind
@@ -2957,7 +2957,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#alimiter)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2965,50 +2965,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='alimiter', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "limit": limit,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "asc": asc,
-                
+
                 "asc_level": asc_level,
-                
+
                 "level": level,
-                
+
                 "latency": latency,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def allpass(
-    
+
     self,
 
 
@@ -3016,15 +3016,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.707'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),order: Int = Default('2'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a two-pole all-pass filter with central frequency (in Hz)
 frequency, and filter-width width.
 An all-pass filter changes the audio's frequency to phase relationship
@@ -3053,7 +3053,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allpass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3061,54 +3061,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='allpass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "order": order,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def aloop(
-    
+
     self,
 
 
@@ -3116,12 +3116,12 @@ References:
 
     *,
     loop: Int = Default('0'),size: Int64 = Default('0'),start: Int64 = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Loop audio samples.
 
 The filter accepts the following options:
@@ -3140,47 +3140,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aloop)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aloop', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "loop": loop,
-                
+
                 "size": size,
-                
+
                 "start": start,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def ametadata(
-    
+
     self,
 
 
@@ -3188,15 +3188,15 @@ References:
 
     *,
     mode: Int| Literal["select","add","modify","delete","print"] | Default = Default('select'),key: String = Default(None),value: String = Default(None),function: Int| Literal["same_str","starts_with","less","equal","greater","expr","ends_with"] | Default = Default('same_str'),expr: String = Default(None),file: String = Default(None),direct: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Manipulate frame metadata.
 
 This filter accepts the following options:
@@ -3220,7 +3220,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#metadata)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3228,73 +3228,73 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ametadata', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "key": key,
-                
+
                 "value": value,
-                
+
                 "function": function,
-                
+
                 "expr": expr,
-                
+
                 "file": file,
-                
+
                 "direct": direct,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def amultiply(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _multiply1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Multiply first audio stream with second audio stream and store result
 in output audio stream. Multiplication is done by multiplying each
 sample from first stream with sample at same position from second stream.
@@ -3313,43 +3313,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amultiply)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='amultiply', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _multiply1,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def anequalizer(
-    
+
     self,
 
 
@@ -3357,15 +3357,15 @@ References:
 
     *,
     params: String = Default(''),curves: Boolean = Default('false'),size: Image_size = Default('hd720'),mgain: Double = Default('60'),fscale: Int| Literal["lin","log"] | Default = Default('log'),colors: String = Default('red|green|blue|yellow|orange|lime|pink|magenta|brown'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 High-order parametric multiband equalizer for each channel.
 
 It accepts the following parameters:
@@ -3389,7 +3389,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anequalizer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3397,45 +3397,45 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='anequalizer', typings_input=('audio',), typings_output='[StreamType.audio] + [StreamType.video] if curves else []'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "params": params,
-                
+
                 "curves": curves,
-                
+
                 "size": size,
-                
+
                 "mgain": mgain,
-                
+
                 "fscale": fscale,
-                
+
                 "colors": colors,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def anlmdn(
-    
+
     self,
 
 
@@ -3443,15 +3443,15 @@ References:
 
     *,
     strength: Float = Default('1e-05'),patch: Duration = Default('0.002'),research: Duration = Default('0.006'),output: Int| Literal["i","o","n"] | Default = Default('o'),smooth: Float = Default('11'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Reduce broadband noise in audio samples using Non-Local Means algorithm.
 
 Each sample is adjusted by looking for other samples with similar contexts. This
@@ -3477,7 +3477,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anlmdn)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3485,66 +3485,66 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='anlmdn', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "strength": strength,
-                
+
                 "patch": patch,
-                
+
                 "research": research,
-                
+
                 "output": output,
-                
+
                 "smooth": smooth,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def anlmf(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('256'),mu: Float = Default('0.75'),eps: Float = Default('1'),leakage: Float = Default('0'),out_mode: Int| Literal["i","d","o","n"] | Default = Default('o'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply Normalized Least-Mean-(Squares|Fourth) algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to mimic a desired filter by finding the filter coefficients that
@@ -3570,7 +3570,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anlmf)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3578,74 +3578,74 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='anlmf', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _desired,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "order": order,
-                
+
                 "mu": mu,
-                
+
                 "eps": eps,
-                
+
                 "leakage": leakage,
-                
+
                 "out_mode": out_mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def anlms(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('256'),mu: Float = Default('0.75'),eps: Float = Default('1'),leakage: Float = Default('0'),out_mode: Int| Literal["i","d","o","n"] | Default = Default('o'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply Normalized Least-Mean-(Squares|Fourth) algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to mimic a desired filter by finding the filter coefficients that
@@ -3671,7 +3671,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anlmf)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3679,65 +3679,65 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='anlms', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _desired,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "order": order,
-                
+
                 "mu": mu,
-                
+
                 "eps": eps,
-                
+
                 "leakage": leakage,
-                
+
                 "out_mode": out_mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def anull(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Pass the audio source unchanged to the output.
 
 
@@ -3751,39 +3751,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anull)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='anull', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def apad(
-    
+
     self,
 
 
@@ -3791,15 +3791,15 @@ References:
 
     *,
     packet_size: Int = Default('4096'),pad_len: Int64 = Default('-1'),whole_len: Int64 = Default('-1'),pad_dur: Duration = Default('-0.000001'),whole_dur: Duration = Default('-0.000001'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Pad the end of an audio stream with silence.
 
 This can be used together with ffmpeg -shortest to
@@ -3824,7 +3824,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#apad)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3832,42 +3832,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='apad', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "packet_size": packet_size,
-                
+
                 "pad_len": pad_len,
-                
+
                 "whole_len": whole_len,
-                
+
                 "pad_dur": pad_dur,
-                
+
                 "whole_dur": whole_dur,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aperms(
-    
+
     self,
 
 
@@ -3875,15 +3875,15 @@ References:
 
     *,
     mode: Int| Literal["none","ro","rw","toggle","random"] | Default = Default('none'),seed: Int64 = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Set read/write permissions for the output frames.
 
 These filters are mainly aimed at developers to test direct path in the
@@ -3905,7 +3905,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#perms)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3913,36 +3913,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aperms', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "seed": seed,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aphasemeter(
-    
+
     self,
 
 
@@ -3950,12 +3950,12 @@ References:
 
     *,
     rate: Video_rate = Default('25'),size: Image_size = Default('800x400'),rc: Int = Default('2'),gc: Int = Default('7'),bc: Int = Default('1'),mpc: String = Default('none'),video: Boolean = Default('true'),phasing: Boolean = Default('false'),tolerance: Float = Default('0'),angle: Float = Default('170'),duration: Duration = Default('2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Measures phase of input audio, which is exported as metadata lavfi.aphasemeter.phase,
 representing mean phase of current audio frame. A video output can also be produced and is
 enabled by default. The audio is passed through as first output.
@@ -3989,58 +3989,58 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aphasemeter)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aphasemeter', typings_input=('audio',), typings_output='[StreamType.audio] + ([StreamType.video] if video else [])'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rate": rate,
-                
+
                 "size": size,
-                
+
                 "rc": rc,
-                
+
                 "gc": gc,
-                
+
                 "bc": bc,
-                
+
                 "mpc": mpc,
-                
+
                 "video": video,
-                
+
                 "phasing": phasing,
-                
+
                 "tolerance": tolerance,
-                
+
                 "angle": angle,
-                
+
                 "duration": duration,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aphaser(
-    
+
     self,
 
 
@@ -4048,12 +4048,12 @@ References:
 
     *,
     in_gain: Double = Default('0.4'),out_gain: Double = Default('0.74'),delay: Double = Default('3'),decay: Double = Default('0.4'),speed: Double = Default('0.5'),type: Int| Literal["triangular","t","sinusoidal","s"] | Default = Default('triangular'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Add a phasing effect to the input audio.
 
 A phaser filter creates series of peaks and troughs in the frequency spectrum.
@@ -4078,47 +4078,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aphaser)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aphaser', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "in_gain": in_gain,
-                
+
                 "out_gain": out_gain,
-                
+
                 "delay": delay,
-                
+
                 "decay": decay,
-                
+
                 "speed": speed,
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aphaseshift(
-    
+
     self,
 
 
@@ -4126,15 +4126,15 @@ References:
 
     *,
     shift: Double = Default('0'),level: Double = Default('1'),order: Int = Default('8'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply phase shift to input audio samples.
 
 The filter accepts the following options:
@@ -4154,7 +4154,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aphaseshift)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4162,38 +4162,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aphaseshift', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "shift": shift,
-                
+
                 "level": level,
-                
+
                 "order": order,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def apsyclip(
-    
+
     self,
 
 
@@ -4201,15 +4201,15 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),clip: Double = Default('1'),diff: Boolean = Default('false'),adaptive: Double = Default('0.5'),iterations: Int = Default('10'),level: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply Psychoacoustic clipper to input audio stream.
 
 The filter accepts the following options:
@@ -4233,7 +4233,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#apsyclip)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4241,46 +4241,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='apsyclip', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "clip": clip,
-                
+
                 "diff": diff,
-                
+
                 "adaptive": adaptive,
-                
+
                 "iterations": iterations,
-                
+
                 "level": level,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def apulsator(
-    
+
     self,
 
 
@@ -4288,12 +4288,12 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),mode: Int| Literal["sine","triangle","square","sawup","sawdown"] | Default = Default('sine'),amount: Double = Default('1'),offset_l: Double = Default('0'),offset_r: Double = Default('0.5'),width: Double = Default('1'),timing: Int| Literal["bpm","ms","hz"] | Default = Default('hz'),bpm: Double = Default('120'),ms: Int = Default('500'),hz: Double = Default('2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Audio pulsator is something between an autopanner and a tremolo.
 But it can produce funny stereo effects as well. Pulsator changes the volume
 of the left and right channel based on a LFO (low frequency oscillator) with
@@ -4332,57 +4332,57 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#apulsator)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='apulsator', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "mode": mode,
-                
+
                 "amount": amount,
-                
+
                 "offset_l": offset_l,
-                
+
                 "offset_r": offset_r,
-                
+
                 "width": width,
-                
+
                 "timing": timing,
-                
+
                 "bpm": bpm,
-                
+
                 "ms": ms,
-                
+
                 "hz": hz,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def arealtime(
-    
+
     self,
 
 
@@ -4390,12 +4390,12 @@ References:
 
     *,
     limit: Duration = Default('2'),speed: Double = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Slow down filtering to match real time approximately.
 
 These filters will pause the filtering for a variable amount of time to
@@ -4417,39 +4417,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#realtime)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='arealtime', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "limit": limit,
-                
+
                 "speed": speed,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aresample(
-    
+
     self,
 
 
@@ -4457,12 +4457,12 @@ References:
 
     *,
     sample_rate: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Resample the input audio to the specified parameters, using the
 libswresample library. If none are specified then the filter will
 automatically convert between its input and output.
@@ -4491,50 +4491,50 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aresample)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aresample', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sample_rate": sample_rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def areverse(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Reverse an audio clip.
 
 Warning: This filter requires memory to buffer the entire clip, so trimming
@@ -4551,35 +4551,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#areverse)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='areverse', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def arnndn(
-    
+
     self,
 
 
@@ -4587,15 +4587,15 @@ References:
 
     *,
     model: String = Default(None),mix: Float = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Reduce noise from speech using Recurrent Neural Networks.
 
 This filter accepts the following options:
@@ -4614,7 +4614,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#arnndn)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4622,57 +4622,57 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='arnndn', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "model": model,
-                
+
                 "mix": mix,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asdr(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _input1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Measure Audio Signal-to-Distortion Ratio.
 
 This filter takes two audio streams for input, and outputs first
@@ -4690,43 +4690,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asdr)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asdr', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _input1,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asegment(
-    
+
     self,
 
 
@@ -4734,12 +4734,12 @@ References:
 
     *,
     timestamps: String = Default(None),samples: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Split single input stream into multiple streams.
 
 This filter does opposite of concat filters.
@@ -4762,40 +4762,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#segment)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asegment', typings_input=('audio',), typings_output="[StreamType.audio] * len(str(timestamps or samples).split('|'))"),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "timestamps": timestamps,
-                
+
                 "samples": samples,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aselect(
-    
+
     self,
 
 
@@ -4803,12 +4803,12 @@ References:
 
     *,
     expr: String = Default('1'),outputs: Int = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Select frames to pass in output.
 
 This filter accepts the following options:
@@ -4827,40 +4827,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#select)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aselect', typings_input=('audio',), typings_output='[StreamType.audio] * int(outputs)'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "expr": expr,
-                
+
                 "outputs": outputs,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asendcmd(
-    
+
     self,
 
 
@@ -4868,12 +4868,12 @@ References:
 
     *,
     commands: String = Default(None),filename: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Send commands to filters in the filtergraph.
 
 These filters read commands to be sent to other filters in the
@@ -4902,39 +4902,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sendcmd)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asendcmd', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "commands": commands,
-                
+
                 "filename": filename,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asetnsamples(
-    
+
     self,
 
 
@@ -4942,12 +4942,12 @@ References:
 
     *,
     nb_out_samples: Int = Default('1024'),pad: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Set the number of samples per each output audio frame.
 
 The last output packet may contain a different number of samples, as
@@ -4969,39 +4969,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asetnsamples)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asetnsamples', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "nb_out_samples": nb_out_samples,
-                
+
                 "pad": pad,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asetpts(
-    
+
     self,
 
 
@@ -5009,12 +5009,12 @@ References:
 
     *,
     expr: String = Default('PTS'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Change the PTS (presentation timestamp) of the input frames.
 
 setpts works on video frames, asetpts on audio frames.
@@ -5033,37 +5033,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setpts)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asetpts', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "expr": expr,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asetrate(
-    
+
     self,
 
 
@@ -5071,12 +5071,12 @@ References:
 
     *,
     sample_rate: Int = Default('44100'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Set the sample rate without altering the PCM data.
 This will result in a change of speed and pitch.
 
@@ -5094,37 +5094,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asetrate)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asetrate', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sample_rate": sample_rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asettb(
-    
+
     self,
 
 
@@ -5132,12 +5132,12 @@ References:
 
     *,
     expr: String = Default('intb'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Set the timebase to use for the output frames timestamps.
 It is mainly useful for testing timebase configuration.
 
@@ -5155,50 +5155,50 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#settb)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asettb', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "expr": expr,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ashowinfo(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Show a line containing various information for each input audio frame.
 The input audio is not modified.
 
@@ -5218,35 +5218,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ashowinfo)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ashowinfo', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asidedata(
-    
+
     self,
 
 
@@ -5254,15 +5254,15 @@ References:
 
     *,
     mode: Int| Literal["select","delete"] | Default = Default('select'),type: Int| Literal["PANSCAN","A53_CC","STEREO3D","MATRIXENCODING","DOWNMIX_INFO","REPLAYGAIN","DISPLAYMATRIX","AFD","MOTION_VECTORS","SKIP_SAMPLES","AUDIO_SERVICE_TYPE","MASTERING_DISPLAY_METADATA","GOP_TIMECODE","SPHERICAL","CONTENT_LIGHT_LEVEL","ICC_PROFILE","S12M_TIMECOD","DYNAMIC_HDR_PLUS","REGIONS_OF_INTEREST","DETECTION_BOUNDING_BOXES","SEI_UNREGISTERED"] | Default = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Delete frame side data, or select frames based on it.
 
 This filter accepts the following options:
@@ -5281,7 +5281,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sidedata)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5289,36 +5289,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asidedata', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asoftclip(
-    
+
     self,
 
 
@@ -5326,15 +5326,15 @@ References:
 
     *,
     type: Int| Literal["hard","tanh","atan","cubic","exp","alg","quintic","sin","erf"] | Default = Default('tanh'),threshold: Double = Default('1'),output: Double = Default('1'),param: Double = Default('1'),oversample: Int = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply audio soft clipping.
 
 Soft clipping is a type of distortion effect where the amplitude of a signal is saturated
@@ -5359,7 +5359,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asoftclip)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5367,42 +5367,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asoftclip', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "type": type,
-                
+
                 "threshold": threshold,
-                
+
                 "output": output,
-                
+
                 "param": param,
-                
+
                 "oversample": oversample,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aspectralstats(
-    
+
     self,
 
 
@@ -5410,12 +5410,12 @@ References:
 
     *,
     win_size: Int = Default('2048'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman"] | Default = Default('hann'),overlap: Float = Default('0.5'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Display frequency domain statistical information about the audio channels.
 Statistics are calculated and stored as metadata for each audio channel and for each audio frame.
 
@@ -5435,41 +5435,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aspectralstats)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aspectralstats', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "win_size": win_size,
-                
+
                 "win_func": win_func,
-                
+
                 "overlap": overlap,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asplit(
-    
+
     self,
 
 
@@ -5477,12 +5477,12 @@ References:
 
     *,
     outputs: Int = Default('2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Split input into several identical outputs.
 
 asplit works with audio input, split with video.
@@ -5503,40 +5503,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#split)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asplit', typings_input=('audio',), typings_output='[StreamType.audio] * int(outputs)'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "outputs": outputs,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def astats(
-    
+
     self,
 
 
@@ -5544,12 +5544,12 @@ References:
 
     *,
     length: Double = Default('0.05'),metadata: Boolean = Default('false'),reset: Int = Default('0'),measure_perchannel: Flags| Literal["none","all","DC_offset","Min_level","Max_level","Min_difference","Max_difference","Mean_difference","RMS_difference","Peak_level","RMS_level","RMS_peak","RMS_trough","Crest_factor","Flat_factor","Peak_count","Bit_depth","Dynamic_range","Zero_crossings","Zero_crossings_rate","Noise_floor","Noise_floor_count","Entropy","Number_of_samples","Number_of_NaNs","Number_of_Infs","Number_of_denormals"] | Default = Default('all+DC_offset+Min_level+Max_level+Min_difference+Max_difference+Mean_difference+RMS_difference+Peak_level+RMS_level+RMS_peak+RMS_trough+Crest_factor+Flat_factor+Peak_count+Bit_depth+Dynamic_range+Zero_crossings+Zero_crossings_rate+Noise_floor+Noise_floor_count+Entropy+Number_of_samples+Number_of_NaNs+Number_of_Infs+Number_of_denormals'),measure_overall: Flags| Literal["none","all","DC_offset","Min_level","Max_level","Min_difference","Max_difference","Mean_difference","RMS_difference","Peak_level","RMS_level","RMS_peak","RMS_trough","Crest_factor","Flat_factor","Peak_count","Bit_depth","Dynamic_range","Zero_crossings","Zero_crossings_rate","Noise_floor","Noise_floor_count","Entropy","Number_of_samples","Number_of_NaNs","Number_of_Infs","Number_of_denormals"] | Default = Default('all+DC_offset+Min_level+Max_level+Min_difference+Max_difference+Mean_difference+RMS_difference+Peak_level+RMS_level+RMS_peak+RMS_trough+Crest_factor+Flat_factor+Peak_count+Bit_depth+Dynamic_range+Zero_crossings+Zero_crossings_rate+Noise_floor+Noise_floor_count+Entropy+Number_of_samples+Number_of_NaNs+Number_of_Infs+Number_of_denormals'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Display time domain statistical information about the audio channels.
 Statistics are calculated and displayed for each audio channel and,
 where applicable, an overall figure is also given.
@@ -5572,47 +5572,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#astats)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='astats', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "length": length,
-                
+
                 "metadata": metadata,
-                
+
                 "reset": reset,
-                
+
                 "measure_perchannel": measure_perchannel,
-                
+
                 "measure_overall": measure_overall,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def asubboost(
-    
+
     self,
 
 
@@ -5620,15 +5620,15 @@ References:
 
     *,
     dry: Double = Default('1'),wet: Double = Default('1'),boost: Double = Default('2'),decay: Double = Default('0'),feedback: Double = Default('0.9'),cutoff: Double = Default('100'),slope: Double = Default('0.5'),delay: Double = Default('20'),channels: String = Default('all'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Boost subwoofer frequencies.
 
 The filter accepts the following options:
@@ -5654,7 +5654,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asubboost)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5662,50 +5662,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asubboost', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dry": dry,
-                
+
                 "wet": wet,
-                
+
                 "boost": boost,
-                
+
                 "decay": decay,
-                
+
                 "feedback": feedback,
-                
+
                 "cutoff": cutoff,
-                
+
                 "slope": slope,
-                
+
                 "delay": delay,
-                
+
                 "channels": channels,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asubcut(
-    
+
     self,
 
 
@@ -5713,15 +5713,15 @@ References:
 
     *,
     cutoff: Double = Default('20'),order: Int = Default('10'),level: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Cut subwoofer frequencies.
 
 This filter allows to set custom, steeper
@@ -5745,7 +5745,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asubcut)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5753,38 +5753,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asubcut', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cutoff": cutoff,
-                
+
                 "order": order,
-                
+
                 "level": level,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asupercut(
-    
+
     self,
 
 
@@ -5792,15 +5792,15 @@ References:
 
     *,
     cutoff: Double = Default('20000'),order: Int = Default('10'),level: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Cut super frequencies.
 
 The filter accepts the following options:
@@ -5820,7 +5820,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asupercut)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5828,38 +5828,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asupercut', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cutoff": cutoff,
-                
+
                 "order": order,
-                
+
                 "level": level,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asuperpass(
-    
+
     self,
 
 
@@ -5867,15 +5867,15 @@ References:
 
     *,
     centerf: Double = Default('1000'),order: Int = Default('4'),qfactor: Double = Default('1'),level: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply high order Butterworth band-pass filter.
 
 The filter accepts the following options:
@@ -5896,7 +5896,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asuperpass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5904,40 +5904,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asuperpass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "centerf": centerf,
-                
+
                 "order": order,
-                
+
                 "qfactor": qfactor,
-                
+
                 "level": level,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asuperstop(
-    
+
     self,
 
 
@@ -5945,15 +5945,15 @@ References:
 
     *,
     centerf: Double = Default('1000'),order: Int = Default('4'),qfactor: Double = Default('1'),level: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply high order Butterworth band-stop filter.
 
 The filter accepts the following options:
@@ -5974,7 +5974,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asuperstop)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5982,42 +5982,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asuperstop', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "centerf": centerf,
-                
+
                 "order": order,
-                
+
                 "qfactor": qfactor,
-                
+
                 "level": level,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def atempo(
-    
+
     self,
 
 
@@ -6025,12 +6025,12 @@ References:
 
     *,
     tempo: Double = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Adjust audio tempo.
 
 The filter accepts exactly one parameter, the audio tempo. If not
@@ -6054,37 +6054,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#atempo)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='atempo', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "tempo": tempo,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def atilt(
-    
+
     self,
 
 
@@ -6092,15 +6092,15 @@ References:
 
     *,
     freq: Double = Default('10000'),slope: Double = Default('0'),width: Double = Default('1000'),order: Int = Default('5'),level: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply spectral tilt filter to audio stream.
 
 This filter apply any spectral roll-off slope over any specified frequency band.
@@ -6124,7 +6124,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#atilt)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6132,42 +6132,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='atilt', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "freq": freq,
-                
+
                 "slope": slope,
-                
+
                 "width": width,
-                
+
                 "order": order,
-                
+
                 "level": level,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def atrim(
-    
+
     self,
 
 
@@ -6175,12 +6175,12 @@ References:
 
     *,
     start: Duration = Default('INT64_MAX'),end: Duration = Default('INT64_MAX'),start_pts: Int64 = Default('I64_MIN'),end_pts: Int64 = Default('I64_MIN'),duration: Duration = Default('0'),start_sample: Int64 = Default('-1'),end_sample: Int64 = Default('I64_MAX'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Trim the input so that the output contains one continuous subpart of the input.
 
 It accepts the following parameters:
@@ -6203,49 +6203,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#atrim)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='atrim', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "start": start,
-                
+
                 "end": end,
-                
+
                 "start_pts": start_pts,
-                
+
                 "end_pts": end_pts,
-                
+
                 "duration": duration,
-                
+
                 "start_sample": start_sample,
-                
+
                 "end_sample": end_sample,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def avectorscope(
-    
+
     self,
 
 
@@ -6253,12 +6253,12 @@ References:
 
     *,
     mode: Int| Literal["lissajous","lissajous_xy","polar"] | Default = Default('lissajous'),rate: Video_rate = Default('25'),size: Image_size = Default('400x400'),rc: Int = Default('40'),gc: Int = Default('160'),bc: Int = Default('80'),ac: Int = Default('255'),rf: Int = Default('15'),gf: Int = Default('10'),bf: Int = Default('5'),af: Int = Default('5'),zoom: Double = Default('1'),draw: Int| Literal["dot","line"] | Default = Default('dot'),scale: Int| Literal["lin","sqrt","cbrt","log"] | Default = Default('lin'),swap: Boolean = Default('true'),mirror: Int| Literal["none","x","y","xy"] | Default = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a video output, representing the audio vector
 scope.
 
@@ -6298,94 +6298,94 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#avectorscope)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='avectorscope', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "rate": rate,
-                
+
                 "size": size,
-                
+
                 "rc": rc,
-                
+
                 "gc": gc,
-                
+
                 "bc": bc,
-                
+
                 "ac": ac,
-                
+
                 "rf": rf,
-                
+
                 "gf": gf,
-                
+
                 "bf": bf,
-                
+
                 "af": af,
-                
+
                 "zoom": zoom,
-                
+
                 "draw": draw,
-                
+
                 "scale": scale,
-                
+
                 "swap": swap,
-                
+
                 "mirror": mirror,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def axcorrelate(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _axcorrelate1: AudioStream,
-        
-    
+
+
 
 
     *,
     size: Int = Default('256'),algo: Int| Literal["slow","fast"] | Default = Default('slow'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Calculate normalized windowed cross-correlation between two input audio streams.
 
 Resulted samples are always between -1 and 1 inclusive.
@@ -6409,47 +6409,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#axcorrelate)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='axcorrelate', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _axcorrelate1,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "algo": algo,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def azmq(
-    
+
     self,
 
 
@@ -6457,12 +6457,12 @@ References:
 
     *,
     bind_address: String = Default('tcp://*:5555'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Receive commands sent through a libzmq client, and forward them to
 filters in the filtergraph.
 
@@ -6521,37 +6521,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#zmq)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='azmq', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "bind_address": bind_address,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def bandpass(
-    
+
     self,
 
 
@@ -6559,15 +6559,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),csg: Boolean = Default('false'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a two-pole Butterworth band-pass filter with central
 frequency frequency, and (3dB-point) band-width width.
 The csg option selects a constant skirt gain (peak gain = Q)
@@ -6598,7 +6598,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bandpass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6606,52 +6606,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bandpass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "csg": csg,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def bandreject(
-    
+
     self,
 
 
@@ -6659,15 +6659,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a two-pole Butterworth band-reject filter with central
 frequency frequency, and (3dB-point) band-width width.
 The filter roll off at 6dB per octave (20dB per decade).
@@ -6695,7 +6695,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bandreject)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6703,50 +6703,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bandreject', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def bass(
-    
+
     self,
 
 
@@ -6754,15 +6754,15 @@ References:
 
     *,
     frequency: Double = Default('100'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),gain: Double = Default('0'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Boost or cut the bass (lower) frequencies of the audio using a two-pole
 shelving filter with a response similar to that of a standard
 hi-fi's tone-controls. This is also known as shelving equalisation (EQ).
@@ -6792,7 +6792,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6800,60 +6800,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "gain": gain,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def biquad(
-    
+
     self,
 
 
@@ -6861,15 +6861,15 @@ References:
 
     *,
     a0: Double = Default('1'),a1: Double = Default('0'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a biquad IIR filter with the given coefficients.
 Where b0, b1, b2 and a0, a1, a2
 are the numerator and denominator coefficients respectively.
@@ -6896,7 +6896,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#biquad)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6904,76 +6904,76 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='biquad', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "a0": a0,
-                
+
                 "a1": a1,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def channelmap(
-    
+
     self,
 
 
@@ -6981,12 +6981,12 @@ References:
 
     *,
     map: String = Default(None),channel_layout: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Remap input channels to new locations.
 
 It accepts the following parameters:
@@ -7004,39 +7004,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#channelmap)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='channelmap', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "map": map,
-                
+
                 "channel_layout": channel_layout,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def channelsplit(
-    
+
     self,
 
 
@@ -7044,12 +7044,12 @@ References:
 
     *,
     channel_layout: String = Default('stereo'),channels: String = Default('all'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Split each channel from an input audio stream into a separate output stream.
 
 It accepts the following parameters:
@@ -7068,40 +7068,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#channelsplit)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='channelsplit', typings_input=('audio',), typings_output='[StreamType.audio] * CHANNEL_LAYOUT[str(channel_layout)]'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "channel_layout": channel_layout,
-                
+
                 "channels": channels,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def chorus(
-    
+
     self,
 
 
@@ -7109,12 +7109,12 @@ References:
 
     *,
     in_gain: Float = Default('0.4'),out_gain: Float = Default('0.4'),delays: String = Default(None),decays: String = Default(None),speeds: String = Default(None),depths: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Add a chorus effect to the audio.
 
 Can make a single vocal sound like a chorus, but can also be applied to instrumentation.
@@ -7145,91 +7145,91 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#chorus)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='chorus', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "in_gain": in_gain,
-                
+
                 "out_gain": out_gain,
-                
+
                 "delays": delays,
-                
+
                 "decays": decays,
-                
+
                 "speeds": speeds,
-                
+
                 "depths": depths,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def compand(
-    
+
     self,
 
 
@@ -7237,12 +7237,12 @@ References:
 
     *,
     attacks: String = Default('0'),decays: String = Default('0.8'),points: String = Default('-70/-70|-60/-20|1/0'),soft_knee: Double = Default('0.01'),gain: Double = Default('0'),volume: Double = Default('0'),delay: Double = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Compress or expand the audio's dynamic range.
 
 It accepts the following parameters:
@@ -7265,49 +7265,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#compand)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='compand', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "attacks": attacks,
-                
+
                 "decays": decays,
-                
+
                 "points": points,
-                
+
                 "soft-knee": soft_knee,
-                
+
                 "gain": gain,
-                
+
                 "volume": volume,
-                
+
                 "delay": delay,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def compensationdelay(
-    
+
     self,
 
 
@@ -7315,15 +7315,15 @@ References:
 
     *,
     mm: Int = Default('0'),cm: Int = Default('0'),m: Int = Default('0'),dry: Double = Default('0'),wet: Double = Default('1'),temp: Int = Default('20'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Compensation Delay Line is a metric based delay to compensate differing
 positions of microphones or speakers.
 
@@ -7362,7 +7362,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#compensationdelay)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7370,60 +7370,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='compensationdelay', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mm": mm,
-                
+
                 "cm": cm,
-                
+
                 "m": m,
-                
+
                 "dry": dry,
-                
+
                 "wet": wet,
-                
+
                 "temp": temp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def crossfeed(
-    
+
     self,
 
 
@@ -7431,15 +7431,15 @@ References:
 
     *,
     strength: Double = Default('0.2'),range: Double = Default('0.5'),slope: Double = Default('0.5'),level_in: Double = Default('0.9'),level_out: Double = Default('1'),block_size: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply headphone crossfeed filter.
 
 Crossfeed is the process of blending the left and right channels of stereo
@@ -7468,7 +7468,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#crossfeed)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7476,44 +7476,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='crossfeed', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "strength": strength,
-                
+
                 "range": range,
-                
+
                 "slope": slope,
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "block_size": block_size,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def crystalizer(
-    
+
     self,
 
 
@@ -7521,15 +7521,15 @@ References:
 
     *,
     i: Float = Default('2'),c: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Simple algorithm for audio noise sharpening.
 
 This filter linearly increases differences betweeen each audio sample.
@@ -7550,7 +7550,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#crystalizer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7558,44 +7558,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='crystalizer', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "i": i,
-                
+
                 "c": c,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def dcshift(
-    
+
     self,
 
 
@@ -7603,15 +7603,15 @@ References:
 
     *,
     shift: Double = Default('0'),limitergain: Double = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a DC shift to the audio.
 
 This can be useful to remove a DC offset (caused perhaps by a hardware problem
@@ -7633,7 +7633,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dcshift)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7641,48 +7641,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dcshift', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "shift": shift,
-                
+
                 "limitergain": limitergain,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def deesser(
-    
+
     self,
 
 
@@ -7690,15 +7690,15 @@ References:
 
     *,
     i: Double = Default('0'),m: Double = Default('0.5'),f: Double = Default('0.5'),s: Int| Literal["i","o","e"] | Default = Default('o'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply de-essing to the audio samples.
 
 
@@ -7717,7 +7717,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deesser)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7725,62 +7725,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deesser', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "i": i,
-                
+
                 "m": m,
-                
+
                 "f": f,
-                
+
                 "s": s,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def dialoguenhance(
-    
+
     self,
 
 
@@ -7788,15 +7788,15 @@ References:
 
     *,
     original: Double = Default('1'),enhance: Double = Default('1'),voice: Double = Default('2'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Enhance dialogue in stereo audio.
 
 This filter accepts stereo input and produce surround (3.0) channels output.
@@ -7821,7 +7821,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dialoguenhance)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7829,60 +7829,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dialoguenhance', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "original": original,
-                
+
                 "enhance": enhance,
-                
+
                 "voice": voice,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def drmeter(
-    
+
     self,
 
 
@@ -7890,12 +7890,12 @@ References:
 
     *,
     length: Double = Default('3'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Measure audio dynamic range.
 
 DR values of 14 and higher is found in very dynamic material. DR of 8 to 13
@@ -7916,37 +7916,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#drmeter)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='drmeter', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "length": length,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dynaudnorm(
-    
+
     self,
 
 
@@ -7954,15 +7954,15 @@ References:
 
     *,
     framelen: Int = Default('500'),gausssize: Int = Default('31'),peak: Double = Default('0.95'),maxgain: Double = Default('10'),targetrms: Double = Default('0'),coupling: Boolean = Default('true'),correctdc: Boolean = Default('false'),altboundary: Boolean = Default('false'),compress: Double = Default('0'),threshold: Double = Default('0'),channels: String = Default('all'),overlap: Double = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Dynamic Audio Normalizer.
 
 This filter applies a certain amount of gain to the input audio in order
@@ -8001,7 +8001,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dynaudnorm)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8009,69 +8009,69 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dynaudnorm', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "framelen": framelen,
-                
+
                 "gausssize": gausssize,
-                
+
                 "peak": peak,
-                
+
                 "maxgain": maxgain,
-                
+
                 "targetrms": targetrms,
-                
+
                 "coupling": coupling,
-                
+
                 "correctdc": correctdc,
-                
+
                 "altboundary": altboundary,
-                
+
                 "compress": compress,
-                
+
                 "threshold": threshold,
-                
+
                 "channels": channels,
-                
+
                 "overlap": overlap,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def earwax(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Make audio easier to listen to on headphones.
 
 This filter adds `cues' to 44.1kHz stereo (i.e. audio CD format) audio
@@ -8092,35 +8092,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#earwax)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='earwax', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ebur128(
-    
+
     self,
 
 
@@ -8128,12 +8128,12 @@ References:
 
     *,
     video: Boolean = Default('false'),size: Image_size = Default('640x480'),meter: Int = Default('9'),framelog: Int| Literal["info","verbose"] | Default = Default('-1'),metadata: Boolean = Default('false'),peak: Flags| Literal["none","sample","true"] | Default = Default('0'),dualmono: Boolean = Default('false'),panlaw: Double = Default('-3.0103'),target: Int = Default('-23'),gauge: Int| Literal["momentary","m","shortterm","s"] | Default = Default('momentary'),scale: Int| Literal["absolute","LUFS","relative","LU"] | Default = Default('absolute'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 EBU R128 scanner filter. This filter takes an audio stream and analyzes its loudness
 level. By default, it logs a message at a frequency of 10Hz with the
 Momentary loudness (identified by M), Short-term loudness (S),
@@ -8183,68 +8183,68 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ebur128)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ebur128', typings_input=('audio',), typings_output='[StreamType.video] if video else [] + [StreamType.audio]'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "video": video,
-                
+
                 "size": size,
-                
+
                 "meter": meter,
-                
+
                 "framelog": framelog,
-                
+
                 "metadata": metadata,
-                
+
                 "peak": peak,
-                
+
                 "dualmono": dualmono,
-                
+
                 "panlaw": panlaw,
-                
+
                 "target": target,
-                
+
                 "gauge": gauge,
-                
+
                 "scale": scale,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def equalizer(
-    
+
     self,
 
 
@@ -8252,15 +8252,15 @@ References:
 
     *,
     frequency: Double = Default('0'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('1'),gain: Double = Default('0'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a two-pole peaking equalisation (EQ) filter. With this
 filter, the signal-level at and around a selected frequency can
 be increased or decreased, whilst (unlike bandpass and bandreject
@@ -8293,7 +8293,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#equalizer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8301,62 +8301,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='equalizer', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "gain": gain,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def extrastereo(
-    
+
     self,
 
 
@@ -8364,15 +8364,15 @@ References:
 
     *,
     m: Float = Default('2.5'),c: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Linearly increases the difference between left and right channels which
 adds some sort of "live" effect to playback.
 
@@ -8392,7 +8392,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#extrastereo)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8400,58 +8400,58 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='extrastereo', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "m": m,
-                
+
                 "c": c,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def firequalizer(
-    
+
     self,
 
 
@@ -8459,12 +8459,12 @@ References:
 
     *,
     gain: String = Default('gain_interpolate(f)'),gain_entry: String = Default(None),delay: Double = Default('0.01'),accuracy: Double = Default('5'),wfunc: Int| Literal["rectangular","hann","hamming","blackman","nuttall3","mnuttall3","nuttall","bnuttall","bharris","tukey"] | Default = Default('hann'),fixed: Boolean = Default('false'),multi: Boolean = Default('false'),zero_phase: Boolean = Default('false'),scale: Int| Literal["linlin","linlog","loglin","loglog"] | Default = Default('linlog'),dumpfile: String = Default(None),dumpscale: Int| Literal["linlin","linlog","loglin","loglog"] | Default = Default('linlog'),fft2: Boolean = Default('false'),min_phase: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply FIR Equalization using arbitrary frequency response.
 
 The filter accepts the following option:
@@ -8493,61 +8493,61 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#firequalizer)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='firequalizer', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "gain": gain,
-                
+
                 "gain_entry": gain_entry,
-                
+
                 "delay": delay,
-                
+
                 "accuracy": accuracy,
-                
+
                 "wfunc": wfunc,
-                
+
                 "fixed": fixed,
-                
+
                 "multi": multi,
-                
+
                 "zero_phase": zero_phase,
-                
+
                 "scale": scale,
-                
+
                 "dumpfile": dumpfile,
-                
+
                 "dumpscale": dumpscale,
-                
+
                 "fft2": fft2,
-                
+
                 "min_phase": min_phase,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def flanger(
-    
+
     self,
 
 
@@ -8555,12 +8555,12 @@ References:
 
     *,
     delay: Double = Default('0'),depth: Double = Default('2'),regen: Double = Default('0'),width: Double = Default('71'),speed: Double = Default('0.5'),shape: Int| Literal["triangular","t","sinusoidal","s"] | Default = Default('sinusoidal'),phase: Double = Default('25'),interp: Int| Literal["linear","quadratic"] | Default = Default('linear'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a flanging effect to the audio.
 
 The filter accepts the following options:
@@ -8584,85 +8584,85 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#flanger)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='flanger', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "delay": delay,
-                
+
                 "depth": depth,
-                
+
                 "regen": regen,
-                
+
                 "width": width,
-                
+
                 "speed": speed,
-                
+
                 "shape": shape,
-                
+
                 "phase": phase,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def haas(
-    
+
     self,
 
 
@@ -8670,12 +8670,12 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),side_gain: Double = Default('1'),middle_source: Int| Literal["left","right","mid","side"] | Default = Default('mid'),middle_phase: Boolean = Default('false'),left_delay: Double = Default('2.05'),left_balance: Double = Default('-1'),left_gain: Double = Default('1'),left_phase: Boolean = Default('false'),right_delay: Double = Default('2.12'),right_balance: Double = Default('1'),right_gain: Double = Default('1'),right_phase: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply Haas effect to audio.
 
 Note that this makes most sense to apply on mono signals.
@@ -8708,65 +8708,65 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#haas)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='haas', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "side_gain": side_gain,
-                
+
                 "middle_source": middle_source,
-                
+
                 "middle_phase": middle_phase,
-                
+
                 "left_delay": left_delay,
-                
+
                 "left_balance": left_balance,
-                
+
                 "left_gain": left_gain,
-                
+
                 "left_phase": left_phase,
-                
+
                 "right_delay": right_delay,
-                
+
                 "right_balance": right_balance,
-                
+
                 "right_gain": right_gain,
-                
+
                 "right_phase": right_phase,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def hdcd(
-    
+
     self,
 
 
@@ -8774,12 +8774,12 @@ References:
 
     *,
     disable_autoconvert: Boolean = Default('true'),process_stereo: Boolean = Default('true'),cdt_ms: Int = Default('2000'),force_pe: Boolean = Default('false'),analyze_mode: Int| Literal["off","lle","pe","cdt","tgm"] | Default = Default('off'),bits_per_sample: Int| Literal["16","20","24"] | Default = Default('16'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Decodes High Definition Compatible Digital (HDCD) data. A 16-bit PCM stream with
 embedded HDCD codes is expanded into a 20-bit PCM stream.
 
@@ -8817,51 +8817,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hdcd)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hdcd', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "disable_autoconvert": disable_autoconvert,
-                
+
                 "process_stereo": process_stereo,
-                
+
                 "cdt_ms": cdt_ms,
-                
+
                 "force_pe": force_pe,
-                
+
                 "analyze_mode": analyze_mode,
-                
+
                 "bits_per_sample": bits_per_sample,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def highpass(
-    
+
     self,
 
 
@@ -8869,15 +8869,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.707'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a high-pass filter with 3dB point frequency.
 The filter can be either single-pole, or double-pole (the default).
 The filter roll off at 6dB per pole per octave (20dB per pole per decade).
@@ -8906,7 +8906,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#highpass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8914,52 +8914,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='highpass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def highshelf(
-    
+
     self,
 
 
@@ -8967,15 +8967,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),gain: Double = Default('0'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Boost or cut treble (upper) frequencies of the audio using a two-pole
 shelving filter with a response similar to that of a standard
 hi-fi's tone-controls. This is also known as shelving equalisation (EQ).
@@ -9005,7 +9005,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#treble)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9013,114 +9013,114 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='highshelf', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "gain": gain,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def loudnorm(
-    
+
     self,
 
 
@@ -9128,12 +9128,12 @@ References:
 
     *,
     I: Double = Default('-24'),LRA: Double = Default('7'),TP: Double = Default('-2'),measured_I: Double = Default('0'),measured_LRA: Double = Default('0'),measured_TP: Double = Default('99'),measured_thresh: Double = Default('-70'),offset: Double = Default('0'),linear: Boolean = Default('true'),dual_mono: Boolean = Default('false'),print_format: Int| Literal["none","json","summary"] | Default = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 EBU R128 loudness normalization. Includes both dynamic and linear normalization modes.
 Support for both single pass (livestreams, files) and double pass (files) modes.
 This algorithm can target IL, LRA, and maximum true peak. In dynamic mode, to accurately
@@ -9164,57 +9164,57 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#loudnorm)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='loudnorm', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "I": I,
-                
+
                 "LRA": LRA,
-                
+
                 "TP": TP,
-                
+
                 "measured_I": measured_I,
-                
+
                 "measured_LRA": measured_LRA,
-                
+
                 "measured_TP": measured_TP,
-                
+
                 "measured_thresh": measured_thresh,
-                
+
                 "offset": offset,
-                
+
                 "linear": linear,
-                
+
                 "dual_mono": dual_mono,
-                
+
                 "print_format": print_format,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lowpass(
-    
+
     self,
 
 
@@ -9222,15 +9222,15 @@ References:
 
     *,
     frequency: Double = Default('500'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.707'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a low-pass filter with 3dB point frequency.
 The filter can be either single-pole or double-pole (the default).
 The filter roll off at 6dB per pole per octave (20dB per pole per decade).
@@ -9259,7 +9259,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lowpass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9267,52 +9267,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lowpass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lowshelf(
-    
+
     self,
 
 
@@ -9320,15 +9320,15 @@ References:
 
     *,
     frequency: Double = Default('100'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),gain: Double = Default('0'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Boost or cut the bass (lower) frequencies of the audio using a two-pole
 shelving filter with a response similar to that of a standard
 hi-fi's tone-controls. This is also known as shelving equalisation (EQ).
@@ -9358,7 +9358,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9366,82 +9366,82 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lowshelf', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "gain": gain,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def mcompand(
-    
+
     self,
 
 
@@ -9449,12 +9449,12 @@ References:
 
     *,
     args: String = Default('0.005,0.1 6 -47/-40,-34/-34,-17/-33 100 | 0.003,0.05 6 -47/-40,-34/-34,-17/-33 400 | 0.000625,0.0125 6 -47/-40,-34/-34,-15/-33 1600 | 0.0001,0.025 6 -47/-40,-34/-34,-31/-31,-0/-30 6400 | 0,0.025 6 -38/-31,-28/-28,-0/-25 22000'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Multiband Compress or expand the audio's dynamic range.
 
 The input audio is divided into bands using 4th order Linkwitz-Riley IIRs.
@@ -9475,109 +9475,109 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mcompand)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='mcompand', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "args": args,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def pan(
-    
+
     self,
 
 
@@ -9585,12 +9585,12 @@ References:
 
     *,
     args: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Mix channels with specific gain levels. The filter accepts the output
 channel layout followed by a set of channels definitions.
 
@@ -9602,7 +9602,7 @@ The filter accepts parameters of the form:
 
 
 Args:
-    args: 
+    args:
     extra_options: Extra options for the filter
 
 Returns:
@@ -9612,104 +9612,104 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pan)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pan', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "args": args,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def replaygain(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 ReplayGain scanner filter. This filter takes an audio stream as an input and
 outputs it unchanged.
 At end of filtering it displays track_gain and track_peak.
@@ -9725,89 +9725,89 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#replaygain)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='replaygain', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def showcqt(
-    
+
     self,
 
 
@@ -9815,12 +9815,12 @@ References:
 
     *,
     size: Image_size = Default('1920x1080'),fps: Video_rate = Default('25'),bar_h: Int = Default('-1'),axis_h: Int = Default('-1'),sono_h: Int = Default('-1'),fullhd: Boolean = Default('true'),sono_v: String = Default('16'),bar_v: String = Default('sono_v'),sono_g: Float = Default('3'),bar_g: Float = Default('1'),bar_t: Float = Default('1'),timeclamp: Double = Default('0.17'),attack: Double = Default('0'),basefreq: Double = Default('20.0152'),endfreq: Double = Default('20495.6'),coeffclamp: Float = Default('1'),tlength: String = Default('384*tc/(384+tc*f)'),count: Int = Default('6'),fcount: Int = Default('0'),fontfile: String = Default(None),font: String = Default(None),fontcolor: String = Default('st(0, (midi(f)-59.5)/12);st(1, if(between(ld(0),0,1), 0.5-0.5*cos(2*PI*ld(0)), 0));r(1-ld(1)) + b(ld(1))'),axisfile: String = Default(None),axis: Boolean = Default('true'),csp: Int| Literal["unspecified","bt709","fcc","bt470bg","smpte170m","smpte240m","bt2020ncl"] | Default = Default('unspecified'),cscheme: String = Default('1|0.5|0|0|0.5|1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a video output representing frequency spectrum
 logarithmically using Brown-Puckette constant Q transform algorithm with
 direct frequency domain coefficient calculation (but the transform itself
@@ -9866,87 +9866,87 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showcqt)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showcqt', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "fps": fps,
-                
+
                 "bar_h": bar_h,
-                
+
                 "axis_h": axis_h,
-                
+
                 "sono_h": sono_h,
-                
+
                 "fullhd": fullhd,
-                
+
                 "sono_v": sono_v,
-                
+
                 "bar_v": bar_v,
-                
+
                 "sono_g": sono_g,
-                
+
                 "bar_g": bar_g,
-                
+
                 "bar_t": bar_t,
-                
+
                 "timeclamp": timeclamp,
-                
+
                 "attack": attack,
-                
+
                 "basefreq": basefreq,
-                
+
                 "endfreq": endfreq,
-                
+
                 "coeffclamp": coeffclamp,
-                
+
                 "tlength": tlength,
-                
+
                 "count": count,
-                
+
                 "fcount": fcount,
-                
+
                 "fontfile": fontfile,
-                
+
                 "font": font,
-                
+
                 "fontcolor": fontcolor,
-                
+
                 "axisfile": axisfile,
-                
+
                 "axis": axis,
-                
+
                 "csp": csp,
-                
+
                 "cscheme": cscheme,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showfreqs(
-    
+
     self,
 
 
@@ -9954,12 +9954,12 @@ References:
 
     *,
     size: Image_size = Default('1024x512'),rate: Video_rate = Default('25'),mode: Int| Literal["line","bar","dot"] | Default = Default('bar'),ascale: Int| Literal["lin","sqrt","cbrt","log"] | Default = Default('log'),fscale: Int| Literal["lin","log","rlog"] | Default = Default('lin'),win_size: Int = Default('2048'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman"] | Default = Default('hann'),overlap: Float = Default('1'),averaging: Int = Default('1'),colors: String = Default('red|green|blue|yellow|orange|lime|pink|magenta|brown'),cmode: Int| Literal["combined","separate"] | Default = Default('combined'),minamp: Float = Default('1e-06'),data: Int| Literal["magnitude","phase","delay"] | Default = Default('magnitude'),channels: String = Default('all'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to video output representing the audio power spectrum.
 Audio amplitude is on Y-axis while frequency is on X-axis.
 
@@ -9990,67 +9990,67 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showfreqs)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showfreqs', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "rate": rate,
-                
+
                 "mode": mode,
-                
+
                 "ascale": ascale,
-                
+
                 "fscale": fscale,
-                
+
                 "win_size": win_size,
-                
+
                 "win_func": win_func,
-                
+
                 "overlap": overlap,
-                
+
                 "averaging": averaging,
-                
+
                 "colors": colors,
-                
+
                 "cmode": cmode,
-                
+
                 "minamp": minamp,
-                
+
                 "data": data,
-                
+
                 "channels": channels,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def showspatial(
-    
+
     self,
 
 
@@ -10058,12 +10058,12 @@ References:
 
     *,
     size: Image_size = Default('512x512'),win_size: Int = Default('4096'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman"] | Default = Default('hann'),overlap: Float = Default('0.5'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert stereo input audio to a video output, representing the spatial relationship
 between two channels.
 
@@ -10084,43 +10084,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showspatial)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showspatial', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "win_size": win_size,
-                
+
                 "win_func": win_func,
-                
+
                 "overlap": overlap,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showspectrum(
-    
+
     self,
 
 
@@ -10128,12 +10128,12 @@ References:
 
     *,
     size: Image_size = Default('640x512'),slide: Int| Literal["replace","scroll","fullframe","rscroll","lreplace"] | Default = Default('replace'),mode: Int| Literal["combined","separate"] | Default = Default('combined'),color: Int| Literal["channel","intensity","rainbow","moreland","nebulae","fire","fiery","fruit","cool","magma","green","viridis","plasma","cividis","terrain"] | Default = Default('channel'),scale: Int| Literal["lin","sqrt","cbrt","log","4thrt","5thrt"] | Default = Default('sqrt'),fscale: Int| Literal["lin","log"] | Default = Default('lin'),saturation: Float = Default('1'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman"] | Default = Default('hann'),orientation: Int| Literal["vertical","horizontal"] | Default = Default('vertical'),overlap: Float = Default('0'),gain: Float = Default('1'),data: Int| Literal["magnitude","phase","uphase"] | Default = Default('magnitude'),rotation: Float = Default('0'),start: Int = Default('0'),stop: Int = Default('0'),fps: String = Default('auto'),legend: Boolean = Default('false'),drange: Float = Default('120'),limit: Float = Default('0'),opacity: Float = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a video output, representing the audio frequency
 spectrum.
 
@@ -10170,75 +10170,75 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showspectrum)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showspectrum', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "slide": slide,
-                
+
                 "mode": mode,
-                
+
                 "color": color,
-                
+
                 "scale": scale,
-                
+
                 "fscale": fscale,
-                
+
                 "saturation": saturation,
-                
+
                 "win_func": win_func,
-                
+
                 "orientation": orientation,
-                
+
                 "overlap": overlap,
-                
+
                 "gain": gain,
-                
+
                 "data": data,
-                
+
                 "rotation": rotation,
-                
+
                 "start": start,
-                
+
                 "stop": stop,
-                
+
                 "fps": fps,
-                
+
                 "legend": legend,
-                
+
                 "drange": drange,
-                
+
                 "limit": limit,
-                
+
                 "opacity": opacity,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showspectrumpic(
-    
+
     self,
 
 
@@ -10246,12 +10246,12 @@ References:
 
     *,
     size: Image_size = Default('4096x2048'),mode: Int| Literal["combined","separate"] | Default = Default('combined'),color: Int| Literal["channel","intensity","rainbow","moreland","nebulae","fire","fiery","fruit","cool","magma","green","viridis","plasma","cividis","terrain"] | Default = Default('intensity'),scale: Int| Literal["lin","sqrt","cbrt","log","4thrt","5thrt"] | Default = Default('log'),fscale: Int| Literal["lin","log"] | Default = Default('lin'),saturation: Float = Default('1'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman"] | Default = Default('hann'),orientation: Int| Literal["vertical","horizontal"] | Default = Default('vertical'),gain: Float = Default('1'),legend: Boolean = Default('true'),rotation: Float = Default('0'),start: Int = Default('0'),stop: Int = Default('0'),drange: Float = Default('120'),limit: Float = Default('0'),opacity: Float = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a single video frame, representing the audio frequency
 spectrum.
 
@@ -10284,67 +10284,67 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showspectrumpic)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showspectrumpic', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "mode": mode,
-                
+
                 "color": color,
-                
+
                 "scale": scale,
-                
+
                 "fscale": fscale,
-                
+
                 "saturation": saturation,
-                
+
                 "win_func": win_func,
-                
+
                 "orientation": orientation,
-                
+
                 "gain": gain,
-                
+
                 "legend": legend,
-                
+
                 "rotation": rotation,
-                
+
                 "start": start,
-                
+
                 "stop": stop,
-                
+
                 "drange": drange,
-                
+
                 "limit": limit,
-                
+
                 "opacity": opacity,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showvolume(
-    
+
     self,
 
 
@@ -10352,12 +10352,12 @@ References:
 
     *,
     rate: Video_rate = Default('25'),b: Int = Default('1'),w: Int = Default('400'),h: Int = Default('20'),f: Double = Default('0.95'),c: String = Default('PEAK*255+floor((1-PEAK)*255)*256+0xff000000'),t: Boolean = Default('true'),v: Boolean = Default('true'),dm: Double = Default('0'),dmc: Color = Default('orange'),o: Int| Literal["h","v"] | Default = Default('h'),s: Int = Default('0'),p: Float = Default('0'),m: Int| Literal["p","r"] | Default = Default('p'),ds: Int| Literal["lin","log"] | Default = Default('lin'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio volume to a video output.
 
 The filter accepts the following options:
@@ -10388,65 +10388,65 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showvolume)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showvolume', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rate": rate,
-                
+
                 "b": b,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "f": f,
-                
+
                 "c": c,
-                
+
                 "t": t,
-                
+
                 "v": v,
-                
+
                 "dm": dm,
-                
+
                 "dmc": dmc,
-                
+
                 "o": o,
-                
+
                 "s": s,
-                
+
                 "p": p,
-                
+
                 "m": m,
-                
+
                 "ds": ds,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showwaves(
-    
+
     self,
 
 
@@ -10454,12 +10454,12 @@ References:
 
     *,
     size: Image_size = Default('600x240'),mode: Int| Literal["point","line","p2p","cline"] | Default = Default('point'),n: Int = Default('0'),rate: Video_rate = Default('25'),split_channels: Boolean = Default('false'),colors: String = Default('red|green|blue|yellow|orange|lime|pink|magenta|brown'),scale: Int| Literal["lin","log","sqrt","cbrt"] | Default = Default('lin'),draw: Int| Literal["scale","full"] | Default = Default('scale'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a video output, representing the samples waves.
 
 The filter accepts the following options:
@@ -10483,51 +10483,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showwaves)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showwaves', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "mode": mode,
-                
+
                 "n": n,
-                
+
                 "rate": rate,
-                
+
                 "split_channels": split_channels,
-                
+
                 "colors": colors,
-                
+
                 "scale": scale,
-                
+
                 "draw": draw,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showwavespic(
-    
+
     self,
 
 
@@ -10535,12 +10535,12 @@ References:
 
     *,
     size: Image_size = Default('600x240'),split_channels: Boolean = Default('false'),colors: String = Default('red|green|blue|yellow|orange|lime|pink|magenta|brown'),scale: Int| Literal["lin","log","sqrt","cbrt"] | Default = Default('lin'),draw: Int| Literal["scale","full"] | Default = Default('scale'),filter: Int| Literal["average","peak"] | Default = Default('average'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a single video frame, representing the samples waves.
 
 The filter accepts the following options:
@@ -10562,74 +10562,74 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showwavespic)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showwavespic', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "split_channels": split_channels,
-                
+
                 "colors": colors,
-                
+
                 "scale": scale,
-                
+
                 "draw": draw,
-                
+
                 "filter": filter,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def sidechaincompress(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _sidechain: AudioStream,
-        
-    
+
+
 
 
     *,
     level_in: Double = Default('1'),mode: Int| Literal["downward","upward"] | Default = Default('downward'),threshold: Double = Default('0.125'),ratio: Double = Default('2'),attack: Double = Default('20'),release: Double = Default('250'),makeup: Double = Default('1'),knee: Double = Default('2.82843'),link: Int| Literal["average","maximum"] | Default = Default('average'),detection: Int| Literal["peak","rms"] | Default = Default('rms'),level_sc: Double = Default('1'),mix: Double = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 This filter acts like normal compressor but has the ability to compress
 detected signal using second input signal.
 It needs two input streams and returns one output stream.
@@ -10662,91 +10662,91 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sidechaincompress)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sidechaincompress', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _sidechain,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "mode": mode,
-                
+
                 "threshold": threshold,
-                
+
                 "ratio": ratio,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "makeup": makeup,
-                
+
                 "knee": knee,
-                
+
                 "link": link,
-                
+
                 "detection": detection,
-                
+
                 "level_sc": level_sc,
-                
+
                 "mix": mix,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def sidechaingate(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _sidechain: AudioStream,
-        
-    
+
+
 
 
     *,
     level_in: Double = Default('1'),mode: Int| Literal["downward","upward"] | Default = Default('downward'),range: Double = Default('0.06125'),threshold: Double = Default('0.125'),ratio: Double = Default('2'),attack: Double = Default('20'),release: Double = Default('250'),makeup: Double = Default('1'),knee: Double = Default('2.82843'),detection: Int| Literal["peak","rms"] | Default = Default('rms'),link: Int| Literal["average","maximum"] | Default = Default('average'),level_sc: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 A sidechain gate acts like a normal (wideband) gate but has the ability to
 filter the detected signal before sending it to the gain reduction stage.
 Normally a gate uses the full range signal to detect a level above the
@@ -10785,7 +10785,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sidechaingate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -10793,72 +10793,72 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sidechaingate', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _sidechain,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "mode": mode,
-                
+
                 "range": range,
-                
+
                 "threshold": threshold,
-                
+
                 "ratio": ratio,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "makeup": makeup,
-                
+
                 "knee": knee,
-                
+
                 "detection": detection,
-                
+
                 "link": link,
-                
+
                 "level_sc": level_sc,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def silencedetect(
-    
+
     self,
 
 
@@ -10866,12 +10866,12 @@ References:
 
     *,
     n: Double = Default('0.001'),d: Duration = Default('2'),mono: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Detect silence in an audio stream.
 
 This filter logs a message when it detects that the input audio volume is less
@@ -10905,41 +10905,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#silencedetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='silencedetect', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "n": n,
-                
+
                 "d": d,
-                
+
                 "mono": mono,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def silenceremove(
-    
+
     self,
 
 
@@ -10947,12 +10947,12 @@ References:
 
     *,
     start_periods: Int = Default('0'),start_duration: Duration = Default('0'),start_threshold: Double = Default('0'),start_silence: Duration = Default('0'),start_mode: Int| Literal["any","all"] | Default = Default('any'),stop_periods: Int = Default('0'),stop_duration: Duration = Default('0'),stop_threshold: Double = Default('0'),stop_silence: Duration = Default('0'),stop_mode: Int| Literal["any","all"] | Default = Default('any'),detection: Int| Literal["peak","rms"] | Default = Default('rms'),window: Duration = Default('0.02'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Remove silence from the beginning, middle or end of the audio.
 
 The filter accepts the following options:
@@ -10980,77 +10980,77 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#silenceremove)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='silenceremove', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "start_periods": start_periods,
-                
+
                 "start_duration": start_duration,
-                
+
                 "start_threshold": start_threshold,
-                
+
                 "start_silence": start_silence,
-                
+
                 "start_mode": start_mode,
-                
+
                 "stop_periods": stop_periods,
-                
+
                 "stop_duration": stop_duration,
-                
+
                 "stop_threshold": stop_threshold,
-                
+
                 "stop_silence": stop_silence,
-                
+
                 "stop_mode": stop_mode,
-                
+
                 "detection": detection,
-                
+
                 "window": window,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def speechnorm(
-    
+
     self,
 
 
@@ -11058,15 +11058,15 @@ References:
 
     *,
     peak: Double = Default('0.95'),expansion: Double = Default('2'),compression: Double = Default('2'),threshold: Double = Default('0'),_raise: Double = Default('0.001'),fall: Double = Default('0.001'),channels: String = Default('all'),invert: Boolean = Default('false'),link: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Speech Normalizer.
 
 This filter expands or compresses each half-cycle of audio samples
@@ -11096,7 +11096,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#speechnorm)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11104,60 +11104,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='speechnorm', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "peak": peak,
-                
+
                 "expansion": expansion,
-                
+
                 "compression": compression,
-                
+
                 "threshold": threshold,
-                
+
                 "raise": _raise,
-                
+
                 "fall": fall,
-                
+
                 "channels": channels,
-                
+
                 "invert": invert,
-                
+
                 "link": link,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def stereotools(
-    
+
     self,
 
 
@@ -11165,15 +11165,15 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),balance_in: Double = Default('0'),balance_out: Double = Default('0'),softclip: Boolean = Default('false'),mutel: Boolean = Default('false'),muter: Boolean = Default('false'),phasel: Boolean = Default('false'),phaser: Boolean = Default('false'),mode: Int| Literal["lr>lr","lr>ms","ms>lr","lr>ll","lr>rr","lr>l+r","lr>rl","ms>ll","ms>rr","ms>rl","lr>l-r"] | Default = Default('lr>lr'),slev: Double = Default('1'),sbal: Double = Default('0'),mlev: Double = Default('1'),mpan: Double = Default('0'),base: Double = Default('0'),delay: Double = Default('0'),sclevel: Double = Default('1'),phase: Double = Default('0'),bmode_in: Int| Literal["balance","amplitude","power"] | Default = Default('balance'),bmode_out: Int| Literal["balance","amplitude","power"] | Default = Default('balance'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 This filter has some handy utilities to manage stereo signals, for converting
 M/S stereo recordings to L/R signal while having control over the parameters
 or spreading the stereo image of master track.
@@ -11212,7 +11212,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#stereotools)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11220,72 +11220,72 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='stereotools', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "balance_in": balance_in,
-                
+
                 "balance_out": balance_out,
-                
+
                 "softclip": softclip,
-                
+
                 "mutel": mutel,
-                
+
                 "muter": muter,
-                
+
                 "phasel": phasel,
-                
+
                 "phaser": phaser,
-                
+
                 "mode": mode,
-                
+
                 "slev": slev,
-                
+
                 "sbal": sbal,
-                
+
                 "mlev": mlev,
-                
+
                 "mpan": mpan,
-                
+
                 "base": base,
-                
+
                 "delay": delay,
-                
+
                 "sclevel": sclevel,
-                
+
                 "phase": phase,
-                
+
                 "bmode_in": bmode_in,
-                
+
                 "bmode_out": bmode_out,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def stereowiden(
-    
+
     self,
 
 
@@ -11293,15 +11293,15 @@ References:
 
     *,
     delay: Float = Default('20'),feedback: Float = Default('0.3'),crossfeed: Float = Default('0.3'),drymix: Float = Default('0.8'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 This filter enhance the stereo effect by suppressing signal common to both
 channels and by delaying the signal of left into right and vice versa,
 thereby widening the stereo effect.
@@ -11324,7 +11324,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#stereowiden)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11332,46 +11332,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='stereowiden', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "delay": delay,
-                
+
                 "feedback": feedback,
-                
+
                 "crossfeed": crossfeed,
-                
+
                 "drymix": drymix,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def superequalizer(
-    
+
     self,
 
 
@@ -11379,12 +11379,12 @@ References:
 
     *,
     _1b: Float = Default('1'),_2b: Float = Default('1'),_3b: Float = Default('1'),_4b: Float = Default('1'),_5b: Float = Default('1'),_6b: Float = Default('1'),_7b: Float = Default('1'),_8b: Float = Default('1'),_9b: Float = Default('1'),_10b: Float = Default('1'),_11b: Float = Default('1'),_12b: Float = Default('1'),_13b: Float = Default('1'),_14b: Float = Default('1'),_15b: Float = Default('1'),_16b: Float = Default('1'),_17b: Float = Default('1'),_18b: Float = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply 18 band equalizer.
 
 The filter accepts the following options:
@@ -11418,71 +11418,71 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#superequalizer)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='superequalizer', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "1b": _1b,
-                
+
                 "2b": _2b,
-                
+
                 "3b": _3b,
-                
+
                 "4b": _4b,
-                
+
                 "5b": _5b,
-                
+
                 "6b": _6b,
-                
+
                 "7b": _7b,
-                
+
                 "8b": _8b,
-                
+
                 "9b": _9b,
-                
+
                 "10b": _10b,
-                
+
                 "11b": _11b,
-                
+
                 "12b": _12b,
-                
+
                 "13b": _13b,
-                
+
                 "14b": _14b,
-                
+
                 "15b": _15b,
-                
+
                 "16b": _16b,
-                
+
                 "17b": _17b,
-                
+
                 "18b": _18b,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def surround(
-    
+
     self,
 
 
@@ -11490,12 +11490,12 @@ References:
 
     *,
     chl_out: String = Default('5.1'),chl_in: String = Default('stereo'),level_in: Float = Default('1'),level_out: Float = Default('1'),lfe: Boolean = Default('true'),lfe_low: Int = Default('128'),lfe_high: Int = Default('256'),lfe_mode: Int| Literal["add","sub"] | Default = Default('add'),angle: Float = Default('90'),fc_in: Float = Default('1'),fc_out: Float = Default('1'),fl_in: Float = Default('1'),fl_out: Float = Default('1'),fr_in: Float = Default('1'),fr_out: Float = Default('1'),sl_in: Float = Default('1'),sl_out: Float = Default('1'),sr_in: Float = Default('1'),sr_out: Float = Default('1'),bl_in: Float = Default('1'),bl_out: Float = Default('1'),br_in: Float = Default('1'),br_out: Float = Default('1'),bc_in: Float = Default('1'),bc_out: Float = Default('1'),lfe_in: Float = Default('1'),lfe_out: Float = Default('1'),allx: Float = Default('-1'),ally: Float = Default('-1'),fcx: Float = Default('0.5'),flx: Float = Default('0.5'),frx: Float = Default('0.5'),blx: Float = Default('0.5'),brx: Float = Default('0.5'),slx: Float = Default('0.5'),srx: Float = Default('0.5'),bcx: Float = Default('0.5'),fcy: Float = Default('0.5'),fly: Float = Default('0.5'),fry: Float = Default('0.5'),bly: Float = Default('0.5'),bry: Float = Default('0.5'),sly: Float = Default('0.5'),sry: Float = Default('0.5'),bcy: Float = Default('0.5'),win_size: Int = Default('4096'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman"] | Default = Default('hann'),overlap: Float = Default('0.5'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply audio surround upmix filter.
 
 This filter allows to produce multichannel output from audio stream.
@@ -11561,151 +11561,151 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#surround)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='surround', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "chl_out": chl_out,
-                
+
                 "chl_in": chl_in,
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "lfe": lfe,
-                
+
                 "lfe_low": lfe_low,
-                
+
                 "lfe_high": lfe_high,
-                
+
                 "lfe_mode": lfe_mode,
-                
+
                 "angle": angle,
-                
+
                 "fc_in": fc_in,
-                
+
                 "fc_out": fc_out,
-                
+
                 "fl_in": fl_in,
-                
+
                 "fl_out": fl_out,
-                
+
                 "fr_in": fr_in,
-                
+
                 "fr_out": fr_out,
-                
+
                 "sl_in": sl_in,
-                
+
                 "sl_out": sl_out,
-                
+
                 "sr_in": sr_in,
-                
+
                 "sr_out": sr_out,
-                
+
                 "bl_in": bl_in,
-                
+
                 "bl_out": bl_out,
-                
+
                 "br_in": br_in,
-                
+
                 "br_out": br_out,
-                
+
                 "bc_in": bc_in,
-                
+
                 "bc_out": bc_out,
-                
+
                 "lfe_in": lfe_in,
-                
+
                 "lfe_out": lfe_out,
-                
+
                 "allx": allx,
-                
+
                 "ally": ally,
-                
+
                 "fcx": fcx,
-                
+
                 "flx": flx,
-                
+
                 "frx": frx,
-                
+
                 "blx": blx,
-                
+
                 "brx": brx,
-                
+
                 "slx": slx,
-                
+
                 "srx": srx,
-                
+
                 "bcx": bcx,
-                
+
                 "fcy": fcy,
-                
+
                 "fly": fly,
-                
+
                 "fry": fry,
-                
+
                 "bly": bly,
-                
+
                 "bry": bry,
-                
+
                 "sly": sly,
-                
+
                 "sry": sry,
-                
+
                 "bcy": bcy,
-                
+
                 "win_size": win_size,
-                
+
                 "win_func": win_func,
-                
+
                 "overlap": overlap,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def tiltshelf(
-    
+
     self,
 
 
@@ -11713,15 +11713,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),gain: Double = Default('0'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Boost or cut the lower frequencies and cut or boost higher frequencies
 of the audio using a two-pole shelving filter with a response similar to
 that of a standard hi-fi's tone-controls.
@@ -11752,7 +11752,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tiltshelf)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11760,78 +11760,78 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tiltshelf', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "gain": gain,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def treble(
-    
+
     self,
 
 
@@ -11839,15 +11839,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),gain: Double = Default('0'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Boost or cut treble (upper) frequencies of the audio using a two-pole
 shelving filter with a response similar to that of a standard
 hi-fi's tone-controls. This is also known as shelving equalisation (EQ).
@@ -11877,7 +11877,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#treble)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11885,54 +11885,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='treble', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "gain": gain,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tremolo(
-    
+
     self,
 
 
@@ -11940,15 +11940,15 @@ References:
 
     *,
     f: Double = Default('5'),d: Double = Default('0.5'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Sinusoidal amplitude modulation.
 
 The filter accepts the following options:
@@ -11967,7 +11967,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tremolo)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11975,60 +11975,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tremolo', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "f": f,
-                
+
                 "d": d,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def vibrato(
-    
+
     self,
 
 
@@ -12036,15 +12036,15 @@ References:
 
     *,
     f: Double = Default('5'),d: Double = Default('0.5'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Sinusoidal phase modulation.
 
 The filter accepts the following options:
@@ -12063,7 +12063,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vibrato)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12071,44 +12071,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vibrato', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "f": f,
-                
+
                 "d": d,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def virtualbass(
-    
+
     self,
 
 
@@ -12116,15 +12116,15 @@ References:
 
     *,
     cutoff: Double = Default('250'),strength: Double = Default('3'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply audio Virtual Bass filter.
 
 This filter accepts stereo input and produce stereo with LFE (2.1) channels output.
@@ -12147,7 +12147,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#virtualbass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12155,38 +12155,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='virtualbass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cutoff": cutoff,
-                
+
                 "strength": strength,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def volume(
-    
+
     self,
 
 
@@ -12194,15 +12194,15 @@ References:
 
     *,
     volume: String = Default('1.0'),precision: Int| Literal["fixed","float","double"] | Default = Default('float'),eval: Int| Literal["once","frame"] | Default = Default('once'),replaygain: Int| Literal["drop","ignore","track","album"] | Default = Default('drop'),replaygain_preamp: Double = Default('0'),replaygain_noclip: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Adjust the input audio volume.
 
 It accepts the following parameters:
@@ -12225,7 +12225,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#volume)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12233,57 +12233,57 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='volume', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "volume": volume,
-                
+
                 "precision": precision,
-                
+
                 "eval": eval,
-                
+
                 "replaygain": replaygain,
-                
+
                 "replaygain_preamp": replaygain_preamp,
-                
+
                 "replaygain_noclip": replaygain_noclip,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def volumedetect(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Detect the volume of the input video.
 
 The filter has no parameters. It supports only 16-bit signed integer samples,
@@ -12308,59 +12308,23 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#volumedetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='volumedetect', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
-
-
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    

--- a/packages/v5/src/ffmpeg/streams/video.py
+++ b/packages/v5/src/ffmpeg/streams/video.py
@@ -48,34 +48,34 @@ class VideoStream(FilterableStream):
     Video stream.
     """
 
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def addroi(
-    
+
     self,
 
 
@@ -83,12 +83,12 @@ class VideoStream(FilterableStream):
 
     *,
     x: String = Default('0'),y: String = Default('0'),w: String = Default('0'),h: String = Default('0'),qoffset: Rational = Default('-1/10'),clear: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Mark a region of interest in a video frame.
 
 The frame data is passed through unchanged, but metadata is attached
@@ -113,128 +113,128 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#addroi)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='addroi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "qoffset": qoffset,
-                
+
                 "clear": clear,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def alphaextract(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Extract the alpha component from the input as a grayscale video. This
 is especially useful with the alphamerge filter.
 
@@ -249,64 +249,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#alphaextract)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='alphaextract', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def alphamerge(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _alpha: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Add or replace the alpha component of the primary input with the
 grayscale value of a second input. This is intended for use with
 alphaextract to allow the transmission or storage of frame
@@ -332,7 +332,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#alphamerge)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -343,50 +343,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='alphamerge', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _alpha,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def amplify(
-    
+
     self,
 
 
@@ -394,15 +394,15 @@ References:
 
     *,
     radius: Int = Default('2'),factor: Float = Default('2'),threshold: Float = Default('10'),tolerance: Float = Default('0'),low: Float = Default('65535'),high: Float = Default('65535'),planes: Flags = Default('7'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Amplify differences between current pixel and pixels of adjacent frames in
 same pixel location.
 
@@ -427,7 +427,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amplify)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -435,112 +435,112 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='amplify', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "radius": radius,
-                
+
                 "factor": factor,
-                
+
                 "threshold": threshold,
-                
+
                 "tolerance": tolerance,
-                
+
                 "low": low,
-                
+
                 "high": high,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def ass(
-    
+
     self,
 
 
@@ -548,12 +548,12 @@ References:
 
     *,
     filename: String = Default(None),original_size: Image_size = Default(None),fontsdir: String = Default(None),alpha: Boolean = Default('false'),shaping: Int| Literal["auto","simple","complex"] | Default = Default('auto'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Same as the subtitles filter, except that it doesn't require libavcodec
 and libavformat to work. On the other hand, it is limited to ASS (Advanced
 Substation Alpha) subtitles files.
@@ -577,59 +577,59 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ass)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ass', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "filename": filename,
-                
+
                 "original_size": original_size,
-                
+
                 "fontsdir": fontsdir,
-                
+
                 "alpha": alpha,
-                
+
                 "shaping": shaping,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def atadenoise(
-    
+
     self,
 
 
@@ -637,15 +637,15 @@ References:
 
     *,
     _0a: Float = Default('0.02'),_0b: Float = Default('0.04'),_1a: Float = Default('0.02'),_1b: Float = Default('0.04'),_2a: Float = Default('0.02'),_2b: Float = Default('0.04'),s: Int = Default('9'),p: Flags = Default('7'),a: Int| Literal["p","s"] | Default = Default('p'),_0s: Float = Default('32767'),_1s: Float = Default('32767'),_2s: Float = Default('32767'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply an Adaptive Temporal Averaging Denoiser to the video input.
 
 The filter accepts the following options:
@@ -674,7 +674,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#atadenoise)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -682,64 +682,64 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='atadenoise', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "0a": _0a,
-                
+
                 "0b": _0b,
-                
+
                 "1a": _1a,
-                
+
                 "1b": _1b,
-                
+
                 "2a": _2a,
-                
+
                 "2b": _2b,
-                
+
                 "s": s,
-                
+
                 "p": p,
-                
+
                 "a": a,
-                
+
                 "0s": _0s,
-                
+
                 "1s": _1s,
-                
+
                 "2s": _2s,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def avgblur(
-    
+
     self,
 
 
@@ -747,15 +747,15 @@ References:
 
     *,
     sizeX: Int = Default('1'),planes: Int = Default('15'),sizeY: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply average blur filter.
 
 The filter accepts the following options:
@@ -775,7 +775,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#avgblur)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -783,38 +783,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='avgblur', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sizeX": sizeX,
-                
+
                 "planes": planes,
-                
+
                 "sizeY": sizeY,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def avgblur_opencl(
-    
+
     self,
 
 
@@ -822,12 +822,12 @@ References:
 
     *,
     sizeX: Int = Default('1'),planes: Int = Default('15'),sizeY: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply average blur filter.
 
 The filter accepts the following options:
@@ -846,53 +846,53 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#avgblur_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='avgblur_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sizeX": sizeX,
-                
+
                 "planes": planes,
-                
+
                 "sizeY": sizeY,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def bbox(
-    
+
     self,
 
 
@@ -900,15 +900,15 @@ References:
 
     *,
     min_val: Int = Default('16'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Compute the bounding box for the non-black pixels in the input frame
 luminance plane.
 
@@ -932,7 +932,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bbox)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -940,34 +940,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bbox', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "min_val": min_val,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def bench(
-    
+
     self,
 
 
@@ -975,12 +975,12 @@ References:
 
     *,
     action: Int| Literal["start","stop"] | Default = Default('start'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Benchmark part of a filtergraph.
 
 The filter accepts the following options:
@@ -997,37 +997,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bench)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bench', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "action": action,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def bilateral(
-    
+
     self,
 
 
@@ -1035,15 +1035,15 @@ References:
 
     *,
     sigmaS: Float = Default('0.1'),sigmaR: Float = Default('0.1'),planes: Int = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply bilateral filter, spatial smoothing while preserving edges.
 
 The filter accepts the following options:
@@ -1063,7 +1063,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bilateral)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1071,40 +1071,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bilateral', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sigmaS": sigmaS,
-                
+
                 "sigmaR": sigmaR,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def bitplanenoise(
-    
+
     self,
 
 
@@ -1112,15 +1112,15 @@ References:
 
     *,
     bitplane: Int = Default('1'),filter: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Show and measure bit plane noise.
 
 The filter accepts the following options:
@@ -1139,7 +1139,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bitplanenoise)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1147,36 +1147,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bitplanenoise', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "bitplane": bitplane,
-                
+
                 "filter": filter,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def blackdetect(
-    
+
     self,
 
 
@@ -1184,12 +1184,12 @@ References:
 
     *,
     d: Double = Default('2'),picture_black_ratio_th: Double = Default('0.98'),pixel_black_th: Double = Default('0.1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect video intervals that are (almost) completely black. Can be
 useful to detect chapter transitions, commercials, or invalid
 recordings.
@@ -1223,41 +1223,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blackdetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='blackdetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "d": d,
-                
+
                 "picture_black_ratio_th": picture_black_ratio_th,
-                
+
                 "pixel_black_th": pixel_black_th,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def blackframe(
-    
+
     self,
 
 
@@ -1265,12 +1265,12 @@ References:
 
     *,
     amount: Int = Default('98'),threshold: Int = Default('32'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect frames that are (almost) completely black. Can be useful to
 detect chapter transitions or commercials. Output lines consist of
 the frame number of the detected frame, the percentage of blackness,
@@ -1298,68 +1298,68 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blackframe)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='blackframe', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "amount": amount,
-                
+
                 "threshold": threshold,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def blend(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _bottom: VideoStream,
-        
-    
+
+
 
 
     *,
     c0_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c1_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c2_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c3_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),all_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('-1'),c0_expr: String = Default(None),c1_expr: String = Default(None),c2_expr: String = Default(None),c3_expr: String = Default(None),all_expr: String = Default(None),c0_opacity: Double = Default('1'),c1_opacity: Double = Default('1'),c2_opacity: Double = Default('1'),c3_opacity: Double = Default('1'),all_opacity: Double = Default('1'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Blend two video frames into each other.
 
 The blend filter takes two input streams and outputs one
@@ -1400,7 +1400,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blend)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -1411,72 +1411,72 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='blend', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _bottom,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "c0_mode": c0_mode,
-                
+
                 "c1_mode": c1_mode,
-                
+
                 "c2_mode": c2_mode,
-                
+
                 "c3_mode": c3_mode,
-                
+
                 "all_mode": all_mode,
-                
+
                 "c0_expr": c0_expr,
-                
+
                 "c1_expr": c1_expr,
-                
+
                 "c2_expr": c2_expr,
-                
+
                 "c3_expr": c3_expr,
-                
+
                 "all_expr": all_expr,
-                
+
                 "c0_opacity": c0_opacity,
-                
+
                 "c1_opacity": c1_opacity,
-                
+
                 "c2_opacity": c2_opacity,
-                
+
                 "c3_opacity": c3_opacity,
-                
+
                 "all_opacity": all_opacity,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def blockdetect(
-    
+
     self,
 
 
@@ -1484,12 +1484,12 @@ References:
 
     *,
     period_min: Int = Default('3'),period_max: Int = Default('24'),planes: Int = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Determines blockiness of frames without altering the input frames.
 
 Based on Remco Muijs and Ihor Kirenko: "A no-reference blocking artifact measure for adaptive video processing." 2005 13th European signal processing conference.
@@ -1510,41 +1510,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blockdetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='blockdetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "period_min": period_min,
-                
+
                 "period_max": period_max,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def blurdetect(
-    
+
     self,
 
 
@@ -1552,12 +1552,12 @@ References:
 
     *,
     high: Float = Default('0.117647'),low: Float = Default('0.0588235'),radius: Int = Default('50'),block_pct: Int = Default('80'),block_width: Int = Default('-1'),planes: Int = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Determines blurriness of frames without altering the input frames.
 
 Based on Marziliano, Pina, et al. "A no-reference perceptual blur metric."
@@ -1582,49 +1582,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blurdetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='blurdetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "high": high,
-                
+
                 "low": low,
-                
+
                 "radius": radius,
-                
+
                 "block_pct": block_pct,
-                
+
                 "block_width": block_width,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def boxblur(
-    
+
     self,
 
 
@@ -1632,15 +1632,15 @@ References:
 
     *,
     luma_radius: String = Default('2'),luma_power: Int = Default('2'),chroma_radius: String = Default(None),chroma_power: Int = Default('-1'),alpha_radius: String = Default(None),alpha_power: Int = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a boxblur algorithm to the input video.
 
 It accepts the following parameters:
@@ -1663,7 +1663,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#boxblur)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1671,44 +1671,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='boxblur', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_radius": luma_radius,
-                
+
                 "luma_power": luma_power,
-                
+
                 "chroma_radius": chroma_radius,
-                
+
                 "chroma_power": chroma_power,
-                
+
                 "alpha_radius": alpha_radius,
-                
+
                 "alpha_power": alpha_power,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def boxblur_opencl(
-    
+
     self,
 
 
@@ -1716,12 +1716,12 @@ References:
 
     *,
     luma_radius: String = Default('2'),luma_power: Int = Default('2'),chroma_radius: String = Default(None),chroma_power: Int = Default('-1'),alpha_radius: String = Default(None),alpha_power: Int = Default('-1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a boxblur algorithm to the input video.
 
 It accepts the following parameters:
@@ -1743,51 +1743,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#boxblur_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='boxblur_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_radius": luma_radius,
-                
+
                 "luma_power": luma_power,
-                
+
                 "chroma_radius": chroma_radius,
-                
+
                 "chroma_power": chroma_power,
-                
+
                 "alpha_radius": alpha_radius,
-                
+
                 "alpha_power": alpha_power,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def bwdif(
-    
+
     self,
 
 
@@ -1795,15 +1795,15 @@ References:
 
     *,
     mode: Int| Literal["send_frame","send_field"] | Default = Default('send_field'),parity: Int| Literal["tff","bff","auto"] | Default = Default('auto'),deint: Int| Literal["all","interlaced"] | Default = Default('all'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlace the input video ("bwdif" stands for "Bob Weaver
 Deinterlacing Filter").
 
@@ -1826,7 +1826,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bwdif)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1834,38 +1834,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bwdif', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "parity": parity,
-                
+
                 "deint": deint,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def cas(
-    
+
     self,
 
 
@@ -1873,15 +1873,15 @@ References:
 
     *,
     strength: Float = Default('0'),planes: Flags = Default('7'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Contrast Adaptive Sharpen filter to video stream.
 
 The filter accepts the following options:
@@ -1900,7 +1900,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#cas)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1908,44 +1908,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='cas', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "strength": strength,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def chromahold(
-    
+
     self,
 
 
@@ -1953,15 +1953,15 @@ References:
 
     *,
     color: Color = Default('black'),similarity: Float = Default('0.01'),blend: Float = Default('0'),yuv: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove all color information for all colors except for certain one.
 
 The filter accepts the following options:
@@ -1982,7 +1982,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#chromahold)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1990,40 +1990,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='chromahold', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "color": color,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
                 "yuv": yuv,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def chromakey(
-    
+
     self,
 
 
@@ -2031,15 +2031,15 @@ References:
 
     *,
     color: Color = Default('black'),similarity: Float = Default('0.01'),blend: Float = Default('0'),yuv: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 YUV colorspace color/chroma keying.
 
 The filter accepts the following options:
@@ -2060,7 +2060,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#chromakey)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2068,40 +2068,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='chromakey', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "color": color,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
                 "yuv": yuv,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def chromanr(
-    
+
     self,
 
 
@@ -2109,15 +2109,15 @@ References:
 
     *,
     thres: Float = Default('30'),sizew: Int = Default('5'),sizeh: Int = Default('5'),stepw: Int = Default('1'),steph: Int = Default('1'),threy: Float = Default('200'),threu: Float = Default('200'),threv: Float = Default('200'),distance: Int| Literal["manhattan","euclidean"] | Default = Default('manhattan'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reduce chrominance noise.
 
 The filter accepts the following options:
@@ -2143,7 +2143,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#chromanr)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2151,50 +2151,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='chromanr', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "thres": thres,
-                
+
                 "sizew": sizew,
-                
+
                 "sizeh": sizeh,
-                
+
                 "stepw": stepw,
-                
+
                 "steph": steph,
-                
+
                 "threy": threy,
-                
+
                 "threu": threu,
-                
+
                 "threv": threv,
-                
+
                 "distance": distance,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def chromashift(
-    
+
     self,
 
 
@@ -2202,15 +2202,15 @@ References:
 
     *,
     cbh: Int = Default('0'),cbv: Int = Default('0'),crh: Int = Default('0'),crv: Int = Default('0'),edge: Int| Literal["smear","wrap"] | Default = Default('smear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Shift chroma pixels horizontally and/or vertically.
 
 The filter accepts the following options:
@@ -2232,7 +2232,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#chromashift)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2240,42 +2240,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='chromashift', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cbh": cbh,
-                
+
                 "cbv": cbv,
-                
+
                 "crh": crh,
-                
+
                 "crv": crv,
-                
+
                 "edge": edge,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ciescope(
-    
+
     self,
 
 
@@ -2283,12 +2283,12 @@ References:
 
     *,
     system: Int| Literal["ntsc","470m","ebu","470bg","smpte","240m","apple","widergb","cie1931","hdtv","rec709","uhdtv","rec2020","dcip3"] | Default = Default('hdtv'),cie: Int| Literal["xyy","ucs","luv"] | Default = Default('xyy'),gamuts: Flags| Literal["ntsc","470m","ebu","470bg","smpte","240m","apple","widergb","cie1931","hdtv","rec709","uhdtv","rec2020","dcip3"] | Default = Default('0'),size: Int = Default('512'),intensity: Float = Default('0.001'),contrast: Float = Default('0.75'),corrgamma: Boolean = Default('true'),showwhite: Boolean = Default('false'),gamma: Double = Default('2.6'),fill: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Display CIE color diagram with pixels overlaid onto it.
 
 The filter accepts the following options:
@@ -2314,55 +2314,55 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ciescope)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ciescope', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "system": system,
-                
+
                 "cie": cie,
-                
+
                 "gamuts": gamuts,
-                
+
                 "size": size,
-                
+
                 "intensity": intensity,
-                
+
                 "contrast": contrast,
-                
+
                 "corrgamma": corrgamma,
-                
+
                 "showwhite": showwhite,
-                
+
                 "gamma": gamma,
-                
+
                 "fill": fill,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def codecview(
-    
+
     self,
 
 
@@ -2370,15 +2370,15 @@ References:
 
     *,
     mv: Flags| Literal["pf","bf","bb"] | Default = Default('0'),qp: Boolean = Default('false'),mv_type: Flags| Literal["fp","bp"] | Default = Default('0'),frame_type: Flags| Literal["if","pf","bf"] | Default = Default('0'),block: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Visualize information exported by some codecs.
 
 Some codecs can export information through frames using side-data or other
@@ -2404,7 +2404,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#codecview)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2412,44 +2412,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='codecview', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mv": mv,
-                
+
                 "qp": qp,
-                
+
                 "mv_type": mv_type,
-                
+
                 "frame_type": frame_type,
-                
+
                 "block": block,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def colorbalance(
-    
+
     self,
 
 
@@ -2457,15 +2457,15 @@ References:
 
     *,
     rs: Float = Default('0'),gs: Float = Default('0'),bs: Float = Default('0'),rm: Float = Default('0'),gm: Float = Default('0'),bm: Float = Default('0'),rh: Float = Default('0'),gh: Float = Default('0'),bh: Float = Default('0'),pl: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Modify intensity of primary colors (red, green and blue) of input frames.
 
 The filter allows an input frame to be adjusted in the shadows, midtones or highlights
@@ -2498,7 +2498,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorbalance)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2506,52 +2506,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorbalance', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rs": rs,
-                
+
                 "gs": gs,
-                
+
                 "bs": bs,
-                
+
                 "rm": rm,
-                
+
                 "gm": gm,
-                
+
                 "bm": bm,
-                
+
                 "rh": rh,
-                
+
                 "gh": gh,
-                
+
                 "bh": bh,
-                
+
                 "pl": pl,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorchannelmixer(
-    
+
     self,
 
 
@@ -2559,15 +2559,15 @@ References:
 
     *,
     rr: Double = Default('1'),rg: Double = Default('0'),rb: Double = Default('0'),ra: Double = Default('0'),gr: Double = Default('0'),gg: Double = Default('1'),gb: Double = Default('0'),ga: Double = Default('0'),br: Double = Default('0'),bg: Double = Default('0'),bb: Double = Default('1'),ba: Double = Default('0'),ar: Double = Default('0'),ag: Double = Default('0'),ab: Double = Default('0'),aa: Double = Default('1'),pc: Int| Literal["none","lum","max","avg","sum","nrm","pwr"] | Default = Default('none'),pa: Double = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust video input frames by re-mixing color channels.
 
 This filter modifies a color channel by adding the values associated to
@@ -2609,7 +2609,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorchannelmixer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2617,70 +2617,70 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorchannelmixer', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rr": rr,
-                
+
                 "rg": rg,
-                
+
                 "rb": rb,
-                
+
                 "ra": ra,
-                
+
                 "gr": gr,
-                
+
                 "gg": gg,
-                
+
                 "gb": gb,
-                
+
                 "ga": ga,
-                
+
                 "br": br,
-                
+
                 "bg": bg,
-                
+
                 "bb": bb,
-                
+
                 "ba": ba,
-                
+
                 "ar": ar,
-                
+
                 "ag": ag,
-                
+
                 "ab": ab,
-                
+
                 "aa": aa,
-                
+
                 "pc": pc,
-                
+
                 "pa": pa,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def colorcontrast(
-    
+
     self,
 
 
@@ -2688,15 +2688,15 @@ References:
 
     *,
     rc: Float = Default('0'),gm: Float = Default('0'),by: Float = Default('0'),rcw: Float = Default('0'),gmw: Float = Default('0'),byw: Float = Default('0'),pl: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust color contrast between RGB components.
 
 The filter accepts the following options:
@@ -2720,7 +2720,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorcontrast)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2728,46 +2728,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorcontrast', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rc": rc,
-                
+
                 "gm": gm,
-                
+
                 "by": by,
-                
+
                 "rcw": rcw,
-                
+
                 "gmw": gmw,
-                
+
                 "byw": byw,
-                
+
                 "pl": pl,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorcorrect(
-    
+
     self,
 
 
@@ -2775,15 +2775,15 @@ References:
 
     *,
     rl: Float = Default('0'),bl: Float = Default('0'),rh: Float = Default('0'),bh: Float = Default('0'),saturation: Float = Default('1'),analyze: Int| Literal["manual","average","minmax","median"] | Default = Default('manual'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust color white balance selectively for blacks and whites.
 This filter operates in YUV colorspace.
 
@@ -2807,7 +2807,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorcorrect)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2815,44 +2815,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorcorrect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rl": rl,
-                
+
                 "bl": bl,
-                
+
                 "rh": rh,
-                
+
                 "bh": bh,
-                
+
                 "saturation": saturation,
-                
+
                 "analyze": analyze,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorhold(
-    
+
     self,
 
 
@@ -2860,15 +2860,15 @@ References:
 
     *,
     color: Color = Default('black'),similarity: Float = Default('0.01'),blend: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove all color information for all RGB colors except for certain one.
 
 The filter accepts the following options:
@@ -2888,7 +2888,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorhold)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2896,38 +2896,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorhold', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "color": color,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorize(
-    
+
     self,
 
 
@@ -2935,15 +2935,15 @@ References:
 
     *,
     hue: Float = Default('0'),saturation: Float = Default('0.5'),lightness: Float = Default('0.5'),mix: Float = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Overlay a solid color on the video stream.
 
 The filter accepts the following options:
@@ -2964,7 +2964,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorize)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2972,40 +2972,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorize', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "hue": hue,
-                
+
                 "saturation": saturation,
-                
+
                 "lightness": lightness,
-                
+
                 "mix": mix,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorkey(
-    
+
     self,
 
 
@@ -3013,15 +3013,15 @@ References:
 
     *,
     color: Color = Default('black'),similarity: Float = Default('0.01'),blend: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 RGB colorspace color keying.
 This filter operates on 8-bit RGB format frames by setting the alpha component of each pixel
 which falls within the similarity radius of the key color to 0. The alpha value for pixels outside
@@ -3044,7 +3044,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorkey)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3052,38 +3052,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorkey', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "color": color,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorkey_opencl(
-    
+
     self,
 
 
@@ -3091,12 +3091,12 @@ References:
 
     *,
     color: Color = Default('black'),similarity: Float = Default('0.01'),blend: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 RGB colorspace color keying.
 
 The filter accepts the following options:
@@ -3115,41 +3115,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorkey_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorkey_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "color": color,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorlevels(
-    
+
     self,
 
 
@@ -3157,15 +3157,15 @@ References:
 
     *,
     rimin: Double = Default('0'),gimin: Double = Default('0'),bimin: Double = Default('0'),aimin: Double = Default('0'),rimax: Double = Default('1'),gimax: Double = Default('1'),bimax: Double = Default('1'),aimax: Double = Default('1'),romin: Double = Default('0'),gomin: Double = Default('0'),bomin: Double = Default('0'),aomin: Double = Default('0'),romax: Double = Default('1'),gomax: Double = Default('1'),bomax: Double = Default('1'),aomax: Double = Default('1'),preserve: Int| Literal["none","lum","max","avg","sum","nrm","pwr"] | Default = Default('none'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust video input frames using levels.
 
 The filter accepts the following options:
@@ -3199,7 +3199,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorlevels)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3207,94 +3207,94 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorlevels', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rimin": rimin,
-                
+
                 "gimin": gimin,
-                
+
                 "bimin": bimin,
-                
+
                 "aimin": aimin,
-                
+
                 "rimax": rimax,
-                
+
                 "gimax": gimax,
-                
+
                 "bimax": bimax,
-                
+
                 "aimax": aimax,
-                
+
                 "romin": romin,
-                
+
                 "gomin": gomin,
-                
+
                 "bomin": bomin,
-                
+
                 "aomin": aomin,
-                
+
                 "romax": romax,
-                
+
                 "gomax": gomax,
-                
+
                 "bomax": bomax,
-                
+
                 "aomax": aomax,
-                
+
                 "preserve": preserve,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colormap(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _target: VideoStream,
-        
-    
+
+
 
 
     *,
     patch_size: Image_size = Default('64x64'),nb_patches: Int = Default('0'),type: Int| Literal["relative","absolute"] | Default = Default('absolute'),kernel: Int| Literal["euclidean","weuclidean"] | Default = Default('euclidean'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply custom color maps to video stream.
 
 This filter needs three input video streams.
@@ -3320,7 +3320,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colormap)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3328,52 +3328,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colormap', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _source,
-                
-            
-                
+
+
+
                 _target,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "patch_size": patch_size,
-                
+
                 "nb_patches": nb_patches,
-                
+
                 "type": type,
-                
+
                 "kernel": kernel,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colormatrix(
-    
+
     self,
 
 
@@ -3381,15 +3381,15 @@ References:
 
     *,
     src: Int| Literal["bt709","fcc","bt601","bt470","bt470bg","smpte170m","smpte240m","bt2020"] | Default = Default('-1'),dst: Int| Literal["bt709","fcc","bt601","bt470","bt470bg","smpte170m","smpte240m","bt2020"] | Default = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert color matrix.
 
 The filter accepts the following options:
@@ -3408,7 +3408,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colormatrix)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3416,36 +3416,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colormatrix', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "src": src,
-                
+
                 "dst": dst,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorspace(
-    
+
     self,
 
 
@@ -3453,15 +3453,15 @@ References:
 
     *,
     all: Int| Literal["bt470m","bt470bg","bt601-6-525","bt601-6-625","bt709","smpte170m","smpte240m","bt2020"] | Default = Default('0'),space: Int| Literal["bt709","fcc","bt470bg","smpte170m","smpte240m","ycgco","gbr","bt2020nc","bt2020ncl"] | Default = Default('2'),range: Int| Literal["tv","mpeg","pc","jpeg"] | Default = Default('0'),primaries: Int| Literal["bt709","bt470m","bt470bg","smpte170m","smpte240m","smpte428","film","smpte431","smpte432","bt2020","jedec-p22","ebu3213"] | Default = Default('2'),trc: Int| Literal["bt709","bt470m","gamma22","bt470bg","gamma28","smpte170m","smpte240m","linear","srgb","iec61966-2-1","xvycc","iec61966-2-4","bt2020-10","bt2020-12"] | Default = Default('2'),format: Int| Literal["yuv420p","yuv420p10","yuv420p12","yuv422p","yuv422p10","yuv422p12","yuv444p","yuv444p10","yuv444p12"] | Default = Default('-1'),fast: Boolean = Default('false'),dither: Int| Literal["none","fsb"] | Default = Default('none'),wpadapt: Int| Literal["bradford","vonkries","identity"] | Default = Default('bradford'),iall: Int| Literal["bt470m","bt470bg","bt601-6-525","bt601-6-625","bt709","smpte170m","smpte240m","bt2020"] | Default = Default('0'),ispace: Int| Literal["bt709","fcc","bt470bg","smpte170m","smpte240m","ycgco","gbr","bt2020nc","bt2020ncl"] | Default = Default('2'),irange: Int| Literal["tv","mpeg","pc","jpeg"] | Default = Default('0'),iprimaries: Int| Literal["bt709","bt470m","bt470bg","smpte170m","smpte240m","smpte428","film","smpte431","smpte432","bt2020","jedec-p22","ebu3213"] | Default = Default('2'),itrc: Int| Literal["bt709","bt470m","gamma22","bt470bg","gamma28","smpte170m","smpte240m","linear","srgb","iec61966-2-1","xvycc","iec61966-2-4","bt2020-10","bt2020-12"] | Default = Default('2'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert colorspace, transfer characteristics or color primaries.
 Input video needs to have an even size.
 
@@ -3493,7 +3493,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorspace)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3501,62 +3501,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorspace', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "all": all,
-                
+
                 "space": space,
-                
+
                 "range": range,
-                
+
                 "primaries": primaries,
-                
+
                 "trc": trc,
-                
+
                 "format": format,
-                
+
                 "fast": fast,
-                
+
                 "dither": dither,
-                
+
                 "wpadapt": wpadapt,
-                
+
                 "iall": iall,
-                
+
                 "ispace": ispace,
-                
+
                 "irange": irange,
-                
+
                 "iprimaries": iprimaries,
-                
+
                 "itrc": itrc,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def colortemperature(
-    
+
     self,
 
 
@@ -3564,15 +3564,15 @@ References:
 
     *,
     temperature: Float = Default('6500'),mix: Float = Default('1'),pl: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust color temperature in video to simulate variations in ambient color temperature.
 
 The filter accepts the following options:
@@ -3592,7 +3592,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colortemperature)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3600,44 +3600,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colortemperature', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "temperature": temperature,
-                
+
                 "mix": mix,
-                
+
                 "pl": pl,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def convolution(
-    
+
     self,
 
 
@@ -3645,15 +3645,15 @@ References:
 
     *,
     _0m: String = Default('0 0 0 0 1 0 0 0 0'),_1m: String = Default('0 0 0 0 1 0 0 0 0'),_2m: String = Default('0 0 0 0 1 0 0 0 0'),_3m: String = Default('0 0 0 0 1 0 0 0 0'),_0rdiv: Float = Default('0'),_1rdiv: Float = Default('0'),_2rdiv: Float = Default('0'),_3rdiv: Float = Default('0'),_0bias: Float = Default('0'),_1bias: Float = Default('0'),_2bias: Float = Default('0'),_3bias: Float = Default('0'),_0mode: Int| Literal["square","row","column"] | Default = Default('square'),_1mode: Int| Literal["square","row","column"] | Default = Default('square'),_2mode: Int| Literal["square","row","column"] | Default = Default('square'),_3mode: Int| Literal["square","row","column"] | Default = Default('square'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply convolution of 3x3, 5x5, 7x7 or horizontal/vertical up to 49 elements.
 
 The filter accepts the following options:
@@ -3686,7 +3686,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#convolution)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3694,64 +3694,64 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='convolution', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "0m": _0m,
-                
+
                 "1m": _1m,
-                
+
                 "2m": _2m,
-                
+
                 "3m": _3m,
-                
+
                 "0rdiv": _0rdiv,
-                
+
                 "1rdiv": _1rdiv,
-                
+
                 "2rdiv": _2rdiv,
-                
+
                 "3rdiv": _3rdiv,
-                
+
                 "0bias": _0bias,
-                
+
                 "1bias": _1bias,
-                
+
                 "2bias": _2bias,
-                
+
                 "3bias": _3bias,
-                
+
                 "0mode": _0mode,
-                
+
                 "1mode": _1mode,
-                
+
                 "2mode": _2mode,
-                
+
                 "3mode": _3mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def convolution_opencl(
-    
+
     self,
 
 
@@ -3759,12 +3759,12 @@ References:
 
     *,
     _0m: String = Default('0 0 0 0 1 0 0 0 0'),_2m: String = Default('0 0 0 0 1 0 0 0 0'),_3m: String = Default('0 0 0 0 1 0 0 0 0'),_0rdiv: Float = Default('1'),_1rdiv: Float = Default('1'),_2rdiv: Float = Default('1'),_3rdiv: Float = Default('1'),_0bias: Float = Default('0'),_1bias: Float = Default('0'),_2bias: Float = Default('0'),_3bias: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply convolution of 3x3, 5x5, 7x7 matrix.
 
 The filter accepts the following options:
@@ -3791,86 +3791,86 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#convolution_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='convolution_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "0m": _0m,
-                
+
                 "2m": _2m,
-                
+
                 "3m": _3m,
-                
+
                 "0rdiv": _0rdiv,
-                
+
                 "1rdiv": _1rdiv,
-                
+
                 "2rdiv": _2rdiv,
-                
+
                 "3rdiv": _3rdiv,
-                
+
                 "0bias": _0bias,
-                
+
                 "1bias": _1bias,
-                
+
                 "2bias": _2bias,
-                
+
                 "3bias": _3bias,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def convolve(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _impulse: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('7'),impulse: Int| Literal["first","all"] | Default = Default('all'),noise: Float = Default('1e-07'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply 2D convolution of video stream in frequency domain using second stream
 as impulse.
 
@@ -3892,7 +3892,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#convolve)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -3903,61 +3903,61 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='convolve', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _impulse,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "impulse": impulse,
-                
+
                 "noise": noise,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def copy(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Copy the input video source unchanged to the output. This is mainly useful for
 testing purposes.
 
@@ -3974,35 +3974,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#copy)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='copy', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def cover_rect(
-    
+
     self,
 
 
@@ -4010,12 +4010,12 @@ References:
 
     *,
     cover: String = Default(None),mode: Int| Literal["cover","blur"] | Default = Default('blur'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Cover a rectangular object
 
 It accepts the following options:
@@ -4033,39 +4033,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#cover_rect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='cover_rect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cover": cover,
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def crop(
-    
+
     self,
 
 
@@ -4073,12 +4073,12 @@ References:
 
     *,
     out_w: String = Default('iw'),out_h: String = Default('ih'),x: String = Default('(in_w-out_w)/2'),y: String = Default('(in_h-out_h)/2'),keep_aspect: Boolean = Default('false'),exact: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Crop the input video to given dimensions.
 
 It accepts the following parameters:
@@ -4100,47 +4100,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#crop)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='crop', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "out_w": out_w,
-                
+
                 "out_h": out_h,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "keep_aspect": keep_aspect,
-                
+
                 "exact": exact,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def cropdetect(
-    
+
     self,
 
 
@@ -4148,15 +4148,15 @@ References:
 
     *,
     limit: Float = Default('0.0941176'),round: Int = Default('16'),reset: Int = Default('0'),skip: Int = Default('2'),reset_count: Int = Default('0'),max_outliers: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Auto-detect the crop size.
 
 It calculates the necessary cropping parameters and prints the
@@ -4183,7 +4183,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#cropdetect)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4191,48 +4191,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='cropdetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "limit": limit,
-                
+
                 "round": round,
-                
+
                 "reset": reset,
-                
+
                 "skip": skip,
-                
+
                 "reset_count": reset_count,
-                
+
                 "max_outliers": max_outliers,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def cue(
-    
+
     self,
 
 
@@ -4240,12 +4240,12 @@ References:
 
     *,
     cue: Int64 = Default('0'),preroll: Duration = Default('0'),buffer: Duration = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Delay video filtering until a given wallclock timestamp. The filter first
 passes on preroll amount of frames, then it buffers at most
 buffer amount of frames and waits for the cue. After reaching the cue
@@ -4274,41 +4274,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#cue)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='cue', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cue": cue,
-                
+
                 "preroll": preroll,
-                
+
                 "buffer": buffer,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def curves(
-    
+
     self,
 
 
@@ -4316,15 +4316,15 @@ References:
 
     *,
     preset: Int| Literal["none","color_negative","cross_process","darker","increase_contrast","lighter","linear_contrast","medium_contrast","negative","strong_contrast","vintage"] | Default = Default('none'),master: String = Default(None),red: String = Default(None),green: String = Default(None),blue: String = Default(None),all: String = Default(None),psfile: String = Default(None),plot: String = Default(None),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply color adjustments using curves.
 
 This filter is similar to the Adobe Photoshop and GIMP curves tools. Each
@@ -4366,7 +4366,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#curves)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4374,48 +4374,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='curves', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "preset": preset,
-                
+
                 "master": master,
-                
+
                 "red": red,
-                
+
                 "green": green,
-                
+
                 "blue": blue,
-                
+
                 "all": all,
-                
+
                 "psfile": psfile,
-                
+
                 "plot": plot,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def datascope(
-    
+
     self,
 
 
@@ -4423,12 +4423,12 @@ References:
 
     *,
     size: Image_size = Default('hd720'),x: Int = Default('0'),y: Int = Default('0'),mode: Int| Literal["mono","color","color2"] | Default = Default('mono'),axis: Boolean = Default('false'),opacity: Float = Default('0.75'),format: Int| Literal["hex","dec"] | Default = Default('hex'),components: Int = Default('15'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Video data analysis filter.
 
 This filter shows hexadecimal pixel values of part of video.
@@ -4454,51 +4454,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#datascope)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='datascope', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "mode": mode,
-                
+
                 "axis": axis,
-                
+
                 "opacity": opacity,
-                
+
                 "format": format,
-                
+
                 "components": components,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dblur(
-    
+
     self,
 
 
@@ -4506,15 +4506,15 @@ References:
 
     *,
     angle: Float = Default('45'),radius: Float = Default('5'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Directional blur filter.
 
 The filter accepts the following options:
@@ -4534,7 +4534,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dblur)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4542,40 +4542,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dblur', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "angle": angle,
-                
+
                 "radius": radius,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def dctdnoiz(
-    
+
     self,
 
 
@@ -4583,15 +4583,15 @@ References:
 
     *,
     sigma: Float = Default('0'),overlap: Int = Default('-1'),expr: String = Default(None),n: Int = Default('3'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Denoise frames using 2D DCT (frequency domain filtering).
 
 This filter is not designed for real time.
@@ -4614,7 +4614,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dctdnoiz)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4622,40 +4622,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dctdnoiz', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sigma": sigma,
-                
+
                 "overlap": overlap,
-                
+
                 "expr": expr,
-                
+
                 "n": n,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def deband(
-    
+
     self,
 
 
@@ -4663,15 +4663,15 @@ References:
 
     *,
     _1thr: Float = Default('0.02'),_2thr: Float = Default('0.02'),_3thr: Float = Default('0.02'),_4thr: Float = Default('0.02'),range: Int = Default('16'),direction: Float = Default('6.28319'),blur: Boolean = Default('true'),coupling: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove banding artifacts from input video.
 It works by replacing banded pixels with average value of referenced pixels.
 
@@ -4697,7 +4697,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deband)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4705,48 +4705,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deband', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "1thr": _1thr,
-                
+
                 "2thr": _2thr,
-                
+
                 "3thr": _3thr,
-                
+
                 "4thr": _4thr,
-                
+
                 "range": range,
-                
+
                 "direction": direction,
-                
+
                 "blur": blur,
-                
+
                 "coupling": coupling,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def deblock(
-    
+
     self,
 
 
@@ -4754,15 +4754,15 @@ References:
 
     *,
     filter: Int| Literal["weak","strong"] | Default = Default('strong'),block: Int = Default('8'),alpha: Float = Default('0.098'),beta: Float = Default('0.05'),gamma: Float = Default('0.05'),delta: Float = Default('0.05'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove blocking artifacts from input video.
 
 The filter accepts the following options:
@@ -4786,7 +4786,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deblock)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4794,77 +4794,77 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deblock', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "filter": filter,
-                
+
                 "block": block,
-                
+
                 "alpha": alpha,
-                
+
                 "beta": beta,
-                
+
                 "gamma": gamma,
-                
+
                 "delta": delta,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def deconvolve(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _impulse: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('7'),impulse: Int| Literal["first","all"] | Default = Default('all'),noise: Float = Default('1e-07'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply 2D deconvolution of video stream in frequency domain using second stream
 as impulse.
 
@@ -4886,7 +4886,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deconvolve)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -4897,48 +4897,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deconvolve', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _impulse,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "impulse": impulse,
-                
+
                 "noise": noise,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dedot(
-    
+
     self,
 
 
@@ -4946,15 +4946,15 @@ References:
 
     *,
     m: Flags| Literal["dotcrawl","rainbows"] | Default = Default('dotcrawl+rainbows'),lt: Float = Default('0.079'),tl: Float = Default('0.079'),tc: Float = Default('0.058'),ct: Float = Default('0.019'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reduce cross-luminance (dot-crawl) and cross-color (rainbows) from video.
 
 It accepts the following options:
@@ -4976,7 +4976,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dedot)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4984,44 +4984,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dedot', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "m": m,
-                
+
                 "lt": lt,
-                
+
                 "tl": tl,
-                
+
                 "tc": tc,
-                
+
                 "ct": ct,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def deflate(
-    
+
     self,
 
 
@@ -5029,15 +5029,15 @@ References:
 
     *,
     threshold0: Int = Default('65535'),threshold1: Int = Default('65535'),threshold2: Int = Default('65535'),threshold3: Int = Default('65535'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply deflate effect to the video.
 
 This filter replaces the pixel by the local(3x3) average by taking into account
@@ -5061,7 +5061,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deflate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5069,40 +5069,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deflate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold0": threshold0,
-                
+
                 "threshold1": threshold1,
-                
+
                 "threshold2": threshold2,
-                
+
                 "threshold3": threshold3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def deflicker(
-    
+
     self,
 
 
@@ -5110,12 +5110,12 @@ References:
 
     *,
     size: Int = Default('5'),mode: Int| Literal["am","gm","hm","qm","cm","pm","median"] | Default = Default('am'),bypass: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove temporal frame luminance variations.
 
 It accepts the following options:
@@ -5134,41 +5134,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deflicker)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deflicker', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "mode": mode,
-                
+
                 "bypass": bypass,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def deinterlace_vaapi(
-    
+
     self,
 
 
@@ -5176,12 +5176,12 @@ References:
 
     *,
     mode: Int| Literal["default","bob","weave","motion_adaptive","motion_compensated"] | Default = Default('default'),rate: Int| Literal["frame","field"] | Default = Default('frame'),auto: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlacing of VAAPI surfaces
 
 
@@ -5198,41 +5198,41 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deinterlace_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "rate": rate,
-                
+
                 "auto": auto,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dejudder(
-    
+
     self,
 
 
@@ -5240,12 +5240,12 @@ References:
 
     *,
     cycle: Int = Default('4'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove judder produced by partially interlaced telecined content.
 
 Judder can be introduced, for instance, by pullup filter. If the original
@@ -5268,37 +5268,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dejudder)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dejudder', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cycle": cycle,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def delogo(
-    
+
     self,
 
 
@@ -5306,15 +5306,15 @@ References:
 
     *,
     x: String = Default('-1'),y: String = Default('-1'),w: String = Default('-1'),h: String = Default('-1'),show: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Suppress a TV station logo by a simple interpolation of the surrounding
 pixels. Just set a rectangle covering the logo and watch it disappear
 (and sometimes something even uglier appear - your mileage may vary).
@@ -5338,7 +5338,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#delogo)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5346,42 +5346,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='delogo', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "show": show,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def denoise_vaapi(
-    
+
     self,
 
 
@@ -5389,12 +5389,12 @@ References:
 
     *,
     denoise: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 VAAPI VPP for de-noise
 
 
@@ -5409,37 +5409,37 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='denoise_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "denoise": denoise,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def derain(
-    
+
     self,
 
 
@@ -5447,15 +5447,15 @@ References:
 
     *,
     filter_type: Int| Literal["derain","dehaze"] | Default = Default('derain'),dnn_backend: Int| Literal["native"] | Default = Default('native'),model: String = Default(None),input: String = Default('x'),output: String = Default('y'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove the rain in the input image/video by applying the derain methods based on
 convolutional neural networks. Supported models:
 
@@ -5476,7 +5476,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#derain)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5484,42 +5484,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='derain', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "filter_type": filter_type,
-                
+
                 "dnn_backend": dnn_backend,
-                
+
                 "model": model,
-                
+
                 "input": input,
-                
+
                 "output": output,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def deshake(
-    
+
     self,
 
 
@@ -5527,12 +5527,12 @@ References:
 
     *,
     x: Int = Default('-1'),y: Int = Default('-1'),w: Int = Default('-1'),h: Int = Default('-1'),rx: Int = Default('16'),ry: Int = Default('16'),edge: Int| Literal["blank","original","clamp","mirror"] | Default = Default('mirror'),blocksize: Int = Default('8'),contrast: Int = Default('125'),search: Int| Literal["exhaustive","less"] | Default = Default('exhaustive'),filename: String = Default(None),opencl: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Attempt to fix small changes in horizontal and/or vertical shift. This
 filter helps remove camera shake from hand-holding a camera, bumping a
 tripod, moving on a vehicle, etc.
@@ -5562,59 +5562,59 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deshake)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deshake', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "rx": rx,
-                
+
                 "ry": ry,
-                
+
                 "edge": edge,
-                
+
                 "blocksize": blocksize,
-                
+
                 "contrast": contrast,
-                
+
                 "search": search,
-                
+
                 "filename": filename,
-                
+
                 "opencl": opencl,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def deshake_opencl(
-    
+
     self,
 
 
@@ -5622,12 +5622,12 @@ References:
 
     *,
     tripod: Boolean = Default('false'),debug: Boolean = Default('false'),adaptive_crop: Boolean = Default('true'),refine_features: Boolean = Default('true'),smooth_strength: Float = Default('0'),smooth_window_multiplier: Float = Default('2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Feature-point based video stabilization filter.
 
 The filter accepts the following options:
@@ -5649,47 +5649,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deshake_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deshake_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "tripod": tripod,
-                
+
                 "debug": debug,
-                
+
                 "adaptive_crop": adaptive_crop,
-                
+
                 "refine_features": refine_features,
-                
+
                 "smooth_strength": smooth_strength,
-                
+
                 "smooth_window_multiplier": smooth_window_multiplier,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def despill(
-    
+
     self,
 
 
@@ -5697,15 +5697,15 @@ References:
 
     *,
     type: Int| Literal["green","blue"] | Default = Default('green'),mix: Float = Default('0.5'),expand: Float = Default('0'),red: Float = Default('0'),green: Float = Default('-1'),blue: Float = Default('0'),brightness: Float = Default('0'),alpha: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove unwanted contamination of foreground colors, caused by reflected color of
 greenscreen or bluescreen.
 
@@ -5731,7 +5731,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#despill)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5739,48 +5739,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='despill', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "type": type,
-                
+
                 "mix": mix,
-                
+
                 "expand": expand,
-                
+
                 "red": red,
-                
+
                 "green": green,
-                
+
                 "blue": blue,
-                
+
                 "brightness": brightness,
-                
+
                 "alpha": alpha,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def detelecine(
-    
+
     self,
 
 
@@ -5788,12 +5788,12 @@ References:
 
     *,
     first_field: Int| Literal["top","t","bottom","b"] | Default = Default('top'),pattern: String = Default('23'),start_frame: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply an exact inverse of the telecine operation. It requires a predefined
 pattern specified using the pattern option which must be the same as that passed
 to the telecine filter.
@@ -5814,43 +5814,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#detelecine)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='detelecine', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "first_field": first_field,
-                
+
                 "pattern": pattern,
-                
+
                 "start_frame": start_frame,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def dilation(
-    
+
     self,
 
 
@@ -5858,15 +5858,15 @@ References:
 
     *,
     coordinates: Int = Default('255'),threshold0: Int = Default('65535'),threshold1: Int = Default('65535'),threshold2: Int = Default('65535'),threshold3: Int = Default('65535'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply dilation effect to the video.
 
 This filter replaces the pixel by the local(3x3) maximum.
@@ -5890,7 +5890,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dilation)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5898,42 +5898,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dilation', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "coordinates": coordinates,
-                
+
                 "threshold0": threshold0,
-                
+
                 "threshold1": threshold1,
-                
+
                 "threshold2": threshold2,
-                
+
                 "threshold3": threshold3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dilation_opencl(
-    
+
     self,
 
 
@@ -5941,12 +5941,12 @@ References:
 
     *,
     threshold0: Float = Default('65535'),threshold1: Float = Default('65535'),threshold2: Float = Default('65535'),threshold3: Float = Default('65535'),coordinates: Int = Default('255'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply dilation effect to the video.
 
 This filter replaces the pixel by the local(3x3) maximum.
@@ -5969,73 +5969,73 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dilation_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dilation_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold0": threshold0,
-                
+
                 "threshold1": threshold1,
-                
+
                 "threshold2": threshold2,
-                
+
                 "threshold3": threshold3,
-                
+
                 "coordinates": coordinates,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def displace(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _xmap: VideoStream,
-        
-    
-        
+
+
+
         _ymap: VideoStream,
-        
-    
+
+
 
 
     *,
     edge: Int| Literal["blank","smear","wrap","mirror"] | Default = Default('smear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Displace pixels as indicated by second and third input stream.
 
 It takes three input streams and outputs one stream, the first input is the
@@ -6064,7 +6064,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#displace)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6072,46 +6072,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='displace', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _xmap,
-                
-            
-                
+
+
+
                 _ymap,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "edge": edge,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dnn_classify(
-    
+
     self,
 
 
@@ -6119,12 +6119,12 @@ References:
 
     *,
     dnn_backend: Int = Default('2'),model: String = Default(None),input: String = Default(None),output: String = Default(None),backend_configs: String = Default(None),options: String = Default(None),_async: Boolean = Default('true'),confidence: Float = Default('0.5'),labels: String = Default(None),target: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Do classification with deep neural networks based on bounding boxes.
 
 The filter accepts the following options:
@@ -6150,55 +6150,55 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dnn_classify)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dnn_classify', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dnn_backend": dnn_backend,
-                
+
                 "model": model,
-                
+
                 "input": input,
-                
+
                 "output": output,
-                
+
                 "backend_configs": backend_configs,
-                
+
                 "options": options,
-                
+
                 "async": _async,
-                
+
                 "confidence": confidence,
-                
+
                 "labels": labels,
-                
+
                 "target": target,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dnn_detect(
-    
+
     self,
 
 
@@ -6206,12 +6206,12 @@ References:
 
     *,
     dnn_backend: Int = Default('2'),model: String = Default(None),input: String = Default(None),output: String = Default(None),backend_configs: String = Default(None),options: String = Default(None),_async: Boolean = Default('true'),confidence: Float = Default('0.5'),labels: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Do object detection with deep neural networks.
 
 The filter accepts the following options:
@@ -6236,53 +6236,53 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dnn_detect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dnn_detect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dnn_backend": dnn_backend,
-                
+
                 "model": model,
-                
+
                 "input": input,
-                
+
                 "output": output,
-                
+
                 "backend_configs": backend_configs,
-                
+
                 "options": options,
-                
+
                 "async": _async,
-                
+
                 "confidence": confidence,
-                
+
                 "labels": labels,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dnn_processing(
-    
+
     self,
 
 
@@ -6290,12 +6290,12 @@ References:
 
     *,
     dnn_backend: Int| Literal["native"] | Default = Default('native'),model: String = Default(None),input: String = Default(None),output: String = Default(None),backend_configs: String = Default(None),options: String = Default(None),_async: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Do image processing with deep neural networks. It works together with another filter
 which converts the pixel format of the Frame to what the dnn network requires.
 
@@ -6319,49 +6319,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dnn_processing)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dnn_processing', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dnn_backend": dnn_backend,
-                
+
                 "model": model,
-                
+
                 "input": input,
-                
+
                 "output": output,
-                
+
                 "backend_configs": backend_configs,
-                
+
                 "options": options,
-                
+
                 "async": _async,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def doubleweave(
-    
+
     self,
 
 
@@ -6369,12 +6369,12 @@ References:
 
     *,
     first_field: Int| Literal["top","t","bottom","b"] | Default = Default('top'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The weave takes a field-based video input and join
 each two sequential fields into single frame, producing a new double
 height clip with half the frame rate and half the frame count.
@@ -6396,37 +6396,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#weave)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='doubleweave', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "first_field": first_field,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def drawbox(
-    
+
     self,
 
 
@@ -6434,15 +6434,15 @@ References:
 
     *,
     x: String = Default('0'),y: String = Default('0'),width: String = Default('0'),height: String = Default('0'),color: String = Default('black'),thickness: String = Default('3'),replace: Boolean = Default('false'),box_source: String = Default(None),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw a colored box on the input image.
 
 It accepts the following parameters:
@@ -6467,7 +6467,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#drawbox)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6475,48 +6475,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='drawbox', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "color": color,
-                
+
                 "thickness": thickness,
-                
+
                 "replace": replace,
-                
+
                 "box_source": box_source,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def drawgraph(
-    
+
     self,
 
 
@@ -6524,12 +6524,12 @@ References:
 
     *,
     m1: String = Default(''),fg1: String = Default('0xffff0000'),m2: String = Default(''),fg2: String = Default('0xff00ff00'),m3: String = Default(''),fg3: String = Default('0xffff00ff'),m4: String = Default(''),fg4: String = Default('0xffffff00'),bg: Color = Default('white'),min: Float = Default('-1'),max: Float = Default('1'),mode: Int| Literal["bar","dot","line"] | Default = Default('line'),slide: Int| Literal["frame","replace","scroll","rscroll","picture"] | Default = Default('frame'),size: Image_size = Default('900x256'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw a graph using input video metadata.
 
 It accepts the following parameters:
@@ -6560,65 +6560,65 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#drawgraph)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='drawgraph', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "m1": m1,
-                
+
                 "fg1": fg1,
-                
+
                 "m2": m2,
-                
+
                 "fg2": fg2,
-                
+
                 "m3": m3,
-                
+
                 "fg3": fg3,
-                
+
                 "m4": m4,
-                
+
                 "fg4": fg4,
-                
+
                 "bg": bg,
-                
+
                 "min": min,
-                
+
                 "max": max,
-                
+
                 "mode": mode,
-                
+
                 "slide": slide,
-                
+
                 "size": size,
-                
+
                 "rate": rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def drawgrid(
-    
+
     self,
 
 
@@ -6626,15 +6626,15 @@ References:
 
     *,
     x: String = Default('0'),y: String = Default('0'),width: String = Default('0'),height: String = Default('0'),color: String = Default('black'),thickness: String = Default('1'),replace: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw a grid on the input image.
 
 It accepts the following parameters:
@@ -6658,7 +6658,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#drawgrid)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6666,46 +6666,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='drawgrid', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "color": color,
-                
+
                 "thickness": thickness,
-                
+
                 "replace": replace,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def drawtext(
-    
+
     self,
 
 
@@ -6713,15 +6713,15 @@ References:
 
     *,
     fontfile: String = Default(None),text: String = Default(None),textfile: String = Default(None),fontcolor: Color = Default('black'),fontcolor_expr: String = Default(''),boxcolor: Color = Default('white'),bordercolor: Color = Default('black'),shadowcolor: Color = Default('black'),box: Boolean = Default('false'),boxborderw: Int = Default('0'),line_spacing: Int = Default('0'),fontsize: String = Default(None),x: String = Default('0'),y: String = Default('0'),shadowx: Int = Default('0'),shadowy: Int = Default('0'),borderw: Int = Default('0'),tabsize: Int = Default('4'),basetime: Int64 = Default('I64_MIN'),font: String = Default('Sans'),expansion: Int| Literal["none","normal","strftime"] | Default = Default('normal'),timecode: String = Default(None),tc24hmax: Boolean = Default('false'),timecode_rate: Rational = Default('0/1'),reload: Int = Default('0'),alpha: String = Default('1'),fix_bounds: Boolean = Default('false'),start_number: Int = Default('0'),text_source: String = Default(None),text_shaping: Boolean = Default('true'),ft_load_flags: Flags| Literal["default","no_scale","no_hinting","render","no_bitmap","vertical_layout","force_autohint","crop_bitmap","pedantic","ignore_global_advance_width","no_recurse","ignore_transform","monochrome","linear_design","no_autohint"] | Default = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw a text string or text from a specified file on top of a video, using the
 libfreetype library.
 
@@ -6775,7 +6775,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#drawtext)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6783,102 +6783,102 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='drawtext', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "fontfile": fontfile,
-                
+
                 "text": text,
-                
+
                 "textfile": textfile,
-                
+
                 "fontcolor": fontcolor,
-                
+
                 "fontcolor_expr": fontcolor_expr,
-                
+
                 "boxcolor": boxcolor,
-                
+
                 "bordercolor": bordercolor,
-                
+
                 "shadowcolor": shadowcolor,
-                
+
                 "box": box,
-                
+
                 "boxborderw": boxborderw,
-                
+
                 "line_spacing": line_spacing,
-                
+
                 "fontsize": fontsize,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "shadowx": shadowx,
-                
+
                 "shadowy": shadowy,
-                
+
                 "borderw": borderw,
-                
+
                 "tabsize": tabsize,
-                
+
                 "basetime": basetime,
-                
+
                 "font": font,
-                
+
                 "expansion": expansion,
-                
+
                 "timecode": timecode,
-                
+
                 "tc24hmax": tc24hmax,
-                
+
                 "timecode_rate": timecode_rate,
-                
+
                 "reload": reload,
-                
+
                 "alpha": alpha,
-                
+
                 "fix_bounds": fix_bounds,
-                
+
                 "start_number": start_number,
-                
+
                 "text_source": text_source,
-                
+
                 "text_shaping": text_shaping,
-                
+
                 "ft_load_flags": ft_load_flags,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def edgedetect(
-    
+
     self,
 
 
@@ -6886,15 +6886,15 @@ References:
 
     *,
     high: Double = Default('0.196078'),low: Double = Default('0.0784314'),mode: Int| Literal["wires","colormix","canny"] | Default = Default('wires'),planes: Flags| Literal["y","u","v","r","g","b"] | Default = Default('y+u+v+r+g+b'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect and draw edges. The filter uses the Canny Edge Detection algorithm.
 
 The filter accepts the following options:
@@ -6915,7 +6915,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#edgedetect)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6923,40 +6923,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='edgedetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "high": high,
-                
+
                 "low": low,
-                
+
                 "mode": mode,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def elbg(
-    
+
     self,
 
 
@@ -6964,12 +6964,12 @@ References:
 
     *,
     codebook_length: Int = Default('256'),nb_steps: Int = Default('1'),seed: Int64 = Default('-1'),pal8: Boolean = Default('false'),use_alpha: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a posterize effect using the ELBG (Enhanced LBG) algorithm.
 
 For each input image, the filter will compute the optimal mapping from
@@ -6994,45 +6994,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#elbg)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='elbg', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "codebook_length": codebook_length,
-                
+
                 "nb_steps": nb_steps,
-                
+
                 "seed": seed,
-                
+
                 "pal8": pal8,
-                
+
                 "use_alpha": use_alpha,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def entropy(
-    
+
     self,
 
 
@@ -7040,15 +7040,15 @@ References:
 
     *,
     mode: Int| Literal["normal","diff"] | Default = Default('normal'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Measure graylevel entropy in histogram of color channels of video frames.
 
 It accepts the following parameters:
@@ -7066,7 +7066,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#entropy)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7074,34 +7074,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='entropy', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def epx(
-    
+
     self,
 
 
@@ -7109,12 +7109,12 @@ References:
 
     *,
     n: Int = Default('3'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply the EPX magnification filter which is designed for pixel art.
 
 It accepts the following option:
@@ -7131,37 +7131,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#epx)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='epx', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "n": n,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def eq(
-    
+
     self,
 
 
@@ -7169,15 +7169,15 @@ References:
 
     *,
     contrast: String = Default('1.0'),brightness: String = Default('0.0'),saturation: String = Default('1.0'),gamma: String = Default('1.0'),gamma_r: String = Default('1.0'),gamma_g: String = Default('1.0'),gamma_b: String = Default('1.0'),gamma_weight: String = Default('1.0'),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Set brightness, contrast, saturation and approximate gamma adjustment.
 
 The filter accepts the following options:
@@ -7203,7 +7203,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#eq)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7211,52 +7211,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='eq', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "contrast": contrast,
-                
+
                 "brightness": brightness,
-                
+
                 "saturation": saturation,
-                
+
                 "gamma": gamma,
-                
+
                 "gamma_r": gamma_r,
-                
+
                 "gamma_g": gamma_g,
-                
+
                 "gamma_b": gamma_b,
-                
+
                 "gamma_weight": gamma_weight,
-                
+
                 "eval": eval,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def erosion(
-    
+
     self,
 
 
@@ -7264,15 +7264,15 @@ References:
 
     *,
     coordinates: Int = Default('255'),threshold0: Int = Default('65535'),threshold1: Int = Default('65535'),threshold2: Int = Default('65535'),threshold3: Int = Default('65535'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply erosion effect to the video.
 
 This filter replaces the pixel by the local(3x3) minimum.
@@ -7296,7 +7296,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#erosion)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7304,42 +7304,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='erosion', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "coordinates": coordinates,
-                
+
                 "threshold0": threshold0,
-                
+
                 "threshold1": threshold1,
-                
+
                 "threshold2": threshold2,
-                
+
                 "threshold3": threshold3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def erosion_opencl(
-    
+
     self,
 
 
@@ -7347,12 +7347,12 @@ References:
 
     *,
     threshold0: Float = Default('65535'),threshold1: Float = Default('65535'),threshold2: Float = Default('65535'),threshold3: Float = Default('65535'),coordinates: Int = Default('255'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply erosion effect to the video.
 
 This filter replaces the pixel by the local(3x3) minimum.
@@ -7375,45 +7375,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#erosion_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='erosion_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold0": threshold0,
-                
+
                 "threshold1": threshold1,
-                
+
                 "threshold2": threshold2,
-                
+
                 "threshold3": threshold3,
-                
+
                 "coordinates": coordinates,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def estdif(
-    
+
     self,
 
 
@@ -7421,15 +7421,15 @@ References:
 
     *,
     mode: Int| Literal["frame","field"] | Default = Default('field'),parity: Int| Literal["tff","bff","auto"] | Default = Default('auto'),deint: Int| Literal["all","interlaced"] | Default = Default('all'),rslope: Int = Default('1'),redge: Int = Default('2'),ecost: Float = Default('1'),mcost: Float = Default('0.5'),dcost: Float = Default('0.5'),interp: Int| Literal["2p","4p","6p"] | Default = Default('4p'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlace the input video ("estdif" stands for "Edge Slope
 Tracing Deinterlacing Filter").
 
@@ -7458,7 +7458,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#estdif)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7466,50 +7466,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='estdif', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "parity": parity,
-                
+
                 "deint": deint,
-                
+
                 "rslope": rslope,
-                
+
                 "redge": redge,
-                
+
                 "ecost": ecost,
-                
+
                 "mcost": mcost,
-                
+
                 "dcost": dcost,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def exposure(
-    
+
     self,
 
 
@@ -7517,15 +7517,15 @@ References:
 
     *,
     exposure: Float = Default('0'),black: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust exposure of the video stream.
 
 The filter accepts the following options:
@@ -7544,7 +7544,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#exposure)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7552,36 +7552,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='exposure', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "exposure": exposure,
-                
+
                 "black": black,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def extractplanes(
-    
+
     self,
 
 
@@ -7589,12 +7589,12 @@ References:
 
     *,
     planes: Flags| Literal["y","u","v","r","g","b","a"] | Default = Default('r'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Extract color channel components from input video stream into
 separate grayscale video streams.
 
@@ -7613,40 +7613,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#extractplanes)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='extractplanes', typings_input=('video',), typings_output="[StreamType.video] * len(planes.split('+'))"),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def fade(
-    
+
     self,
 
 
@@ -7654,15 +7654,15 @@ References:
 
     *,
     type: Int| Literal["in","out"] | Default = Default('in'),start_frame: Int = Default('0'),nb_frames: Int = Default('25'),alpha: Boolean = Default('false'),start_time: Duration = Default('0'),duration: Duration = Default('0'),color: Color = Default('black'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a fade-in/out effect to the input video.
 
 It accepts the following parameters:
@@ -7686,7 +7686,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fade)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7694,77 +7694,77 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fade', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "type": type,
-                
+
                 "start_frame": start_frame,
-                
+
                 "nb_frames": nb_frames,
-                
+
                 "alpha": alpha,
-                
+
                 "start_time": start_time,
-                
+
                 "duration": duration,
-                
+
                 "color": color,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def feedback(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _feedin: VideoStream,
-        
-    
+
+
 
 
     *,
     x: Int = Default('0'),w: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> tuple[
-    
-        
+
+
             VideoStream,
-        
-    
-        
+
+
+
             VideoStream,
-        
-    
+
+
 ]:
         """
-        
+
 Apply feedback video filter.
 
 This filter pass cropped input frames to 2nd output.
@@ -7791,58 +7791,58 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#feedback)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='feedback', typings_input=('video', 'video'), typings_output=('video', 'video')),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _feedin,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "w": w,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return (
-            
-                
+
+
                     filter_node.video(0),
-                
-            
-                
+
+
+
                     filter_node.video(1),
-                
-            
+
+
         )
 
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fftdnoiz(
-    
+
     self,
 
 
@@ -7850,15 +7850,15 @@ References:
 
     *,
     sigma: Float = Default('1'),amount: Float = Default('1'),block: Int = Default('32'),overlap: Float = Default('0.5'),method: Int| Literal["wiener","hard"] | Default = Default('wiener'),prev: Int = Default('0'),next: Int = Default('0'),planes: Int = Default('7'),window: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman"] | Default = Default('hann'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Denoise frames using 3D FFT (frequency domain filtering).
 
 The filter accepts the following options:
@@ -7884,7 +7884,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fftdnoiz)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7892,50 +7892,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fftdnoiz', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sigma": sigma,
-                
+
                 "amount": amount,
-                
+
                 "block": block,
-                
+
                 "overlap": overlap,
-                
+
                 "method": method,
-                
+
                 "prev": prev,
-                
+
                 "next": next,
-                
+
                 "planes": planes,
-                
+
                 "window": window,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fftfilt(
-    
+
     self,
 
 
@@ -7943,15 +7943,15 @@ References:
 
     *,
     dc_Y: Int = Default('0'),dc_U: Int = Default('0'),dc_V: Int = Default('0'),weight_Y: String = Default('1'),weight_U: String = Default(None),weight_V: String = Default(None),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply arbitrary expressions to samples in frequency domain
 
 
@@ -7973,7 +7973,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fftfilt)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7981,46 +7981,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fftfilt', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dc_Y": dc_Y,
-                
+
                 "dc_U": dc_U,
-                
+
                 "dc_V": dc_V,
-                
+
                 "weight_Y": weight_Y,
-                
+
                 "weight_U": weight_U,
-                
+
                 "weight_V": weight_V,
-                
+
                 "eval": eval,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def field(
-    
+
     self,
 
 
@@ -8028,12 +8028,12 @@ References:
 
     *,
     type: Int| Literal["top","bottom"] | Default = Default('top'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Extract a single field from an interlaced image using stride
 arithmetic to avoid wasting CPU time. The output frames are marked as
 non-interlaced.
@@ -8052,37 +8052,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#field)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='field', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fieldhint(
-    
+
     self,
 
 
@@ -8090,12 +8090,12 @@ References:
 
     *,
     hint: String = Default(None),mode: Int| Literal["absolute","relative","pattern"] | Default = Default('absolute'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Create new frames by copying the top and bottom fields from surrounding frames
 supplied as numbers by the hint file.
 
@@ -8112,41 +8112,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fieldhint)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fieldhint', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "hint": hint,
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def fieldorder(
-    
+
     self,
 
 
@@ -8154,15 +8154,15 @@ References:
 
     *,
     order: Int| Literal["bff","tff"] | Default = Default('tff'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Transform the field order of the input video.
 
 It accepts the following parameters:
@@ -8180,7 +8180,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fieldorder)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8188,47 +8188,47 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fieldorder', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "order": order,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fifo(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Buffer input images and send them when they are requested.
 
 It is mainly useful when auto-inserted by the libavfilter
@@ -8247,35 +8247,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fifo)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fifo', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fillborders(
-    
+
     self,
 
 
@@ -8283,15 +8283,15 @@ References:
 
     *,
     left: Int = Default('0'),right: Int = Default('0'),top: Int = Default('0'),bottom: Int = Default('0'),mode: Int| Literal["smear","mirror","fixed","reflect","wrap","fade","margins"] | Default = Default('smear'),color: Color = Default('black'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Fill borders of the input video, without changing video stream dimensions.
 Sometimes video can have garbage at the four edges and you may not want to
 crop video input to keep size multiple of some number.
@@ -8316,7 +8316,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fillborders)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8324,44 +8324,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fillborders', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "left": left,
-                
+
                 "right": right,
-                
+
                 "top": top,
-                
+
                 "bottom": bottom,
-                
+
                 "mode": mode,
-                
+
                 "color": color,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def find_rect(
-    
+
     self,
 
 
@@ -8369,12 +8369,12 @@ References:
 
     *,
     object: String = Default(None),threshold: Float = Default('0.5'),mipmaps: Int = Default('3'),xmin: Int = Default('0'),discard: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Find a rectangular object
 
 It accepts the following options:
@@ -8395,49 +8395,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#find_rect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='find_rect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "object": object,
-                
+
                 "threshold": threshold,
-                
+
                 "mipmaps": mipmaps,
-                
+
                 "xmin": xmin,
-                
+
                 "discard": discard,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def floodfill(
-    
+
     self,
 
 
@@ -8445,15 +8445,15 @@ References:
 
     *,
     x: Int = Default('0'),y: Int = Default('0'),s0: Int = Default('0'),s1: Int = Default('0'),s2: Int = Default('0'),s3: Int = Default('0'),d0: Int = Default('0'),d1: Int = Default('0'),d2: Int = Default('0'),d3: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Flood area with values of same pixel components with another values.
 
 It accepts the following options:
@@ -8480,7 +8480,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#floodfill)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8488,52 +8488,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='floodfill', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "s0": s0,
-                
+
                 "s1": s1,
-                
+
                 "s2": s2,
-                
+
                 "s3": s3,
-                
+
                 "d0": d0,
-                
+
                 "d1": d1,
-                
+
                 "d2": d2,
-                
+
                 "d3": d3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def format(
-    
+
     self,
 
 
@@ -8541,12 +8541,12 @@ References:
 
     *,
     pix_fmts: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert the input video to one of the specified pixel formats.
 Libavfilter will try to pick one that is suitable as input to
 the next filter.
@@ -8565,37 +8565,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#format)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='format', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "pix_fmts": pix_fmts,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fps(
-    
+
     self,
 
 
@@ -8603,12 +8603,12 @@ References:
 
     *,
     fps: String = Default('25'),start_time: Double = Default('DBL_MAX'),round: Int| Literal["zero","inf","down","up","near"] | Default = Default('near'),eof_action: Int| Literal["round","pass"] | Default = Default('round'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert the video to specified constant frame rate by duplicating or dropping
 frames as necessary.
 
@@ -8629,64 +8629,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fps)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fps', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "fps": fps,
-                
+
                 "start_time": start_time,
-                
+
                 "round": round,
-                
+
                 "eof_action": eof_action,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def framepack(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _right: VideoStream,
-        
-    
+
+
 
 
     *,
     format: Int| Literal["sbs","tab","frameseq","lines","columns"] | Default = Default('sbs'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pack two different video streams into a stereoscopic video, setting proper
 metadata on supported codecs. The two views should have the same size and
 framerate and processing will stop when the shorter video ends. Please note
@@ -8707,45 +8707,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#framepack)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='framepack', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _right,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "format": format,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def framerate(
-    
+
     self,
 
 
@@ -8753,12 +8753,12 @@ References:
 
     *,
     fps: Video_rate = Default('50'),interp_start: Int = Default('15'),interp_end: Int = Default('240'),scene: Double = Default('8.2'),flags: Flags| Literal["scene_change_detect","scd"] | Default = Default('scene_change_detect+scd'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Change the frame rate by interpolating new video output frames from the source
 frames.
 
@@ -8784,45 +8784,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#framerate)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='framerate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "fps": fps,
-                
+
                 "interp_start": interp_start,
-                
+
                 "interp_end": interp_end,
-                
+
                 "scene": scene,
-                
+
                 "flags": flags,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def framestep(
-    
+
     self,
 
 
@@ -8830,15 +8830,15 @@ References:
 
     *,
     step: Int = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Select one frame every N-th frame.
 
 This filter accepts the following option:
@@ -8856,7 +8856,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#framestep)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8864,34 +8864,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='framestep', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "step": step,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def freezedetect(
-    
+
     self,
 
 
@@ -8899,12 +8899,12 @@ References:
 
     *,
     n: Double = Default('0.001'),d: Duration = Default('2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect frozen video.
 
 This filter logs a message and sets frame metadata when it detects that the
@@ -8935,60 +8935,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#freezedetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='freezedetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "n": n,
-                
+
                 "d": d,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def freezeframes(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _replace: VideoStream,
-        
-    
+
+
 
 
     *,
     first: Int64 = Default('0'),last: Int64 = Default('0'),replace: Int64 = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Freeze video frames.
 
 This filter freezes video frames using frame from 2nd input.
@@ -9009,49 +9009,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#freezeframes)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='freezeframes', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _replace,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "first": first,
-                
+
                 "last": last,
-                
+
                 "replace": replace,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fspp(
-    
+
     self,
 
 
@@ -9059,15 +9059,15 @@ References:
 
     *,
     quality: Int = Default('4'),qp: Int = Default('0'),strength: Int = Default('0'),use_bframe_qp: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply fast and simple postprocessing. It is a faster version of spp.
 
 It splits (I)DCT into horizontal/vertical passes. Unlike the simple post-
@@ -9092,7 +9092,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fspp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9100,40 +9100,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fspp', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "quality": quality,
-                
+
                 "qp": qp,
-                
+
                 "strength": strength,
-                
+
                 "use_bframe_qp": use_bframe_qp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def gblur(
-    
+
     self,
 
 
@@ -9141,15 +9141,15 @@ References:
 
     *,
     sigma: Float = Default('0.5'),steps: Int = Default('1'),planes: Int = Default('15'),sigmaV: Float = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Gaussian blur filter.
 
 The filter accepts the following options:
@@ -9170,7 +9170,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#gblur)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9178,40 +9178,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='gblur', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sigma": sigma,
-                
+
                 "steps": steps,
-                
+
                 "planes": planes,
-                
+
                 "sigmaV": sigmaV,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def geq(
-    
+
     self,
 
 
@@ -9219,15 +9219,15 @@ References:
 
     *,
     lum_expr: String = Default(None),cb_expr: String = Default(None),cr_expr: String = Default(None),alpha_expr: String = Default(None),red_expr: String = Default(None),green_expr: String = Default(None),blue_expr: String = Default(None),interpolation: Int| Literal["nearest","n","bilinear","b"] | Default = Default('bilinear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply generic equation to each pixel.
 
 The filter accepts the following options:
@@ -9252,7 +9252,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#geq)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9260,48 +9260,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='geq', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "lum_expr": lum_expr,
-                
+
                 "cb_expr": cb_expr,
-                
+
                 "cr_expr": cr_expr,
-                
+
                 "alpha_expr": alpha_expr,
-                
+
                 "red_expr": red_expr,
-                
+
                 "green_expr": green_expr,
-                
+
                 "blue_expr": blue_expr,
-                
+
                 "interpolation": interpolation,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def gradfun(
-    
+
     self,
 
 
@@ -9309,15 +9309,15 @@ References:
 
     *,
     strength: Float = Default('1.2'),radius: Int = Default('16'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Fix the banding artifacts that are sometimes introduced into nearly flat
 regions by truncation to 8-bit color depth.
 Interpolate the gradients that should go where the bands are, and
@@ -9343,7 +9343,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#gradfun)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9351,38 +9351,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='gradfun', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "strength": strength,
-                
+
                 "radius": radius,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def graphmonitor(
-    
+
     self,
 
 
@@ -9390,12 +9390,12 @@ References:
 
     *,
     size: Image_size = Default('hd720'),opacity: Float = Default('0.9'),mode: Int| Literal["full","compact"] | Default = Default('full'),flags: Flags| Literal["queue","frame_count_in","frame_count_out","frame_count_delta","pts","pts_delta","time","time_delta","timebase","format","size","rate","eof","sample_count_in","sample_count_out","sample_count_delta"] | Default = Default('queue'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Show various filtergraph stats.
 
 With this filter one can debug complete filtergraph.
@@ -9419,61 +9419,61 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#graphmonitor)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='graphmonitor', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "opacity": opacity,
-                
+
                 "mode": mode,
-                
+
                 "flags": flags,
-                
+
                 "rate": rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def grayworld(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 A color constancy filter that applies color correction based on the grayworld assumption
 
 See: https://www.researchgate.net/publication/275213614_A_New_Color_Correction_Method_for_Underwater_Imaging
@@ -9497,7 +9497,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#grayworld)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9505,32 +9505,32 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='grayworld', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def greyedge(
-    
+
     self,
 
 
@@ -9538,15 +9538,15 @@ References:
 
     *,
     difford: Int = Default('1'),minknorm: Int = Default('1'),sigma: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 A color constancy variation filter which estimates scene illumination via grey edge algorithm
 and corrects the scene colors accordingly.
 
@@ -9569,7 +9569,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#greyedge)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9577,71 +9577,71 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='greyedge', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "difford": difford,
-                
+
                 "minknorm": minknorm,
-                
+
                 "sigma": sigma,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def haldclut(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _clut: VideoStream,
-        
-    
+
+
 
 
     *,
     clut: Int| Literal["first","all"] | Default = Default('all'),interp: Int| Literal["nearest","trilinear","tetrahedral","pyramid","prism"] | Default = Default('tetrahedral'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a Hald CLUT to a video stream.
 
 First input is the video stream to process, and second one is the Hald CLUT.
@@ -9664,7 +9664,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#haldclut)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -9675,68 +9675,68 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='haldclut', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _clut,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "clut": clut,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def hflip(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Flip the input video horizontally.
 
 For example, to horizontally flip the input video with ffmpeg:
@@ -9756,7 +9756,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hflip)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9764,38 +9764,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hflip', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def histeq(
-    
+
     self,
 
 
@@ -9803,15 +9803,15 @@ References:
 
     *,
     strength: Float = Default('0.2'),intensity: Float = Default('0.21'),antibanding: Int| Literal["none","weak","strong"] | Default = Default('none'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 This filter applies a global color histogram equalization on a
 per-frame basis.
 
@@ -9839,7 +9839,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#histeq)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9847,38 +9847,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='histeq', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "strength": strength,
-                
+
                 "intensity": intensity,
-                
+
                 "antibanding": antibanding,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def histogram(
-    
+
     self,
 
 
@@ -9886,12 +9886,12 @@ References:
 
     *,
     level_height: Int = Default('200'),scale_height: Int = Default('12'),display_mode: Int| Literal["overlay","parade","stack"] | Default = Default('stack'),levels_mode: Int| Literal["linear","logarithmic"] | Default = Default('linear'),components: Int = Default('7'),fgopacity: Float = Default('0.7'),bgopacity: Float = Default('0.5'),colors_mode: Int| Literal["whiteonblack","blackonwhite","whiteongray","blackongray","coloronblack","coloronwhite","colorongray","blackoncolor","whiteoncolor","grayoncolor"] | Default = Default('whiteonblack'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Compute and draw a color distribution histogram for the input video.
 
 The computed histogram is a representation of the color component
@@ -9923,51 +9923,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#histogram)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='histogram', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_height": level_height,
-                
+
                 "scale_height": scale_height,
-                
+
                 "display_mode": display_mode,
-                
+
                 "levels_mode": levels_mode,
-                
+
                 "components": components,
-                
+
                 "fgopacity": fgopacity,
-                
+
                 "bgopacity": bgopacity,
-                
+
                 "colors_mode": colors_mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hqdn3d(
-    
+
     self,
 
 
@@ -9975,15 +9975,15 @@ References:
 
     *,
     luma_spatial: Double = Default('0'),chroma_spatial: Double = Default('0'),luma_tmp: Double = Default('0'),chroma_tmp: Double = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 This is a high precision/quality 3d denoise filter. It aims to reduce
 image noise, producing smooth images and making still images really
 still. It should enhance compressibility.
@@ -10006,7 +10006,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hqdn3d)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -10014,40 +10014,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hqdn3d', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_spatial": luma_spatial,
-                
+
                 "chroma_spatial": chroma_spatial,
-                
+
                 "luma_tmp": luma_tmp,
-                
+
                 "chroma_tmp": chroma_tmp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hqx(
-    
+
     self,
 
 
@@ -10055,12 +10055,12 @@ References:
 
     *,
     n: Int = Default('3'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a high-quality magnification filter designed for pixel art. This filter
 was originally created by Maxim Stepin.
 
@@ -10078,39 +10078,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hqx)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hqx', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "n": n,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def hsvhold(
-    
+
     self,
 
 
@@ -10118,15 +10118,15 @@ References:
 
     *,
     hue: Float = Default('0'),sat: Float = Default('0'),val: Float = Default('0'),similarity: Float = Default('0.01'),blend: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Turns a certain HSV range into gray values.
 
 This filter measures color difference between set HSV color in options
@@ -10152,7 +10152,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hsvhold)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -10160,42 +10160,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hsvhold', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "hue": hue,
-                
+
                 "sat": sat,
-                
+
                 "val": val,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hsvkey(
-    
+
     self,
 
 
@@ -10203,15 +10203,15 @@ References:
 
     *,
     hue: Float = Default('0'),sat: Float = Default('0'),val: Float = Default('0'),similarity: Float = Default('0.01'),blend: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Turns a certain HSV range into transparency.
 
 This filter measures color difference between set HSV color in options
@@ -10237,7 +10237,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hsvkey)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -10245,42 +10245,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hsvkey', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "hue": hue,
-                
+
                 "sat": sat,
-                
+
                 "val": val,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hue(
-    
+
     self,
 
 
@@ -10288,15 +10288,15 @@ References:
 
     *,
     h: String = Default(None),s: String = Default('1'),H: String = Default(None),b: String = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Modify the hue and/or the saturation of the input.
 
 It accepts the following parameters:
@@ -10317,7 +10317,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hue)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -10325,40 +10325,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hue', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "h": h,
-                
+
                 "s": s,
-                
+
                 "H": H,
-                
+
                 "b": b,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def huesaturation(
-    
+
     self,
 
 
@@ -10366,15 +10366,15 @@ References:
 
     *,
     hue: Float = Default('0'),saturation: Float = Default('0'),intensity: Float = Default('0'),colors: Flags| Literal["r","y","g","c","b","m","a"] | Default = Default('r+y+g+c+b+m+a'),strength: Float = Default('1'),rw: Float = Default('0.333'),gw: Float = Default('0.334'),bw: Float = Default('0.333'),lightness: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply hue-saturation-intensity adjustments to input video stream.
 
 This filter operates in RGB colorspace.
@@ -10402,7 +10402,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#huesaturation)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -10410,63 +10410,63 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='huesaturation', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "hue": hue,
-                
+
                 "saturation": saturation,
-                
+
                 "intensity": intensity,
-                
+
                 "colors": colors,
-                
+
                 "strength": strength,
-                
+
                 "rw": rw,
-                
+
                 "gw": gw,
-                
+
                 "bw": bw,
-                
+
                 "lightness": lightness,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hwdownload(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Download hardware frames to system memory.
 
 The input must be in hardware frames, and the output a non-hardware format.
@@ -10485,35 +10485,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hwdownload)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hwdownload', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hwmap(
-    
+
     self,
 
 
@@ -10521,12 +10521,12 @@ References:
 
     *,
     mode: Flags| Literal["read","write","overwrite","direct"] | Default = Default('read+write'),derive_device: String = Default(None),reverse: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Map hardware frames to system memory or to another device.
 
 This filter has several different modes of operation; which one is used depends
@@ -10546,41 +10546,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hwmap)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hwmap', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "derive_device": derive_device,
-                
+
                 "reverse": reverse,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hwupload(
-    
+
     self,
 
 
@@ -10588,12 +10588,12 @@ References:
 
     *,
     derive_device: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Upload system memory frames to hardware surfaces.
 
 The device to upload to must be supplied when the filter is initialised.  If
@@ -10617,66 +10617,66 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hwupload)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hwupload', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "derive_device": derive_device,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hysteresis(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _alt: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),threshold: Int = Default('0'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Grow first stream into second stream by connecting components.
 This makes it possible to build more robust edge masks.
 
@@ -10697,7 +10697,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hysteresis)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -10708,75 +10708,75 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hysteresis', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _alt,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "threshold": threshold,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def identity(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the identity score between two input videos.
 
 This filter takes two input videos.
@@ -10810,7 +10810,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#identity)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -10821,42 +10821,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='identity', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def idet(
-    
+
     self,
 
 
@@ -10864,12 +10864,12 @@ References:
 
     *,
     intl_thres: Float = Default('1.04'),prog_thres: Float = Default('1.5'),rep_thres: Float = Default('3'),half_life: Float = Default('0'),analyze_interlaced_flag: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect video interlacing type.
 
 This filter tries to detect if the input frames are interlaced, progressive,
@@ -10897,45 +10897,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#idet)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='idet', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "intl_thres": intl_thres,
-                
+
                 "prog_thres": prog_thres,
-                
+
                 "rep_thres": rep_thres,
-                
+
                 "half_life": half_life,
-                
+
                 "analyze_interlaced_flag": analyze_interlaced_flag,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def il(
-    
+
     self,
 
 
@@ -10943,15 +10943,15 @@ References:
 
     *,
     luma_mode: Int| Literal["none","interleave","i","deinterleave","d"] | Default = Default('none'),chroma_mode: Int| Literal["none","interleave","i","deinterleave","d"] | Default = Default('none'),alpha_mode: Int| Literal["none","interleave","i","deinterleave","d"] | Default = Default('none'),luma_swap: Boolean = Default('false'),chroma_swap: Boolean = Default('false'),alpha_swap: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterleave or interleave fields.
 
 This filter allows one to process interlaced images fields without
@@ -10980,7 +10980,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#il)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -10988,44 +10988,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='il', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_mode": luma_mode,
-                
+
                 "chroma_mode": chroma_mode,
-                
+
                 "alpha_mode": alpha_mode,
-                
+
                 "luma_swap": luma_swap,
-                
+
                 "chroma_swap": chroma_swap,
-                
+
                 "alpha_swap": alpha_swap,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def inflate(
-    
+
     self,
 
 
@@ -11033,15 +11033,15 @@ References:
 
     *,
     threshold0: Int = Default('65535'),threshold1: Int = Default('65535'),threshold2: Int = Default('65535'),threshold3: Int = Default('65535'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply inflate effect to the video.
 
 This filter replaces the pixel by the local(3x3) average by taking into account
@@ -11065,7 +11065,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#inflate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11073,40 +11073,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='inflate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold0": threshold0,
-                
+
                 "threshold1": threshold1,
-                
+
                 "threshold2": threshold2,
-                
+
                 "threshold3": threshold3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def interlace(
-    
+
     self,
 
 
@@ -11114,12 +11114,12 @@ References:
 
     *,
     scan: Int| Literal["tff","bff"] | Default = Default('tff'),lowpass: Int| Literal["off","linear","complex"] | Default = Default('linear'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Simple interlacing filter from progressive contents. This interleaves upper (or
 lower) lines from odd frames with lower (or upper) lines from even frames,
 halving the frame rate and preserving image height.
@@ -11151,43 +11151,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#interlace)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='interlace', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "scan": scan,
-                
+
                 "lowpass": lowpass,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def kerndeint(
-    
+
     self,
 
 
@@ -11195,12 +11195,12 @@ References:
 
     *,
     thresh: Int = Default('10'),map: Boolean = Default('false'),order: Boolean = Default('false'),sharp: Boolean = Default('false'),twoway: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlace input video by applying Donald Graft's adaptive kernel
 deinterling. Work on interlaced parts of a video to produce
 progressive frames.
@@ -11223,45 +11223,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#kerndeint)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='kerndeint', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "thresh": thresh,
-                
+
                 "map": map,
-                
+
                 "order": order,
-                
+
                 "sharp": sharp,
-                
+
                 "twoway": twoway,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def kirsch(
-    
+
     self,
 
 
@@ -11269,15 +11269,15 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply kirsch operator to input video stream.
 
 The filter accepts the following option:
@@ -11297,7 +11297,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#kirsch)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11305,38 +11305,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='kirsch', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lagfun(
-    
+
     self,
 
 
@@ -11344,15 +11344,15 @@ References:
 
     *,
     decay: Float = Default('0.95'),planes: Flags = Default('F'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Slowly update darker pixels.
 
 This filter makes short flashes of light appear longer.
@@ -11372,7 +11372,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lagfun)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11380,52 +11380,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lagfun', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "decay": decay,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def latency(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Measure filtering latency.
 
 Report previous filter filtering latency, delay in number of audio samples for audio filters
@@ -11446,7 +11446,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#latency)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11454,32 +11454,32 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='latency', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lenscorrection(
-    
+
     self,
 
 
@@ -11487,15 +11487,15 @@ References:
 
     *,
     cx: Double = Default('0.5'),cy: Double = Default('0.5'),k1: Double = Default('0'),k2: Double = Default('0'),i: Int| Literal["nearest","bilinear"] | Default = Default('nearest'),fc: Color = Default('black@0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Correct radial lens distortion
 
 This filter can be used to correct for radial distortion as can result from the use
@@ -11531,7 +11531,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lenscorrection)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11539,48 +11539,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lenscorrection', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cx": cx,
-                
+
                 "cy": cy,
-                
+
                 "k1": k1,
-                
+
                 "k2": k2,
-                
+
                 "i": i,
-                
+
                 "fc": fc,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def limiter(
-    
+
     self,
 
 
@@ -11588,15 +11588,15 @@ References:
 
     *,
     min: Int = Default('0'),max: Int = Default('65535'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Limits the pixel components values to the specified range [min, max].
 
 The filter accepts the following options:
@@ -11616,7 +11616,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#limiter)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11624,38 +11624,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='limiter', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "min": min,
-                
+
                 "max": max,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def loop(
-    
+
     self,
 
 
@@ -11663,12 +11663,12 @@ References:
 
     *,
     loop: Int = Default('0'),size: Int64 = Default('0'),start: Int64 = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Loop video frames.
 
 The filter accepts the following options:
@@ -11687,47 +11687,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#loop)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='loop', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "loop": loop,
-                
+
                 "size": size,
-                
+
                 "start": start,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def lumakey(
-    
+
     self,
 
 
@@ -11735,15 +11735,15 @@ References:
 
     *,
     threshold: Double = Default('0'),tolerance: Double = Default('0.01'),softness: Double = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Turn certain luma values into transparency.
 
 The filter accepts the following options:
@@ -11763,7 +11763,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lumakey)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11771,38 +11771,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lumakey', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold": threshold,
-                
+
                 "tolerance": tolerance,
-                
+
                 "softness": softness,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lut(
-    
+
     self,
 
 
@@ -11810,15 +11810,15 @@ References:
 
     *,
     c0: String = Default('clipval'),c1: String = Default('clipval'),c2: String = Default('clipval'),c3: String = Default('clipval'),y: String = Default('clipval'),u: String = Default('clipval'),v: String = Default('clipval'),r: String = Default('clipval'),g: String = Default('clipval'),b: String = Default('clipval'),a: String = Default('clipval'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Compute a look-up table for binding each pixel component input value
 to an output value, and apply it to the input video.
 
@@ -11850,7 +11850,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11858,54 +11858,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lut', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "c0": c0,
-                
+
                 "c1": c1,
-                
+
                 "c2": c2,
-                
+
                 "c3": c3,
-                
+
                 "y": y,
-                
+
                 "u": u,
-                
+
                 "v": v,
-                
+
                 "r": r,
-                
+
                 "g": g,
-                
+
                 "b": b,
-                
+
                 "a": a,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lut1d(
-    
+
     self,
 
 
@@ -11913,15 +11913,15 @@ References:
 
     *,
     file: String = Default(None),interp: Int| Literal["nearest","linear","cosine","cubic","spline"] | Default = Default('linear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a 1D LUT to an input video.
 
 The filter accepts the following options:
@@ -11940,7 +11940,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut1d)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11948,65 +11948,65 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lut1d', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "file": file,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lut2(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _srcy: VideoStream,
-        
-    
+
+
 
 
     *,
     c0: String = Default('x'),c1: String = Default('x'),c2: String = Default('x'),c3: String = Default('x'),d: Int = Default('0'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The lut2 filter takes two input streams and outputs one
 stream.
 
@@ -12033,7 +12033,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut2)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -12044,52 +12044,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lut2', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _srcy,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "c0": c0,
-                
+
                 "c1": c1,
-                
+
                 "c2": c2,
-                
+
                 "c3": c3,
-                
+
                 "d": d,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lut3d(
-    
+
     self,
 
 
@@ -12097,15 +12097,15 @@ References:
 
     *,
     file: String = Default(None),clut: Int| Literal["first","all"] | Default = Default('all'),interp: Int| Literal["nearest","trilinear","tetrahedral","pyramid","prism"] | Default = Default('tetrahedral'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a 3D LUT to an input video.
 
 The filter accepts the following options:
@@ -12125,7 +12125,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut3d)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12133,38 +12133,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lut3d', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "file": file,
-                
+
                 "clut": clut,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lutrgb(
-    
+
     self,
 
 
@@ -12172,15 +12172,15 @@ References:
 
     *,
     c0: String = Default('clipval'),c1: String = Default('clipval'),c2: String = Default('clipval'),c3: String = Default('clipval'),y: String = Default('clipval'),u: String = Default('clipval'),v: String = Default('clipval'),r: String = Default('clipval'),g: String = Default('clipval'),b: String = Default('clipval'),a: String = Default('clipval'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Compute a look-up table for binding each pixel component input value
 to an output value, and apply it to the input video.
 
@@ -12212,7 +12212,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12220,54 +12220,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lutrgb', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "c0": c0,
-                
+
                 "c1": c1,
-                
+
                 "c2": c2,
-                
+
                 "c3": c3,
-                
+
                 "y": y,
-                
+
                 "u": u,
-                
+
                 "v": v,
-                
+
                 "r": r,
-                
+
                 "g": g,
-                
+
                 "b": b,
-                
+
                 "a": a,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lutyuv(
-    
+
     self,
 
 
@@ -12275,15 +12275,15 @@ References:
 
     *,
     c0: String = Default('clipval'),c1: String = Default('clipval'),c2: String = Default('clipval'),c3: String = Default('clipval'),y: String = Default('clipval'),u: String = Default('clipval'),v: String = Default('clipval'),r: String = Default('clipval'),g: String = Default('clipval'),b: String = Default('clipval'),a: String = Default('clipval'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Compute a look-up table for binding each pixel component input value
 to an output value, and apply it to the input video.
 
@@ -12315,7 +12315,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12323,84 +12323,84 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lutyuv', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "c0": c0,
-                
+
                 "c1": c1,
-                
+
                 "c2": c2,
-                
+
                 "c3": c3,
-                
+
                 "y": y,
-                
+
                 "u": u,
-                
+
                 "v": v,
-                
+
                 "r": r,
-                
+
                 "g": g,
-                
+
                 "b": b,
-                
+
                 "a": a,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def maskedclamp(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _dark: VideoStream,
-        
-    
-        
+
+
+
         _bright: VideoStream,
-        
-    
+
+
 
 
     *,
     undershoot: Int = Default('0'),overshoot: Int = Default('0'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Clamp the first input stream with the second input and third input stream.
 
 Returns the value of first stream to be between second input
@@ -12423,7 +12423,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedclamp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12431,78 +12431,78 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='maskedclamp', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _dark,
-                
-            
-                
+
+
+
                 _bright,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "undershoot": undershoot,
-                
+
                 "overshoot": overshoot,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def maskedmax(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _filter1: VideoStream,
-        
-    
-        
+
+
+
         _filter2: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Merge the second and third input stream into output stream using absolute differences
 between second input stream and first input stream and absolute difference between
 third input stream and first input stream. The picked value will be from second input
@@ -12524,7 +12524,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedmax)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12532,74 +12532,74 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='maskedmax', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _filter1,
-                
-            
-                
+
+
+
                 _filter2,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def maskedmerge(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _overlay: VideoStream,
-        
-    
-        
+
+
+
         _mask: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Merge the first input stream with the second input stream using per pixel
 weights in the third input stream.
 
@@ -12624,7 +12624,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedmerge)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12632,74 +12632,74 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='maskedmerge', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _overlay,
-                
-            
-                
+
+
+
                 _mask,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def maskedmin(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _filter1: VideoStream,
-        
-    
-        
+
+
+
         _filter2: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Merge the second and third input stream into output stream using absolute differences
 between second input stream and first input stream and absolute difference between
 third input stream and first input stream. The picked value will be from second input
@@ -12721,7 +12721,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedmin)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12729,70 +12729,70 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='maskedmin', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _filter1,
-                
-            
-                
+
+
+
                 _filter2,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def maskedthreshold(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     threshold: Int = Default('1'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pick pixels comparing absolute difference of two video streams with fixed
 threshold.
 
@@ -12817,7 +12817,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedthreshold)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12825,44 +12825,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='maskedthreshold', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "threshold": threshold,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def maskfun(
-    
+
     self,
 
 
@@ -12870,15 +12870,15 @@ References:
 
     *,
     low: Int = Default('10'),high: Int = Default('10'),planes: Int = Default('15'),fill: Int = Default('0'),sum: Int = Default('10'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Create mask from input video.
 
 For example it is useful to create motion masks after tblend filter.
@@ -12902,7 +12902,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskfun)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12910,44 +12910,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='maskfun', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "low": low,
-                
+
                 "high": high,
-                
+
                 "planes": planes,
-                
+
                 "fill": fill,
-                
+
                 "sum": sum,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def median(
-    
+
     self,
 
 
@@ -12955,15 +12955,15 @@ References:
 
     *,
     radius: Int = Default('1'),planes: Int = Default('15'),radiusV: Int = Default('0'),percentile: Float = Default('0.5'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pick median pixel from certain rectangle defined by radius.
 
 This filter accepts the following options:
@@ -12984,7 +12984,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#median)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12992,42 +12992,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='median', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "radius": radius,
-                
+
                 "planes": planes,
-                
+
                 "radiusV": radiusV,
-                
+
                 "percentile": percentile,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def mestimate(
-    
+
     self,
 
 
@@ -13035,12 +13035,12 @@ References:
 
     *,
     method: Int| Literal["esa","tss","tdls","ntss","fss","ds","hexbs","epzs","umh"] | Default = Default('esa'),mb_size: Int = Default('16'),search_param: Int = Default('7'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Estimate and export motion vectors using block matching algorithms.
 Motion vectors are stored in frame side data to be used by other filters.
 
@@ -13060,41 +13060,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mestimate)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='mestimate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "method": method,
-                
+
                 "mb_size": mb_size,
-                
+
                 "search_param": search_param,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def metadata(
-    
+
     self,
 
 
@@ -13102,15 +13102,15 @@ References:
 
     *,
     mode: Int| Literal["select","add","modify","delete","print"] | Default = Default('select'),key: String = Default(None),value: String = Default(None),function: Int| Literal["same_str","starts_with","less","equal","greater","expr","ends_with"] | Default = Default('same_str'),expr: String = Default(None),file: String = Default(None),direct: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Manipulate frame metadata.
 
 This filter accepts the following options:
@@ -13134,7 +13134,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#metadata)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -13142,70 +13142,70 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='metadata', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "key": key,
-                
+
                 "value": value,
-                
+
                 "function": function,
-                
+
                 "expr": expr,
-                
+
                 "file": file,
-                
+
                 "direct": direct,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def midequalizer(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _in1: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Midway Image Equalization effect using two video streams.
 
 Midway Image Equalization adjusts a pair of images to have the same
@@ -13231,7 +13231,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#midequalizer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -13239,42 +13239,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='midequalizer', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _in1,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def minterpolate(
-    
+
     self,
 
 
@@ -13282,12 +13282,12 @@ References:
 
     *,
     fps: Video_rate = Default('60'),mi_mode: Int| Literal["dup","blend","mci"] | Default = Default('mci'),mc_mode: Int| Literal["obmc","aobmc"] | Default = Default('obmc'),me_mode: Int| Literal["bidir","bilat"] | Default = Default('bilat'),me: Int| Literal["esa","tss","tdls","ntss","fss","ds","hexbs","epzs","umh"] | Default = Default('epzs'),mb_size: Int = Default('16'),search_param: Int = Default('32'),vsbmc: Int = Default('0'),scd: Int| Literal["none","fdiff"] | Default = Default('fdiff'),scd_threshold: Double = Default('10'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert the video to specified frame rate using motion interpolation.
 
 This filter accepts the following options:
@@ -13313,57 +13313,57 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#minterpolate)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='minterpolate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "fps": fps,
-                
+
                 "mi_mode": mi_mode,
-                
+
                 "mc_mode": mc_mode,
-                
+
                 "me_mode": me_mode,
-                
+
                 "me": me,
-                
+
                 "mb_size": mb_size,
-                
+
                 "search_param": search_param,
-                
+
                 "vsbmc": vsbmc,
-                
+
                 "scd": scd,
-                
+
                 "scd_threshold": scd_threshold,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def monochrome(
-    
+
     self,
 
 
@@ -13371,15 +13371,15 @@ References:
 
     *,
     cb: Float = Default('0'),cr: Float = Default('0'),size: Float = Default('1'),high: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert video to gray using custom color filter.
 
 A description of the accepted options follows.
@@ -13400,7 +13400,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#monochrome)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -13408,69 +13408,69 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='monochrome', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cb": cb,
-                
+
                 "cr": cr,
-                
+
                 "size": size,
-                
+
                 "high": high,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def morpho(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _structure: VideoStream,
-        
-    
+
+
 
 
     *,
     mode: Int| Literal["erode","dilate","open","close","gradient","tophat","blackhat"] | Default = Default('erode'),planes: Int = Default('7'),structure: Int| Literal["first","all"] | Default = Default('all'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 This filter allows to apply main morphological grayscale transforms,
 erode and dilate with arbitrary structures set in second input stream.
 
@@ -13496,7 +13496,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#morpho)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -13507,50 +13507,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='morpho', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _structure,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "planes": planes,
-                
+
                 "structure": structure,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def mpdecimate(
-    
+
     self,
 
 
@@ -13558,12 +13558,12 @@ References:
 
     *,
     max: Int = Default('0'),hi: Int = Default('768'),lo: Int = Default('320'),frac: Float = Default('0.33'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Drop frames that do not differ greatly from the previous frame in
 order to reduce frame rate.
 
@@ -13588,74 +13588,74 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mpdecimate)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='mpdecimate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "max": max,
-                
+
                 "hi": hi,
-                
+
                 "lo": lo,
-                
+
                 "frac": frac,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def msad(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the MSAD (Mean Sum of Absolute Differences) between two input videos.
 
 This filter takes two input videos.
@@ -13689,7 +13689,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#msad)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -13700,66 +13700,66 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='msad', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def multiply(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _factor: VideoStream,
-        
-    
+
+
 
 
     *,
     scale: Float = Default('1'),offset: Float = Default('0.5'),planes: Flags = Default('F'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Multiply first video stream pixels values with second video stream pixels values.
 
 The filter accepts the following options:
@@ -13779,7 +13779,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#multiply)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -13787,46 +13787,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='multiply', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _factor,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "scale": scale,
-                
+
                 "offset": offset,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def negate(
-    
+
     self,
 
 
@@ -13834,15 +13834,15 @@ References:
 
     *,
     components: Flags| Literal["y","u","v","r","g","b","a"] | Default = Default('y+u+v+r+g+b'),negate_alpha: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Negate (invert) the input video.
 
 It accepts the following option:
@@ -13861,7 +13861,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#negate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -13869,36 +13869,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='negate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "components": components,
-                
+
                 "negate_alpha": negate_alpha,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def nlmeans(
-    
+
     self,
 
 
@@ -13906,15 +13906,15 @@ References:
 
     *,
     s: Double = Default('1'),p: Int = Default('7'),pc: Int = Default('0'),r: Int = Default('15'),rc: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Denoise frames using Non-Local Means algorithm.
 
 Each pixel is adjusted by looking for other pixels with similar contexts. This
@@ -13944,7 +13944,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#nlmeans)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -13952,42 +13952,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='nlmeans', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "s": s,
-                
+
                 "p": p,
-                
+
                 "pc": pc,
-                
+
                 "r": r,
-                
+
                 "rc": rc,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def nlmeans_opencl(
-    
+
     self,
 
 
@@ -13995,12 +13995,12 @@ References:
 
     *,
     s: Double = Default('1'),p: Int = Default('7'),pc: Int = Default('0'),r: Int = Default('15'),rc: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Non-local Means denoise filter through OpenCL, this filter accepts same options as nlmeans.
 
 
@@ -14019,45 +14019,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#nlmeans_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='nlmeans_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "s": s,
-                
+
                 "p": p,
-                
+
                 "pc": pc,
-                
+
                 "r": r,
-                
+
                 "rc": rc,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def nnedi(
-    
+
     self,
 
 
@@ -14065,15 +14065,15 @@ References:
 
     *,
     weights: String = Default('nnedi3_weights.bin'),deint: Int| Literal["all","interlaced"] | Default = Default('all'),field: Int| Literal["af","a","t","b","tf","bf"] | Default = Default('a'),planes: Int = Default('7'),nsize: Int| Literal["s8x6","s16x6","s32x6","s48x6","s8x4","s16x4","s32x4"] | Default = Default('s32x4'),nns: Int| Literal["n16","n32","n64","n128","n256"] | Default = Default('n32'),qual: Int| Literal["fast","slow"] | Default = Default('fast'),etype: Int| Literal["a","abs","s","mse"] | Default = Default('a'),pscrn: Int| Literal["none","original","new","new2","new3"] | Default = Default('new'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlace video using neural network edge directed interpolation.
 
 This filter accepts the following options:
@@ -14099,7 +14099,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#nnedi)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14107,50 +14107,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='nnedi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "weights": weights,
-                
+
                 "deint": deint,
-                
+
                 "field": field,
-                
+
                 "planes": planes,
-                
+
                 "nsize": nsize,
-                
+
                 "nns": nns,
-                
+
                 "qual": qual,
-                
+
                 "etype": etype,
-                
+
                 "pscrn": pscrn,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def noformat(
-    
+
     self,
 
 
@@ -14158,12 +14158,12 @@ References:
 
     *,
     pix_fmts: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Force libavfilter not to use any of the specified pixel formats for the
 input to the next filter.
 
@@ -14181,37 +14181,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#noformat)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='noformat', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "pix_fmts": pix_fmts,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def noise(
-    
+
     self,
 
 
@@ -14219,15 +14219,15 @@ References:
 
     *,
     all_seed: Int = Default('-1'),all_strength: Int = Default('0'),all_flags: Flags| Literal["a","p","t","u"] | Default = Default('0'),c0_seed: Int = Default('-1'),c0_strength: Int = Default('0'),c0_flags: Flags| Literal["a","p","t","u"] | Default = Default('0'),c1_seed: Int = Default('-1'),c1_strength: Int = Default('0'),c1_flags: Flags| Literal["a","p","t","u"] | Default = Default('0'),c2_seed: Int = Default('-1'),c2_strength: Int = Default('0'),c2_flags: Flags| Literal["a","p","t","u"] | Default = Default('0'),c3_seed: Int = Default('-1'),c3_strength: Int = Default('0'),c3_flags: Flags| Literal["a","p","t","u"] | Default = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Add noise on video input frame.
 
 The filter accepts the following options:
@@ -14259,7 +14259,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#noise)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14267,62 +14267,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='noise', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "all_seed": all_seed,
-                
+
                 "all_strength": all_strength,
-                
+
                 "all_flags": all_flags,
-                
+
                 "c0_seed": c0_seed,
-                
+
                 "c0_strength": c0_strength,
-                
+
                 "c0_flags": c0_flags,
-                
+
                 "c1_seed": c1_seed,
-                
+
                 "c1_strength": c1_strength,
-                
+
                 "c1_flags": c1_flags,
-                
+
                 "c2_seed": c2_seed,
-                
+
                 "c2_strength": c2_strength,
-                
+
                 "c2_flags": c2_flags,
-                
+
                 "c3_seed": c3_seed,
-                
+
                 "c3_strength": c3_strength,
-                
+
                 "c3_flags": c3_flags,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def normalize(
-    
+
     self,
 
 
@@ -14330,15 +14330,15 @@ References:
 
     *,
     blackpt: Color = Default('black'),whitept: Color = Default('white'),smoothing: Int = Default('0'),independence: Float = Default('1'),strength: Float = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Normalize RGB video (aka histogram stretching, contrast stretching).
 See: https://en.wikipedia.org/wiki/Normalization_(image_processing)
 
@@ -14377,7 +14377,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#normalize)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14385,55 +14385,55 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='normalize', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "blackpt": blackpt,
-                
+
                 "whitept": whitept,
-                
+
                 "smoothing": smoothing,
-                
+
                 "independence": independence,
-                
+
                 "strength": strength,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def null(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pass the video source unchanged to the output.
 
 
@@ -14447,41 +14447,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#null)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='null', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def oscilloscope(
-    
+
     self,
 
 
@@ -14489,15 +14489,15 @@ References:
 
     *,
     x: Float = Default('0.5'),y: Float = Default('0.5'),s: Float = Default('0.8'),t: Float = Default('0.5'),o: Float = Default('0.8'),tx: Float = Default('0.5'),ty: Float = Default('0.9'),tw: Float = Default('0.8'),th: Float = Default('0.3'),c: Int = Default('7'),g: Boolean = Default('true'),st: Boolean = Default('true'),sc: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 2D Video Oscilloscope.
 
 Useful to measure spatial impulse, step responses, chroma delays, etc.
@@ -14529,7 +14529,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#oscilloscope)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14537,87 +14537,87 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='oscilloscope', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "s": s,
-                
+
                 "t": t,
-                
+
                 "o": o,
-                
+
                 "tx": tx,
-                
+
                 "ty": ty,
-                
+
                 "tw": tw,
-                
+
                 "th": th,
-                
+
                 "c": c,
-                
+
                 "g": g,
-                
+
                 "st": st,
-                
+
                 "sc": sc,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def overlay(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _overlay: VideoStream,
-        
-    
+
+
 
 
     *,
     x: String = Default('0'),y: String = Default('0'),eof_action: Int| Literal["repeat","endall","pass"] | Default = Default('repeat'),eval: Int| Literal["init","frame"] | Default = Default('frame'),shortest: Boolean = Default('false'),format: Int| Literal["yuv420","yuv420p10","yuv422","yuv422p10","yuv444","rgb","gbrp","auto"] | Default = Default('yuv420'),repeatlast: Boolean = Default('true'),alpha: Int| Literal["straight","premultiplied"] | Default = Default('straight'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
-    
-    
-    
-    
-    
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Overlay one video on top of another.
 
 It takes two inputs and has one output. The first input is the "main"
@@ -14648,7 +14648,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14656,79 +14656,79 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='overlay', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _overlay,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "eof_action": eof_action,
-                
+
                 "eval": eval,
-                
+
                 "shortest": shortest,
-                
+
                 "format": format,
-                
+
                 "repeatlast": repeatlast,
-                
+
                 "alpha": alpha,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def overlay_opencl(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _overlay: VideoStream,
-        
-    
+
+
 
 
     *,
     x: Int = Default('0'),y: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Overlay one video on top of another.
 
 It takes two inputs and has one output. The first input is the "main" video on which the second input is overlaid.
@@ -14749,68 +14749,68 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='overlay_opencl', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _overlay,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def overlay_vaapi(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _overlay: VideoStream,
-        
-    
+
+
 
 
     *,
     x: Int = Default('0'),y: Int = Default('0'),w: Int = Default('0'),h: Int = Default('0'),alpha: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Overlay one video on the top of another.
 
 It takes two inputs and has one output. The first input is the "main" video on which the second input is overlaid.
@@ -14834,53 +14834,53 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay_vaapi)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='overlay_vaapi', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _overlay,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "alpha": alpha,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def owdenoise(
-    
+
     self,
 
 
@@ -14888,15 +14888,15 @@ References:
 
     *,
     depth: Int = Default('8'),luma_strength: Double = Default('1'),chroma_strength: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Overcomplete Wavelet denoiser.
 
 The filter accepts the following options:
@@ -14916,7 +14916,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#owdenoise)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14924,38 +14924,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='owdenoise', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "depth": depth,
-                
+
                 "luma_strength": luma_strength,
-                
+
                 "chroma_strength": chroma_strength,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pad(
-    
+
     self,
 
 
@@ -14963,12 +14963,12 @@ References:
 
     *,
     width: String = Default('iw'),height: String = Default('ih'),x: String = Default('0'),y: String = Default('0'),color: Color = Default('black'),eval: Int| Literal["init","frame"] | Default = Default('init'),aspect: Rational = Default('0/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Add paddings to the input image, and place the original input at the
 provided x, y coordinates.
 
@@ -14992,49 +14992,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pad)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pad', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "color": color,
-                
+
                 "eval": eval,
-                
+
                 "aspect": aspect,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pad_opencl(
-    
+
     self,
 
 
@@ -15042,12 +15042,12 @@ References:
 
     *,
     width: String = Default('iw'),height: String = Default('ih'),x: String = Default('0'),y: String = Default('0'),color: Color = Default('black'),aspect: Rational = Default('0/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Add paddings to the input image, and place the original input at the
 provided x, y coordinates.
 
@@ -15070,51 +15070,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pad_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pad_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "color": color,
-                
+
                 "aspect": aspect,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def palettegen(
-    
+
     self,
 
 
@@ -15122,12 +15122,12 @@ References:
 
     *,
     max_colors: Int = Default('256'),reserve_transparent: Boolean = Default('true'),transparency_color: Color = Default('lime'),stats_mode: Int| Literal["full","diff","single"] | Default = Default('full'),use_alpha: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Generate one palette for a whole video stream.
 
 It accepts the following options:
@@ -15148,66 +15148,66 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#palettegen)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='palettegen', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "max_colors": max_colors,
-                
+
                 "reserve_transparent": reserve_transparent,
-                
+
                 "transparency_color": transparency_color,
-                
+
                 "stats_mode": stats_mode,
-                
+
                 "use_alpha": use_alpha,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def paletteuse(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _palette: VideoStream,
-        
-    
+
+
 
 
     *,
     dither: Int| Literal["bayer","heckbert","floyd_steinberg","sierra2","sierra2_4a"] | Default = Default('sierra2_4a'),bayer_scale: Int = Default('2'),diff_mode: Int| Literal["rectangle"] | Default = Default('0'),new: Boolean = Default('false'),alpha_threshold: Int = Default('128'),use_alpha: Boolean = Default('false'),debug_kdtree: String = Default(None),color_search: Int| Literal["nns_iterative","nns_recursive","bruteforce"] | Default = Default('nns_iterative'),mean_err: Boolean = Default('false'),debug_accuracy: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Use a palette to downsample an input video stream.
 
 The filter takes two inputs: one video stream and a palette. The palette must
@@ -15236,65 +15236,65 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#paletteuse)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='paletteuse', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _palette,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "dither": dither,
-                
+
                 "bayer_scale": bayer_scale,
-                
+
                 "diff_mode": diff_mode,
-                
+
                 "new": new,
-                
+
                 "alpha_threshold": alpha_threshold,
-                
+
                 "use_alpha": use_alpha,
-                
+
                 "debug_kdtree": debug_kdtree,
-                
+
                 "color_search": color_search,
-                
+
                 "mean_err": mean_err,
-                
+
                 "debug_accuracy": debug_accuracy,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def perms(
-    
+
     self,
 
 
@@ -15302,15 +15302,15 @@ References:
 
     *,
     mode: Int| Literal["none","ro","rw","toggle","random"] | Default = Default('none'),seed: Int64 = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Set read/write permissions for the output frames.
 
 These filters are mainly aimed at developers to test direct path in the
@@ -15332,7 +15332,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#perms)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -15340,36 +15340,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='perms', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "seed": seed,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def perspective(
-    
+
     self,
 
 
@@ -15377,15 +15377,15 @@ References:
 
     *,
     x0: String = Default('0'),y0: String = Default('0'),x1: String = Default('W'),y1: String = Default('0'),x2: String = Default('0'),y2: String = Default('H'),x3: String = Default('W'),y3: String = Default('H'),interpolation: Int| Literal["linear","cubic"] | Default = Default('linear'),sense: Int| Literal["source","destination"] | Default = Default('source'),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Correct perspective of video not recorded perpendicular to the screen.
 
 A description of the accepted parameters follows.
@@ -15413,7 +15413,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#perspective)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -15421,54 +15421,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='perspective', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x0": x0,
-                
+
                 "y0": y0,
-                
+
                 "x1": x1,
-                
+
                 "y1": y1,
-                
+
                 "x2": x2,
-                
+
                 "y2": y2,
-                
+
                 "x3": x3,
-                
+
                 "y3": y3,
-                
+
                 "interpolation": interpolation,
-                
+
                 "sense": sense,
-                
+
                 "eval": eval,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def phase(
-    
+
     self,
 
 
@@ -15476,15 +15476,15 @@ References:
 
     *,
     mode: Int| Literal["p","t","b","T","B","u","U","a","A"] | Default = Default('A'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Delay interlaced video by one field time so that the field order changes.
 
 The intended use is to fix PAL movies that have been captured with the
@@ -15505,7 +15505,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#phase)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -15513,34 +15513,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='phase', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def photosensitivity(
-    
+
     self,
 
 
@@ -15548,12 +15548,12 @@ References:
 
     *,
     frames: Int = Default('30'),threshold: Float = Default('1'),skip: Int = Default('1'),bypass: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reduce various flashes in video, so to help users with epilepsy.
 
 It accepts the following options:
@@ -15573,56 +15573,56 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#photosensitivity)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='photosensitivity', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frames": frames,
-                
+
                 "threshold": threshold,
-                
+
                 "skip": skip,
-                
+
                 "bypass": bypass,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pixdesctest(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pixel format descriptor test filter, mainly useful for internal
 testing. The output video should be equal to the input video.
 
@@ -15644,35 +15644,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pixdesctest)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pixdesctest', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pixelize(
-    
+
     self,
 
 
@@ -15680,15 +15680,15 @@ References:
 
     *,
     width: Int = Default('16'),height: Int = Default('16'),mode: Int| Literal["avg","min","max"] | Default = Default('avg'),planes: Flags = Default('F'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply pixelization to video stream.
 
 The filter accepts the following options:
@@ -15709,7 +15709,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pixelize)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -15717,40 +15717,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pixelize', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "mode": mode,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pixscope(
-    
+
     self,
 
 
@@ -15758,15 +15758,15 @@ References:
 
     *,
     x: Float = Default('0.5'),y: Float = Default('0.5'),w: Int = Default('7'),h: Int = Default('7'),o: Float = Default('0.5'),wx: Float = Default('-1'),wy: Float = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Display sample values of color channels. Mainly useful for checking color
 and levels. Minimum supported resolution is 640x480.
 
@@ -15791,7 +15791,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pixscope)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -15799,46 +15799,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pixscope', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "o": o,
-                
+
                 "wx": wx,
-                
+
                 "wy": wy,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pp(
-    
+
     self,
 
 
@@ -15846,15 +15846,15 @@ References:
 
     *,
     subfilters: String = Default('de'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Enable the specified chain of postprocessing subfilters using libpostproc. This
 library should be automatically selected with a GPL build (--enable-gpl).
 Subfilters must be separated by '/' and can be disabled by prepending a '-'.
@@ -15876,7 +15876,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -15884,34 +15884,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pp', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "subfilters": subfilters,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pp7(
-    
+
     self,
 
 
@@ -15919,15 +15919,15 @@ References:
 
     *,
     qp: Int = Default('0'),mode: Int| Literal["hard","soft","medium"] | Default = Default('medium'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Postprocessing filter 7. It is variant of the spp filter,
 similar to spp = 6 with 7 point DCT, where only the center sample is
 used after IDCT.
@@ -15948,7 +15948,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pp7)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -15956,38 +15956,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pp7', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "qp": qp,
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def prewitt(
-    
+
     self,
 
 
@@ -15995,15 +15995,15 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply prewitt operator to input video stream.
 
 The filter accepts the following option:
@@ -16023,7 +16023,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#prewitt)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -16031,38 +16031,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='prewitt', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def prewitt_opencl(
-    
+
     self,
 
 
@@ -16070,12 +16070,12 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply the Prewitt operator (https://en.wikipedia.org/wiki/Prewitt_operator) to input video stream.
 
 The filter accepts the following option:
@@ -16094,41 +16094,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#prewitt_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='prewitt_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def procamp_vaapi(
-    
+
     self,
 
 
@@ -16136,12 +16136,12 @@ References:
 
     *,
     b: Float = Default('0'),s: Float = Default('1'),c: Float = Default('1'),h: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 ProcAmp (color balance) adjustments for hue, saturation, brightness, contrast
 
 
@@ -16159,45 +16159,45 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='procamp_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "b": b,
-                
+
                 "s": s,
-                
+
                 "c": c,
-                
+
                 "h": h,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def pseudocolor(
-    
+
     self,
 
 
@@ -16205,15 +16205,15 @@ References:
 
     *,
     c0: String = Default('val'),c1: String = Default('val'),c2: String = Default('val'),c3: String = Default('val'),index: Int = Default('0'),preset: Int| Literal["none","magma","inferno","plasma","viridis","turbo","cividis","range1","range2","shadows","highlights","solar","nominal","preferred","total"] | Default = Default('none'),opacity: Float = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Alter frame colors in video with pseudocolors.
 
 This filter accepts the following options:
@@ -16237,7 +16237,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pseudocolor)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -16245,75 +16245,75 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pseudocolor', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "c0": c0,
-                
+
                 "c1": c1,
-                
+
                 "c2": c2,
-                
+
                 "c3": c3,
-                
+
                 "index": index,
-                
+
                 "preset": preset,
-                
+
                 "opacity": opacity,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def psnr(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),stats_version: Int = Default('1'),output_max: Boolean = Default('false'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the average, maximum and minimum PSNR (Peak Signal to Noise
 Ratio) between two input videos.
 
@@ -16357,7 +16357,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#psnr)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -16368,48 +16368,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='psnr', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "stats_file": stats_file,
-                
+
                 "stats_version": stats_version,
-                
+
                 "output_max": output_max,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pullup(
-    
+
     self,
 
 
@@ -16417,12 +16417,12 @@ References:
 
     *,
     jl: Int = Default('1'),jr: Int = Default('1'),jt: Int = Default('4'),jb: Int = Default('4'),sb: Boolean = Default('false'),mp: Int| Literal["y","u","v"] | Default = Default('y'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pulldown reversal (inverse telecine) filter, capable of handling mixed
 hard-telecine, 24000/1001 fps progressive, and 30000/1001 fps progressive
 content.
@@ -16455,47 +16455,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pullup)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pullup', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "jl": jl,
-                
+
                 "jr": jr,
-                
+
                 "jt": jt,
-                
+
                 "jb": jb,
-                
+
                 "sb": sb,
-                
+
                 "mp": mp,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def qp(
-    
+
     self,
 
 
@@ -16503,15 +16503,15 @@ References:
 
     *,
     qp: String = Default(None),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Change video quantization parameters (QP).
 
 The filter accepts the following option:
@@ -16529,7 +16529,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#qp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -16537,34 +16537,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='qp', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "qp": qp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def random(
-    
+
     self,
 
 
@@ -16572,12 +16572,12 @@ References:
 
     *,
     frames: Int = Default('30'),seed: Int64 = Default('-1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Flush video frames from internal cache of frames into a random order.
 No frame is discarded.
 Inspired by frei0r nervous filter.
@@ -16595,39 +16595,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#random)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='random', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frames": frames,
-                
+
                 "seed": seed,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def readeia608(
-    
+
     self,
 
 
@@ -16635,15 +16635,15 @@ References:
 
     *,
     scan_min: Int = Default('0'),scan_max: Int = Default('29'),spw: Float = Default('0.27'),chp: Boolean = Default('false'),lp: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Read closed captioning (EIA-608) information from the top lines of a video frame.
 
 This filter adds frame metadata for lavfi.readeia608.X.cc and
@@ -16667,7 +16667,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#readeia608)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -16675,42 +16675,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='readeia608', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "scan_min": scan_min,
-                
+
                 "scan_max": scan_max,
-                
+
                 "spw": spw,
-                
+
                 "chp": chp,
-                
+
                 "lp": lp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def readvitc(
-    
+
     self,
 
 
@@ -16718,12 +16718,12 @@ References:
 
     *,
     scan_max: Int = Default('45'),thr_b: Double = Default('0.2'),thr_w: Double = Default('0.6'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Read vertical interval timecode (VITC) information from the top lines of a
 video frame.
 
@@ -16748,41 +16748,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#readvitc)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='readvitc', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "scan_max": scan_max,
-                
+
                 "thr_b": thr_b,
-                
+
                 "thr_w": thr_w,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def realtime(
-    
+
     self,
 
 
@@ -16790,12 +16790,12 @@ References:
 
     *,
     limit: Duration = Default('2'),speed: Double = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Slow down filtering to match real time approximately.
 
 These filters will pause the filtering for a variable amount of time to
@@ -16817,64 +16817,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#realtime)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='realtime', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "limit": limit,
-                
+
                 "speed": speed,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def remap(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _xmap: VideoStream,
-        
-    
-        
+
+
+
         _ymap: VideoStream,
-        
-    
+
+
 
 
     *,
     format: Int| Literal["color","gray"] | Default = Default('color'),fill: Color = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remap pixels using 2nd: Xmap and 3rd: Ymap input video stream.
 
 Destination pixel at position (X, Y) will be picked from source (x, y) position
@@ -16898,76 +16898,76 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#remap)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='remap', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _xmap,
-                
-            
-                
+
+
+
                 _ymap,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "format": format,
-                
+
                 "fill": fill,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def remap_opencl(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _xmap: VideoStream,
-        
-    
-        
+
+
+
         _ymap: VideoStream,
-        
-    
+
+
 
 
     *,
     interp: Int| Literal["near","linear"] | Default = Default('linear'),fill: Color = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remap pixels using 2nd: Xmap and 3rd: Ymap input video stream.
 
 Destination pixel at position (X, Y) will be picked from source (x, y) position
@@ -16991,51 +16991,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#remap_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='remap_opencl', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _xmap,
-                
-            
-                
+
+
+
                 _ymap,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "interp": interp,
-                
+
                 "fill": fill,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def removegrain(
-    
+
     self,
 
 
@@ -17043,15 +17043,15 @@ References:
 
     *,
     m0: Int = Default('0'),m1: Int = Default('0'),m2: Int = Default('0'),m3: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The removegrain filter is a spatial denoiser for progressive video.
 
 
@@ -17070,7 +17070,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#removegrain)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -17078,40 +17078,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='removegrain', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "m0": m0,
-                
+
                 "m1": m1,
-                
+
                 "m2": m2,
-                
+
                 "m3": m3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def removelogo(
-    
+
     self,
 
 
@@ -17119,15 +17119,15 @@ References:
 
     *,
     filename: String = Default(None),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Suppress a TV station logo, using an image file to determine which
 pixels comprise the logo. It works by filling in the pixels that
 comprise the logo with neighboring pixels.
@@ -17147,7 +17147,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#removelogo)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -17155,47 +17155,47 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='removelogo', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "filename": filename,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def repeatfields(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 This filter uses the repeat_field flag from the Video ES headers and hard repeats
 fields based on its value.
 
@@ -17210,50 +17210,50 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#repeatfields)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='repeatfields', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def reverse(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reverse a video clip.
 
 Warning: This filter requires memory to buffer the entire clip, so trimming
@@ -17270,35 +17270,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#reverse)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='reverse', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def rgbashift(
-    
+
     self,
 
 
@@ -17306,15 +17306,15 @@ References:
 
     *,
     rh: Int = Default('0'),rv: Int = Default('0'),gh: Int = Default('0'),gv: Int = Default('0'),bh: Int = Default('0'),bv: Int = Default('0'),ah: Int = Default('0'),av: Int = Default('0'),edge: Int| Literal["smear","wrap"] | Default = Default('smear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Shift R/G/B/A pixels horizontally and/or vertically.
 
 The filter accepts the following options:
@@ -17340,7 +17340,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#rgbashift)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -17348,52 +17348,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='rgbashift', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rh": rh,
-                
+
                 "rv": rv,
-                
+
                 "gh": gh,
-                
+
                 "gv": gv,
-                
+
                 "bh": bh,
-                
+
                 "bv": bv,
-                
+
                 "ah": ah,
-                
+
                 "av": av,
-                
+
                 "edge": edge,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def roberts(
-    
+
     self,
 
 
@@ -17401,15 +17401,15 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply roberts cross operator to input video stream.
 
 The filter accepts the following option:
@@ -17429,7 +17429,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#roberts)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -17437,38 +17437,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='roberts', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def roberts_opencl(
-    
+
     self,
 
 
@@ -17476,12 +17476,12 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply the Roberts cross operator (https://en.wikipedia.org/wiki/Roberts_cross) to input video stream.
 
 The filter accepts the following option:
@@ -17500,41 +17500,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#roberts_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='roberts_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def rotate(
-    
+
     self,
 
 
@@ -17542,15 +17542,15 @@ References:
 
     *,
     angle: String = Default('0'),out_w: String = Default('iw'),out_h: String = Default('ih'),fillcolor: String = Default('black'),bilinear: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Rotate video by an arbitrary angle expressed in radians.
 
 The filter accepts the following options:
@@ -17574,7 +17574,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#rotate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -17582,42 +17582,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='rotate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "angle": angle,
-                
+
                 "out_w": out_w,
-                
+
                 "out_h": out_h,
-                
+
                 "fillcolor": fillcolor,
-                
+
                 "bilinear": bilinear,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def sab(
-    
+
     self,
 
 
@@ -17625,15 +17625,15 @@ References:
 
     *,
     luma_radius: Float = Default('1'),luma_pre_filter_radius: Float = Default('1'),luma_strength: Float = Default('1'),chroma_radius: Float = Default('-0.9'),chroma_pre_filter_radius: Float = Default('-0.9'),chroma_strength: Float = Default('-0.9'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Shape Adaptive Blur.
 
 The filter accepts the following options:
@@ -17656,7 +17656,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sab)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -17664,44 +17664,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sab', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_radius": luma_radius,
-                
+
                 "luma_pre_filter_radius": luma_pre_filter_radius,
-                
+
                 "luma_strength": luma_strength,
-                
+
                 "chroma_radius": chroma_radius,
-                
+
                 "chroma_pre_filter_radius": chroma_pre_filter_radius,
-                
+
                 "chroma_strength": chroma_strength,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def scale(
-    
+
     self,
 
 
@@ -17709,12 +17709,12 @@ References:
 
     *,
     w: String = Default(None),h: String = Default(None),flags: String = Default(''),interl: Boolean = Default('false'),in_color_matrix: String| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default('auto'),out_color_matrix: String| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default(None),in_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),out_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),in_v_chr_pos: Int = Default('-513'),in_h_chr_pos: Int = Default('-513'),out_v_chr_pos: Int = Default('-513'),out_h_chr_pos: Int = Default('-513'),force_original_aspect_ratio: Int| Literal["disable","decrease","increase"] | Default = Default('disable'),force_divisible_by: Int = Default('1'),param0: Double = Default('123456'),param1: Double = Default('123456'),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Scale (resize) the input video, using the libswscale library.
 
 The scale filter forces the output display aspect ratio to be the same
@@ -17752,100 +17752,100 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#scale)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='scale', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "flags": flags,
-                
+
                 "interl": interl,
-                
+
                 "in_color_matrix": in_color_matrix,
-                
+
                 "out_color_matrix": out_color_matrix,
-                
+
                 "in_range": in_range,
-                
+
                 "out_range": out_range,
-                
+
                 "in_v_chr_pos": in_v_chr_pos,
-                
+
                 "in_h_chr_pos": in_h_chr_pos,
-                
+
                 "out_v_chr_pos": out_v_chr_pos,
-                
+
                 "out_h_chr_pos": out_h_chr_pos,
-                
+
                 "force_original_aspect_ratio": force_original_aspect_ratio,
-                
+
                 "force_divisible_by": force_divisible_by,
-                
+
                 "param0": param0,
-                
+
                 "param1": param1,
-                
+
                 "eval": eval,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def scale2ref(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _ref: VideoStream,
-        
-    
+
+
 
 
     *,
     w: String = Default(None),h: String = Default(None),flags: String = Default(''),interl: Boolean = Default('false'),in_color_matrix: String| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default('auto'),out_color_matrix: String| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default(None),in_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),out_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),in_v_chr_pos: Int = Default('-513'),in_h_chr_pos: Int = Default('-513'),out_v_chr_pos: Int = Default('-513'),out_h_chr_pos: Int = Default('-513'),force_original_aspect_ratio: Int| Literal["disable","decrease","increase"] | Default = Default('disable'),force_divisible_by: Int = Default('1'),param0: Double = Default('123456'),param1: Double = Default('123456'),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> tuple[
-    
-        
+
+
             VideoStream,
-        
-    
-        
+
+
+
             VideoStream,
-        
-    
+
+
 ]:
         """
-        
+
 Scale (resize) the input video, based on a reference video.
 
 See the scale filter for available options, scale2ref supports the same but
@@ -17882,88 +17882,88 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#scale2ref)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='scale2ref', typings_input=('video', 'video'), typings_output=('video', 'video')),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _ref,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "flags": flags,
-                
+
                 "interl": interl,
-                
+
                 "in_color_matrix": in_color_matrix,
-                
+
                 "out_color_matrix": out_color_matrix,
-                
+
                 "in_range": in_range,
-                
+
                 "out_range": out_range,
-                
+
                 "in_v_chr_pos": in_v_chr_pos,
-                
+
                 "in_h_chr_pos": in_h_chr_pos,
-                
+
                 "out_v_chr_pos": out_v_chr_pos,
-                
+
                 "out_h_chr_pos": out_h_chr_pos,
-                
+
                 "force_original_aspect_ratio": force_original_aspect_ratio,
-                
+
                 "force_divisible_by": force_divisible_by,
-                
+
                 "param0": param0,
-                
+
                 "param1": param1,
-                
+
                 "eval": eval,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return (
-            
-                
+
+
                     filter_node.video(0),
-                
-            
-                
+
+
+
                     filter_node.video(1),
-                
-            
+
+
         )
 
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def scale_vaapi(
-    
+
     self,
 
 
@@ -17971,12 +17971,12 @@ References:
 
     *,
     w: String = Default('iw'),h: String = Default('ih'),format: String = Default(None),mode: Int| Literal["default","fast","hq","nl_anamorphic"] | Default = Default('hq'),out_color_matrix: String = Default(None),out_range: Int| Literal["full","limited","jpeg","mpeg","tv","pc"] | Default = Default('0'),out_color_primaries: String = Default(None),out_color_transfer: String = Default(None),out_chroma_location: String = Default(None),force_original_aspect_ratio: Int| Literal["disable","decrease","increase"] | Default = Default('disable'),force_divisible_by: Int = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Scale to/from VAAPI surfaces.
 
 
@@ -18001,57 +18001,57 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='scale_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "format": format,
-                
+
                 "mode": mode,
-                
+
                 "out_color_matrix": out_color_matrix,
-                
+
                 "out_range": out_range,
-                
+
                 "out_color_primaries": out_color_primaries,
-                
+
                 "out_color_transfer": out_color_transfer,
-                
+
                 "out_chroma_location": out_chroma_location,
-                
+
                 "force_original_aspect_ratio": force_original_aspect_ratio,
-                
+
                 "force_divisible_by": force_divisible_by,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def scdet(
-    
+
     self,
 
 
@@ -18059,12 +18059,12 @@ References:
 
     *,
     threshold: Double = Default('10'),sc_pass: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect video scene change.
 
 This filter sets frame metadata with mafd between frame, the scene score, and
@@ -18097,39 +18097,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#scdet)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='scdet', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold": threshold,
-                
+
                 "sc_pass": sc_pass,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def scharr(
-    
+
     self,
 
 
@@ -18137,15 +18137,15 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply scharr operator to input video stream.
 
 The filter accepts the following option:
@@ -18165,7 +18165,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#scharr)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -18173,38 +18173,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='scharr', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def scroll(
-    
+
     self,
 
 
@@ -18212,15 +18212,15 @@ References:
 
     *,
     horizontal: Float = Default('0'),vertical: Float = Default('0'),hpos: Float = Default('0'),vpos: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Scroll input video horizontally and/or vertically by constant speed.
 
 The filter accepts the following options:
@@ -18241,7 +18241,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#scroll)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -18249,40 +18249,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='scroll', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "horizontal": horizontal,
-                
+
                 "vertical": vertical,
-                
+
                 "hpos": hpos,
-                
+
                 "vpos": vpos,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def segment(
-    
+
     self,
 
 
@@ -18290,12 +18290,12 @@ References:
 
     *,
     timestamps: String = Default(None),frames: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Split single input stream into multiple streams.
 
 This filter does opposite of concat filters.
@@ -18318,40 +18318,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#segment)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='segment', typings_input=('video',), typings_output="[StreamType.video] * len((str(timestamps or frames)).split('|'))"),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "timestamps": timestamps,
-                
+
                 "frames": frames,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def select(
-    
+
     self,
 
 
@@ -18359,12 +18359,12 @@ References:
 
     *,
     expr: String = Default('1'),outputs: Int = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Select frames to pass in output.
 
 This filter accepts the following options:
@@ -18383,40 +18383,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#select)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='select', typings_input=('video',), typings_output='[StreamType.video] * int(outputs)'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "expr": expr,
-                
+
                 "outputs": outputs,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def selectivecolor(
-    
+
     self,
 
 
@@ -18424,15 +18424,15 @@ References:
 
     *,
     correction_method: Int| Literal["absolute","relative"] | Default = Default('absolute'),reds: String = Default(None),yellows: String = Default(None),greens: String = Default(None),cyans: String = Default(None),blues: String = Default(None),magentas: String = Default(None),whites: String = Default(None),neutrals: String = Default(None),blacks: String = Default(None),psfile: String = Default(None),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust cyan, magenta, yellow and black (CMYK) to certain ranges of colors (such
 as "reds", "yellows", "greens", "cyans", ...). The adjustment range is defined
 by the "purity" of the color (that is, how saturated it already is).
@@ -18464,7 +18464,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#selectivecolor)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -18472,54 +18472,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='selectivecolor', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "correction_method": correction_method,
-                
+
                 "reds": reds,
-                
+
                 "yellows": yellows,
-                
+
                 "greens": greens,
-                
+
                 "cyans": cyans,
-                
+
                 "blues": blues,
-                
+
                 "magentas": magentas,
-                
+
                 "whites": whites,
-                
+
                 "neutrals": neutrals,
-                
+
                 "blacks": blacks,
-                
+
                 "psfile": psfile,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def sendcmd(
-    
+
     self,
 
 
@@ -18527,12 +18527,12 @@ References:
 
     *,
     commands: String = Default(None),filename: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Send commands to filters in the filtergraph.
 
 These filters read commands to be sent to other filters in the
@@ -18561,52 +18561,52 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sendcmd)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sendcmd', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "commands": commands,
-                
+
                 "filename": filename,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def separatefields(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The separatefields takes a frame-based video input and splits
 each frame into its components fields, producing a new half height clip
 with twice the frame rate and twice the frame count.
@@ -18626,35 +18626,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#separatefields)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='separatefields', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def setdar(
-    
+
     self,
 
 
@@ -18662,12 +18662,12 @@ References:
 
     *,
     dar: String = Default('0'),max: Int = Default('100'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The setdar filter sets the Display Aspect Ratio for the filter
 output video.
 
@@ -18709,39 +18709,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setdar)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='setdar', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dar": dar,
-                
+
                 "max": max,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def setfield(
-    
+
     self,
 
 
@@ -18749,12 +18749,12 @@ References:
 
     *,
     mode: Int| Literal["auto","bff","tff","prog"] | Default = Default('auto'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Force field for the output video frame.
 
 The setfield filter marks the interlace type field for the
@@ -18776,37 +18776,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setfield)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='setfield', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def setparams(
-    
+
     self,
 
 
@@ -18814,12 +18814,12 @@ References:
 
     *,
     field_mode: Int| Literal["auto","bff","tff","prog"] | Default = Default('auto'),range: Int| Literal["auto","unspecified","unknown","limited","tv","mpeg","full","pc","jpeg"] | Default = Default('auto'),color_primaries: Int| Literal["auto","bt709","unknown","bt470m","bt470bg","smpte170m","smpte240m","film","bt2020","smpte428","smpte431","smpte432","jedec-p22","ebu3213"] | Default = Default('auto'),color_trc: Int| Literal["auto","bt709","unknown","bt470m","bt470bg","smpte170m","smpte240m","linear","log100","log316","iec61966-2-4","bt1361e","iec61966-2-1","bt2020-10","bt2020-12","smpte2084","smpte428","arib-std-b67"] | Default = Default('auto'),colorspace: Int| Literal["auto","gbr","bt709","unknown","fcc","bt470bg","smpte170m","smpte240m","ycgco","bt2020nc","bt2020c","smpte2085","chroma-derived-nc","chroma-derived-c","ictcp"] | Default = Default('auto'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Force frame parameter for the output video frame.
 
 The setparams filter marks interlace and color range for the
@@ -18843,45 +18843,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setparams)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='setparams', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "field_mode": field_mode,
-                
+
                 "range": range,
-                
+
                 "color_primaries": color_primaries,
-                
+
                 "color_trc": color_trc,
-                
+
                 "colorspace": colorspace,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def setpts(
-    
+
     self,
 
 
@@ -18889,12 +18889,12 @@ References:
 
     *,
     expr: String = Default('PTS'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Change the PTS (presentation timestamp) of the input frames.
 
 setpts works on video frames, asetpts on audio frames.
@@ -18913,37 +18913,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setpts)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='setpts', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "expr": expr,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def setrange(
-    
+
     self,
 
 
@@ -18951,12 +18951,12 @@ References:
 
     *,
     range: Int| Literal["auto","unspecified","unknown","limited","tv","mpeg","full","pc","jpeg"] | Default = Default('auto'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Force color range for the output video frame.
 
 The setrange filter marks the color range property for the
@@ -18978,37 +18978,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setrange)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='setrange', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "range": range,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def setsar(
-    
+
     self,
 
 
@@ -19016,12 +19016,12 @@ References:
 
     *,
     sar: String = Default('0'),max: Int = Default('100'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The setdar filter sets the Display Aspect Ratio for the filter
 output video.
 
@@ -19063,39 +19063,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setdar)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='setsar', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sar": sar,
-                
+
                 "max": max,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def settb(
-    
+
     self,
 
 
@@ -19103,12 +19103,12 @@ References:
 
     *,
     expr: String = Default('intb'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Set the timebase to use for the output frames timestamps.
 It is mainly useful for testing timebase configuration.
 
@@ -19126,37 +19126,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#settb)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='settb', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "expr": expr,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def sharpness_vaapi(
-    
+
     self,
 
 
@@ -19164,12 +19164,12 @@ References:
 
     *,
     sharpness: Int = Default('44'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 VAAPI VPP for sharpness
 
 
@@ -19184,37 +19184,37 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sharpness_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sharpness": sharpness,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def shear(
-    
+
     self,
 
 
@@ -19222,15 +19222,15 @@ References:
 
     *,
     shx: Float = Default('0'),shy: Float = Default('0'),fillcolor: String = Default('black'),interp: Int| Literal["nearest","bilinear"] | Default = Default('bilinear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply shear transform to input video.
 
 This filter supports the following options:
@@ -19251,7 +19251,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#shear)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -19259,44 +19259,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='shear', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "shx": shx,
-                
+
                 "shy": shy,
-                
+
                 "fillcolor": fillcolor,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def showinfo(
-    
+
     self,
 
 
@@ -19304,12 +19304,12 @@ References:
 
     *,
     checksum: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Show a line containing various information for each input video frame.
 The input video is not modified.
 
@@ -19327,37 +19327,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showinfo)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showinfo', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "checksum": checksum,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showpalette(
-    
+
     self,
 
 
@@ -19365,12 +19365,12 @@ References:
 
     *,
     s: Int = Default('30'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Displays the 256 colors palette of each frame. This filter is only relevant for
 pal8 pixel format frames.
 
@@ -19388,49 +19388,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showpalette)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showpalette', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "s": s,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def shuffleframes(
-    
+
     self,
 
 
@@ -19438,15 +19438,15 @@ References:
 
     *,
     mapping: String = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reorder and/or duplicate and/or drop video frames.
 
 It accepts the following parameters:
@@ -19464,7 +19464,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#shuffleframes)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -19472,34 +19472,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='shuffleframes', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mapping": mapping,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def shufflepixels(
-    
+
     self,
 
 
@@ -19507,15 +19507,15 @@ References:
 
     *,
     direction: Int| Literal["forward","inverse"] | Default = Default('forward'),mode: Int| Literal["horizontal","vertical","block"] | Default = Default('horizontal'),width: Int = Default('10'),height: Int = Default('10'),seed: Int64 = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reorder pixels in video frames.
 
 This filter accepts the following options:
@@ -19537,7 +19537,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#shufflepixels)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -19545,42 +19545,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='shufflepixels', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "direction": direction,
-                
+
                 "mode": mode,
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "seed": seed,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def shuffleplanes(
-    
+
     self,
 
 
@@ -19588,15 +19588,15 @@ References:
 
     *,
     map0: Int = Default('0'),map1: Int = Default('1'),map2: Int = Default('2'),map3: Int = Default('3'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reorder and/or duplicate video planes.
 
 It accepts the following parameters:
@@ -19617,7 +19617,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#shuffleplanes)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -19625,44 +19625,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='shuffleplanes', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "map0": map0,
-                
+
                 "map1": map1,
-                
+
                 "map2": map2,
-                
+
                 "map3": map3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def sidedata(
-    
+
     self,
 
 
@@ -19670,15 +19670,15 @@ References:
 
     *,
     mode: Int| Literal["select","delete"] | Default = Default('select'),type: Int| Literal["PANSCAN","A53_CC","STEREO3D","MATRIXENCODING","DOWNMIX_INFO","REPLAYGAIN","DISPLAYMATRIX","AFD","MOTION_VECTORS","SKIP_SAMPLES","AUDIO_SERVICE_TYPE","MASTERING_DISPLAY_METADATA","GOP_TIMECODE","SPHERICAL","CONTENT_LIGHT_LEVEL","ICC_PROFILE","S12M_TIMECOD","DYNAMIC_HDR_PLUS","REGIONS_OF_INTEREST","DETECTION_BOUNDING_BOXES","SEI_UNREGISTERED"] | Default = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Delete frame side data, or select frames based on it.
 
 This filter accepts the following options:
@@ -19697,7 +19697,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sidedata)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -19705,38 +19705,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sidedata', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def signalstats(
-    
+
     self,
 
 
@@ -19744,12 +19744,12 @@ References:
 
     *,
     stat: Flags| Literal["tout","vrep","brng"] | Default = Default('0'),out: Int| Literal["tout","vrep","brng"] | Default = Default('-1'),c: Color = Default('yellow'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Evaluate various visual metrics that assist in determining issues associated
 with the digitization of analog video media.
 
@@ -19769,51 +19769,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#signalstats)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='signalstats', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "stat": stat,
-                
+
                 "out": out,
-                
+
                 "c": c,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def siti(
-    
+
     self,
 
 
@@ -19821,12 +19821,12 @@ References:
 
     *,
     print_summary: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Calculate Spatial Info (SI) and Temporal Info (TI) scores for a video, as defined
 in ITU-T P.910: Subjective video quality assessment methods for multimedia
 applications. Available PDF at https://www.itu.int/rec/T-REC-P.910-199909-S/en .
@@ -19845,37 +19845,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#siti)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='siti', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "print_summary": print_summary,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def smartblur(
-    
+
     self,
 
 
@@ -19883,15 +19883,15 @@ References:
 
     *,
     luma_radius: Float = Default('1'),luma_strength: Float = Default('1'),luma_threshold: Int = Default('0'),chroma_radius: Float = Default('-0.9'),chroma_strength: Float = Default('-2'),chroma_threshold: Int = Default('-31'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Blur the input video without impacting the outlines.
 
 It accepts the following options:
@@ -19914,7 +19914,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#smartblur)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -19922,48 +19922,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='smartblur', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_radius": luma_radius,
-                
+
                 "luma_strength": luma_strength,
-                
+
                 "luma_threshold": luma_threshold,
-                
+
                 "chroma_radius": chroma_radius,
-                
+
                 "chroma_strength": chroma_strength,
-                
+
                 "chroma_threshold": chroma_threshold,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def sobel(
-    
+
     self,
 
 
@@ -19971,15 +19971,15 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply sobel operator to input video stream.
 
 The filter accepts the following option:
@@ -19999,7 +19999,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sobel)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -20007,38 +20007,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sobel', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def sobel_opencl(
-    
+
     self,
 
 
@@ -20046,12 +20046,12 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply the Sobel operator (https://en.wikipedia.org/wiki/Sobel_operator) to input video stream.
 
 The filter accepts the following option:
@@ -20070,62 +20070,62 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sobel_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sobel_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def spectrumsynth(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _phase: VideoStream,
-        
-    
+
+
 
 
     *,
     sample_rate: Int = Default('44100'),channels: Int = Default('1'),scale: Int| Literal["lin","log"] | Default = Default('log'),slide: Int| Literal["replace","scroll","fullframe","rscroll"] | Default = Default('fullframe'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman"] | Default = Default('rect'),overlap: Float = Default('1'),orientation: Int| Literal["vertical","horizontal"] | Default = Default('vertical'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Synthesize audio from 2 input video spectrums, first input stream represents
 magnitude across time and second represents phase across time.
 The filter will transform from frequency domain as displayed in videos back
@@ -20162,59 +20162,59 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#spectrumsynth)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='spectrumsynth', typings_input=('video', 'video'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _phase,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "sample_rate": sample_rate,
-                
+
                 "channels": channels,
-                
+
                 "scale": scale,
-                
+
                 "slide": slide,
-                
+
                 "win_func": win_func,
-                
+
                 "overlap": overlap,
-                
+
                 "orientation": orientation,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def split(
-    
+
     self,
 
 
@@ -20222,12 +20222,12 @@ References:
 
     *,
     outputs: Int = Default('2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Split input into several identical outputs.
 
 asplit works with audio input, split with video.
@@ -20248,38 +20248,38 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#split)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='split', typings_input=('video',), typings_output='[StreamType.video] * int(outputs)'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "outputs": outputs,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def spp(
-    
+
     self,
 
 
@@ -20287,15 +20287,15 @@ References:
 
     *,
     quality: Int = Default('3'),qp: Int = Default('0'),mode: Int| Literal["hard","soft"] | Default = Default('hard'),use_bframe_qp: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a simple postprocessing filter that compresses and decompresses the image
 at several (or - in the case of quality level 6 - all) shifts
 and average the results.
@@ -20318,7 +20318,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#spp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -20326,40 +20326,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='spp', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "quality": quality,
-                
+
                 "qp": qp,
-                
+
                 "mode": mode,
-                
+
                 "use_bframe_qp": use_bframe_qp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def sr(
-    
+
     self,
 
 
@@ -20367,12 +20367,12 @@ References:
 
     *,
     dnn_backend: Int| Literal["native"] | Default = Default('native'),scale_factor: Int = Default('2'),model: String = Default(None),input: String = Default('x'),output: String = Default('y'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Scale the input by applying one of the super-resolution methods based on
 convolutional neural networks. Supported models:
 
@@ -20392,74 +20392,74 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sr)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sr', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dnn_backend": dnn_backend,
-                
+
                 "scale_factor": scale_factor,
-                
+
                 "model": model,
-                
+
                 "input": input,
-                
+
                 "output": output,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ssim(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the SSIM (Structural SImilarity Metric) between two input videos.
 
 This filter takes in input two input videos, the first input is
@@ -20489,7 +20489,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ssim)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -20500,44 +20500,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ssim', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "stats_file": stats_file,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def stereo3d(
-    
+
     self,
 
 
@@ -20545,12 +20545,12 @@ References:
 
     *,
     _in: Int| Literal["ab2l","tb2l","ab2r","tb2r","abl","tbl","abr","tbr","al","ar","sbs2l","sbs2r","sbsl","sbsr","irl","irr","icl","icr"] | Default = Default('sbsl'),out: Int| Literal["ab2l","tb2l","ab2r","tb2r","abl","tbl","abr","tbr","agmc","agmd","agmg","agmh","al","ar","arbg","arcc","arcd","arcg","arch","argg","aybc","aybd","aybg","aybh","irl","irr","ml","mr","sbs2l","sbs2r","sbsl","sbsr","chl","chr","icl","icr","hdmi"] | Default = Default('arcd'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert between different stereoscopic image formats.
 
 The filters accept the following options:
@@ -20568,45 +20568,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#stereo3d)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='stereo3d', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "in": _in,
-                
+
                 "out": out,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def subtitles(
-    
+
     self,
 
 
@@ -20614,12 +20614,12 @@ References:
 
     *,
     filename: String = Default(None),original_size: Image_size = Default(None),fontsdir: String = Default(None),alpha: Boolean = Default('false'),charenc: String = Default(None),stream_index: Int = Default('-1'),force_style: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw subtitles on top of input video using the libass library.
 
 To enable compilation of this filter you need to configure FFmpeg with
@@ -20647,62 +20647,62 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#subtitles)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='subtitles', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "filename": filename,
-                
+
                 "original_size": original_size,
-                
+
                 "fontsdir": fontsdir,
-                
+
                 "alpha": alpha,
-                
+
                 "charenc": charenc,
-                
+
                 "stream_index": stream_index,
-                
+
                 "force_style": force_style,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def super2xsai(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Scale the input by 2x and smooth using the Super2xSaI (Scale and
 Interpolate) pixel art scaling algorithm.
 
@@ -20719,39 +20719,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#super2xsai)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='super2xsai', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def swaprect(
-    
+
     self,
 
 
@@ -20759,15 +20759,15 @@ References:
 
     *,
     w: String = Default('w/2'),h: String = Default('h/2'),x1: String = Default('w/2'),y1: String = Default('h/2'),x2: String = Default('0'),y2: String = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Swap two rectangular objects in video.
 
 This filter accepts the following options:
@@ -20790,7 +20790,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#swaprect)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -20798,60 +20798,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='swaprect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "x1": x1,
-                
+
                 "y1": y1,
-                
+
                 "x2": x2,
-                
+
                 "y2": y2,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def swapuv(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Swap U & V plane.
 
 
@@ -20866,7 +20866,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#swapuv)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -20874,32 +20874,32 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='swapuv', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tblend(
-    
+
     self,
 
 
@@ -20907,15 +20907,15 @@ References:
 
     *,
     c0_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c1_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c2_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c3_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),all_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('-1'),c0_expr: String = Default(None),c1_expr: String = Default(None),c2_expr: String = Default(None),c3_expr: String = Default(None),all_expr: String = Default(None),c0_opacity: Double = Default('1'),c1_opacity: Double = Default('1'),c2_opacity: Double = Default('1'),c3_opacity: Double = Default('1'),all_opacity: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Blend successive video frames.
 
 See blend
@@ -20947,7 +20947,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tblend)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -20955,62 +20955,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tblend', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "c0_mode": c0_mode,
-                
+
                 "c1_mode": c1_mode,
-                
+
                 "c2_mode": c2_mode,
-                
+
                 "c3_mode": c3_mode,
-                
+
                 "all_mode": all_mode,
-                
+
                 "c0_expr": c0_expr,
-                
+
                 "c1_expr": c1_expr,
-                
+
                 "c2_expr": c2_expr,
-                
+
                 "c3_expr": c3_expr,
-                
+
                 "all_expr": all_expr,
-                
+
                 "c0_opacity": c0_opacity,
-                
+
                 "c1_opacity": c1_opacity,
-                
+
                 "c2_opacity": c2_opacity,
-                
+
                 "c3_opacity": c3_opacity,
-                
+
                 "all_opacity": all_opacity,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def telecine(
-    
+
     self,
 
 
@@ -21018,12 +21018,12 @@ References:
 
     *,
     first_field: Int| Literal["top","t","bottom","b"] | Default = Default('top'),pattern: String = Default('23'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply telecine process to the video.
 
 This filter accepts the following options:
@@ -21041,43 +21041,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#telecine)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='telecine', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "first_field": first_field,
-                
+
                 "pattern": pattern,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def thistogram(
-    
+
     self,
 
 
@@ -21085,12 +21085,12 @@ References:
 
     *,
     width: Int = Default('0'),display_mode: Int| Literal["overlay","parade","stack"] | Default = Default('stack'),levels_mode: Int| Literal["linear","logarithmic"] | Default = Default('linear'),components: Int = Default('7'),bgopacity: Float = Default('0.9'),envelope: Boolean = Default('false'),ecolor: Color = Default('gold'),slide: Int| Literal["frame","replace","scroll","rscroll","picture"] | Default = Default('replace'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Compute and draw a color distribution histogram for the input video across time.
 
 Unlike histogram video filter which only shows histogram of single input frame
@@ -21121,83 +21121,83 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#thistogram)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='thistogram', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "width": width,
-                
+
                 "display_mode": display_mode,
-                
+
                 "levels_mode": levels_mode,
-                
+
                 "components": components,
-                
+
                 "bgopacity": bgopacity,
-                
+
                 "envelope": envelope,
-                
+
                 "ecolor": ecolor,
-                
+
                 "slide": slide,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def threshold(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _threshold: VideoStream,
-        
-    
-        
+
+
+
         _min: VideoStream,
-        
-    
-        
+
+
+
         _max: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply threshold effect to video stream.
 
 This filter needs four video streams to perform thresholding.
@@ -21220,7 +21220,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#threshold)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -21228,50 +21228,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='threshold', typings_input=('video', 'video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _threshold,
-                
-            
-                
+
+
+
                 _min,
-                
-            
-                
+
+
+
                 _max,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def thumbnail(
-    
+
     self,
 
 
@@ -21279,15 +21279,15 @@ References:
 
     *,
     n: Int = Default('100'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Select the most representative frame in a given sequence of consecutive frames.
 
 The filter accepts the following options:
@@ -21305,7 +21305,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#thumbnail)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -21313,34 +21313,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='thumbnail', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "n": n,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tile(
-    
+
     self,
 
 
@@ -21348,12 +21348,12 @@ References:
 
     *,
     layout: Image_size = Default('6x5'),nb_frames: Int = Default('0'),margin: Int = Default('0'),padding: Int = Default('0'),color: Color = Default('black'),overlap: Int = Default('0'),init_padding: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Tile several successive frames together.
 
 The untile filter can do the reverse.
@@ -21378,51 +21378,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tile)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tile', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "layout": layout,
-                
+
                 "nb_frames": nb_frames,
-                
+
                 "margin": margin,
-                
+
                 "padding": padding,
-                
+
                 "color": color,
-                
+
                 "overlap": overlap,
-                
+
                 "init_padding": init_padding,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def tinterlace(
-    
+
     self,
 
 
@@ -21430,12 +21430,12 @@ References:
 
     *,
     mode: Int| Literal["merge","drop_even","drop_odd","pad","interleave_top","interleave_bottom","interlacex2","mergex2"] | Default = Default('merge'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Perform various types of temporal field interlacing.
 
 Frames are counted starting from 1, so the first input frame is
@@ -21455,37 +21455,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tinterlace)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tinterlace', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tlut2(
-    
+
     self,
 
 
@@ -21493,15 +21493,15 @@ References:
 
     *,
     c0: String = Default('x'),c1: String = Default('x'),c2: String = Default('x'),c3: String = Default('x'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The lut2 filter takes two input streams and outputs one
 stream.
 
@@ -21526,7 +21526,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut2)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -21534,40 +21534,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tlut2', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "c0": c0,
-                
+
                 "c1": c1,
-                
+
                 "c2": c2,
-                
+
                 "c3": c3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tmedian(
-    
+
     self,
 
 
@@ -21575,15 +21575,15 @@ References:
 
     *,
     radius: Int = Default('1'),planes: Int = Default('15'),percentile: Float = Default('0.5'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pick median pixels from several successive input video frames.
 
 The filter accepts the following options:
@@ -21603,7 +21603,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tmedian)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -21611,38 +21611,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tmedian', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "radius": radius,
-                
+
                 "planes": planes,
-                
+
                 "percentile": percentile,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tmidequalizer(
-    
+
     self,
 
 
@@ -21650,15 +21650,15 @@ References:
 
     *,
     radius: Int = Default('5'),sigma: Float = Default('0.5'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Temporal Midway Video Equalization effect.
 
 Midway Video Equalization adjusts a sequence of video frames to have the same
@@ -21682,7 +21682,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tmidequalizer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -21690,38 +21690,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tmidequalizer', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "radius": radius,
-                
+
                 "sigma": sigma,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tmix(
-    
+
     self,
 
 
@@ -21729,15 +21729,15 @@ References:
 
     *,
     frames: Int = Default('3'),weights: String = Default('1 1 1'),scale: Float = Default('0'),planes: Flags = Default('F'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Mix successive video frames.
 
 A description of the accepted options follows.
@@ -21758,7 +21758,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tmix)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -21766,40 +21766,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tmix', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frames": frames,
-                
+
                 "weights": weights,
-                
+
                 "scale": scale,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tonemap(
-    
+
     self,
 
 
@@ -21807,12 +21807,12 @@ References:
 
     *,
     tonemap: Int| Literal["none","linear","gamma","clip","reinhard","hable","mobius"] | Default = Default('none'),param: Double = Default('nan'),desat: Double = Default('2'),peak: Double = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Tone map colors from different dynamic ranges.
 
 This filter expects data in single precision floating point, as it needs to
@@ -21841,43 +21841,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tonemap)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tonemap', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "tonemap": tonemap,
-                
+
                 "param": param,
-                
+
                 "desat": desat,
-                
+
                 "peak": peak,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tonemap_opencl(
-    
+
     self,
 
 
@@ -21885,12 +21885,12 @@ References:
 
     *,
     tonemap: Int| Literal["none","linear","gamma","clip","reinhard","hable","mobius"] | Default = Default('none'),transfer: Int| Literal["bt709","bt2020"] | Default = Default('bt709'),matrix: Int| Literal["bt709","bt2020"] | Default = Default('-1'),primaries: Int| Literal["bt709","bt2020"] | Default = Default('-1'),range: Int| Literal["tv","pc","limited","full"] | Default = Default('-1'),format: Pix_fmt = Default('none'),peak: Double = Default('0'),param: Double = Default('nan'),desat: Double = Default('0.5'),threshold: Double = Default('0.2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Perform HDR(PQ/HLG) to SDR conversion with tone-mapping.
 
 It accepts the following parameters:
@@ -21916,55 +21916,55 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tonemap_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tonemap_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "tonemap": tonemap,
-                
+
                 "transfer": transfer,
-                
+
                 "matrix": matrix,
-                
+
                 "primaries": primaries,
-                
+
                 "range": range,
-                
+
                 "format": format,
-                
+
                 "peak": peak,
-                
+
                 "param": param,
-                
+
                 "desat": desat,
-                
+
                 "threshold": threshold,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tonemap_vaapi(
-    
+
     self,
 
 
@@ -21972,12 +21972,12 @@ References:
 
     *,
     format: String = Default(None),matrix: String = Default(None),primaries: String = Default(None),transfer: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Perform HDR(High Dynamic Range) to SDR(Standard Dynamic Range) conversion with tone-mapping.
 It maps the dynamic range of HDR10 content to the SDR content.
 It currently only accepts HDR10 as input.
@@ -21999,43 +21999,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tonemap_vaapi)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tonemap_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "format": format,
-                
+
                 "matrix": matrix,
-                
+
                 "primaries": primaries,
-                
+
                 "transfer": transfer,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tpad(
-    
+
     self,
 
 
@@ -22043,12 +22043,12 @@ References:
 
     *,
     start: Int = Default('0'),stop: Int = Default('0'),start_mode: Int| Literal["add","clone"] | Default = Default('add'),stop_mode: Int| Literal["add","clone"] | Default = Default('add'),start_duration: Duration = Default('0'),stop_duration: Duration = Default('0'),color: Color = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Temporarily pad video frames.
 
 The filter accepts the following options:
@@ -22071,49 +22071,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tpad)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tpad', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "start": start,
-                
+
                 "stop": stop,
-                
+
                 "start_mode": start_mode,
-                
+
                 "stop_mode": stop_mode,
-                
+
                 "start_duration": start_duration,
-                
+
                 "stop_duration": stop_duration,
-                
+
                 "color": color,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def transpose(
-    
+
     self,
 
 
@@ -22121,12 +22121,12 @@ References:
 
     *,
     dir: Int| Literal["cclock_flip","clock","cclock","clock_flip"] | Default = Default('cclock_flip'),passthrough: Int| Literal["none","portrait","landscape"] | Default = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Transpose rows with columns in the input video and optionally flip it.
 
 It accepts the following parameters:
@@ -22144,39 +22144,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#transpose)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='transpose', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dir": dir,
-                
+
                 "passthrough": passthrough,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def transpose_opencl(
-    
+
     self,
 
 
@@ -22184,12 +22184,12 @@ References:
 
     *,
     dir: Int| Literal["cclock_flip","clock","cclock","clock_flip"] | Default = Default('cclock_flip'),passthrough: Int| Literal["none","portrait","landscape"] | Default = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Transpose input video
 
 
@@ -22205,39 +22205,39 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='transpose_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dir": dir,
-                
+
                 "passthrough": passthrough,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def transpose_vaapi(
-    
+
     self,
 
 
@@ -22245,12 +22245,12 @@ References:
 
     *,
     dir: Int| Literal["cclock_flip","clock","cclock","clock_flip","reversal","hflip","vflip"] | Default = Default('cclock_flip'),passthrough: Int| Literal["none","portrait","landscape"] | Default = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 VAAPI VPP for transpose
 
 
@@ -22266,43 +22266,43 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='transpose_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dir": dir,
-                
+
                 "passthrough": passthrough,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def trim(
-    
+
     self,
 
 
@@ -22310,12 +22310,12 @@ References:
 
     *,
     start: Duration = Default('INT64_MAX'),end: Duration = Default('INT64_MAX'),start_pts: Int64 = Default('I64_MIN'),end_pts: Int64 = Default('I64_MIN'),duration: Duration = Default('0'),start_frame: Int64 = Default('-1'),end_frame: Int64 = Default('I64_MAX'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Trim the input so that the output contains one continuous subpart of the input.
 
 It accepts the following parameters:
@@ -22338,51 +22338,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#trim)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='trim', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "start": start,
-                
+
                 "end": end,
-                
+
                 "start_pts": start_pts,
-                
+
                 "end_pts": end_pts,
-                
+
                 "duration": duration,
-                
+
                 "start_frame": start_frame,
-                
+
                 "end_frame": end_frame,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def unsharp(
-    
+
     self,
 
 
@@ -22390,15 +22390,15 @@ References:
 
     *,
     luma_msize_x: Int = Default('5'),luma_msize_y: Int = Default('5'),luma_amount: Float = Default('1'),chroma_msize_x: Int = Default('5'),chroma_msize_y: Int = Default('5'),chroma_amount: Float = Default('0'),alpha_msize_x: Int = Default('5'),alpha_msize_y: Int = Default('5'),alpha_amount: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Sharpen or blur the input video.
 
 It accepts the following parameters:
@@ -22424,7 +22424,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#unsharp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -22432,50 +22432,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='unsharp', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_msize_x": luma_msize_x,
-                
+
                 "luma_msize_y": luma_msize_y,
-                
+
                 "luma_amount": luma_amount,
-                
+
                 "chroma_msize_x": chroma_msize_x,
-                
+
                 "chroma_msize_y": chroma_msize_y,
-                
+
                 "chroma_amount": chroma_amount,
-                
+
                 "alpha_msize_x": alpha_msize_x,
-                
+
                 "alpha_msize_y": alpha_msize_y,
-                
+
                 "alpha_amount": alpha_amount,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def unsharp_opencl(
-    
+
     self,
 
 
@@ -22483,12 +22483,12 @@ References:
 
     *,
     luma_msize_x: Float = Default('5'),luma_msize_y: Float = Default('5'),luma_amount: Float = Default('1'),chroma_msize_x: Float = Default('5'),chroma_msize_y: Float = Default('5'),chroma_amount: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Sharpen or blur the input video.
 
 It accepts the following parameters:
@@ -22510,47 +22510,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#unsharp_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='unsharp_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_msize_x": luma_msize_x,
-                
+
                 "luma_msize_y": luma_msize_y,
-                
+
                 "luma_amount": luma_amount,
-                
+
                 "chroma_msize_x": chroma_msize_x,
-                
+
                 "chroma_msize_y": chroma_msize_y,
-                
+
                 "chroma_amount": chroma_amount,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def untile(
-    
+
     self,
 
 
@@ -22558,12 +22558,12 @@ References:
 
     *,
     layout: Image_size = Default('6x5'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Decompose a video made of tiled images into the individual images.
 
 The frame rate of the output video is the frame rate of the input video
@@ -22585,37 +22585,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#untile)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='untile', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "layout": layout,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def v360(
-    
+
     self,
 
 
@@ -22623,12 +22623,12 @@ References:
 
     *,
     input: Int| Literal["e","equirect","c3x2","c6x1","eac","dfisheye","flat","rectilinear","gnomonic","barrel","fb","c1x6","sg","mercator","ball","hammer","sinusoidal","fisheye","pannini","cylindrical","tetrahedron","barrelsplit","tsp","hequirect","he","equisolid","og","octahedron","cylindricalea"] | Default = Default('e'),output: Int| Literal["e","equirect","c3x2","c6x1","eac","dfisheye","flat","rectilinear","gnomonic","barrel","fb","c1x6","sg","mercator","ball","hammer","sinusoidal","fisheye","pannini","cylindrical","perspective","tetrahedron","barrelsplit","tsp","hequirect","he","equisolid","og","octahedron","cylindricalea"] | Default = Default('c3x2'),interp: Int| Literal["near","nearest","line","linear","lagrange9","cube","cubic","lanc","lanczos","sp16","spline16","gauss","gaussian","mitchell"] | Default = Default('line'),w: Int = Default('0'),h: Int = Default('0'),in_stereo: Int| Literal["2d","sbs","tb"] | Default = Default('2d'),out_stereo: Int| Literal["2d","sbs","tb"] | Default = Default('2d'),in_forder: String = Default('rludfb'),out_forder: String = Default('rludfb'),in_frot: String = Default('000000'),out_frot: String = Default('000000'),in_pad: Float = Default('0'),out_pad: Float = Default('0'),fin_pad: Int = Default('0'),fout_pad: Int = Default('0'),yaw: Float = Default('0'),pitch: Float = Default('0'),roll: Float = Default('0'),rorder: String = Default('ypr'),h_fov: Float = Default('0'),v_fov: Float = Default('0'),d_fov: Float = Default('0'),h_flip: Boolean = Default('false'),v_flip: Boolean = Default('false'),d_flip: Boolean = Default('false'),ih_flip: Boolean = Default('false'),iv_flip: Boolean = Default('false'),in_trans: Boolean = Default('false'),out_trans: Boolean = Default('false'),ih_fov: Float = Default('0'),iv_fov: Float = Default('0'),id_fov: Float = Default('0'),h_offset: Float = Default('0'),v_offset: Float = Default('0'),alpha_mask: Boolean = Default('false'),reset_rot: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert 360 videos between various formats.
 
 The filter accepts the following options:
@@ -22680,107 +22680,107 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#v360)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='v360', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "input": input,
-                
+
                 "output": output,
-                
+
                 "interp": interp,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "in_stereo": in_stereo,
-                
+
                 "out_stereo": out_stereo,
-                
+
                 "in_forder": in_forder,
-                
+
                 "out_forder": out_forder,
-                
+
                 "in_frot": in_frot,
-                
+
                 "out_frot": out_frot,
-                
+
                 "in_pad": in_pad,
-                
+
                 "out_pad": out_pad,
-                
+
                 "fin_pad": fin_pad,
-                
+
                 "fout_pad": fout_pad,
-                
+
                 "yaw": yaw,
-                
+
                 "pitch": pitch,
-                
+
                 "roll": roll,
-                
+
                 "rorder": rorder,
-                
+
                 "h_fov": h_fov,
-                
+
                 "v_fov": v_fov,
-                
+
                 "d_fov": d_fov,
-                
+
                 "h_flip": h_flip,
-                
+
                 "v_flip": v_flip,
-                
+
                 "d_flip": d_flip,
-                
+
                 "ih_flip": ih_flip,
-                
+
                 "iv_flip": iv_flip,
-                
+
                 "in_trans": in_trans,
-                
+
                 "out_trans": out_trans,
-                
+
                 "ih_fov": ih_fov,
-                
+
                 "iv_fov": iv_fov,
-                
+
                 "id_fov": id_fov,
-                
+
                 "h_offset": h_offset,
-                
+
                 "v_offset": v_offset,
-                
+
                 "alpha_mask": alpha_mask,
-                
+
                 "reset_rot": reset_rot,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vaguedenoiser(
-    
+
     self,
 
 
@@ -22788,15 +22788,15 @@ References:
 
     *,
     threshold: Float = Default('2'),method: Int| Literal["hard","soft","garrote"] | Default = Default('garrote'),nsteps: Int = Default('6'),percent: Float = Default('85'),planes: Int = Default('15'),type: Int| Literal["universal","bayes"] | Default = Default('universal'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a wavelet based denoiser.
 
 It transforms each frame from the video input into the wavelet domain,
@@ -22825,7 +22825,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vaguedenoiser)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -22833,73 +22833,73 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vaguedenoiser', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold": threshold,
-                
+
                 "method": method,
-                
+
                 "nsteps": nsteps,
-                
+
                 "percent": percent,
-                
+
                 "planes": planes,
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def varblur(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _radius: VideoStream,
-        
-    
+
+
 
 
     *,
     min_r: Int = Default('0'),max_r: Int = Default('8'),planes: Int = Default('15'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply variable blur filter by using 2nd video stream to set blur radius.
 The 2nd stream must have the same dimensions.
 
@@ -22921,7 +22921,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#varblur)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -22932,48 +22932,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='varblur', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _radius,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "min_r": min_r,
-                
+
                 "max_r": max_r,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vectorscope(
-    
+
     self,
 
 
@@ -22981,12 +22981,12 @@ References:
 
     *,
     mode: Int| Literal["gray","tint","color","color2","color3","color4","color5"] | Default = Default('gray'),x: Int = Default('1'),y: Int = Default('2'),intensity: Float = Default('0.004'),envelope: Int| Literal["none","instant","peak","peak+instant"] | Default = Default('none'),graticule: Int| Literal["none","green","color","invert"] | Default = Default('none'),opacity: Float = Default('0.75'),flags: Flags| Literal["white","black","name"] | Default = Default('name'),bgopacity: Float = Default('0.3'),lthreshold: Float = Default('0'),hthreshold: Float = Default('1'),colorspace: Int| Literal["auto","601","709"] | Default = Default('auto'),tint0: Float = Default('0'),tint1: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Display 2 color component values in the two dimensional graph (which is called
 a vectorscope).
 
@@ -23017,79 +23017,79 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vectorscope)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vectorscope', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "intensity": intensity,
-                
+
                 "envelope": envelope,
-                
+
                 "graticule": graticule,
-                
+
                 "opacity": opacity,
-                
+
                 "flags": flags,
-                
+
                 "bgopacity": bgopacity,
-                
+
                 "lthreshold": lthreshold,
-                
+
                 "hthreshold": hthreshold,
-                
+
                 "colorspace": colorspace,
-                
+
                 "tint0": tint0,
-                
+
                 "tint1": tint1,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vflip(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Flip the input video vertically.
 
 For example, to vertically flip a video with ffmpeg:
@@ -23109,7 +23109,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vflip)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -23117,45 +23117,45 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vflip', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vfrdet(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect variable frame rate video.
 
 This filter tries to detect if the input is variable or constant frame rate.
@@ -23176,35 +23176,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vfrdet)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vfrdet', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vibrance(
-    
+
     self,
 
 
@@ -23212,15 +23212,15 @@ References:
 
     *,
     intensity: Float = Default('0'),rbal: Float = Default('1'),gbal: Float = Default('1'),bbal: Float = Default('1'),rlum: Float = Default('0.072186'),glum: Float = Default('0.715158'),blum: Float = Default('0.212656'),alternate: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Boost or alter saturation.
 
 The filter accepts the following options:
@@ -23245,7 +23245,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vibrance)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -23253,50 +23253,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vibrance', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "intensity": intensity,
-                
+
                 "rbal": rbal,
-                
+
                 "gbal": gbal,
-                
+
                 "bbal": bbal,
-                
+
                 "rlum": rlum,
-                
+
                 "glum": glum,
-                
+
                 "blum": blum,
-                
+
                 "alternate": alternate,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def vidstabdetect(
-    
+
     self,
 
 
@@ -23304,12 +23304,12 @@ References:
 
     *,
     result: String = Default('transforms.trf'),shakiness: Int = Default('5'),accuracy: Int = Default('15'),stepsize: Int = Default('6'),mincontrast: Double = Default('0.25'),show: Int = Default('0'),tripod: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Analyze video stabilization/deshaking. Perform pass 1 of 2, see
 vidstabtransform for pass 2.
 
@@ -23340,49 +23340,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vidstabdetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vidstabdetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "result": result,
-                
+
                 "shakiness": shakiness,
-                
+
                 "accuracy": accuracy,
-                
+
                 "stepsize": stepsize,
-                
+
                 "mincontrast": mincontrast,
-                
+
                 "show": show,
-                
+
                 "tripod": tripod,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vidstabtransform(
-    
+
     self,
 
 
@@ -23390,12 +23390,12 @@ References:
 
     *,
     input: String = Default('transforms.trf'),smoothing: Int = Default('15'),optalgo: Int| Literal["opt","gauss","avg"] | Default = Default('opt'),maxshift: Int = Default('-1'),maxangle: Double = Default('-1'),crop: Int| Literal["keep","black"] | Default = Default('keep'),invert: Int = Default('0'),relative: Int = Default('1'),zoom: Double = Default('0'),optzoom: Int = Default('1'),zoomspeed: Double = Default('0.25'),interpol: Int| Literal["no","linear","bilinear","bicubic"] | Default = Default('bilinear'),tripod: Boolean = Default('false'),debug: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Video stabilization/deshaking: pass 2 of 2,
 see vidstabdetect for pass 1.
 
@@ -23433,87 +23433,87 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vidstabtransform)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vidstabtransform', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "input": input,
-                
+
                 "smoothing": smoothing,
-                
+
                 "optalgo": optalgo,
-                
+
                 "maxshift": maxshift,
-                
+
                 "maxangle": maxangle,
-                
+
                 "crop": crop,
-                
+
                 "invert": invert,
-                
+
                 "relative": relative,
-                
+
                 "zoom": zoom,
-                
+
                 "optzoom": optzoom,
-                
+
                 "zoomspeed": zoomspeed,
-                
+
                 "interpol": interpol,
-                
+
                 "tripod": tripod,
-                
+
                 "debug": debug,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vif(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the average VIF (Visual Information Fidelity) between two input videos.
 
 This filter takes two input videos.
@@ -23547,7 +23547,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vif)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -23555,40 +23555,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vif', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vignette(
-    
+
     self,
 
 
@@ -23596,15 +23596,15 @@ References:
 
     *,
     angle: String = Default('PI/5'),x0: String = Default('w/2'),y0: String = Default('h/2'),mode: Int| Literal["forward","backward"] | Default = Default('forward'),eval: Int| Literal["init","frame"] | Default = Default('init'),dither: Boolean = Default('true'),aspect: Rational = Default('1/1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Make or reverse a natural vignetting effect.
 
 The filter accepts the following options:
@@ -23628,7 +23628,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vignette)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -23636,48 +23636,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vignette', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "angle": angle,
-                
+
                 "x0": x0,
-                
+
                 "y0": y0,
-                
+
                 "mode": mode,
-                
+
                 "eval": eval,
-                
+
                 "dither": dither,
-                
+
                 "aspect": aspect,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def vmafmotion(
-    
+
     self,
 
 
@@ -23685,12 +23685,12 @@ References:
 
     *,
     stats_file: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the average VMAF motion score of a video.
 It is one of the component metrics of VMAF.
 
@@ -23710,43 +23710,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vmafmotion)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vmafmotion', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "stats_file": stats_file,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def w3fdif(
-    
+
     self,
 
 
@@ -23754,15 +23754,15 @@ References:
 
     *,
     filter: Int| Literal["simple","complex"] | Default = Default('complex'),mode: Int| Literal["frame","field"] | Default = Default('field'),parity: Int| Literal["tff","bff","auto"] | Default = Default('auto'),deint: Int| Literal["all","interlaced"] | Default = Default('all'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlace the input video ("w3fdif" stands for "Weston 3 Field
 Deinterlacing Filter").
 
@@ -23795,7 +23795,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#w3fdif)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -23803,40 +23803,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='w3fdif', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "filter": filter,
-                
+
                 "mode": mode,
-                
+
                 "parity": parity,
-                
+
                 "deint": deint,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def waveform(
-    
+
     self,
 
 
@@ -23844,12 +23844,12 @@ References:
 
     *,
     mode: Int| Literal["row","column"] | Default = Default('column'),intensity: Float = Default('0.04'),mirror: Boolean = Default('true'),display: Int| Literal["overlay","stack","parade"] | Default = Default('stack'),components: Int = Default('1'),envelope: Int| Literal["none","instant","peak","peak+instant"] | Default = Default('none'),filter: Int| Literal["lowpass","flat","aflat","chroma","color","acolor","xflat","yflat"] | Default = Default('lowpass'),graticule: Int| Literal["none","green","orange","invert"] | Default = Default('none'),opacity: Float = Default('0.75'),flags: Flags| Literal["numbers","dots"] | Default = Default('numbers'),scale: Int| Literal["digital","millivolts","ire"] | Default = Default('digital'),bgopacity: Float = Default('0.75'),tint0: Float = Default('0'),tint1: Float = Default('0'),fitmode: Int| Literal["none","size"] | Default = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Video waveform monitor.
 
 The waveform monitor plots color component intensity. By default luminance
@@ -23884,65 +23884,65 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#waveform)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='waveform', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "intensity": intensity,
-                
+
                 "mirror": mirror,
-                
+
                 "display": display,
-                
+
                 "components": components,
-                
+
                 "envelope": envelope,
-                
+
                 "filter": filter,
-                
+
                 "graticule": graticule,
-                
+
                 "opacity": opacity,
-                
+
                 "flags": flags,
-                
+
                 "scale": scale,
-                
+
                 "bgopacity": bgopacity,
-                
+
                 "tint0": tint0,
-                
+
                 "tint1": tint1,
-                
+
                 "fitmode": fitmode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def weave(
-    
+
     self,
 
 
@@ -23950,12 +23950,12 @@ References:
 
     *,
     first_field: Int| Literal["top","t","bottom","b"] | Default = Default('top'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The weave takes a field-based video input and join
 each two sequential fields into single frame, producing a new double
 height clip with half the frame rate and half the frame count.
@@ -23977,37 +23977,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#weave)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='weave', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "first_field": first_field,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def xbr(
-    
+
     self,
 
 
@@ -24015,12 +24015,12 @@ References:
 
     *,
     n: Int = Default('3'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply the xBR high-quality magnification filter which is designed for pixel
 art. It follows a set of edge-detection rules, see
 https://forums.libretro.com/t/xbr-algorithm-tutorial/123.
@@ -24039,66 +24039,66 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xbr)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='xbr', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "n": n,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def xcorrelate(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _secondary: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('7'),secondary: Int| Literal["first","all"] | Default = Default('all'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply normalized cross-correlation between first and second input video stream.
 
 Second input video stream dimensions must be lower than first input video stream.
@@ -24120,7 +24120,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xcorrelate)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -24131,67 +24131,67 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='xcorrelate', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _secondary,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "secondary": secondary,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def xfade(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _xfade: VideoStream,
-        
-    
+
+
 
 
     *,
     transition: Int| Literal["custom","fade","wipeleft","wiperight","wipeup","wipedown","slideleft","slideright","slideup","slidedown","circlecrop","rectcrop","distance","fadeblack","fadewhite","radial","smoothleft","smoothright","smoothup","smoothdown","circleopen","circleclose","vertopen","vertclose","horzopen","horzclose","dissolve","pixelize","diagtl","diagtr","diagbl","diagbr","hlslice","hrslice","vuslice","vdslice","hblur","fadegrays","wipetl","wipetr","wipebl","wipebr","squeezeh","squeezev","zoomin","fadefast","fadeslow"] | Default = Default('fade'),duration: Duration = Default('1'),offset: Duration = Default('0'),expr: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply cross fade from one input video stream to another input video stream.
 The cross fade is applied for specified duration.
 
@@ -24215,72 +24215,72 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xfade)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='xfade', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _xfade,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "transition": transition,
-                
+
                 "duration": duration,
-                
+
                 "offset": offset,
-                
+
                 "expr": expr,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def xfade_opencl(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _xfade: VideoStream,
-        
-    
+
+
 
 
     *,
     transition: Int| Literal["custom","fade","wipeleft","wiperight","wipeup","wipedown","slideleft","slideright","slideup","slidedown"] | Default = Default('fade'),source: String = Default(None),kernel: String = Default(None),duration: Duration = Default('1'),offset: Duration = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Cross fade two videos with custom transition effect by using OpenCL.
 
 It accepts the following options:
@@ -24301,57 +24301,57 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xfade_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='xfade_opencl', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _xfade,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "transition": transition,
-                
+
                 "source": source,
-                
+
                 "kernel": kernel,
-                
+
                 "duration": duration,
-                
+
                 "offset": offset,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def yadif(
-    
+
     self,
 
 
@@ -24359,15 +24359,15 @@ References:
 
     *,
     mode: Int| Literal["send_frame","send_field","send_frame_nospatial","send_field_nospatial"] | Default = Default('send_frame'),parity: Int| Literal["tff","bff","auto"] | Default = Default('auto'),deint: Int| Literal["all","interlaced"] | Default = Default('all'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlace the input video ("yadif" means "yet another deinterlacing
 filter").
 
@@ -24388,7 +24388,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#yadif)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -24396,38 +24396,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='yadif', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "parity": parity,
-                
+
                 "deint": deint,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def yaepblur(
-    
+
     self,
 
 
@@ -24435,15 +24435,15 @@ References:
 
     *,
     radius: Int = Default('3'),planes: Int = Default('1'),sigma: Int = Default('128'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply blur filter while preserving edges ("yaepblur" means "yet another edge preserving blur filter").
 The algorithm is described in
 "J. S. Lee, Digital image enhancement and noise filtering by use of local statistics, IEEE Trans. Pattern Anal. Mach. Intell. PAMI-2, 1980."
@@ -24465,7 +24465,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#yaepblur)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -24473,40 +24473,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='yaepblur', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "radius": radius,
-                
+
                 "planes": planes,
-                
+
                 "sigma": sigma,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def zmq(
-    
+
     self,
 
 
@@ -24514,12 +24514,12 @@ References:
 
     *,
     bind_address: String = Default('tcp://*:5555'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Receive commands sent through a libzmq client, and forward them to
 filters in the filtergraph.
 
@@ -24578,37 +24578,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#zmq)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='zmq', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "bind_address": bind_address,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def zoompan(
-    
+
     self,
 
 
@@ -24616,12 +24616,12 @@ References:
 
     *,
     zoom: String = Default('1'),x: String = Default('0'),y: String = Default('0'),d: String = Default('90'),s: Image_size = Default('hd720'),fps: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Zoom & Pan effect.
 
 This filter accepts the following options:
@@ -24643,47 +24643,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#zoompan)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='zoompan', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "zoom": zoom,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "d": d,
-                
+
                 "s": s,
-                
+
                 "fps": fps,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def zscale(
-    
+
     self,
 
 
@@ -24691,12 +24691,12 @@ References:
 
     *,
     w: String = Default(None),h: String = Default(None),size: String = Default(None),dither: Int| Literal["none","ordered","random","error_diffusion"] | Default = Default('none'),filter: Int| Literal["point","bilinear","bicubic","spline16","spline36","lanczos"] | Default = Default('bilinear'),out_range: Int| Literal["input","limited","full","unknown","tv","pc"] | Default = Default('input'),primaries: Int| Literal["input","709","unspecified","170m","240m","2020","unknown","bt709","bt470m","bt470bg","smpte170m","smpte240m","film","bt2020","smpte428","smpte431","smpte432","jedec-p22","ebu3213"] | Default = Default('input'),transfer: Int| Literal["input","709","unspecified","601","linear","2020_10","2020_12","unknown","bt470m","bt470bg","smpte170m","bt709","log100","log316","bt2020-10","bt2020-12","smpte2084","iec61966-2-4","iec61966-2-1","arib-std-b67"] | Default = Default('input'),matrix: Int| Literal["input","709","unspecified","470bg","170m","2020_ncl","2020_cl","unknown","gbr","bt709","fcc","bt470bg","smpte170m","smpte2400m","ycgco","bt2020nc","bt2020c","chroma-derived-nc","chroma-derived-c","ictcp"] | Default = Default('input'),in_range: Int| Literal["input","limited","full","unknown","tv","pc"] | Default = Default('input'),primariesin: Int| Literal["input","709","unspecified","170m","240m","2020","unknown","bt709","bt470m","bt470bg","smpte170m","smpte240m","film","bt2020","smpte428","smpte431","smpte432","jedec-p22","ebu3213"] | Default = Default('input'),transferin: Int| Literal["input","709","unspecified","601","linear","2020_10","2020_12","unknown","bt470m","bt470bg","smpte170m","bt709","log100","log316","bt2020-10","bt2020-12","smpte2084","iec61966-2-4","iec61966-2-1","arib-std-b67"] | Default = Default('input'),matrixin: Int| Literal["input","709","unspecified","470bg","170m","2020_ncl","2020_cl","unknown","gbr","bt709","fcc","bt470bg","smpte170m","smpte2400m","ycgco","bt2020nc","bt2020c","chroma-derived-nc","chroma-derived-c","ictcp"] | Default = Default('input'),chromal: Int| Literal["input","left","center","topleft","top","bottomleft","bottom"] | Default = Default('input'),chromalin: Int| Literal["input","left","center","topleft","top","bottomleft","bottom"] | Default = Default('input'),npl: Double = Default('nan'),agamma: Boolean = Default('true'),param_a: Double = Default('nan'),param_b: Double = Default('nan'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Scale (resize) the input video, using the z.lib library:
 https://github.com/sekrit-twc/zimg. To enable compilation of this
 filter, you need to configure FFmpeg with --enable-libzimg.
@@ -24738,65 +24738,61 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#zscale)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='zscale', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "size": size,
-                
+
                 "dither": dither,
-                
+
                 "filter": filter,
-                
+
                 "out_range": out_range,
-                
+
                 "primaries": primaries,
-                
+
                 "transfer": transfer,
-                
+
                 "matrix": matrix,
-                
+
                 "in_range": in_range,
-                
+
                 "primariesin": primariesin,
-                
+
                 "transferin": transferin,
-                
+
                 "matrixin": matrixin,
-                
+
                 "chromal": chromal,
-                
+
                 "chromalin": chromalin,
-                
+
                 "npl": npl,
-                
+
                 "agamma": agamma,
-                
+
                 "param_a": param_a,
-                
+
                 "param_b": param_b,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
-
-
-        
-    

--- a/packages/v6/pyproject.toml
+++ b/packages/v6/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = ["ffmpeg-core>=1.0.0a1,<2.0"]
 ffmpeg-core = { workspace = true }
 
 [project.optional-dependencies]
-dev = ["pytest>=7.0", "pytest-cov>=4.0", "syrupy>=5.0", "ruff>=0.9.6"]
+dev = ["pytest>=7.0", "pytest-cov>=4.0", "syrupy>=5.0", "ruff==0.12.2"]
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/packages/v6/src/ffmpeg/codecs/decoders.py
+++ b/packages/v6/src/ffmpeg/codecs/decoders.py
@@ -450,295 +450,295 @@ from ..streams.audio import AudioStream
 
 
 def _012v(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed 4:2:2 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def _4xm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     4X Movie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def _8bps(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QuickTime 8BPS video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def aasc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Autodesk RLE
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def agm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Amuse Graphics Movie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def aic(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Apple Intermediate Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def alias_pix(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Alias/Wavefront PIX image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def amv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AMV Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def anm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Deluxe Paint Animation
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ansi(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ASCII/ANSI art
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def apng(
-    
+
 ) -> FFMpegDecoderOption:
     """
     APNG (Animated Portable Network Graphics) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def arbc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Gryphon's Anim Compressor
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def argo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Argonaut Games Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def asv1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ASUS V1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def asv2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ASUS V2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def aura(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Auravision AURA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def aura2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Auravision Aura 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def libdav1d(
-    
+
     tilethreads: int | None = None,
-    
+
     framethreads: int | None = None,
-    
+
     max_frame_delay: int | None = None,
-    
+
     filmgrain: bool | None = None,
-    
+
     oppoint: int | None = None,
-    
+
     alllayers: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     dav1d AV1 decoder by VideoLAN (codec av1)
-    
+
     Args:
         tilethreads: Tile threads (from 0 to 256) (default 0)
         framethreads: Frame threads (from 0 to 256) (default 0)
@@ -751,31 +751,31 @@ def libdav1d(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "tilethreads": tilethreads,
-        
+
         "framethreads": framethreads,
-        
+
         "max_frame_delay": max_frame_delay,
-        
+
         "filmgrain": filmgrain,
-        
+
         "oppoint": oppoint,
-        
+
         "alllayers": alllayers,
-        
+
     }))
 
 
 
 def av1(
-    
+
     operating_point: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Alliance for Open Media AV1
-    
+
     Args:
         operating_point: Select an operating point of the scalable bitstream (from 0 to 31) (default 0)
 
@@ -783,667 +783,667 @@ def av1(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "operating_point": operating_point,
-        
+
     }))
 
 
 
 def avrn(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Avid AVI Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def avrp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Avid 1:1 10-bit RGB Packer
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def avs(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AVS (Audio Video Standard) video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def avui(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Avid Meridien Uncompressed
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ayuv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed packed MS 4:4:4:4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bethsoftvid(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bethesda VID video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bfi(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Brute Force & Ignorance
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def binkvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bink video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bintext(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Binary text
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bitpacked(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bitpacked
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bmp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     BMP (Windows and OS/2 bitmap)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bmv_video(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Discworld II BMV video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def brender_pix(
-    
+
 ) -> FFMpegDecoderOption:
     """
     BRender PIX image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def c93(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Interplay C93
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cavs(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Chinese AVS (Audio Video Standard) (AVS1-P2, JiZhun profile)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cdgraphics(
-    
+
 ) -> FFMpegDecoderOption:
     """
     CD Graphics video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cdtoons(
-    
+
 ) -> FFMpegDecoderOption:
     """
     CDToons video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cdxl(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Commodore CDXL video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cfhd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     GoPro CineForm HD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cinepak(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Cinepak
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def clearvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Iterated Systems ClearVideo
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cljr(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Cirrus Logic AccuPak
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cllc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Canopus Lossless Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def eacmv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Electronic Arts CMV video (codec cmv)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cpia(
-    
+
 ) -> FFMpegDecoderOption:
     """
     CPiA video format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cri(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Cintel RAW
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def camstudio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     CamStudio (codec cscd)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cyuv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Creative YUV (CYUV)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dds(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DirectDraw Surface image decoder
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dfa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Chronomaster DFA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dirac(
-    
+
 ) -> FFMpegDecoderOption:
     """
     BBC Dirac VC-2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dnxhd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     VC3/DNxHD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dpx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPX (Digital Picture Exchange) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dsicinvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Delphine Software International CIN video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dvvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DV (Digital Video)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dxa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Feeble Files/ScummVM DXA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dxtory(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Dxtory
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dxv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Resolume DXV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def escape124(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Escape 124
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def escape130(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Escape 130
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def exr(
-    
+
     layer: str | None = None,
-    
+
     part: int | None = None,
-    
+
     gamma: float | None = None,
-    
+
     apply_trc: int | None| Literal["bt709", "gamma", "gamma22", "gamma28", "smpte170m", "smpte240m", "linear", "log", "log_sqrt", "iec61966_2_4", "bt1361", "iec61966_2_1", "bt2020_10bit", "bt2020_12bit", "smpte2084", "smpte428_1"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     OpenEXR image
-    
+
     Args:
         layer: Set the decoding layer (default "")
         part: Set the decoding part (from 0 to INT_MAX) (default 0)
@@ -1454,59 +1454,59 @@ def exr(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "layer": layer,
-        
+
         "part": part,
-        
+
         "gamma": gamma,
-        
+
         "apply_trc": apply_trc,
-        
+
     }))
 
 
 
 def ffv1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     FFmpeg video codec #1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ffvhuff(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Huffyuv FFmpeg variant
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def fic(
-    
+
     skip_cursor: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Mirillis FIC
-    
+
     Args:
         skip_cursor: skip the cursor (default false)
 
@@ -1514,21 +1514,21 @@ def fic(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "skip_cursor": skip_cursor,
-        
+
     }))
 
 
 
 def fits(
-    
+
     blank_value: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Flexible Image Transport System
-    
+
     Args:
         blank_value: value that is used to replace BLANK pixels in data array (from 0 to 65535) (default 0)
 
@@ -1536,117 +1536,117 @@ def fits(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "blank_value": blank_value,
-        
+
     }))
 
 
 
 def flashsv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Flash Screen Video v1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def flashsv2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Flash Screen Video v2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def flic(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Autodesk Animator Flic video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def flv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     FLV / Sorenson Spark / Sorenson H.263 (Flash Video) (codec flv1)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def fmvc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     FM Screen Capture Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def fraps(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Fraps
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def frwu(
-    
+
     change_field_order: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Forward Uncompressed
-    
+
     Args:
         change_field_order: Change field order (default false)
 
@@ -1654,69 +1654,69 @@ def frwu(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "change_field_order": change_field_order,
-        
+
     }))
 
 
 
 def g2m(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Go2Meeting
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def gdv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Gremlin Digital Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def gem(
-    
+
 ) -> FFMpegDecoderOption:
     """
     GEM Raster image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def gif(
-    
+
     trans_color: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     GIF (Graphics Interchange Format)
-    
+
     Args:
         trans_color: color value (ARGB) that is used instead of transparent color (from 0 to UINT32_MAX) (default 16777215)
 
@@ -1724,55 +1724,55 @@ def gif(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "trans_color": trans_color,
-        
+
     }))
 
 
 
 def h261(
-    
+
 ) -> FFMpegDecoderOption:
     """
     H.261
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def h263(
-    
+
 ) -> FFMpegDecoderOption:
     """
     H.263 / H.263-1996, H.263+ / H.263-1998 / H.263 version 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def h263_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem H.263 decoder wrapper (codec h263)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -1781,61 +1781,61 @@ def h263_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def h263i(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Intel H.263
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def h263p(
-    
+
 ) -> FFMpegDecoderOption:
     """
     H.263 / H.263-1996, H.263+ / H.263-1998 / H.263 version 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def h264(
-    
+
     is_avc: bool | None = None,
-    
+
     nal_length_size: int | None = None,
-    
+
     enable_er: bool | None = None,
-    
+
     x264_build: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10
-    
+
     Args:
         is_avc: is avc (default false)
         nal_length_size: nal_length_size (from 0 to 4) (default 0)
@@ -1846,29 +1846,29 @@ def h264(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "is_avc": is_avc,
-        
+
         "nal_length_size": nal_length_size,
-        
+
         "enable_er": enable_er,
-        
+
         "x264_build": x264_build,
-        
+
     }))
 
 
 
 def h264_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem H.264 decoder wrapper (codec h264)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -1877,57 +1877,57 @@ def h264_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def hap(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Vidvox Hap
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hdr(
-    
+
 ) -> FFMpegDecoderOption:
     """
     HDR (Radiance RGBE format) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hevc(
-    
+
     apply_defdispwin: bool | None = None,
-    
+
     strict_displaywin: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     HEVC (High Efficiency Video Coding)
-    
+
     Args:
         apply_defdispwin: Apply default display window from VUI (default false)
         strict_displaywin: stricly apply default display window size (default false)
@@ -1936,25 +1936,25 @@ def hevc(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "apply_defdispwin": apply_defdispwin,
-        
+
         "strict-displaywin": strict_displaywin,
-        
+
     }))
 
 
 
 def hevc_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem HEVC decoder wrapper (codec hevc)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -1963,279 +1963,279 @@ def hevc_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def hnm4video(
-    
+
 ) -> FFMpegDecoderOption:
     """
     HNM 4 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hq_hqa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Canopus HQ/HQA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hqx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Canopus HQX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def huffyuv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Huffyuv / HuffYUV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hymt(
-    
+
 ) -> FFMpegDecoderOption:
     """
     HuffYUV MT
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def idcinvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     id Quake II CIN video (codec idcin)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def idf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     iCEDraw text
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def iff(
-    
+
 ) -> FFMpegDecoderOption:
     """
     IFF ACBM/ANIM/DEEP/ILBM/PBM/RGB8/RGBN (codec iff_ilbm)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def imm4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Infinity IMM4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def imm5(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Infinity IMM5
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def indeo2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Intel Indeo 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def indeo3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Intel Indeo 3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def indeo4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Intel Indeo Video Interactive 4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def indeo5(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Intel Indeo Video Interactive 5
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def interplayvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Interplay MVE video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ipu(
-    
+
 ) -> FFMpegDecoderOption:
     """
     IPU Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def jpeg2000(
-    
+
     lowres: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     JPEG 2000
-    
+
     Args:
         lowres: Lower the decoding resolution by a power of two (from 0 to 33) (default 0)
 
@@ -2243,229 +2243,229 @@ def jpeg2000(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "lowres": lowres,
-        
+
     }))
 
 
 
 def jpegls(
-    
+
 ) -> FFMpegDecoderOption:
     """
     JPEG-LS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def jv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bitmap Brothers JV video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def kgv1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Kega Game Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def kmvc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Karl Morton's video codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def lagarith(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Lagarith lossless
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def loco(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LOCO
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def lscr(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LEAD Screen Capture
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def m101(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Matrox Uncompressed SD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def eamad(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Electronic Arts Madcow Video (codec mad)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def magicyuv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MagicYUV video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mdec(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sony PlayStation MDEC (Motion DECoder)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def media100(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Media 100
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mimic(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Mimic
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mjpeg(
-    
+
     extern_huff: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     MJPEG (Motion JPEG)
-    
+
     Args:
         extern_huff: Use external huffman table. (default false)
 
@@ -2473,103 +2473,103 @@ def mjpeg(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "extern_huff": extern_huff,
-        
+
     }))
 
 
 
 def mjpegb(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Apple MJPEG-B
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mmvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     American Laser Games MM Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mobiclip(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MobiClip Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def motionpixels(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Motion Pixels video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpeg1video(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-1 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpeg1_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem MPEG1 decoder wrapper (codec mpeg1video)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -2578,57 +2578,57 @@ def mpeg1_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def mpeg2video(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-2 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpegvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-1 video (codec mpeg2video)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpeg2_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem MPEG2 decoder wrapper (codec mpeg2video)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -2637,41 +2637,41 @@ def mpeg2_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def mpeg4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-4 part 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpeg4_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem MPEG4 decoder wrapper (codec mpeg4)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -2680,519 +2680,519 @@ def mpeg4_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def msa1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MS ATC Screen
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mscc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Mandsoft Screen Capture Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msmpeg4v1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-4 part 2 Microsoft variant version 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msmpeg4v2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-4 part 2 Microsoft variant version 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msmpeg4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-4 part 2 Microsoft variant version 3 (codec msmpeg4v3)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msp2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Microsoft Paint (MSP) version 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msrle(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Microsoft RLE
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mss1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MS Screen 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mss2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MS Windows Media Video V9 Screen
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msvideo1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Microsoft Video 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mszh(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LCL (LossLess Codec Library) MSZH
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mts2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MS Expression Encoder Screen
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mv30(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MidiVid 3.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mvc1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Silicon Graphics Motion Video Compressor 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mvc2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Silicon Graphics Motion Video Compressor 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mvdv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MidiVid VQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mvha(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MidiVid Archive Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mwsc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MatchWare Screen Capture Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mxpeg(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Mobotix MxPEG video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def notchlc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     NotchLC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def nuv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     NuppelVideo/RTJPEG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def paf_video(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Amazing Studio Packed Animation File Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pam(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PAM (Portable AnyMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pbm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PBM (Portable BitMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PC Paintbrush PCX image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pdv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PDV (PlayDate Video)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pfm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PFM (Portable FloatMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pgm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PGM (Portable GrayMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pgmyuv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PGMYUV (Portable GrayMap YUV) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pgx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PGX (JPEG2000 Test Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def phm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PHM (Portable HalfFloatMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def photocd(
-    
+
     lowres: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Kodak Photo CD
-    
+
     Args:
         lowres: Lower the decoding resolution by a power of two (from 0 to 4) (default 0)
 
@@ -3200,245 +3200,245 @@ def photocd(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "lowres": lowres,
-        
+
     }))
 
 
 
 def pictor(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Pictor/PC Paint
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pixlet(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Apple Pixlet
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def png(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PNG (Portable Network Graphics) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ppm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PPM (Portable PixelMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def prores(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Apple ProRes (iCodec Pro)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def prosumer(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Brooktree ProSumer Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def psd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Photoshop PSD file
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ptx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     V.Flash PTX image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qdraw(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Apple QuickDraw
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qoi(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QOI (Quite OK Image format) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qpeg(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Q-team QPEG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qtrle(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QuickTime Animation (RLE) video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def r10k(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AJA Kona 10-bit RGB Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def r210(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed RGB 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rasc(
-    
+
     skip_cursor: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     RemotelyAnywhere Screen Capture
-    
+
     Args:
         skip_cursor: skip the cursor (default false)
 
@@ -3446,21 +3446,21 @@ def rasc(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "skip_cursor": skip_cursor,
-        
+
     }))
 
 
 
 def rawvideo(
-    
+
     top: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     raw video
-    
+
     Args:
         top: top field first (default auto)
 
@@ -3468,585 +3468,585 @@ def rawvideo(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "top": top,
-        
+
     }))
 
 
 
 def rl2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RL2 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def roqvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     id RoQ video (codec roq)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rpza(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QuickTime video (RPZA)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rscc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     innoHeim/Rsupport Screen Capture Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rtv1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RTV1 (RivaTuner Video)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rv10(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealVideo 1.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rv20(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealVideo 2.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rv30(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealVideo 3.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rv40(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealVideo 4.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sanm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LucasArts SANM/Smush video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def scpr(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ScreenPressor
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def screenpresso(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Screenpresso
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sga(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Digital Pictures SGA Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sgi(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SGI image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sgirle(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Silicon Graphics RLE 8-bit video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sheervideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     BitJazz SheerVideo
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def simbiosis_imx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Simbiosis Interactive IMX Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def smackvid(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Smacker video (codec smackvideo)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def smc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QuickTime Graphics (SMC)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def smvjpeg(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SMV JPEG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def snow(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Snow
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sp5x(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sunplus JPEG (SP5X)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def speedhq(
-    
+
 ) -> FFMpegDecoderOption:
     """
     NewTek SpeedHQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def srgc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Screen Recorder Gold Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sunrast(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sun Rasterfile image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def svq1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sorenson Vector Quantizer 1 / Sorenson Video 1 / SVQ1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def svq3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sorenson Vector Quantizer 3 / Sorenson Video 3 / SVQ3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def targa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Truevision Targa image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def targa_y216(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Pinnacle TARGA CineWave YUV16
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def tdsc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     TDSC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def eatgq(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Electronic Arts TGQ video (codec tgq)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def eatgv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Electronic Arts TGV video (codec tgv)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def theora(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Theora
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def thp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Nintendo Gamecube THP video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def tiertexseqvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Tiertex Limited SEQ video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def tiff(
-    
+
     subimage: bool | None = None,
-    
+
     thumbnail: bool | None = None,
-    
+
     page: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     TIFF image
-    
+
     Args:
         subimage: decode subimage instead if available (default false)
         thumbnail: decode embedded thumbnail subimage instead if available (default false)
@@ -4056,185 +4056,185 @@ def tiff(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "subimage": subimage,
-        
+
         "thumbnail": thumbnail,
-        
+
         "page": page,
-        
+
     }))
 
 
 
 def tmv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     8088flex TMV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def eatqi(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Electronic Arts TQI Video (codec tqi)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def truemotion1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Duck TrueMotion 1.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def truemotion2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Duck TrueMotion 2.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def truemotion2rt(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Duck TrueMotion 2.0 Real Time
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def camtasia(
-    
+
 ) -> FFMpegDecoderOption:
     """
     TechSmith Screen Capture Codec (codec tscc)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def tscc2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     TechSmith Screen Codec 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def txd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Renderware TXD (TeXture Dictionary) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ultimotion(
-    
+
 ) -> FFMpegDecoderOption:
     """
     IBM UltiMotion (codec ulti)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def utvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Ut Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def v210(
-    
+
     custom_stride: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed 4:2:2 10-bit
-    
+
     Args:
         custom_stride: Custom V210 stride (from -1 to INT_MAX) (default 0)
 
@@ -4242,151 +4242,151 @@ def v210(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "custom_stride": custom_stride,
-        
+
     }))
 
 
 
 def v210x(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed 4:2:2 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def v308(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed packed 4:4:4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def v408(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed packed QT 4:4:4:4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def v410(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed 4:4:4 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vb(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Beam Software VB
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vble(
-    
+
 ) -> FFMpegDecoderOption:
     """
     VBLE Lossless Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vbn(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Vizrt Binary Image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vc1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SMPTE VC-1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vc1_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem VC1 decoder wrapper (codec vc1)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -4395,265 +4395,265 @@ def vc1_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def vc1image(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Video 9 Image v2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vcr1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATI VCR1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xl(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Miro VideoXL (codec vixl)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vmdvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sierra VMD video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vmix(
-    
+
 ) -> FFMpegDecoderOption:
     """
     vMix Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vmnc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     VMware Screen Codec / VMware Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vnull(
-    
+
 ) -> FFMpegDecoderOption:
     """
     null video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp5(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP5
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp6(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP6
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp6a(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP6 (Flash version, with alpha channel)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp6f(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP6 (Flash version)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp7(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP7
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp8(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP8
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp8_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem VP8 decoder wrapper (codec vp8)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -4662,57 +4662,57 @@ def vp8_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def libvpx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     libvpx VP8 (codec vp8)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp9(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Google VP9
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp9_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem VP9 decoder wrapper (codec vp9)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -4721,457 +4721,457 @@ def vp9_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def vqc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ViewQuest VQC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wbmp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     WBMP (Wireless Application Protocol Bitmap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wcmv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     WinCAM Motion Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def webp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     WebP image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmv1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Video 7
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmv2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Video 8
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmv3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Video 9
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmv3image(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Video 9 Image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wnv1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Winnov WNV1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wrapped_avframe(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AVPacket to AVFrame passthrough
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vqavideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Westwood Studios VQA (Vector Quantized Animation) video (codec ws_vqa)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xan_wc3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Wing Commander III / Xan
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xan_wc4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Wing Commander IV / Xxan
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xbin(
-    
+
 ) -> FFMpegDecoderOption:
     """
     eXtended BINary text
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xbm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     XBM (X BitMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xface(
-    
+
 ) -> FFMpegDecoderOption:
     """
     X-face image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xpm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     XPM (X PixMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xwd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     XWD (X Window Dump) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def y41p(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed YUV 4:1:1 12-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ylc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     YUY2 Lossless Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def yop(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Psygnosis YOP Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def yuv4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed packed 4:2:0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def zerocodec(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ZeroCodec Lossless Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def zlib(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LCL (LossLess Codec Library) ZLIB
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def zmbv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Zip Motion Blocks Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def _8svx_exp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     8SVX exponential
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def _8svx_fib(
-    
+
 ) -> FFMpegDecoderOption:
     """
     8SVX fibonacci
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def aac(
-    
+
     dual_mono_mode: int | None| Literal["auto", "main", "sub", "both"] = None,
-    
+
     channel_order: int | None| Literal["default", "coded"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     AAC (Advanced Audio Coding)
-    
+
     Args:
         dual_mono_mode: Select the channel to decode for dual mono (from -1 to 2) (default auto)
         channel_order: Order in which the channels are to be exported (from 0 to 1) (default default)
@@ -5180,25 +5180,25 @@ def aac(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "dual_mono_mode": dual_mono_mode,
-        
+
         "channel_order": channel_order,
-        
+
     }))
 
 
 
 def aac_fixed(
-    
+
     dual_mono_mode: int | None| Literal["auto", "main", "sub", "both"] = None,
-    
+
     channel_order: int | None| Literal["default", "coded"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     AAC (Advanced Audio Coding) (codec aac)
-    
+
     Args:
         dual_mono_mode: Select the channel to decode for dual mono (from -1 to 2) (default auto)
         channel_order: Order in which the channels are to be exported (from 0 to 1) (default default)
@@ -5207,47 +5207,47 @@ def aac_fixed(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "dual_mono_mode": dual_mono_mode,
-        
+
         "channel_order": channel_order,
-        
+
     }))
 
 
 
 def aac_latm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AAC LATM (Advanced Audio Coding LATM syntax)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ac3(
-    
+
     cons_noisegen: bool | None = None,
-    
+
     drc_scale: float | None = None,
-    
+
     heavy_compr: bool | None = None,
-    
+
     target_level: int | None = None,
-    
+
     downmix: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATSC A/52A (AC-3)
-    
+
     Args:
         cons_noisegen: enable consistent noise generation (default false)
         drc_scale: percentage of dynamic range compression to apply (from 0 to 6) (default 1)
@@ -5259,35 +5259,35 @@ def ac3(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "cons_noisegen": cons_noisegen,
-        
+
         "drc_scale": drc_scale,
-        
+
         "heavy_compr": heavy_compr,
-        
+
         "target_level": target_level,
-        
+
         "downmix": downmix,
-        
+
     }))
 
 
 
 def ac3_fixed(
-    
+
     cons_noisegen: bool | None = None,
-    
+
     drc_scale: float | None = None,
-    
+
     heavy_compr: bool | None = None,
-    
+
     downmix: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATSC A/52A (AC-3) (codec ac3)
-    
+
     Args:
         cons_noisegen: enable consistent noise generation (default false)
         drc_scale: percentage of dynamic range compression to apply (from 0 to 6) (default 1)
@@ -5298,251 +5298,251 @@ def ac3_fixed(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "cons_noisegen": cons_noisegen,
-        
+
         "drc_scale": drc_scale,
-        
+
         "heavy_compr": heavy_compr,
-        
+
         "downmix": downmix,
-        
+
     }))
 
 
 
 def adpcm_4xm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM 4X Movie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_adx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SEGA CRI ADX ADPCM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_afc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Nintendo Gamecube AFC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_agm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM AmuseGraphics Movie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_aica(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Yamaha AICA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_argo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Argonaut Games
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ct(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Creative Technology
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_dtk(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Nintendo Gamecube DTK
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ea(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Electronic Arts
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ea_maxis_xa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Electronic Arts Maxis CDROM XA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ea_r1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Electronic Arts R1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ea_r2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Electronic Arts R2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ea_r3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Electronic Arts R3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ea_xas(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Electronic Arts XAS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def g722(
-    
+
     bits_per_codeword: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     G.722 ADPCM (codec adpcm_g722)
-    
+
     Args:
         bits_per_codeword: Bits per G722 codeword (from 6 to 8) (default 8)
 
@@ -5550,613 +5550,613 @@ def g722(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "bits_per_codeword": bits_per_codeword,
-        
+
     }))
 
 
 
 def g726(
-    
+
 ) -> FFMpegDecoderOption:
     """
     G.726 ADPCM (codec adpcm_g726)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def g726le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     G.726 ADPCM little-endian (codec adpcm_g726le)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_acorn(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Acorn Replay
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_alp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA High Voltage Software ALP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_amv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA AMV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_apc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA CRYO APC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_apm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Ubisoft APM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_cunning(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Cunning Developments
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_dat4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Eurocom DAT4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_dk3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Duck DK3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_dk4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Duck DK4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_ea_eacs(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Electronic Arts EACS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_ea_sead(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Electronic Arts SEAD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_iss(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Funcom ISS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_moflex(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA MobiClip MOFLEX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_mtf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Capcom's MT Framework
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_oki(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Dialogic OKI
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_qt(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA QuickTime
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_rad(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Radical
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_smjpeg(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Loki SDL MJPEG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_ssi(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Simon & Schuster Interactive
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_wav(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA WAV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_ws(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Westwood
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ms(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Microsoft
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_mtaf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM MTAF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_psx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Playstation
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_sbpro_2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Sound Blaster Pro 2-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_sbpro_3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Sound Blaster Pro 2.6-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_sbpro_4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Sound Blaster Pro 4-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_swf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Shockwave Flash
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_thp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Nintendo THP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_thp_le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Nintendo THP (little-endian)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_vima(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LucasArts VIMA audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_xa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM CDROM XA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_xmd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Konami XMD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_yamaha(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Yamaha
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_zork(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Zork
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def alac(
-    
+
     extra_bits_bug: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     ALAC (Apple Lossless Audio Codec)
-    
+
     Args:
         extra_bits_bug: Force non-standard decoding process (default false)
 
@@ -6164,117 +6164,117 @@ def alac(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "extra_bits_bug": extra_bits_bug,
-        
+
     }))
 
 
 
 def amrnb(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AMR-NB (Adaptive Multi-Rate NarrowBand) (codec amr_nb)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def libopencore_amrnb(
-    
+
 ) -> FFMpegDecoderOption:
     """
     OpenCORE AMR-NB (Adaptive Multi-Rate Narrow-Band) (codec amr_nb)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def amrwb(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AMR-WB (Adaptive Multi-Rate WideBand) (codec amr_wb)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def libopencore_amrwb(
-    
+
 ) -> FFMpegDecoderOption:
     """
     OpenCORE AMR-WB (Adaptive Multi-Rate Wide-Band) (codec amr_wb)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def anull(
-    
+
 ) -> FFMpegDecoderOption:
     """
     null audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def apac(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Marian's A-pac audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ape(
-    
+
     max_samples: int | None| Literal["all"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Monkey's Audio
-    
+
     Args:
         max_samples: maximum number of samples decoded per call (from 1 to INT_MAX) (default 4608)
 
@@ -6282,309 +6282,309 @@ def ape(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "max_samples": max_samples,
-        
+
     }))
 
 
 
 def aptx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     aptX (Audio Processing Technology for Bluetooth)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def aptx_hd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     aptX HD (Audio Processing Technology for Bluetooth)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def atrac1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATRAC1 (Adaptive TRansform Acoustic Coding)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def atrac3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATRAC3 (Adaptive TRansform Acoustic Coding 3)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def atrac3al(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATRAC3 AL (Adaptive TRansform Acoustic Coding 3 Advanced Lossless)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def atrac3plus(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATRAC3+ (Adaptive TRansform Acoustic Coding 3+) (codec atrac3p)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def atrac3plusal(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATRAC3+ AL (Adaptive TRansform Acoustic Coding 3+ Advanced Lossless) (codec atrac3pal)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def atrac9(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATRAC9 (Adaptive TRansform Acoustic Coding 9)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def on2avc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 Audio for Video Codec (codec avc)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def binkaudio_dct(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bink Audio (DCT)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def binkaudio_rdft(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bink Audio (RDFT)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bmv_audio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Discworld II BMV audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bonk(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bonk audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cbd2_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Cuberoot-Delta-Exact
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def comfortnoise(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RFC 3389 comfort noise generator
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cook(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Cook / Cooker / Gecko (RealAudio G2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def derf_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Xilam DERF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dfpwm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DFPWM1a audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dolby_e(
-    
+
     channel_order: int | None| Literal["default", "coded"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Dolby E
-    
+
     Args:
         channel_order: Order in which the channels are to be exported (from 0 to 1) (default default)
 
@@ -6592,137 +6592,137 @@ def dolby_e(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "channel_order": channel_order,
-        
+
     }))
 
 
 
 def dsd_lsbf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DSD (Direct Stream Digital), least significant bit first
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dsd_lsbf_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DSD (Direct Stream Digital), least significant bit first, planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dsd_msbf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DSD (Direct Stream Digital), most significant bit first
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dsd_msbf_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DSD (Direct Stream Digital), most significant bit first, planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dsicinaudio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Delphine Software International CIN audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dss_sp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Digital Speech Standard - Standard Play mode (DSS SP)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dst(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DST (Digital Stream Transfer)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dca(
-    
+
     core_only: bool | None = None,
-    
+
     channel_order: int | None| Literal["default", "coded"] = None,
-    
+
     downmix: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     DCA (DTS Coherent Acoustics) (codec dts)
-    
+
     Args:
         core_only: Decode core only without extensions (default false)
         channel_order: Order in which the channels are to be exported (from 0 to 1) (default default)
@@ -6732,49 +6732,49 @@ def dca(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "core_only": core_only,
-        
+
         "channel_order": channel_order,
-        
+
         "downmix": downmix,
-        
+
     }))
 
 
 
 def dvaudio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Ulead DV Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def eac3(
-    
+
     cons_noisegen: bool | None = None,
-    
+
     drc_scale: float | None = None,
-    
+
     heavy_compr: bool | None = None,
-    
+
     target_level: int | None = None,
-    
+
     downmix: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATSC A/52B (AC-3, E-AC-3)
-    
+
     Args:
         cons_noisegen: enable consistent noise generation (default false)
         drc_scale: percentage of dynamic range compression to apply (from 0 to 6) (default 1)
@@ -6786,29 +6786,29 @@ def eac3(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "cons_noisegen": cons_noisegen,
-        
+
         "drc_scale": drc_scale,
-        
+
         "heavy_compr": heavy_compr,
-        
+
         "target_level": target_level,
-        
+
         "downmix": downmix,
-        
+
     }))
 
 
 
 def evrc(
-    
+
     postfilter: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     EVRC (Enhanced Variable Rate Codec)
-    
+
     Args:
         postfilter: enable postfilter (default true)
 
@@ -6816,37 +6816,37 @@ def evrc(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "postfilter": postfilter,
-        
+
     }))
 
 
 
 def fastaudio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MobiClip FastAudio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def flac(
-    
+
     use_buggy_lpc: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     FLAC (Free Lossless Audio Codec)
-    
+
     Args:
         use_buggy_lpc: emulate old buggy lavc behavior (default false)
 
@@ -6854,37 +6854,37 @@ def flac(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "use_buggy_lpc": use_buggy_lpc,
-        
+
     }))
 
 
 
 def ftr(
-    
+
 ) -> FFMpegDecoderOption:
     """
     FTR Voice
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def g723_1(
-    
+
     postfilter: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     G.723.1
-    
+
     Args:
         postfilter: enable postfilter (default true)
 
@@ -6892,261 +6892,261 @@ def g723_1(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "postfilter": postfilter,
-        
+
     }))
 
 
 
 def g729(
-    
+
 ) -> FFMpegDecoderOption:
     """
     G.729
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def gremlin_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Gremlin
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def gsm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     GSM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def gsm_ms(
-    
+
 ) -> FFMpegDecoderOption:
     """
     GSM Microsoft variant
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hca(
-    
+
 ) -> FFMpegDecoderOption:
     """
     CRI HCA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hcom(
-    
+
 ) -> FFMpegDecoderOption:
     """
     HCOM Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def iac(
-    
+
 ) -> FFMpegDecoderOption:
     """
     IAC (Indeo Audio Coder)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ilbc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     iLBC (Internet Low Bitrate Codec)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def imc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     IMC (Intel Music Coder)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def interplay_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Interplay
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def interplayacm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Interplay ACM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mace3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MACE (Macintosh Audio Compression/Expansion) 3:1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mace6(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MACE (Macintosh Audio Compression/Expansion) 6:1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def metasound(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Voxware MetaSound
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def misc4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Micronas SC-4 Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mlp(
-    
+
     downmix: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     MLP (Meridian Lossless Packing)
-    
+
     Args:
         downmix: Request a specific channel layout from the decoder
 
@@ -7154,261 +7154,261 @@ def mlp(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "downmix": downmix,
-        
+
     }))
 
 
 
 def mp1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP1 (MPEG audio layer 1)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp1float(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP1 (MPEG audio layer 1) (codec mp1)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP2 (MPEG audio layer 2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp2float(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP2 (MPEG audio layer 2) (codec mp2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp3float(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP3 (MPEG audio layer 3) (codec mp3)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP3 (MPEG audio layer 3)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp3adufloat(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADU (Application Data Unit) MP3 (MPEG audio layer 3) (codec mp3adu)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp3adu(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADU (Application Data Unit) MP3 (MPEG audio layer 3)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp3on4float(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP3onMP4 (codec mp3on4)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp3on4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP3onMP4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def als(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-4 Audio Lossless Coding (ALS) (codec mp4als)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msnsiren(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MSN Siren
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpc7(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Musepack SV7 (codec musepack7)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpc8(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Musepack SV8 (codec musepack8)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def nellymoser(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Nellymoser Asao
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def opus(
-    
+
     apply_phase_inv: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Opus
-    
+
     Args:
         apply_phase_inv: Apply intensity stereo phase inversion (default true)
 
@@ -7416,21 +7416,21 @@ def opus(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "apply_phase_inv": apply_phase_inv,
-        
+
     }))
 
 
 
 def libopus(
-    
+
     apply_phase_inv: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     libopus Opus (codec opus)
-    
+
     Args:
         apply_phase_inv: Apply intensity stereo phase inversion (default true)
 
@@ -7438,741 +7438,741 @@ def libopus(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "apply_phase_inv": apply_phase_inv,
-        
+
     }))
 
 
 
 def osq(
-    
+
 ) -> FFMpegDecoderOption:
     """
     OSQ (Original Sound Quality)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def paf_audio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Amazing Studio Packed Animation File Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_alaw(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM A-law / G.711 A-law
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_bluray(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 16|20|24-bit big-endian for Blu-ray media
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_dvd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 16|20|24-bit big-endian for DVD media
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f16le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM 16.8 floating point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f24le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM 24.0 floating point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f32be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM 32-bit floating point big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f32le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM 32-bit floating point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f64be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM 64-bit floating point big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f64le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM 64-bit floating point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_lxf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 20-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_mulaw(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM mu-law / G.711 mu-law
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 16-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16be_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 16-bit big-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 16-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16le_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 16-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 24-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24daud(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM D-Cinema audio signed 24-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 24-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24le_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 24-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s32be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 32-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s32le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 32-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s32le_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 32-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s64be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 64-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s64le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 64-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s8(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 8-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s8_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 8-bit planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_sga(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM SGA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u16be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 16-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u16le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 16-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u24be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 24-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u24le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 24-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u32be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 32-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u32le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 32-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u8(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 8-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_vidc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM Archimedes VIDC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qcelp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QCELP / PureVoice
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qdm2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QDesign Music Codec 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qdmc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QDesign Music Codec 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def real_144(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealAudio 1.0 (14.4K) (codec ra_144)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def real_288(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealAudio 2.0 (28.8K) (codec ra_288)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ralf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealAudio Lossless
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rka(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RKA (RK Audio)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def roq_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM id RoQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def s302m(
-    
+
     non_pcm_mode: int | None| Literal["copy", "drop", "decode_copy", "decode_drop"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     SMPTE 302M
-    
+
     Args:
         non_pcm_mode: Chooses what to do with NON-PCM (from 0 to 3) (default decode_drop)
 
@@ -8180,181 +8180,181 @@ def s302m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "non_pcm_mode": non_pcm_mode,
-        
+
     }))
 
 
 
 def sbc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SBC (low-complexity subband codec)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sdx2_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Squareroot-Delta-Exact
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def shorten(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Shorten
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sipr(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealAudio SIPR / ACELP.NET
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def siren(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Siren
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def smackaud(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Smacker audio (codec smackaudio)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sol_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Sol
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sonic(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sonic
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def speex(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Speex
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def tak(
-    
+
 ) -> FFMpegDecoderOption:
     """
     TAK (Tom's lossless Audio Kompressor)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def truehd(
-    
+
     downmix: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     TrueHD
-    
+
     Args:
         downmix: Request a specific channel layout from the decoder
 
@@ -8362,37 +8362,37 @@ def truehd(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "downmix": downmix,
-        
+
     }))
 
 
 
 def truespeech(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DSP Group TrueSpeech
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def tta(
-    
+
     password: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     TTA (True Audio)
-    
+
     Args:
         password: Set decoding password
 
@@ -8400,329 +8400,329 @@ def tta(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "password": password,
-        
+
     }))
 
 
 
 def twinvq(
-    
+
 ) -> FFMpegDecoderOption:
     """
     VQF TwinVQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vmdaudio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sierra VMD audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vorbis(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Vorbis
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def libvorbis(
-    
+
 ) -> FFMpegDecoderOption:
     """
     libvorbis (codec vorbis)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wady_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Marble WADY
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wavarc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Waveform Archiver
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wavesynth(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Wave synthesis pseudo-codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wavpack(
-    
+
 ) -> FFMpegDecoderOption:
     """
     WavPack
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ws_snd1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Westwood Audio (SND1) (codec westwood_snd1)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmalossless(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Audio Lossless
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmapro(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Audio 9 Professional
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmav1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Audio 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmav2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Audio 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmavoice(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Audio Voice
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xan_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Xan
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xma1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Xbox Media Audio 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xma2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Xbox Media Audio 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ssa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ASS (Advanced SubStation Alpha) subtitle (codec ass)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ass(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ASS (Advanced SubStation Alpha) subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dvbsub(
-    
+
     compute_edt: bool | None = None,
-    
+
     compute_clut: bool | None = None,
-    
+
     dvb_substream: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     DVB subtitles (codec dvb_subtitle)
-    
+
     Args:
         compute_edt: compute end of time using pts or timeout (default false)
         compute_clut: compute clut when not available(-1) or only once (-2) or always(1) or never(0) (default auto)
@@ -8732,29 +8732,29 @@ def dvbsub(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "compute_edt": compute_edt,
-        
+
         "compute_clut": compute_clut,
-        
+
         "dvb_substream": dvb_substream,
-        
+
     }))
 
 
 
 def dvdsub(
-    
+
     palette: str | None = None,
-    
+
     ifo_palette: str | None = None,
-    
+
     forced_subs_only: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     DVD subtitles (codec dvd_subtitle)
-    
+
     Args:
         palette: set the global palette
         ifo_palette: obtain the global palette from .IFO file
@@ -8764,29 +8764,29 @@ def dvdsub(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "palette": palette,
-        
+
         "ifo_palette": ifo_palette,
-        
+
         "forced_subs_only": forced_subs_only,
-        
+
     }))
 
 
 
 def cc_dec(
-    
+
     real_time: bool | None = None,
-    
+
     real_time_latency_msec: int | None = None,
-    
+
     data_field: int | None| Literal["auto", "first", "second"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Closed Caption (EIA-608 / CEA-708) (codec eia_608)
-    
+
     Args:
         real_time: emit subtitle events as they are decoded for real-time display (default false)
         real_time_latency_msec: minimum elapsed time between emitting real-time subtitle events (from 0 to 500) (default 200)
@@ -8796,25 +8796,25 @@ def cc_dec(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "real_time": real_time,
-        
+
         "real_time_latency_msec": real_time_latency_msec,
-        
+
         "data_field": data_field,
-        
+
     }))
 
 
 
 def pgssub(
-    
+
     forced_subs_only: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     HDMV Presentation Graphic Stream subtitles (codec hdmv_pgs_subtitle)
-    
+
     Args:
         forced_subs_only: Only show forced subtitles (default false)
 
@@ -8822,55 +8822,55 @@ def pgssub(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "forced_subs_only": forced_subs_only,
-        
+
     }))
 
 
 
 def jacosub(
-    
+
 ) -> FFMpegDecoderOption:
     """
     JACOsub subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def microdvd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MicroDVD subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mov_text(
-    
+
     width: int | None = None,
-    
+
     height: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     3GPP Timed Text subtitle
-    
+
     Args:
         width: Frame width, usually video width (from 0 to INT_MAX) (default 0)
         height: Frame height, usually video height (from 0 to INT_MAX) (default 0)
@@ -8879,39 +8879,39 @@ def mov_text(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "width": width,
-        
+
         "height": height,
-        
+
     }))
 
 
 
 def mpl2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPL2 subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pjs(
-    
+
     keep_ass_markup: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     PJS subtitle
-    
+
     Args:
         keep_ass_markup: Set if ASS tags must be escaped (default false)
 
@@ -8919,53 +8919,53 @@ def pjs(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "keep_ass_markup": keep_ass_markup,
-        
+
     }))
 
 
 
 def realtext(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealText subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sami(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SAMI subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def stl(
-    
+
     keep_ass_markup: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Spruce subtitle format
-    
+
     Args:
         keep_ass_markup: Set if ASS tags must be escaped (default false)
 
@@ -8973,69 +8973,69 @@ def stl(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "keep_ass_markup": keep_ass_markup,
-        
+
     }))
 
 
 
 def srt(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SubRip subtitle (codec subrip)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def subrip(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SubRip subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def subviewer(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SubViewer subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def subviewer1(
-    
+
     keep_ass_markup: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     SubViewer1 subtitle
-    
+
     Args:
         keep_ass_markup: Set if ASS tags must be escaped (default false)
 
@@ -9043,21 +9043,21 @@ def subviewer1(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "keep_ass_markup": keep_ass_markup,
-        
+
     }))
 
 
 
 def text(
-    
+
     keep_ass_markup: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Raw text subtitle
-    
+
     Args:
         keep_ass_markup: Set if ASS tags must be escaped (default false)
 
@@ -9065,21 +9065,21 @@ def text(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "keep_ass_markup": keep_ass_markup,
-        
+
     }))
 
 
 
 def vplayer(
-    
+
     keep_ass_markup: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     VPlayer subtitle
-    
+
     Args:
         keep_ass_markup: Set if ASS tags must be escaped (default false)
 
@@ -9087,40 +9087,39 @@ def vplayer(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "keep_ass_markup": keep_ass_markup,
-        
+
     }))
 
 
 
 def webvtt(
-    
+
 ) -> FFMpegDecoderOption:
     """
     WebVTT subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xsub(
-    
+
 ) -> FFMpegDecoderOption:
     """
     XSUB
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
-    }))
 
+    }))

--- a/packages/v6/src/ffmpeg/codecs/encoders.py
+++ b/packages/v6/src/ffmpeg/codecs/encoders.py
@@ -44,105 +44,105 @@ from ..streams.audio import AudioStream
 
 
 def a64multi(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Multicolor charset for Commodore 64 (codec a64_multi)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def a64multi5(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Multicolor charset for Commodore 64, extended with 5th color (colram) (codec a64_multi5)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def alias_pix(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Alias/Wavefront PIX image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def amv(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     huffman: int | None| Literal["default", "optimal"] = None,
-    
+
     force_duplicated_matrix: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     AMV Video
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -172,69 +172,69 @@ def amv(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "huffman": huffman,
-        
+
         "force_duplicated_matrix": force_duplicated_matrix,
-        
+
     }))
 
 
 
 def apng(
-    
+
     dpi: int | None = None,
-    
+
     dpm: int | None = None,
-    
+
     pred: int | None| Literal["none", "sub", "up", "avg", "paeth", "mixed"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     APNG (Animated Portable Network Graphics) image
-    
+
     Args:
         dpi: Set image resolution (in dots per inch) (from 0 to 65536) (default 0)
         dpm: Set image resolution (in dots per meter) (from 0 to 65536) (default 0)
@@ -244,77 +244,77 @@ def apng(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "dpi": dpi,
-        
+
         "dpm": dpm,
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def asv1(
-    
+
 ) -> FFMpegEncoderOption:
     """
     ASUS V1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def asv2(
-    
+
 ) -> FFMpegEncoderOption:
     """
     ASUS V2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def av1_vaapi(
-    
+
     low_power: bool | None = None,
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     rc_mode: int | None| Literal["auto", "CQP", "CBR", "VBR", "ICQ", "QVBR", "AVBR"] = None,
-    
+
     profile: int | None| Literal["main", "high", "professional"] = None,
-    
+
     tier: int | None| Literal["main", "high"] = None,
-    
+
     level: int | None| Literal["2.0", "2.1", "3.0", "3.1", "4.0", "4.1", "5.0", "5.1", "5.2", "5.3", "6.0", "6.1", "6.2", "6.3"] = None,
-    
+
     tiles: str | None = None,
-    
+
     tile_groups: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     AV1 (VAAPI) (codec av1)
-    
+
     Args:
         low_power: Use low-power encoding mode (only available on some platforms; may not support all encoding features) (default false)
         idr_interval: Distance (in I-frames) between IDR frames (from 0 to INT_MAX) (default 0)
@@ -332,121 +332,121 @@ def av1_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "low_power": low_power,
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "rc_mode": rc_mode,
-        
+
         "profile": profile,
-        
+
         "tier": tier,
-        
+
         "level": level,
-        
+
         "tiles": tiles,
-        
+
         "tile_groups": tile_groups,
-        
+
     }))
 
 
 
 def avrp(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Avid 1:1 10-bit RGB Packer
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def avui(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Avid Meridien Uncompressed
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def ayuv(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed packed MS 4:4:4:4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def bitpacked(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Bitpacked
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def bmp(
-    
+
 ) -> FFMpegEncoderOption:
     """
     BMP (Windows and OS/2 bitmap)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def cfhd(
-    
+
     quality: int | None| Literal["film3+", "film3", "film2+", "film2", "film1.5", "film1+", "film1", "high+", "high", "medium+", "medium", "low+", "low"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     GoPro CineForm HD
-    
+
     Args:
         quality: set quality (from 0 to 12) (default film3+)
 
@@ -454,29 +454,29 @@ def cfhd(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "quality": quality,
-        
+
     }))
 
 
 
 def cinepak(
-    
+
     max_extra_cb_iterations: int | None = None,
-    
+
     skip_empty_cb: bool | None = None,
-    
+
     max_strips: int | None = None,
-    
+
     min_strips: int | None = None,
-    
+
     strip_number_adaptivity: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Cinepak
-    
+
     Args:
         max_extra_cb_iterations: Max extra codebook recalculation passes, more is better and slower (from 0 to INT_MAX) (default 2)
         skip_empty_cb: Avoid wasting bytes, ignore vintage MacOS decoder (default false)
@@ -488,29 +488,29 @@ def cinepak(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "max_extra_cb_iterations": max_extra_cb_iterations,
-        
+
         "skip_empty_cb": skip_empty_cb,
-        
+
         "max_strips": max_strips,
-        
+
         "min_strips": min_strips,
-        
+
         "strip_number_adaptivity": strip_number_adaptivity,
-        
+
     }))
 
 
 
 def cljr(
-    
+
     dither_type: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Cirrus Logic AccuPak
-    
+
     Args:
         dither_type: Dither type (from 0 to 2) (default 1)
 
@@ -518,31 +518,31 @@ def cljr(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "dither_type": dither_type,
-        
+
     }))
 
 
 
 def vc2(
-    
+
     tolerance: float | None = None,
-    
+
     slice_width: int | None = None,
-    
+
     slice_height: int | None = None,
-    
+
     wavelet_depth: int | None = None,
-    
+
     wavelet_type: int | None| Literal["9_7", "5_3", "haar", "haar_noshift"] = None,
-    
+
     qm: int | None| Literal["default", "color", "flat"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     SMPTE VC-2 (codec dirac)
-    
+
     Args:
         tolerance: Max undershoot in percent (from 0 to 45) (default 5)
         slice_width: Slice width (from 32 to 1024) (default 32)
@@ -555,35 +555,35 @@ def vc2(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "tolerance": tolerance,
-        
+
         "slice_width": slice_width,
-        
+
         "slice_height": slice_height,
-        
+
         "wavelet_depth": wavelet_depth,
-        
+
         "wavelet_type": wavelet_type,
-        
+
         "qm": qm,
-        
+
     }))
 
 
 
 def dnxhd(
-    
+
     nitris_compat: bool | None = None,
-    
+
     ibias: int | None = None,
-    
+
     profile: int | None| Literal["dnxhd", "dnxhr_444", "dnxhr_hqx", "dnxhr_hq", "dnxhr_sq", "dnxhr_lb"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     VC3/DNxHD
-    
+
     Args:
         nitris_compat: encode with Avid Nitris compatibility (default false)
         ibias: intra quant bias (from INT_MIN to INT_MAX) (default 0)
@@ -593,41 +593,41 @@ def dnxhd(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "nitris_compat": nitris_compat,
-        
+
         "ibias": ibias,
-        
+
         "profile": profile,
-        
+
     }))
 
 
 
 def dpx(
-    
+
 ) -> FFMpegEncoderOption:
     """
     DPX (Digital Picture Exchange) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def dvvideo(
-    
+
     quant_deadzone: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     DV (Digital Video)
-    
+
     Args:
         quant_deadzone: Quantizer dead zone (from 0 to 1024) (default 7)
 
@@ -635,25 +635,25 @@ def dvvideo(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "quant_deadzone": quant_deadzone,
-        
+
     }))
 
 
 
 def exr(
-    
+
     compression: int | None| Literal["none", "rle", "zip1", "zip16"] = None,
-    
+
     format: int | None| Literal["half", "float"] = None,
-    
+
     gamma: float | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     OpenEXR image
-    
+
     Args:
         compression: set compression type (from 0 to 3) (default none)
         format: set pixel type (from 1 to 2) (default float)
@@ -663,29 +663,29 @@ def exr(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "compression": compression,
-        
+
         "format": format,
-        
+
         "gamma": gamma,
-        
+
     }))
 
 
 
 def ffv1(
-    
+
     slicecrc: bool | None = None,
-    
+
     coder: int | None| Literal["rice", "range_def", "range_tab", "ac"] = None,
-    
+
     context: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     FFmpeg video codec #1
-    
+
     Args:
         slicecrc: Protect slices with CRCs (default auto)
         coder: Coder type (from -2 to 2) (default rice)
@@ -695,29 +695,29 @@ def ffv1(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "slicecrc": slicecrc,
-        
+
         "coder": coder,
-        
+
         "context": context,
-        
+
     }))
 
 
 
 def ffvhuff(
-    
+
     non_deterministic: bool | None = None,
-    
+
     pred: int | None| Literal["left", "plane", "median"] = None,
-    
+
     context: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Huffyuv FFmpeg variant
-    
+
     Args:
         non_deterministic: Allow multithreading for e.g. context=1 at the expense of determinism (default false)
         pred: Prediction method (from 0 to 2) (default left)
@@ -727,121 +727,121 @@ def ffvhuff(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "non_deterministic": non_deterministic,
-        
+
         "pred": pred,
-        
+
         "context": context,
-        
+
     }))
 
 
 
 def fits(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Flexible Image Transport System
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def flashsv(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Flash Screen Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def flashsv2(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Flash Screen Video Version 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def flv(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     FLV / Sorenson Spark / Sorenson H.263 (Flash Video) (codec flv1)
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -873,73 +873,73 @@ def flv(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def gif(
-    
+
     gifflags: str | None = None,
-    
+
     gifimage: bool | None = None,
-    
+
     global_palette: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     GIF (Graphics Interchange Format)
-    
+
     Args:
         gifflags: set GIF flags (default offsetting+transdiff)
         gifimage: enable encoding only images per frame (default false)
@@ -949,73 +949,73 @@ def gif(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "gifflags": gifflags,
-        
+
         "gifimage": gifimage,
-        
+
         "global_palette": global_palette,
-        
+
     }))
 
 
 
 def h261(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     H.261
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -1047,121 +1047,121 @@ def h261(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def h263(
-    
+
     obmc: bool | None = None,
-    
+
     mb_info: int | None = None,
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     H.263 / H.263-1996
-    
+
     Args:
         obmc: use overlapped block motion compensation. (default false)
         mb_info: emit macroblock info for RFC 2190 packetization, the parameter value is the maximum payload size (from 0 to INT_MAX) (default 0)
@@ -1195,75 +1195,75 @@ def h263(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "obmc": obmc,
-        
+
         "mb_info": mb_info,
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def h263_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     V4L2 mem2mem H.263 encoder wrapper (codec h263)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 4 to INT_MAX) (default 4)
@@ -1272,79 +1272,79 @@ def h263_v4l2m2m(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def h263p(
-    
+
     umv: bool | None = None,
-    
+
     aiv: bool | None = None,
-    
+
     obmc: bool | None = None,
-    
+
     structured_slices: bool | None = None,
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     H.263+ / H.263-1998 / H.263 version 2
-    
+
     Args:
         umv: Use unlimited motion vectors. (default false)
         aiv: Use alternative inter VLC. (default false)
@@ -1380,169 +1380,169 @@ def h263p(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "umv": umv,
-        
+
         "aiv": aiv,
-        
+
         "obmc": obmc,
-        
+
         "structured_slices": structured_slices,
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def libx264(
-    
+
     preset: str | None = None,
-    
+
     tune: str | None = None,
-    
+
     profile: str | None = None,
-    
+
     fastfirstpass: bool | None = None,
-    
+
     level: str | None = None,
-    
+
     passlogfile: str | None = None,
-    
+
     wpredp: str | None = None,
-    
+
     a53cc: bool | None = None,
-    
+
     x264opts: str | None = None,
-    
+
     crf: float | None = None,
-    
+
     crf_max: float | None = None,
-    
+
     qp: int | None = None,
-    
+
     aq_mode: int | None| Literal["none", "variance", "autovariance", "autovariance-biased"] = None,
-    
+
     aq_strength: float | None = None,
-    
+
     psy: bool | None = None,
-    
+
     psy_rd: str | None = None,
-    
+
     rc_lookahead: int | None = None,
-    
+
     weightb: bool | None = None,
-    
+
     weightp: int | None| Literal["none", "simple", "smart"] = None,
-    
+
     ssim: bool | None = None,
-    
+
     intra_refresh: bool | None = None,
-    
+
     bluray_compat: bool | None = None,
-    
+
     b_bias: int | None = None,
-    
+
     b_pyramid: int | None| Literal["none", "strict", "normal"] = None,
-    
+
     mixed_refs: bool | None = None,
-    
+
     _8x8dct: bool | None = None,
-    
+
     fast_pskip: bool | None = None,
-    
+
     aud: bool | None = None,
-    
+
     mbtree: bool | None = None,
-    
+
     deblock: str | None = None,
-    
+
     cplxblur: float | None = None,
-    
+
     partitions: str | None = None,
-    
+
     direct_pred: int | None| Literal["none", "spatial", "temporal", "auto"] = None,
-    
+
     slice_max_size: int | None = None,
-    
+
     stats: str | None = None,
-    
+
     nal_hrd: int | None| Literal["none", "vbr", "cbr"] = None,
-    
+
     avcintra_class: int | None = None,
-    
+
     me_method: int | None| Literal["dia", "hex", "umh", "esa", "tesa"] = None,
-    
+
     forced_idr: bool | None = None,
-    
+
     coder: int | None| Literal["default", "cavlc", "cabac", "vlc", "ac"] = None,
-    
+
     b_strategy: int | None = None,
-    
+
     chromaoffset: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     udu_sei: bool | None = None,
-    
+
     x264_params: str | None = None,
-    
+
     mb_info: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libx264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 (codec h264)
-    
+
     Args:
         preset: Set the encoding preset (cf. x264 --fullhelp) (default "medium")
         tune: Tune the encoding params (cf. x264 --fullhelp)
@@ -1596,205 +1596,205 @@ def libx264(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "preset": preset,
-        
+
         "tune": tune,
-        
+
         "profile": profile,
-        
+
         "fastfirstpass": fastfirstpass,
-        
+
         "level": level,
-        
+
         "passlogfile": passlogfile,
-        
+
         "wpredp": wpredp,
-        
+
         "a53cc": a53cc,
-        
+
         "x264opts": x264opts,
-        
+
         "crf": crf,
-        
+
         "crf_max": crf_max,
-        
+
         "qp": qp,
-        
+
         "aq-mode": aq_mode,
-        
+
         "aq-strength": aq_strength,
-        
+
         "psy": psy,
-        
+
         "psy-rd": psy_rd,
-        
+
         "rc-lookahead": rc_lookahead,
-        
+
         "weightb": weightb,
-        
+
         "weightp": weightp,
-        
+
         "ssim": ssim,
-        
+
         "intra-refresh": intra_refresh,
-        
+
         "bluray-compat": bluray_compat,
-        
+
         "b-bias": b_bias,
-        
+
         "b-pyramid": b_pyramid,
-        
+
         "mixed-refs": mixed_refs,
-        
+
         "8x8dct": _8x8dct,
-        
+
         "fast-pskip": fast_pskip,
-        
+
         "aud": aud,
-        
+
         "mbtree": mbtree,
-        
+
         "deblock": deblock,
-        
+
         "cplxblur": cplxblur,
-        
+
         "partitions": partitions,
-        
+
         "direct-pred": direct_pred,
-        
+
         "slice-max-size": slice_max_size,
-        
+
         "stats": stats,
-        
+
         "nal-hrd": nal_hrd,
-        
+
         "avcintra-class": avcintra_class,
-        
+
         "me_method": me_method,
-        
+
         "forced-idr": forced_idr,
-        
+
         "coder": coder,
-        
+
         "b_strategy": b_strategy,
-        
+
         "chromaoffset": chromaoffset,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "udu_sei": udu_sei,
-        
+
         "x264-params": x264_params,
-        
+
         "mb_info": mb_info,
-        
+
     }))
 
 
 
 def libx264rgb(
-    
+
     preset: str | None = None,
-    
+
     tune: str | None = None,
-    
+
     profile: str | None = None,
-    
+
     fastfirstpass: bool | None = None,
-    
+
     level: str | None = None,
-    
+
     passlogfile: str | None = None,
-    
+
     wpredp: str | None = None,
-    
+
     a53cc: bool | None = None,
-    
+
     x264opts: str | None = None,
-    
+
     crf: float | None = None,
-    
+
     crf_max: float | None = None,
-    
+
     qp: int | None = None,
-    
+
     aq_mode: int | None| Literal["none", "variance", "autovariance", "autovariance-biased"] = None,
-    
+
     aq_strength: float | None = None,
-    
+
     psy: bool | None = None,
-    
+
     psy_rd: str | None = None,
-    
+
     rc_lookahead: int | None = None,
-    
+
     weightb: bool | None = None,
-    
+
     weightp: int | None| Literal["none", "simple", "smart"] = None,
-    
+
     ssim: bool | None = None,
-    
+
     intra_refresh: bool | None = None,
-    
+
     bluray_compat: bool | None = None,
-    
+
     b_bias: int | None = None,
-    
+
     b_pyramid: int | None| Literal["none", "strict", "normal"] = None,
-    
+
     mixed_refs: bool | None = None,
-    
+
     _8x8dct: bool | None = None,
-    
+
     fast_pskip: bool | None = None,
-    
+
     aud: bool | None = None,
-    
+
     mbtree: bool | None = None,
-    
+
     deblock: str | None = None,
-    
+
     cplxblur: float | None = None,
-    
+
     partitions: str | None = None,
-    
+
     direct_pred: int | None| Literal["none", "spatial", "temporal", "auto"] = None,
-    
+
     slice_max_size: int | None = None,
-    
+
     stats: str | None = None,
-    
+
     nal_hrd: int | None| Literal["none", "vbr", "cbr"] = None,
-    
+
     avcintra_class: int | None = None,
-    
+
     me_method: int | None| Literal["dia", "hex", "umh", "esa", "tesa"] = None,
-    
+
     forced_idr: bool | None = None,
-    
+
     coder: int | None| Literal["default", "cavlc", "cabac", "vlc", "ac"] = None,
-    
+
     b_strategy: int | None = None,
-    
+
     chromaoffset: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     udu_sei: bool | None = None,
-    
+
     x264_params: str | None = None,
-    
+
     mb_info: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libx264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 RGB (codec h264)
-    
+
     Args:
         preset: Set the encoding preset (cf. x264 --fullhelp) (default "medium")
         tune: Tune the encoding params (cf. x264 --fullhelp)
@@ -1848,115 +1848,115 @@ def libx264rgb(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "preset": preset,
-        
+
         "tune": tune,
-        
+
         "profile": profile,
-        
+
         "fastfirstpass": fastfirstpass,
-        
+
         "level": level,
-        
+
         "passlogfile": passlogfile,
-        
+
         "wpredp": wpredp,
-        
+
         "a53cc": a53cc,
-        
+
         "x264opts": x264opts,
-        
+
         "crf": crf,
-        
+
         "crf_max": crf_max,
-        
+
         "qp": qp,
-        
+
         "aq-mode": aq_mode,
-        
+
         "aq-strength": aq_strength,
-        
+
         "psy": psy,
-        
+
         "psy-rd": psy_rd,
-        
+
         "rc-lookahead": rc_lookahead,
-        
+
         "weightb": weightb,
-        
+
         "weightp": weightp,
-        
+
         "ssim": ssim,
-        
+
         "intra-refresh": intra_refresh,
-        
+
         "bluray-compat": bluray_compat,
-        
+
         "b-bias": b_bias,
-        
+
         "b-pyramid": b_pyramid,
-        
+
         "mixed-refs": mixed_refs,
-        
+
         "8x8dct": _8x8dct,
-        
+
         "fast-pskip": fast_pskip,
-        
+
         "aud": aud,
-        
+
         "mbtree": mbtree,
-        
+
         "deblock": deblock,
-        
+
         "cplxblur": cplxblur,
-        
+
         "partitions": partitions,
-        
+
         "direct-pred": direct_pred,
-        
+
         "slice-max-size": slice_max_size,
-        
+
         "stats": stats,
-        
+
         "nal-hrd": nal_hrd,
-        
+
         "avcintra-class": avcintra_class,
-        
+
         "me_method": me_method,
-        
+
         "forced-idr": forced_idr,
-        
+
         "coder": coder,
-        
+
         "b_strategy": b_strategy,
-        
+
         "chromaoffset": chromaoffset,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "udu_sei": udu_sei,
-        
+
         "x264-params": x264_params,
-        
+
         "mb_info": mb_info,
-        
+
     }))
 
 
 
 def h264_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     V4L2 mem2mem H.264 encoder wrapper (codec h264)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 4 to INT_MAX) (default 4)
@@ -1965,47 +1965,47 @@ def h264_v4l2m2m(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def h264_vaapi(
-    
+
     low_power: bool | None = None,
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     rc_mode: int | None| Literal["auto", "CQP", "CBR", "VBR", "ICQ", "QVBR", "AVBR"] = None,
-    
+
     qp: int | None = None,
-    
+
     quality: int | None = None,
-    
+
     coder: int | None| Literal["cavlc", "cabac", "vlc", "ac"] = None,
-    
+
     aud: bool | None = None,
-    
+
     sei: str | None = None,
-    
+
     profile: int | None| Literal["constrained_baseline", "main", "high", "high10"] = None,
-    
+
     level: int | None| Literal["1", "1.1", "1.2", "1.3", "2", "2.1", "2.2", "3", "3.1", "3.2", "4", "4.1", "4.2", "5", "5.1", "5.2", "6", "6.1", "6.2"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     H.264/AVC (VAAPI) (codec h264)
-    
+
     Args:
         low_power: Use low-power encoding mode (only available on some platforms; may not support all encoding features) (default false)
         idr_interval: Distance (in I-frames) between IDR frames (from 0 to INT_MAX) (default 0)
@@ -2025,77 +2025,77 @@ def h264_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "low_power": low_power,
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "rc_mode": rc_mode,
-        
+
         "qp": qp,
-        
+
         "quality": quality,
-        
+
         "coder": coder,
-        
+
         "aud": aud,
-        
+
         "sei": sei,
-        
+
         "profile": profile,
-        
+
         "level": level,
-        
+
     }))
 
 
 
 def hdr(
-    
+
 ) -> FFMpegEncoderOption:
     """
     HDR (Radiance RGBE format) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def libx265(
-    
+
     crf: float | None = None,
-    
+
     qp: int | None = None,
-    
+
     forced_idr: bool | None = None,
-    
+
     preset: str | None = None,
-    
+
     tune: str | None = None,
-    
+
     profile: str | None = None,
-    
+
     udu_sei: bool | None = None,
-    
+
     a53cc: bool | None = None,
-    
+
     x265_params: str | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libx265 H.265 / HEVC (codec hevc)
-    
+
     Args:
         crf: set the x265 crf (from -1 to FLT_MAX) (default -1)
         qp: set the x265 qp (from -1 to INT_MAX) (default -1)
@@ -2111,39 +2111,39 @@ def libx265(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "crf": crf,
-        
+
         "qp": qp,
-        
+
         "forced-idr": forced_idr,
-        
+
         "preset": preset,
-        
+
         "tune": tune,
-        
+
         "profile": profile,
-        
+
         "udu_sei": udu_sei,
-        
+
         "a53cc": a53cc,
-        
+
         "x265-params": x265_params,
-        
+
     }))
 
 
 
 def hevc_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     V4L2 mem2mem HEVC encoder wrapper (codec hevc)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 4 to INT_MAX) (default 4)
@@ -2152,47 +2152,47 @@ def hevc_v4l2m2m(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def hevc_vaapi(
-    
+
     low_power: bool | None = None,
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     rc_mode: int | None| Literal["auto", "CQP", "CBR", "VBR", "ICQ", "QVBR", "AVBR"] = None,
-    
+
     qp: int | None = None,
-    
+
     aud: bool | None = None,
-    
+
     profile: int | None| Literal["main", "main10", "rext"] = None,
-    
+
     tier: int | None| Literal["main", "high"] = None,
-    
+
     level: int | None| Literal["1", "2", "2.1", "3", "3.1", "4", "4.1", "5", "5.1", "5.2", "6", "6.1", "6.2"] = None,
-    
+
     sei: str | None = None,
-    
+
     tiles: str | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     H.265/HEVC (VAAPI) (codec hevc)
-    
+
     Args:
         low_power: Use low-power encoding mode (only available on some platforms; may not support all encoding features) (default false)
         idr_interval: Distance (in I-frames) between IDR frames (from 0 to INT_MAX) (default 0)
@@ -2212,47 +2212,47 @@ def hevc_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "low_power": low_power,
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "rc_mode": rc_mode,
-        
+
         "qp": qp,
-        
+
         "aud": aud,
-        
+
         "profile": profile,
-        
+
         "tier": tier,
-        
+
         "level": level,
-        
+
         "sei": sei,
-        
+
         "tiles": tiles,
-        
+
     }))
 
 
 
 def huffyuv(
-    
+
     non_deterministic: bool | None = None,
-    
+
     pred: int | None| Literal["left", "plane", "median"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Huffyuv / HuffYUV
-    
+
     Args:
         non_deterministic: Allow multithreading for e.g. context=1 at the expense of determinism (default false)
         pred: Prediction method (from 0 to 2) (default left)
@@ -2261,37 +2261,37 @@ def huffyuv(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "non_deterministic": non_deterministic,
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def jpeg2000(
-    
+
     format: int | None| Literal["j2k", "jp2"] = None,
-    
+
     tile_width: int | None = None,
-    
+
     tile_height: int | None = None,
-    
+
     pred: int | None| Literal["dwt97int", "dwt53"] = None,
-    
+
     sop: int | None = None,
-    
+
     eph: int | None = None,
-    
+
     prog: int | None| Literal["lrcp", "rlcp", "rpcl", "pcrl", "cprl"] = None,
-    
+
     layer_rates: str | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     JPEG 2000
-    
+
     Args:
         format: Codec Format (from 0 to 1) (default jp2)
         tile_width: Tile Width (from 1 to 1.07374e+09) (default 256)
@@ -2306,49 +2306,49 @@ def jpeg2000(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "format": format,
-        
+
         "tile_width": tile_width,
-        
+
         "tile_height": tile_height,
-        
+
         "pred": pred,
-        
+
         "sop": sop,
-        
+
         "eph": eph,
-        
+
         "prog": prog,
-        
+
         "layer_rates": layer_rates,
-        
+
     }))
 
 
 
 def libopenjpeg(
-    
+
     format: int | None| Literal["j2k", "jp2"] = None,
-    
+
     profile: int | None| Literal["jpeg2000", "cinema2k", "cinema4k"] = None,
-    
+
     cinema_mode: int | None| Literal["off", "2k_24", "2k_48", "4k_24"] = None,
-    
+
     prog_order: int | None| Literal["lrcp", "rlcp", "rpcl", "pcrl", "cprl"] = None,
-    
+
     numresolution: int | None = None,
-    
+
     irreversible: int | None = None,
-    
+
     disto_alloc: int | None = None,
-    
+
     fixed_quality: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     OpenJPEG JPEG 2000 (codec jpeg2000)
-    
+
     Args:
         format: Codec Format (from 0 to 2) (default jp2)
         profile: (from 0 to 4) (default jpeg2000)
@@ -2363,35 +2363,35 @@ def libopenjpeg(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "format": format,
-        
+
         "profile": profile,
-        
+
         "cinema_mode": cinema_mode,
-        
+
         "prog_order": prog_order,
-        
+
         "numresolution": numresolution,
-        
+
         "irreversible": irreversible,
-        
+
         "disto_alloc": disto_alloc,
-        
+
         "fixed_quality": fixed_quality,
-        
+
     }))
 
 
 
 def jpegls(
-    
+
     pred: int | None| Literal["left", "plane", "median"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     JPEG-LS
-    
+
     Args:
         pred: Prediction method (from 0 to 2) (default left)
 
@@ -2399,21 +2399,21 @@ def jpegls(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def ljpeg(
-    
+
     pred: int | None| Literal["left", "plane", "median"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Lossless JPEG
-    
+
     Args:
         pred: Prediction method (from 1 to 3) (default left)
 
@@ -2421,21 +2421,21 @@ def ljpeg(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def magicyuv(
-    
+
     pred: int | None| Literal["left", "gradient", "median"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MagicYUV video
-    
+
     Args:
         pred: Prediction method (from 1 to 3) (default left)
 
@@ -2443,65 +2443,65 @@ def magicyuv(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def mjpeg(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     huffman: int | None| Literal["default", "optimal"] = None,
-    
+
     force_duplicated_matrix: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MJPEG (Motion JPEG)
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -2531,77 +2531,77 @@ def mjpeg(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "huffman": huffman,
-        
+
         "force_duplicated_matrix": force_duplicated_matrix,
-        
+
     }))
 
 
 
 def mjpeg_vaapi(
-    
+
     low_power: bool | None = None,
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     jfif: bool | None = None,
-    
+
     huffman: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MJPEG (VAAPI) (codec mjpeg)
-    
+
     Args:
         low_power: Use low-power encoding mode (only available on some platforms; may not support all encoding features) (default false)
         idr_interval: Distance (in I-frames) between IDR frames (from 0 to INT_MAX) (default 0)
@@ -2615,95 +2615,95 @@ def mjpeg_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "low_power": low_power,
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "jfif": jfif,
-        
+
         "huffman": huffman,
-        
+
     }))
 
 
 
 def mpeg1video(
-    
+
     gop_timecode: str | None = None,
-    
+
     drop_frame_timecode: bool | None = None,
-    
+
     scan_offset: bool | None = None,
-    
+
     timecode_frame_start: int | None = None,
-    
+
     b_strategy: int | None = None,
-    
+
     b_sensitivity: int | None = None,
-    
+
     brd_scale: int | None = None,
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MPEG-1 video
-    
+
     Args:
         gop_timecode: MPEG GOP Timecode in hh:mm:ss[:;.]ff format. Overrides timecode_frame_start.
         drop_frame_timecode: Timecode is in drop frame format. (default false)
@@ -2742,157 +2742,157 @@ def mpeg1video(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "gop_timecode": gop_timecode,
-        
+
         "drop_frame_timecode": drop_frame_timecode,
-        
+
         "scan_offset": scan_offset,
-        
+
         "timecode_frame_start": timecode_frame_start,
-        
+
         "b_strategy": b_strategy,
-        
+
         "b_sensitivity": b_sensitivity,
-        
+
         "brd_scale": brd_scale,
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def mpeg2video(
-    
+
     gop_timecode: str | None = None,
-    
+
     drop_frame_timecode: bool | None = None,
-    
+
     scan_offset: bool | None = None,
-    
+
     timecode_frame_start: int | None = None,
-    
+
     b_strategy: int | None = None,
-    
+
     b_sensitivity: int | None = None,
-    
+
     brd_scale: int | None = None,
-    
+
     intra_vlc: bool | None = None,
-    
+
     non_linear_quant: bool | None = None,
-    
+
     alternate_scan: bool | None = None,
-    
+
     a53cc: bool | None = None,
-    
+
     seq_disp_ext: int | None| Literal["auto", "never", "always"] = None,
-    
+
     video_format: int | None| Literal["component", "pal", "ntsc", "secam", "mac", "unspecified"] = None,
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MPEG-2 video
-    
+
     Args:
         gop_timecode: MPEG GOP Timecode in hh:mm:ss[:;.]ff format. Overrides timecode_frame_start.
         drop_frame_timecode: Timecode is in drop frame format. (default false)
@@ -2937,109 +2937,109 @@ def mpeg2video(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "gop_timecode": gop_timecode,
-        
+
         "drop_frame_timecode": drop_frame_timecode,
-        
+
         "scan_offset": scan_offset,
-        
+
         "timecode_frame_start": timecode_frame_start,
-        
+
         "b_strategy": b_strategy,
-        
+
         "b_sensitivity": b_sensitivity,
-        
+
         "brd_scale": brd_scale,
-        
+
         "intra_vlc": intra_vlc,
-        
+
         "non_linear_quant": non_linear_quant,
-        
+
         "alternate_scan": alternate_scan,
-        
+
         "a53cc": a53cc,
-        
+
         "seq_disp_ext": seq_disp_ext,
-        
+
         "video_format": video_format,
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def mpeg2_vaapi(
-    
+
     low_power: bool | None = None,
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     rc_mode: int | None| Literal["auto", "CQP", "CBR", "VBR", "ICQ", "QVBR", "AVBR"] = None,
-    
+
     profile: int | None| Literal["simple", "main"] = None,
-    
+
     level: int | None| Literal["low", "main", "high_1440", "high"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MPEG-2 (VAAPI) (codec mpeg2video)
-    
+
     Args:
         low_power: Use low-power encoding mode (only available on some platforms; may not support all encoding features) (default false)
         idr_interval: Distance (in I-frames) between IDR frames (from 0 to INT_MAX) (default 0)
@@ -3054,95 +3054,95 @@ def mpeg2_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "low_power": low_power,
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "rc_mode": rc_mode,
-        
+
         "profile": profile,
-        
+
         "level": level,
-        
+
     }))
 
 
 
 def mpeg4(
-    
+
     data_partitioning: bool | None = None,
-    
+
     alternate_scan: bool | None = None,
-    
+
     mpeg_quant: int | None = None,
-    
+
     b_strategy: int | None = None,
-    
+
     b_sensitivity: int | None = None,
-    
+
     brd_scale: int | None = None,
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MPEG-4 part 2
-    
+
     Args:
         data_partitioning: Use data partitioning. (default false)
         alternate_scan: Enable alternate scantable. (default false)
@@ -3180,93 +3180,93 @@ def mpeg4(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "data_partitioning": data_partitioning,
-        
+
         "alternate_scan": alternate_scan,
-        
+
         "mpeg_quant": mpeg_quant,
-        
+
         "b_strategy": b_strategy,
-        
+
         "b_sensitivity": b_sensitivity,
-        
+
         "brd_scale": brd_scale,
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def libxvid(
-    
+
     lumi_aq: int | None = None,
-    
+
     variance_aq: int | None = None,
-    
+
     ssim: int | None| Literal["off", "avg", "frame"] = None,
-    
+
     ssim_acc: int | None = None,
-    
+
     gmc: int | None = None,
-    
+
     me_quality: int | None = None,
-    
+
     mpeg_quant: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libxvidcore MPEG-4 part 2 (codec mpeg4)
-    
+
     Args:
         lumi_aq: Luminance masking AQ (from 0 to 1) (default 0)
         variance_aq: Variance AQ (from 0 to 1) (default 0)
@@ -3280,35 +3280,35 @@ def libxvid(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "lumi_aq": lumi_aq,
-        
+
         "variance_aq": variance_aq,
-        
+
         "ssim": ssim,
-        
+
         "ssim_acc": ssim_acc,
-        
+
         "gmc": gmc,
-        
+
         "me_quality": me_quality,
-        
+
         "mpeg_quant": mpeg_quant,
-        
+
     }))
 
 
 
 def mpeg4_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     V4L2 mem2mem MPEG4 encoder wrapper (codec mpeg4)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 4 to INT_MAX) (default 4)
@@ -3317,71 +3317,71 @@ def mpeg4_v4l2m2m(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def msmpeg4v2(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MPEG-4 part 2 Microsoft variant version 2
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -3413,117 +3413,117 @@ def msmpeg4v2(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def msmpeg4(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MPEG-4 part 2 Microsoft variant version 3 (codec msmpeg4v3)
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -3555,217 +3555,217 @@ def msmpeg4(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def msrle(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Microsoft RLE
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def msvideo1(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Microsoft Video-1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pam(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PAM (Portable AnyMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pbm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PBM (Portable BitMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcx(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PC Paintbrush PCX image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pfm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PFM (Portable FloatMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pgm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PGM (Portable GrayMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pgmyuv(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PGMYUV (Portable GrayMap YUV) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def phm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PHM (Portable HalfFloatMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def png(
-    
+
     dpi: int | None = None,
-    
+
     dpm: int | None = None,
-    
+
     pred: int | None| Literal["none", "sub", "up", "avg", "paeth", "mixed"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     PNG (Portable Network Graphics) image
-    
+
     Args:
         dpi: Set image resolution (in dots per inch) (from 0 to 65536) (default 0)
         dpm: Set image resolution (in dots per meter) (from 0 to 65536) (default 0)
@@ -3775,41 +3775,41 @@ def png(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "dpi": dpi,
-        
+
         "dpm": dpm,
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def ppm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PPM (Portable PixelMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def prores(
-    
+
     vendor: str | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Apple ProRes
-    
+
     Args:
         vendor: vendor ID (default "fmpg")
 
@@ -3817,21 +3817,21 @@ def prores(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "vendor": vendor,
-        
+
     }))
 
 
 
 def prores_aw(
-    
+
     vendor: str | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Apple ProRes (codec prores)
-    
+
     Args:
         vendor: vendor ID (default "fmpg")
 
@@ -3839,31 +3839,31 @@ def prores_aw(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "vendor": vendor,
-        
+
     }))
 
 
 
 def prores_ks(
-    
+
     mbs_per_slice: int | None = None,
-    
+
     profile: int | None| Literal["auto", "proxy", "lt", "standard", "hq", "4444", "4444xq"] = None,
-    
+
     vendor: str | None = None,
-    
+
     bits_per_mb: int | None = None,
-    
+
     quant_mat: int | None| Literal["auto", "proxy", "lt", "standard", "hq", "default"] = None,
-    
+
     alpha_bits: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Apple ProRes (iCodec Pro) (codec prores)
-    
+
     Args:
         mbs_per_slice: macroblocks per slice (from 1 to 8) (default 8)
         profile: (from -1 to 5) (default auto)
@@ -3876,111 +3876,111 @@ def prores_ks(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mbs_per_slice": mbs_per_slice,
-        
+
         "profile": profile,
-        
+
         "vendor": vendor,
-        
+
         "bits_per_mb": bits_per_mb,
-        
+
         "quant_mat": quant_mat,
-        
+
         "alpha_bits": alpha_bits,
-        
+
     }))
 
 
 
 def qoi(
-    
+
 ) -> FFMpegEncoderOption:
     """
     QOI (Quite OK Image format) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def qtrle(
-    
+
 ) -> FFMpegEncoderOption:
     """
     QuickTime Animation (RLE) video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def r10k(
-    
+
 ) -> FFMpegEncoderOption:
     """
     AJA Kona 10-bit RGB Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def r210(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed RGB 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def rawvideo(
-    
+
 ) -> FFMpegEncoderOption:
     """
     raw video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def roqvideo(
-    
+
     quake3_compat: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     id RoQ video (codec roq)
-    
+
     Args:
         quake3_compat: Whether to respect known limitations in Quake 3 decoder (default true)
 
@@ -3988,25 +3988,25 @@ def roqvideo(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "quake3_compat": quake3_compat,
-        
+
     }))
 
 
 
 def rpza(
-    
+
     skip_frame_thresh: int | None = None,
-    
+
     continue_one_color_thresh: int | None = None,
-    
+
     sixteen_color_thresh: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     QuickTime video (RPZA)
-    
+
     Args:
         skip_frame_thresh: (from 0 to 24) (default 1)
         continue_one_color_thresh: (from 0 to 24) (default 0)
@@ -4016,73 +4016,73 @@ def rpza(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "skip_frame_thresh": skip_frame_thresh,
-        
+
         "continue_one_color_thresh": continue_one_color_thresh,
-        
+
         "sixteen_color_thresh": sixteen_color_thresh,
-        
+
     }))
 
 
 
 def rv10(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     RealVideo 1.0
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -4114,117 +4114,117 @@ def rv10(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def rv20(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     RealVideo 2.0
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -4256,69 +4256,69 @@ def rv20(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def sgi(
-    
+
     rle: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     SGI image
-    
+
     Args:
         rle: Use run-length compression (from 0 to 1) (default 1)
 
@@ -4326,51 +4326,51 @@ def sgi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "rle": rle,
-        
+
     }))
 
 
 
 def smc(
-    
+
 ) -> FFMpegEncoderOption:
     """
     QuickTime Graphics (SMC)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def snow(
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone", "iter"] = None,
-    
+
     memc_only: bool | None = None,
-    
+
     no_bitstream: bool | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
     iterative_dia_size: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     pred: int | None| Literal["dwt97", "dwt53"] = None,
-    
+
     rc_eq: str | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Snow
-    
+
     Args:
         motion_est: motion estimation algorithm (from 0 to 3) (default epzs)
         memc_only: Only do ME/MC (I frames -> ref, P frame -> ME+MC). (default false)
@@ -4385,83 +4385,83 @@ def snow(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "motion_est": motion_est,
-        
+
         "memc_only": memc_only,
-        
+
         "no_bitstream": no_bitstream,
-        
+
         "intra_penalty": intra_penalty,
-        
+
         "iterative_dia_size": iterative_dia_size,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "pred": pred,
-        
+
         "rc_eq": rc_eq,
-        
+
     }))
 
 
 
 def speedhq(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     NewTek SpeedHQ
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -4493,69 +4493,69 @@ def speedhq(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def sunrast(
-    
+
     rle: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Sun Rasterfile image
-    
+
     Args:
         rle: Use run-length compression (from 0 to 1) (default 1)
 
@@ -4563,21 +4563,21 @@ def sunrast(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "rle": rle,
-        
+
     }))
 
 
 
 def svq1(
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Sorenson Vector Quantizer 1 / Sorenson Video 1 / SVQ1
-    
+
     Args:
         motion_est: Motion estimation algorithm (from 0 to 2) (default epzs)
 
@@ -4585,21 +4585,21 @@ def svq1(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "motion-est": motion_est,
-        
+
     }))
 
 
 
 def targa(
-    
+
     rle: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Truevision Targa image
-    
+
     Args:
         rle: Use run-length compression (from 0 to 1) (default 1)
 
@@ -4607,39 +4607,39 @@ def targa(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "rle": rle,
-        
+
     }))
 
 
 
 def libtheora(
-    
+
 ) -> FFMpegEncoderOption:
     """
     libtheora Theora (codec theora)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def tiff(
-    
+
     dpi: int | None = None,
-    
+
     compression_algo: int | None| Literal["packbits", "raw", "lzw", "deflate"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     TIFF image
-    
+
     Args:
         dpi: set the image resolution (in dpi) (from 1 to 65536) (default 72)
         compression_algo: (from 1 to 32946) (default packbits)
@@ -4648,23 +4648,23 @@ def tiff(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "dpi": dpi,
-        
+
         "compression_algo": compression_algo,
-        
+
     }))
 
 
 
 def utvideo(
-    
+
     pred: int | None| Literal["none", "left", "gradient", "median"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Ut Video
-    
+
     Args:
         pred: Prediction method (from 0 to 3) (default left)
 
@@ -4672,85 +4672,85 @@ def utvideo(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def v210(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed 4:2:2 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def v308(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed packed 4:4:4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def v408(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed packed QT 4:4:4:4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def v410(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed 4:4:4 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def vbn(
-    
+
     format: int | None| Literal["raw", "dxt1", "dxt5"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Vizrt Binary Image
-    
+
     Args:
         format: Texture format (from 0 to 3) (default dxt5)
 
@@ -4758,81 +4758,81 @@ def vbn(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "format": format,
-        
+
     }))
 
 
 
 def vnull(
-    
+
 ) -> FFMpegEncoderOption:
     """
     null video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def libvpx(
-    
+
     lag_in_frames: int | None = None,
-    
+
     arnr_maxframes: int | None = None,
-    
+
     arnr_strength: int | None = None,
-    
+
     arnr_type: int | None| Literal["backward", "forward", "centered"] = None,
-    
+
     tune: int | None| Literal["psnr", "ssim"] = None,
-    
+
     deadline: int | None| Literal["best", "good", "realtime"] = None,
-    
+
     error_resilient: str | None = None,
-    
+
     max_intra_rate: int | None = None,
-    
+
     crf: int | None = None,
-    
+
     static_thresh: int | None = None,
-    
+
     drop_threshold: int | None = None,
-    
+
     noise_sensitivity: int | None = None,
-    
+
     undershoot_pct: int | None = None,
-    
+
     overshoot_pct: int | None = None,
-    
+
     ts_parameters: str | None = None,
-    
+
     auto_alt_ref: int | None = None,
-    
+
     cpu_used: int | None = None,
-    
+
     speed: int | None = None,
-    
+
     quality: int | None| Literal["best", "good", "realtime"] = None,
-    
+
     vp8flags: str | None = None,
-    
+
     arnr_max_frames: int | None = None,
-    
+
     rc_lookahead: int | None = None,
-    
+
     sharpness: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libvpx VP8 (codec vp8)
-    
+
     Args:
         lag_in_frames: Number of frames to look ahead for alternate reference frame selection (from -1 to INT_MAX) (default -1)
         arnr_maxframes: altref noise reduction max frame count (from -1 to INT_MAX) (default -1)
@@ -4862,67 +4862,67 @@ def libvpx(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "lag-in-frames": lag_in_frames,
-        
+
         "arnr-maxframes": arnr_maxframes,
-        
+
         "arnr-strength": arnr_strength,
-        
+
         "arnr-type": arnr_type,
-        
+
         "tune": tune,
-        
+
         "deadline": deadline,
-        
+
         "error-resilient": error_resilient,
-        
+
         "max-intra-rate": max_intra_rate,
-        
+
         "crf": crf,
-        
+
         "static-thresh": static_thresh,
-        
+
         "drop-threshold": drop_threshold,
-        
+
         "noise-sensitivity": noise_sensitivity,
-        
+
         "undershoot-pct": undershoot_pct,
-        
+
         "overshoot-pct": overshoot_pct,
-        
+
         "ts-parameters": ts_parameters,
-        
+
         "auto-alt-ref": auto_alt_ref,
-        
+
         "cpu-used": cpu_used,
-        
+
         "speed": speed,
-        
+
         "quality": quality,
-        
+
         "vp8flags": vp8flags,
-        
+
         "arnr_max_frames": arnr_max_frames,
-        
+
         "rc_lookahead": rc_lookahead,
-        
+
         "sharpness": sharpness,
-        
+
     }))
 
 
 
 def vp8_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     V4L2 mem2mem VP8 encoder wrapper (codec vp8)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 4 to INT_MAX) (default 4)
@@ -4931,37 +4931,37 @@ def vp8_v4l2m2m(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def vp8_vaapi(
-    
+
     low_power: bool | None = None,
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     rc_mode: int | None| Literal["auto", "CQP", "CBR", "VBR", "ICQ", "QVBR", "AVBR"] = None,
-    
+
     loop_filter_level: int | None = None,
-    
+
     loop_filter_sharpness: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     VP8 (VAAPI) (codec vp8)
-    
+
     Args:
         low_power: Use low-power encoding mode (only available on some platforms; may not support all encoding features) (default false)
         idr_interval: Distance (in I-frames) between IDR frames (from 0 to INT_MAX) (default 0)
@@ -4976,49 +4976,49 @@ def vp8_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "low_power": low_power,
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "rc_mode": rc_mode,
-        
+
         "loop_filter_level": loop_filter_level,
-        
+
         "loop_filter_sharpness": loop_filter_sharpness,
-        
+
     }))
 
 
 
 def vp9_vaapi(
-    
+
     low_power: bool | None = None,
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     rc_mode: int | None| Literal["auto", "CQP", "CBR", "VBR", "ICQ", "QVBR", "AVBR"] = None,
-    
+
     loop_filter_level: int | None = None,
-    
+
     loop_filter_sharpness: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     VP9 (VAAPI) (codec vp9)
-    
+
     Args:
         low_power: Use low-power encoding mode (only available on some platforms; may not support all encoding features) (default false)
         idr_interval: Distance (in I-frames) between IDR frames (from 0 to INT_MAX) (default 0)
@@ -5033,59 +5033,59 @@ def vp9_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "low_power": low_power,
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "rc_mode": rc_mode,
-        
+
         "loop_filter_level": loop_filter_level,
-        
+
         "loop_filter_sharpness": loop_filter_sharpness,
-        
+
     }))
 
 
 
 def wbmp(
-    
+
 ) -> FFMpegEncoderOption:
     """
     WBMP (Wireless Application Protocol Bitmap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def libwebp_anim(
-    
+
     lossless: int | None = None,
-    
+
     preset: int | None| Literal["none", "default", "picture", "photo", "drawing", "icon", "text"] = None,
-    
+
     cr_threshold: int | None = None,
-    
+
     cr_size: int | None = None,
-    
+
     quality: float | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libwebp WebP image (codec webp)
-    
+
     Args:
         lossless: Use lossless mode (from 0 to 1) (default 0)
         preset: Configuration preset (from -1 to 5) (default none)
@@ -5097,37 +5097,37 @@ def libwebp_anim(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "lossless": lossless,
-        
+
         "preset": preset,
-        
+
         "cr_threshold": cr_threshold,
-        
+
         "cr_size": cr_size,
-        
+
         "quality": quality,
-        
+
     }))
 
 
 
 def libwebp(
-    
+
     lossless: int | None = None,
-    
+
     preset: int | None| Literal["none", "default", "picture", "photo", "drawing", "icon", "text"] = None,
-    
+
     cr_threshold: int | None = None,
-    
+
     cr_size: int | None = None,
-    
+
     quality: float | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libwebp WebP image (codec webp)
-    
+
     Args:
         lossless: Use lossless mode (from 0 to 1) (default 0)
         preset: Configuration preset (from -1 to 5) (default none)
@@ -5139,77 +5139,77 @@ def libwebp(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "lossless": lossless,
-        
+
         "preset": preset,
-        
+
         "cr_threshold": cr_threshold,
-        
+
         "cr_size": cr_size,
-        
+
         "quality": quality,
-        
+
     }))
 
 
 
 def wmv1(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Windows Media Video 7
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -5241,117 +5241,117 @@ def wmv1(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def wmv2(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Windows Media Video 8
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -5383,211 +5383,211 @@ def wmv2(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def wrapped_avframe(
-    
+
 ) -> FFMpegEncoderOption:
     """
     AVFrame to AVPacket passthrough
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def xbm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     XBM (X BitMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def xface(
-    
+
 ) -> FFMpegEncoderOption:
     """
     X-face image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def xwd(
-    
+
 ) -> FFMpegEncoderOption:
     """
     XWD (X Window Dump) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def y41p(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed YUV 4:1:1 12-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def yuv4(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed packed 4:2:0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def zlib(
-    
+
 ) -> FFMpegEncoderOption:
     """
     LCL (LossLess Codec Library) ZLIB
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def zmbv(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Zip Motion Blocks Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def aac(
-    
+
     aac_coder: int | None| Literal["anmr", "twoloop", "fast"] = None,
-    
+
     aac_ms: bool | None = None,
-    
+
     aac_is: bool | None = None,
-    
+
     aac_pns: bool | None = None,
-    
+
     aac_tns: bool | None = None,
-    
+
     aac_ltp: bool | None = None,
-    
+
     aac_pred: bool | None = None,
-    
+
     aac_pce: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     AAC (Advanced Audio Coding)
-    
+
     Args:
         aac_coder: Coding algorithm (from 0 to 2) (default twoloop)
         aac_ms: Force M/S stereo coding (default auto)
@@ -5602,73 +5602,73 @@ def aac(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "aac_coder": aac_coder,
-        
+
         "aac_ms": aac_ms,
-        
+
         "aac_is": aac_is,
-        
+
         "aac_pns": aac_pns,
-        
+
         "aac_tns": aac_tns,
-        
+
         "aac_ltp": aac_ltp,
-        
+
         "aac_pred": aac_pred,
-        
+
         "aac_pce": aac_pce,
-        
+
     }))
 
 
 
 def ac3(
-    
+
     center_mixlev: float | None = None,
-    
+
     surround_mixlev: float | None = None,
-    
+
     mixing_level: int | None = None,
-    
+
     room_type: int | None| Literal["notindicated", "large", "small"] = None,
-    
+
     per_frame_metadata: bool | None = None,
-    
+
     copyright: int | None = None,
-    
+
     dialnorm: int | None = None,
-    
+
     dsur_mode: int | None| Literal["notindicated", "on", "off"] = None,
-    
+
     original: int | None = None,
-    
+
     dmix_mode: int | None| Literal["notindicated", "ltrt", "loro", "dplii"] = None,
-    
+
     ltrt_cmixlev: float | None = None,
-    
+
     ltrt_surmixlev: float | None = None,
-    
+
     loro_cmixlev: float | None = None,
-    
+
     loro_surmixlev: float | None = None,
-    
+
     dsurex_mode: int | None| Literal["notindicated", "on", "off", "dpliiz"] = None,
-    
+
     dheadphone_mode: int | None| Literal["notindicated", "on", "off"] = None,
-    
+
     ad_conv_type: int | None| Literal["standard", "hdcd"] = None,
-    
+
     stereo_rematrixing: bool | None = None,
-    
+
     channel_coupling: int | None| Literal["auto"] = None,
-    
+
     cpl_start_band: int | None| Literal["auto"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ATSC A/52A (AC-3)
-    
+
     Args:
         center_mixlev: Center Mix Level (from 0 to 1) (default 0.594604)
         surround_mixlev: Surround Mix Level (from 0 to 1) (default 0.5)
@@ -5695,97 +5695,97 @@ def ac3(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "center_mixlev": center_mixlev,
-        
+
         "surround_mixlev": surround_mixlev,
-        
+
         "mixing_level": mixing_level,
-        
+
         "room_type": room_type,
-        
+
         "per_frame_metadata": per_frame_metadata,
-        
+
         "copyright": copyright,
-        
+
         "dialnorm": dialnorm,
-        
+
         "dsur_mode": dsur_mode,
-        
+
         "original": original,
-        
+
         "dmix_mode": dmix_mode,
-        
+
         "ltrt_cmixlev": ltrt_cmixlev,
-        
+
         "ltrt_surmixlev": ltrt_surmixlev,
-        
+
         "loro_cmixlev": loro_cmixlev,
-        
+
         "loro_surmixlev": loro_surmixlev,
-        
+
         "dsurex_mode": dsurex_mode,
-        
+
         "dheadphone_mode": dheadphone_mode,
-        
+
         "ad_conv_type": ad_conv_type,
-        
+
         "stereo_rematrixing": stereo_rematrixing,
-        
+
         "channel_coupling": channel_coupling,
-        
+
         "cpl_start_band": cpl_start_band,
-        
+
     }))
 
 
 
 def ac3_fixed(
-    
+
     center_mixlev: float | None = None,
-    
+
     surround_mixlev: float | None = None,
-    
+
     mixing_level: int | None = None,
-    
+
     room_type: int | None| Literal["notindicated", "large", "small"] = None,
-    
+
     per_frame_metadata: bool | None = None,
-    
+
     copyright: int | None = None,
-    
+
     dialnorm: int | None = None,
-    
+
     dsur_mode: int | None| Literal["notindicated", "on", "off"] = None,
-    
+
     original: int | None = None,
-    
+
     dmix_mode: int | None| Literal["notindicated", "ltrt", "loro", "dplii"] = None,
-    
+
     ltrt_cmixlev: float | None = None,
-    
+
     ltrt_surmixlev: float | None = None,
-    
+
     loro_cmixlev: float | None = None,
-    
+
     loro_surmixlev: float | None = None,
-    
+
     dsurex_mode: int | None| Literal["notindicated", "on", "off", "dpliiz"] = None,
-    
+
     dheadphone_mode: int | None| Literal["notindicated", "on", "off"] = None,
-    
+
     ad_conv_type: int | None| Literal["standard", "hdcd"] = None,
-    
+
     stereo_rematrixing: bool | None = None,
-    
+
     channel_coupling: int | None| Literal["auto"] = None,
-    
+
     cpl_start_band: int | None| Literal["auto"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ATSC A/52A (AC-3) (codec ac3)
-    
+
     Args:
         center_mixlev: Center Mix Level (from 0 to 1) (default 0.594604)
         surround_mixlev: Surround Mix Level (from 0 to 1) (default 0.5)
@@ -5812,75 +5812,75 @@ def ac3_fixed(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "center_mixlev": center_mixlev,
-        
+
         "surround_mixlev": surround_mixlev,
-        
+
         "mixing_level": mixing_level,
-        
+
         "room_type": room_type,
-        
+
         "per_frame_metadata": per_frame_metadata,
-        
+
         "copyright": copyright,
-        
+
         "dialnorm": dialnorm,
-        
+
         "dsur_mode": dsur_mode,
-        
+
         "original": original,
-        
+
         "dmix_mode": dmix_mode,
-        
+
         "ltrt_cmixlev": ltrt_cmixlev,
-        
+
         "ltrt_surmixlev": ltrt_surmixlev,
-        
+
         "loro_cmixlev": loro_cmixlev,
-        
+
         "loro_surmixlev": loro_surmixlev,
-        
+
         "dsurex_mode": dsurex_mode,
-        
+
         "dheadphone_mode": dheadphone_mode,
-        
+
         "ad_conv_type": ad_conv_type,
-        
+
         "stereo_rematrixing": stereo_rematrixing,
-        
+
         "channel_coupling": channel_coupling,
-        
+
         "cpl_start_band": cpl_start_band,
-        
+
     }))
 
 
 
 def adpcm_adx(
-    
+
 ) -> FFMpegEncoderOption:
     """
     SEGA CRI ADX ADPCM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_argo(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM Argonaut Games
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -5888,37 +5888,37 @@ def adpcm_argo(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def g722(
-    
+
 ) -> FFMpegEncoderOption:
     """
     G.722 ADPCM (codec adpcm_g722)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def g726(
-    
+
     code_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     G.726 ADPCM (codec adpcm_g726)
-    
+
     Args:
         code_size: Bits per code (from 2 to 5) (default 4)
 
@@ -5926,21 +5926,21 @@ def g726(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "code_size": code_size,
-        
+
     }))
 
 
 
 def g726le(
-    
+
     code_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     G.726 little endian ADPCM ("right-justified") (codec adpcm_g726le)
-    
+
     Args:
         code_size: Bits per code (from 2 to 5) (default 4)
 
@@ -5948,21 +5948,21 @@ def g726le(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "code_size": code_size,
-        
+
     }))
 
 
 
 def adpcm_ima_alp(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA High Voltage Software ALP
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -5970,21 +5970,21 @@ def adpcm_ima_alp(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ima_amv(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA AMV
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -5992,21 +5992,21 @@ def adpcm_ima_amv(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ima_apm(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA Ubisoft APM
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6014,21 +6014,21 @@ def adpcm_ima_apm(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ima_qt(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA QuickTime
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6036,21 +6036,21 @@ def adpcm_ima_qt(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ima_ssi(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA Simon & Schuster Interactive
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6058,21 +6058,21 @@ def adpcm_ima_ssi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ima_wav(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA WAV
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6080,21 +6080,21 @@ def adpcm_ima_wav(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ima_ws(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA Westwood
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6102,21 +6102,21 @@ def adpcm_ima_ws(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ms(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM Microsoft
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6124,21 +6124,21 @@ def adpcm_ms(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_swf(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM Shockwave Flash
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6146,21 +6146,21 @@ def adpcm_swf(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_yamaha(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM Yamaha
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6168,23 +6168,23 @@ def adpcm_yamaha(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def alac(
-    
+
     min_prediction_order: int | None = None,
-    
+
     max_prediction_order: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ALAC (Apple Lossless Audio Codec)
-    
+
     Args:
         min_prediction_order: (from 1 to 30) (default 4)
         max_prediction_order: (from 1 to 30) (default 6)
@@ -6193,23 +6193,23 @@ def alac(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "min_prediction_order": min_prediction_order,
-        
+
         "max_prediction_order": max_prediction_order,
-        
+
     }))
 
 
 
 def libopencore_amrnb(
-    
+
     dtx: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     OpenCORE AMR-NB (Adaptive Multi-Rate Narrow-Band) (codec amr_nb)
-    
+
     Args:
         dtx: Allow DTX (generate comfort noise) (from 0 to 1) (default 0)
 
@@ -6217,101 +6217,101 @@ def libopencore_amrnb(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "dtx": dtx,
-        
+
     }))
 
 
 
 def anull(
-    
+
 ) -> FFMpegEncoderOption:
     """
     null audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def aptx(
-    
+
 ) -> FFMpegEncoderOption:
     """
     aptX (Audio Processing Technology for Bluetooth)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def aptx_hd(
-    
+
 ) -> FFMpegEncoderOption:
     """
     aptX HD (Audio Processing Technology for Bluetooth)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def comfortnoise(
-    
+
 ) -> FFMpegEncoderOption:
     """
     RFC 3389 comfort noise generator
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def dfpwm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     DFPWM1a audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def dca(
-    
+
     dca_adpcm: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     DCA (DTS Coherent Acoustics) (codec dts)
-    
+
     Args:
         dca_adpcm: Use ADPCM encoding (default false)
 
@@ -6319,55 +6319,55 @@ def dca(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "dca_adpcm": dca_adpcm,
-        
+
     }))
 
 
 
 def eac3(
-    
+
     mixing_level: int | None = None,
-    
+
     room_type: int | None| Literal["notindicated", "large", "small"] = None,
-    
+
     per_frame_metadata: bool | None = None,
-    
+
     copyright: int | None = None,
-    
+
     dialnorm: int | None = None,
-    
+
     dsur_mode: int | None| Literal["notindicated", "on", "off"] = None,
-    
+
     original: int | None = None,
-    
+
     dmix_mode: int | None| Literal["notindicated", "ltrt", "loro", "dplii"] = None,
-    
+
     ltrt_cmixlev: float | None = None,
-    
+
     ltrt_surmixlev: float | None = None,
-    
+
     loro_cmixlev: float | None = None,
-    
+
     loro_surmixlev: float | None = None,
-    
+
     dsurex_mode: int | None| Literal["notindicated", "on", "off", "dpliiz"] = None,
-    
+
     dheadphone_mode: int | None| Literal["notindicated", "on", "off"] = None,
-    
+
     ad_conv_type: int | None| Literal["standard", "hdcd"] = None,
-    
+
     stereo_rematrixing: bool | None = None,
-    
+
     channel_coupling: int | None| Literal["auto"] = None,
-    
+
     cpl_start_band: int | None| Literal["auto"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ATSC A/52 E-AC-3
-    
+
     Args:
         mixing_level: Mixing Level (from -1 to 111) (default -1)
         room_type: Room Type (from -1 to 2) (default -1)
@@ -6392,71 +6392,71 @@ def eac3(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mixing_level": mixing_level,
-        
+
         "room_type": room_type,
-        
+
         "per_frame_metadata": per_frame_metadata,
-        
+
         "copyright": copyright,
-        
+
         "dialnorm": dialnorm,
-        
+
         "dsur_mode": dsur_mode,
-        
+
         "original": original,
-        
+
         "dmix_mode": dmix_mode,
-        
+
         "ltrt_cmixlev": ltrt_cmixlev,
-        
+
         "ltrt_surmixlev": ltrt_surmixlev,
-        
+
         "loro_cmixlev": loro_cmixlev,
-        
+
         "loro_surmixlev": loro_surmixlev,
-        
+
         "dsurex_mode": dsurex_mode,
-        
+
         "dheadphone_mode": dheadphone_mode,
-        
+
         "ad_conv_type": ad_conv_type,
-        
+
         "stereo_rematrixing": stereo_rematrixing,
-        
+
         "channel_coupling": channel_coupling,
-        
+
         "cpl_start_band": cpl_start_band,
-        
+
     }))
 
 
 
 def flac(
-    
+
     lpc_coeff_precision: int | None = None,
-    
+
     lpc_type: int | None| Literal["none", "fixed", "levinson", "cholesky"] = None,
-    
+
     lpc_passes: int | None = None,
-    
+
     min_partition_order: int | None = None,
-    
+
     prediction_order_method: int | None| Literal["estimation", "2level", "4level", "8level", "search", "log"] = None,
-    
+
     ch_mode: int | None| Literal["auto", "indep", "left_side", "right_side", "mid_side"] = None,
-    
+
     exact_rice_parameters: bool | None = None,
-    
+
     multi_dim_quant: bool | None = None,
-    
+
     min_prediction_order: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     FLAC (Free Lossless Audio Codec)
-    
+
     Args:
         lpc_coeff_precision: LPC coefficient precision (from 0 to 15) (default 15)
         lpc_type: LPC algorithm (from -1 to 3) (default -1)
@@ -6472,65 +6472,65 @@ def flac(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "lpc_coeff_precision": lpc_coeff_precision,
-        
+
         "lpc_type": lpc_type,
-        
+
         "lpc_passes": lpc_passes,
-        
+
         "min_partition_order": min_partition_order,
-        
+
         "prediction_order_method": prediction_order_method,
-        
+
         "ch_mode": ch_mode,
-        
+
         "exact_rice_parameters": exact_rice_parameters,
-        
+
         "multi_dim_quant": multi_dim_quant,
-        
+
         "min_prediction_order": min_prediction_order,
-        
+
     }))
 
 
 
 def g723_1(
-    
+
 ) -> FFMpegEncoderOption:
     """
     G.723.1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def mlp(
-    
+
     max_interval: int | None = None,
-    
+
     lpc_coeff_precision: int | None = None,
-    
+
     lpc_type: int | None| Literal["levinson", "cholesky"] = None,
-    
+
     lpc_passes: int | None = None,
-    
+
     codebook_search: int | None = None,
-    
+
     prediction_order: int | None| Literal["estimation", "search"] = None,
-    
+
     rematrix_precision: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MLP (Meridian Lossless Packing)
-    
+
     Args:
         max_interval: Max number of frames between each new header (from 8 to 128) (default 16)
         lpc_coeff_precision: LPC coefficient precision (from 0 to 15) (default 15)
@@ -6544,73 +6544,73 @@ def mlp(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "max_interval": max_interval,
-        
+
         "lpc_coeff_precision": lpc_coeff_precision,
-        
+
         "lpc_type": lpc_type,
-        
+
         "lpc_passes": lpc_passes,
-        
+
         "codebook_search": codebook_search,
-        
+
         "prediction_order": prediction_order,
-        
+
         "rematrix_precision": rematrix_precision,
-        
+
     }))
 
 
 
 def mp2(
-    
+
 ) -> FFMpegEncoderOption:
     """
     MP2 (MPEG audio layer 2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def mp2fixed(
-    
+
 ) -> FFMpegEncoderOption:
     """
     MP2 fixed point (MPEG audio layer 2) (codec mp2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def libmp3lame(
-    
+
     reservoir: bool | None = None,
-    
+
     joint_stereo: bool | None = None,
-    
+
     abr: bool | None = None,
-    
+
     copyright: bool | None = None,
-    
+
     original: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libmp3lame MP3 (MPEG audio layer 3) (codec mp3)
-    
+
     Args:
         reservoir: use bit reservoir (default true)
         joint_stereo: use joint stereo (default true)
@@ -6622,47 +6622,47 @@ def libmp3lame(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "reservoir": reservoir,
-        
+
         "joint_stereo": joint_stereo,
-        
+
         "abr": abr,
-        
+
         "copyright": copyright,
-        
+
         "original": original,
-        
+
     }))
 
 
 
 def nellymoser(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Nellymoser Asao
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def opus(
-    
+
     opus_delay: float | None = None,
-    
+
     apply_phase_inv: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Opus
-    
+
     Args:
         opus_delay: Maximum delay in milliseconds (from 2.5 to 360) (default 360)
         apply_phase_inv: Apply intensity stereo phase inversion (default true)
@@ -6671,35 +6671,35 @@ def opus(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "opus_delay": opus_delay,
-        
+
         "apply_phase_inv": apply_phase_inv,
-        
+
     }))
 
 
 
 def libopus(
-    
+
     application: int | None| Literal["voip", "audio", "lowdelay"] = None,
-    
+
     frame_duration: float | None = None,
-    
+
     packet_loss: int | None = None,
-    
+
     fec: bool | None = None,
-    
+
     vbr: int | None| Literal["off", "on", "constrained"] = None,
-    
+
     mapping_family: int | None = None,
-    
+
     apply_phase_inv: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libopus Opus (codec opus)
-    
+
     Args:
         application: Intended application type (from 2048 to 2051) (default audio)
         frame_duration: Duration of a frame in milliseconds (from 2.5 to 120) (default 20)
@@ -6713,579 +6713,579 @@ def libopus(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "application": application,
-        
+
         "frame_duration": frame_duration,
-        
+
         "packet_loss": packet_loss,
-        
+
         "fec": fec,
-        
+
         "vbr": vbr,
-        
+
         "mapping_family": mapping_family,
-        
+
         "apply_phase_inv": apply_phase_inv,
-        
+
     }))
 
 
 
 def pcm_alaw(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM A-law / G.711 A-law
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_bluray(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 16|20|24-bit big-endian for Blu-ray media
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_dvd(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 16|20|24-bit big-endian for DVD media
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f32be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM 32-bit floating point big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f32le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM 32-bit floating point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f64be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM 64-bit floating point big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f64le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM 64-bit floating point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_mulaw(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM mu-law / G.711 mu-law
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 16-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16be_planar(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 16-bit big-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 16-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16le_planar(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 16-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 24-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24daud(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM D-Cinema audio signed 24-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 24-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24le_planar(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 24-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s32be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 32-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s32le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 32-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s32le_planar(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 32-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s64be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 64-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s64le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 64-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s8(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 8-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s8_planar(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 8-bit planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u16be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 16-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u16le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 16-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u24be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 24-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u24le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 24-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u32be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 32-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u32le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 32-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u8(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 8-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_vidc(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM Archimedes VIDC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def real_144(
-    
+
 ) -> FFMpegEncoderOption:
     """
     RealAudio 1.0 (14.4K) (codec ra_144)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def roq_dpcm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     id RoQ DPCM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def s302m(
-    
+
 ) -> FFMpegEncoderOption:
     """
     SMPTE 302M
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def sbc(
-    
+
     sbc_delay: str | None = None,
-    
+
     msbc: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     SBC (low-complexity subband codec)
-    
+
     Args:
         sbc_delay: set maximum algorithmic latency (default 0.013)
         msbc: use mSBC mode (wideband speech mono SBC) (default false)
@@ -7294,67 +7294,67 @@ def sbc(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "sbc_delay": sbc_delay,
-        
+
         "msbc": msbc,
-        
+
     }))
 
 
 
 def sonic(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Sonic
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def sonicls(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Sonic lossless
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def truehd(
-    
+
     max_interval: int | None = None,
-    
+
     lpc_coeff_precision: int | None = None,
-    
+
     lpc_type: int | None| Literal["levinson", "cholesky"] = None,
-    
+
     lpc_passes: int | None = None,
-    
+
     codebook_search: int | None = None,
-    
+
     prediction_order: int | None| Literal["estimation", "search"] = None,
-    
+
     rematrix_precision: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     TrueHD
-    
+
     Args:
         max_interval: Max number of frames between each new header (from 8 to 128) (default 16)
         lpc_coeff_precision: LPC coefficient precision (from 0 to 15) (default 15)
@@ -7368,65 +7368,65 @@ def truehd(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "max_interval": max_interval,
-        
+
         "lpc_coeff_precision": lpc_coeff_precision,
-        
+
         "lpc_type": lpc_type,
-        
+
         "lpc_passes": lpc_passes,
-        
+
         "codebook_search": codebook_search,
-        
+
         "prediction_order": prediction_order,
-        
+
         "rematrix_precision": rematrix_precision,
-        
+
     }))
 
 
 
 def tta(
-    
+
 ) -> FFMpegEncoderOption:
     """
     TTA (True Audio)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def vorbis(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Vorbis
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def libvorbis(
-    
+
     iblock: float | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libvorbis (codec vorbis)
-    
+
     Args:
         iblock: Sets the impulse block bias (from -15 to 0) (default 0)
 
@@ -7434,23 +7434,23 @@ def libvorbis(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "iblock": iblock,
-        
+
     }))
 
 
 
 def wavpack(
-    
+
     joint_stereo: bool | None = None,
-    
+
     optimize_mono: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     WavPack
-    
+
     Args:
         joint_stereo: (default auto)
         optimize_mono: (default false)
@@ -7459,105 +7459,105 @@ def wavpack(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "joint_stereo": joint_stereo,
-        
+
         "optimize_mono": optimize_mono,
-        
+
     }))
 
 
 
 def wmav1(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Windows Media Audio 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def wmav2(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Windows Media Audio 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def ssa(
-    
+
 ) -> FFMpegEncoderOption:
     """
     ASS (Advanced SubStation Alpha) subtitle (codec ass)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def ass(
-    
+
 ) -> FFMpegEncoderOption:
     """
     ASS (Advanced SubStation Alpha) subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def dvbsub(
-    
+
 ) -> FFMpegEncoderOption:
     """
     DVB subtitles (codec dvb_subtitle)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def dvdsub(
-    
+
     palette: str | None = None,
-    
+
     even_rows_fix: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     DVD subtitles (codec dvd_subtitle)
-    
+
     Args:
         palette: set the global palette
         even_rows_fix: Make number of rows even (workaround for some players) (default false)
@@ -7566,23 +7566,23 @@ def dvdsub(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "palette": palette,
-        
+
         "even_rows_fix": even_rows_fix,
-        
+
     }))
 
 
 
 def mov_text(
-    
+
     height: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     3GPP Timed Text subtitle
-    
+
     Args:
         height: Frame height, usually video height (from 0 to INT_MAX) (default 0)
 
@@ -7590,1120 +7590,103 @@ def mov_text(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "height": height,
-        
+
     }))
 
 
 
 def srt(
-    
+
 ) -> FFMpegEncoderOption:
     """
     SubRip subtitle (codec subrip)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def subrip(
-    
+
 ) -> FFMpegEncoderOption:
     """
     SubRip subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def text(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Raw text subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def ttml(
-    
+
 ) -> FFMpegEncoderOption:
     """
     TTML subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def webvtt(
-    
+
 ) -> FFMpegEncoderOption:
     """
     WebVTT subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def xsub(
-    
+
 ) -> FFMpegEncoderOption:
     """
     DivX subtitles (XSUB)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/packages/v6/src/ffmpeg/dag/global_runnable/global_args.py
+++ b/packages/v6/src/ffmpeg/dag/global_runnable/global_args.py
@@ -94,245 +94,245 @@ class GlobalArgs(ABC):
 
         return self._global_node(**merge(
             {
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "loglevel": loglevel,
-                
+
                 "v": v,
-                
+
                 "report": report,
-                
+
                 "max_alloc": max_alloc,
-                
+
                 "cpuflags": cpuflags,
-                
+
                 "cpucount": cpucount,
-                
+
                 "hide_banner": hide_banner,
-                
-                
-                
-                
+
+
+
+
                 "y": y,
-                
+
                 "n": n,
-                
+
                 "ignore_unknown": ignore_unknown,
-                
+
                 "copy_unknown": copy_unknown,
-                
+
                 "recast_media": recast_media,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "benchmark": benchmark,
-                
+
                 "benchmark_all": benchmark_all,
-                
+
                 "progress": progress,
-                
+
                 "stdin": stdin,
-                
+
                 "timelimit": timelimit,
-                
+
                 "dump": dump,
-                
+
                 "hex": hex,
-                
-                
-                
-                
-                
+
+
+
+
+
                 "vsync": vsync,
-                
+
                 "frame_drop_threshold": frame_drop_threshold,
-                
+
                 "adrift_threshold": adrift_threshold,
-                
+
                 "copyts": copyts,
-                
+
                 "start_at_zero": start_at_zero,
-                
+
                 "copytb": copytb,
-                
-                
-                
-                
-                
+
+
+
+
+
                 "dts_delta_threshold": dts_delta_threshold,
-                
+
                 "dts_error_threshold": dts_error_threshold,
-                
+
                 "xerror": xerror,
-                
+
                 "abort_on": abort_on,
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
                 "filter_threads": filter_threads,
-                
-                
-                
+
+
+
                 "filter_complex": filter_complex,
-                
+
                 "filter_complex_threads": filter_complex_threads,
-                
+
                 "lavfi": lavfi,
-                
+
                 "filter_complex_script": filter_complex_script,
-                
+
                 "auto_conversion_filters": auto_conversion_filters,
-                
+
                 "stats": stats,
-                
+
                 "stats_period": stats_period,
-                
-                
-                
-                
+
+
+
+
                 "debug_ts": debug_ts,
-                
+
                 "max_error_rate": max_error_rate,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "psnr": psnr,
-                
+
                 "vstats": vstats,
-                
+
                 "vstats_file": vstats_file,
-                
+
                 "vstats_version": vstats_version,
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
                 "qphist": qphist,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "vaapi_device": vaapi_device,
-                
+
                 "init_hw_device": init_hw_device,
-                
+
                 "filter_hw_device": filter_hw_device,
-                
-                
+
+
             }, extra_options)
         ).stream()

--- a/packages/v6/src/ffmpeg/dag/io/_input.py
+++ b/packages/v6/src/ffmpeg/dag/io/_input.py
@@ -125,250 +125,250 @@ def input(
     return InputNode(
         filename=str(filename),
         kwargs=merge({
-            
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "f": f,
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 "c": c,
-                
+
                 "codec": codec,
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 "t": t,
-                
+
                 "to": to,
-                
-                
+
+
                 "ss": ss,
-                
+
                 "sseof": sseof,
-                
+
                 "seek_timestamp": seek_timestamp,
-                
+
                 "accurate_seek": accurate_seek,
-                
+
                 "isync": isync,
-                
+
                 "itsoffset": itsoffset,
-                
+
                 "itsscale": itsscale,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
                 "re": re,
-                
+
                 "readrate": readrate,
-                
+
                 "readrate_initial_burst": readrate_initial_burst,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
                 "bitexact": bitexact,
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
                 "tag": tag,
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
                 "reinit_filter": reinit_filter,
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
                 "dump_attachment": dump_attachment,
-                
+
                 "stream_loop": stream_loop,
-                
-                
-                
+
+
+
                 "discard": discard,
-                
-                
+
+
                 "thread_queue_size": thread_queue_size,
-                
+
                 "find_stream_info": find_stream_info,
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
                 "r": r,
-                
-                
+
+
                 "s": s,
-                
-                
+
+
                 "pix_fmt": pix_fmt,
-                
+
                 "display_rotation": display_rotation,
-                
+
                 "display_hflip": display_hflip,
-                
+
                 "display_vflip": display_vflip,
-                
+
                 "vn": vn,
-                
-                
+
+
                 "vcodec": vcodec,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
                 "top": top,
-                
+
                 "vtag": vtag,
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
                 "hwaccel": hwaccel,
-                
+
                 "hwaccel_device": hwaccel_device,
-                
+
                 "hwaccel_output_format": hwaccel_output_format,
-                
-                
+
+
                 "autorotate": autorotate,
-                
-                
-                
-                
-                
+
+
+
+
+
                 "ar": ar,
-                
+
                 "ac": ac,
-                
+
                 "an": an,
-                
+
                 "acodec": acodec,
-                
-                
-                
+
+
+
                 "sample_fmt": sample_fmt,
-                
+
                 "channel_layout": channel_layout,
-                
+
                 "ch_layout": ch_layout,
-                
-                
+
+
                 "guess_layout_max": guess_layout_max,
-                
+
                 "sn": sn,
-                
+
                 "scodec": scodec,
-                
-                
+
+
                 "fix_sub_duration": fix_sub_duration,
-                
+
                 "canvas_size": canvas_size,
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 "bsf": bsf,
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
                 "dcodec": dcodec,
-                
+
                 "dn": dn,
-                
-                
-                
-                
-                
+
+
+
+
+
         }, decoder_options, demuxer_options, format_options, codec_options, extra_options )
     ).stream()

--- a/packages/v6/src/ffmpeg/dag/io/_output.py
+++ b/packages/v6/src/ffmpeg/dag/io/_output.py
@@ -165,294 +165,294 @@ def output(
         inputs=streams,
         filename=str(filename),
         kwargs=merge({
-            
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "f": f,
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 "c": c,
-                
+
                 "codec": codec,
-                
+
                 "pre": pre,
-                
+
                 "map": map,
-                
+
                 "map_channel": map_channel,
-                
+
                 "map_metadata": map_metadata,
-                
+
                 "map_chapters": map_chapters,
-                
+
                 "t": t,
-                
+
                 "to": to,
-                
+
                 "fs": fs,
-                
+
                 "ss": ss,
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
                 "timestamp": timestamp,
-                
+
                 "metadata": metadata,
-                
+
                 "program": program,
-                
+
                 "dframes": dframes,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
                 "target": target,
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
                 "shortest": shortest,
-                
+
                 "shortest_buf_duration": shortest_buf_duration,
-                
+
                 "bitexact": bitexact,
-                
+
                 "apad": apad,
-                
-                
-                
-                
-                
+
+
+
+
+
                 "copyinkf": copyinkf,
-                
+
                 "copypriorss": copypriorss,
-                
+
                 "frames": frames,
-                
+
                 "tag": tag,
-                
+
                 "q": q,
-                
+
                 "qscale": qscale,
-                
+
                 "profile": profile,
-                
+
                 "filter": filter,
-                
-                
+
+
                 "filter_script": filter_script,
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
                 "attach": attach,
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 "disposition": disposition,
-                
+
                 "thread_queue_size": thread_queue_size,
-                
-                
+
+
                 "bits_per_raw_sample": bits_per_raw_sample,
-                
+
                 "stats_enc_pre": stats_enc_pre,
-                
+
                 "stats_enc_post": stats_enc_post,
-                
+
                 "stats_mux_pre": stats_mux_pre,
-                
+
                 "stats_enc_pre_fmt": stats_enc_pre_fmt,
-                
+
                 "stats_enc_post_fmt": stats_enc_post_fmt,
-                
+
                 "stats_mux_pre_fmt": stats_mux_pre_fmt,
-                
+
                 "vframes": vframes,
-                
+
                 "r": r,
-                
+
                 "fpsmax": fpsmax,
-                
+
                 "s": s,
-                
+
                 "aspect": aspect,
-                
+
                 "pix_fmt": pix_fmt,
-                
-                
-                
-                
+
+
+
+
                 "vn": vn,
-                
+
                 "rc_override": rc_override,
-                
+
                 "vcodec": vcodec,
-                
+
                 "timecode": timecode,
-                
+
                 "pass": _pass,
-                
+
                 "passlogfile": passlogfile,
-                
-                
-                
-                
-                
+
+
+
+
+
                 "vf": vf,
-                
+
                 "intra_matrix": intra_matrix,
-                
+
                 "inter_matrix": inter_matrix,
-                
+
                 "chroma_intra_matrix": chroma_intra_matrix,
-                
+
                 "top": top,
-                
+
                 "vtag": vtag,
-                
-                
+
+
                 "fps_mode": fps_mode,
-                
+
                 "force_fps": force_fps,
-                
+
                 "streamid": streamid,
-                
+
                 "force_key_frames": force_key_frames,
-                
+
                 "b": b,
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 "autoscale": autoscale,
-                
+
                 "fix_sub_duration_heartbeat": fix_sub_duration_heartbeat,
-                
+
                 "aframes": aframes,
-                
+
                 "aq": aq,
-                
+
                 "ar": ar,
-                
+
                 "ac": ac,
-                
+
                 "an": an,
-                
+
                 "acodec": acodec,
-                
+
                 "ab": ab,
-                
+
                 "atag": atag,
-                
+
                 "sample_fmt": sample_fmt,
-                
+
                 "channel_layout": channel_layout,
-                
+
                 "ch_layout": ch_layout,
-                
+
                 "af": af,
-                
-                
+
+
                 "sn": sn,
-                
+
                 "scodec": scodec,
-                
+
                 "stag": stag,
-                
-                
-                
+
+
+
                 "muxdelay": muxdelay,
-                
+
                 "muxpreload": muxpreload,
-                
+
                 "sdp_file": sdp_file,
-                
+
                 "time_base": time_base,
-                
+
                 "enc_time_base": enc_time_base,
-                
+
                 "bsf": bsf,
-                
+
                 "absf": absf,
-                
+
                 "vbsf": vbsf,
-                
+
                 "apre": apre,
-                
+
                 "vpre": vpre,
-                
+
                 "spre": spre,
-                
+
                 "fpre": fpre,
-                
+
                 "max_muxing_queue_size": max_muxing_queue_size,
-                
+
                 "muxing_queue_data_threshold": muxing_queue_data_threshold,
-                
+
                 "dcodec": dcodec,
-                
+
                 "dn": dn,
-                
-                
-                
-                
-                
+
+
+
+
+
         }, encoder_options, muxer_options, format_options, codec_options, extra_options )
     ).stream()

--- a/packages/v6/src/ffmpeg/dag/io/output_args.py
+++ b/packages/v6/src/ffmpeg/dag/io/output_args.py
@@ -175,293 +175,293 @@ class OutputArgs(ABC):
         """
 
         return self._output_node(*streams, filename=filename, **merge({
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
             "f": f,
-                
-            
-            
-            
-            
-            
+
+
+
+
+
+
             "c": c,
-                
+
             "codec": codec,
-                
+
             "pre": pre,
-                
+
             "map": map,
-                
+
             "map_channel": map_channel,
-                
+
             "map_metadata": map_metadata,
-                
+
             "map_chapters": map_chapters,
-                
+
             "t": t,
-                
+
             "to": to,
-                
+
             "fs": fs,
-                
+
             "ss": ss,
-                
-            
-            
-            
-            
-            
-            
+
+
+
+
+
+
+
             "timestamp": timestamp,
-                
+
             "metadata": metadata,
-                
+
             "program": program,
-                
+
             "dframes": dframes,
-                
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
+
+
+
+
+
+
+
+
+
+
+
             "target": target,
-                
-            
-            
-            
-            
-            
-            
+
+
+
+
+
+
+
             "shortest": shortest,
-                
+
             "shortest_buf_duration": shortest_buf_duration,
-                
+
             "bitexact": bitexact,
-                
+
             "apad": apad,
-                
-            
-            
-            
-            
+
+
+
+
+
             "copyinkf": copyinkf,
-                
+
             "copypriorss": copypriorss,
-                
+
             "frames": frames,
-                
+
             "tag": tag,
-                
+
             "q": q,
-                
+
             "qscale": qscale,
-                
+
             "profile": profile,
-                
+
             "filter": filter,
-                
-            
+
+
             "filter_script": filter_script,
-                
-            
-            
-            
-            
-            
-            
-            
-            
+
+
+
+
+
+
+
+
+
             "attach": attach,
-                
-            
-            
-            
-            
-            
+
+
+
+
+
+
             "disposition": disposition,
-                
+
             "thread_queue_size": thread_queue_size,
-                
-            
+
+
             "bits_per_raw_sample": bits_per_raw_sample,
-                
+
             "stats_enc_pre": stats_enc_pre,
-                
+
             "stats_enc_post": stats_enc_post,
-                
+
             "stats_mux_pre": stats_mux_pre,
-                
+
             "stats_enc_pre_fmt": stats_enc_pre_fmt,
-                
+
             "stats_enc_post_fmt": stats_enc_post_fmt,
-                
+
             "stats_mux_pre_fmt": stats_mux_pre_fmt,
-                
+
             "vframes": vframes,
-                
+
             "r": r,
-                
+
             "fpsmax": fpsmax,
-                
+
             "s": s,
-                
+
             "aspect": aspect,
-                
+
             "pix_fmt": pix_fmt,
-                
-            
-            
-            
+
+
+
+
             "vn": vn,
-                
+
             "rc_override": rc_override,
-                
+
             "vcodec": vcodec,
-                
+
             "timecode": timecode,
-                
+
             "pass": _pass,
-                
+
             "passlogfile": passlogfile,
-                
-            
-            
-            
-            
+
+
+
+
+
             "vf": vf,
-                
+
             "intra_matrix": intra_matrix,
-                
+
             "inter_matrix": inter_matrix,
-                
+
             "chroma_intra_matrix": chroma_intra_matrix,
-                
+
             "top": top,
-                
+
             "vtag": vtag,
-                
-            
+
+
             "fps_mode": fps_mode,
-                
+
             "force_fps": force_fps,
-                
+
             "streamid": streamid,
-                
+
             "force_key_frames": force_key_frames,
-                
+
             "b": b,
-                
-            
-            
-            
-            
-            
+
+
+
+
+
+
             "autoscale": autoscale,
-                
+
             "fix_sub_duration_heartbeat": fix_sub_duration_heartbeat,
-                
+
             "aframes": aframes,
-                
+
             "aq": aq,
-                
+
             "ar": ar,
-                
+
             "ac": ac,
-                
+
             "an": an,
-                
+
             "acodec": acodec,
-                
+
             "ab": ab,
-                
+
             "atag": atag,
-                
+
             "sample_fmt": sample_fmt,
-                
+
             "channel_layout": channel_layout,
-                
+
             "ch_layout": ch_layout,
-                
+
             "af": af,
-                
-            
+
+
             "sn": sn,
-                
+
             "scodec": scodec,
-                
+
             "stag": stag,
-                
-            
-            
+
+
+
             "muxdelay": muxdelay,
-                
+
             "muxpreload": muxpreload,
-                
+
             "sdp_file": sdp_file,
-                
+
             "time_base": time_base,
-                
+
             "enc_time_base": enc_time_base,
-                
+
             "bsf": bsf,
-                
+
             "absf": absf,
-                
+
             "vbsf": vbsf,
-                
+
             "apre": apre,
-                
+
             "vpre": vpre,
-                
+
             "spre": spre,
-                
+
             "fpre": fpre,
-                
+
             "max_muxing_queue_size": max_muxing_queue_size,
-                
+
             "muxing_queue_data_threshold": muxing_queue_data_threshold,
-                
+
             "dcodec": dcodec,
-                
+
             "dn": dn,
-                
-            
-            
-            
-            
+
+
+
+
+
         }, encoder_options, muxer_options, format_options, codec_options, extra_options)).stream()

--- a/packages/v6/src/ffmpeg/filters.py
+++ b/packages/v6/src/ffmpeg/filters.py
@@ -45,47 +45,47 @@ import re
 
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
 def acrossfade(
-    
 
-    
-        
+
+
+
         _crossfade0: AudioStream,
-        
-    
-        
+
+
+
         _crossfade1: AudioStream,
-        
-    
+
+
 
 
     *,
     nb_samples: Int = Default('44100'),duration: Duration = Default('0'),overlap: Boolean = Default('true'),curve1: Int| Literal["nofade","tri","qsin","esin","hsin","log","ipar","qua","cub","squ","cbr","par","exp","iqsin","ihsin","dese","desi","losi","sinc","isinc","quat","quatr","qsin2","hsin2"] | Default = Default('tri'),curve2: Int| Literal["nofade","tri","qsin","esin","hsin","log","ipar","qua","cub","squ","cbr","par","exp","iqsin","ihsin","dese","desi","losi","sinc","isinc","quat","quatr","qsin2","hsin2"] | Default = Default('tri'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Apply cross fade from one input audio stream to another input audio stream.
 The cross fade is applied for specified duration near the end of first stream.
 
@@ -107,134 +107,134 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acrossfade)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='acrossfade', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _crossfade0,
-            
-        
-            
+
+
+
             _crossfade1,
-            
-        
+
+
 
 
         **merge({
-            
+
             "nb_samples": nb_samples,
-            
+
             "duration": duration,
-            
+
             "overlap": overlap,
-            
+
             "curve1": curve1,
-            
+
             "curve2": curve2,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def ainterleave(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     nb_inputs: Int = Auto('len(streams)'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Temporally interleave frames from several inputs.
 
 interleave works with video inputs, ainterleave with audio.
@@ -273,82 +273,82 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#interleave)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='ainterleave', typings_input='[StreamType.audio] * int(nb_inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "nb_inputs": nb_inputs,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
 def alphamerge(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _alpha: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Add or replace the alpha component of the primary input with the
 grayscale value of a second input. This is intended for use with
 alphaextract to allow the transmission or storage of frame
@@ -374,7 +374,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#alphamerge)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -385,55 +385,55 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='alphamerge', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _alpha,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def amerge(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Merge two or more audio streams into a single multi-channel stream.
 
 The filter accepts the following options:
@@ -450,54 +450,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amerge)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='amerge', typings_input='[StreamType.audio] * int(inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def amix(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),dropout_transition: Float = Default('2'),weights: String = Default('1 1'),normalize: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Mixes multiple audio inputs into a single output.
 
 Note that this filter only supports float samples (the amerge
@@ -523,70 +523,70 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amix)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='amix', typings_input='[StreamType.audio] * int(inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "duration": duration,
-            
+
             "dropout_transition": dropout_transition,
-            
+
             "weights": weights,
-            
+
             "normalize": normalize,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def amultiply(
-    
 
-    
-        
+
+
+
         _multiply0: AudioStream,
-        
-    
-        
+
+
+
         _multiply1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Multiply first audio stream with second audio stream and store result
 in output audio stream. Multiplication is done by multiplying each
 sample from first stream with sample at same position from second stream.
@@ -605,69 +605,69 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amultiply)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='amultiply', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _multiply0,
-            
-        
-            
+
+
+
             _multiply1,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def anlmf(
-    
 
-    
-        
+
+
+
         _input: AudioStream,
-        
-    
-        
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('256'),mu: Float = Default('0.75'),eps: Float = Default('1'),leakage: Float = Default('0'),out_mode: Int| Literal["i","d","o","n","e"] | Default = Default('o'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Apply Normalized Least-Mean-(Squares|Fourth) algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to mimic a desired filter by finding the filter coefficients that
@@ -693,7 +693,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anlmf)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -701,72 +701,72 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='anlmf', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _input,
-            
-        
-            
+
+
+
             _desired,
-            
-        
+
+
 
 
         **merge({
-            
+
             "order": order,
-            
+
             "mu": mu,
-            
+
             "eps": eps,
-            
+
             "leakage": leakage,
-            
+
             "out_mode": out_mode,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
+
+
+
 def anlms(
-    
 
-    
-        
+
+
+
         _input: AudioStream,
-        
-    
-        
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('256'),mu: Float = Default('0.75'),eps: Float = Default('1'),leakage: Float = Default('0'),out_mode: Int| Literal["i","d","o","n","e"] | Default = Default('o'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Apply Normalized Least-Mean-(Squares|Fourth) algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to mimic a desired filter by finding the filter coefficients that
@@ -792,7 +792,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anlmf)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -800,90 +800,90 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='anlms', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _input,
-            
-        
-            
+
+
+
             _desired,
-            
-        
+
+
 
 
         **merge({
-            
+
             "order": order,
-            
+
             "mu": mu,
-            
+
             "eps": eps,
-            
+
             "leakage": leakage,
-            
+
             "out_mode": out_mode,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
 def apsnr(
-    
 
-    
-        
+
+
+
         _input0: AudioStream,
-        
-    
-        
+
+
+
         _input1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Measure Audio Peak Signal-to-Noise Ratio.
 
 This filter takes two audio streams for input, and outputs first
@@ -902,7 +902,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#apsnr)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -910,72 +910,72 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='apsnr', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _input0,
-            
-        
-            
+
+
+
             _input1,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
 def arls(
-    
 
-    
-        
+
+
+
         _input: AudioStream,
-        
-    
-        
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('16'),_lambda: Float = Default('1'),delta: Float = Default('2'),out_mode: Int| Literal["i","d","o","n","e"] | Default = Default('o'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Apply Recursive Least Squares algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to mimic a desired filter by recursively finding the filter coefficients that
@@ -1000,7 +1000,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#arls)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -1008,72 +1008,72 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='arls', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _input,
-            
-        
-            
+
+
+
             _desired,
-            
-        
+
+
 
 
         **merge({
-            
+
             "order": order,
-            
+
             "lambda": _lambda,
-            
+
             "delta": delta,
-            
+
             "out_mode": out_mode,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def asdr(
-    
 
-    
-        
+
+
+
         _input0: AudioStream,
-        
-    
-        
+
+
+
         _input1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Measure Audio Signal-to-Distortion Ratio.
 
 This filter takes two audio streams for input, and outputs first
@@ -1092,7 +1092,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asdr)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -1100,80 +1100,80 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='asdr', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _input0,
-            
-        
-            
+
+
+
             _input1,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
 def asisdr(
-    
 
-    
-        
+
+
+
         _input0: AudioStream,
-        
-    
-        
+
+
+
         _input1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Measure Audio Scaled-Invariant Signal-to-Distortion Ratio.
 
 This filter takes two audio streams for input, and outputs first
@@ -1192,7 +1192,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asisdr)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -1200,63 +1200,63 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='asisdr', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _input0,
-            
-        
-            
+
+
+
             _input1,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
 def astreamselect(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),map: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Select video or audio streams.
 
 The filter accepts the following options:
@@ -1275,87 +1275,87 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#streamselect)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='astreamselect', typings_input='[StreamType.audio] * int(inputs)', typings_output="[StreamType.audio] * len(re.findall(r'\\d+', str(map)))"),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "map": map,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def axcorrelate(
-    
 
-    
-        
+
+
+
         _axcorrelate0: AudioStream,
-        
-    
-        
+
+
+
         _axcorrelate1: AudioStream,
-        
-    
+
+
 
 
     *,
     size: Int = Default('256'),algo: Int| Literal["slow","fast","best"] | Default = Default('best'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Calculate normalized windowed cross-correlation between two input audio streams.
 
 Resulted samples are always between -1 and 1 inclusive.
@@ -1379,98 +1379,98 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#axcorrelate)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='axcorrelate', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _axcorrelate0,
-            
-        
-            
+
+
+
             _axcorrelate1,
-            
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "algo": algo,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def blend(
-    
 
-    
-        
+
+
+
         _top: VideoStream,
-        
-    
-        
+
+
+
         _bottom: VideoStream,
-        
-    
+
+
 
 
     *,
     c0_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c1_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c2_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c3_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),all_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('-1'),c0_expr: String = Default(None),c1_expr: String = Default(None),c2_expr: String = Default(None),c3_expr: String = Default(None),all_expr: String = Default(None),c0_opacity: Double = Default('1'),c1_opacity: Double = Default('1'),c2_opacity: Double = Default('1'),c3_opacity: Double = Default('1'),all_opacity: Double = Default('1'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Blend two video frames into each other.
 
 The blend filter takes two input streams and outputs one
@@ -1511,7 +1511,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blend)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -1522,92 +1522,92 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='blend', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _top,
-            
-        
-            
+
+
+
             _bottom,
-            
-        
+
+
 
 
         **merge({
-            
+
             "c0_mode": c0_mode,
-            
+
             "c1_mode": c1_mode,
-            
+
             "c2_mode": c2_mode,
-            
+
             "c3_mode": c3_mode,
-            
+
             "all_mode": all_mode,
-            
+
             "c0_expr": c0_expr,
-            
+
             "c1_expr": c1_expr,
-            
+
             "c2_expr": c2_expr,
-            
+
             "c3_expr": c3_expr,
-            
+
             "all_expr": all_expr,
-            
+
             "c0_opacity": c0_opacity,
-            
+
             "c1_opacity": c1_opacity,
-            
+
             "c2_opacity": c2_opacity,
-            
+
             "c3_opacity": c3_opacity,
-            
+
             "all_opacity": all_opacity,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def bm3d(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     sigma: Float = Default('1'),block: Int = Default('16'),bstep: Int = Default('4'),group: Int = Default('1'),range: Int = Default('9'),mstep: Int = Default('1'),thmse: Float = Default('0'),hdthr: Float = Default('2.7'),estim: Int| Literal["basic","final"] | Default = Default('basic'),ref: Boolean = Default('false'),planes: Int = Default('7'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Denoise frames using Block-Matching 3D algorithm.
 
 The filter accepts the following options.
@@ -1635,7 +1635,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bm3d)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -1643,138 +1643,138 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='bm3d', typings_input='[StreamType.video] + [StreamType.video] if ref else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "sigma": sigma,
-            
+
             "block": block,
-            
+
             "bstep": bstep,
-            
+
             "group": group,
-            
+
             "range": range,
-            
+
             "mstep": mstep,
-            
+
             "thmse": thmse,
-            
+
             "hdthr": hdthr,
-            
+
             "estim": estim,
-            
+
             "ref": ref,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def colormap(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _target: VideoStream,
-        
-    
+
+
 
 
     *,
     patch_size: Image_size = Default('64x64'),nb_patches: Int = Default('0'),type: Int| Literal["relative","absolute"] | Default = Default('absolute'),kernel: Int| Literal["euclidean","weuclidean"] | Default = Default('euclidean'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply custom color maps to video stream.
 
 This filter needs three input video streams.
@@ -1800,7 +1800,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colormap)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -1808,77 +1808,77 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='colormap', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _target,
-            
-        
+
+
 
 
         **merge({
-            
+
             "patch_size": patch_size,
-            
+
             "nb_patches": nb_patches,
-            
+
             "type": type,
-            
+
             "kernel": kernel,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
 def concat(
-    
 
-    
+
+
     *streams: FilterableStream,
-    
 
 
-    
+
+
     n: Int = Auto('len(streams) // (int(v) + int(a))'),v: Int = Default('1'),a: Int = Default('0'),unsafe: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Concatenate audio and video streams, joining them together one after the
 other.
 
@@ -1904,77 +1904,77 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#concat)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='concat', typings_input='([StreamType.video]*int(v) + [StreamType.audio]*int(a))*int(n)', typings_output='[StreamType.video]*int(v) + [StreamType.audio]*int(a)'),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "n": n,
-            
+
             "v": v,
-            
+
             "a": a,
-            
+
             "unsafe": unsafe,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def convolve(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _impulse: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('7'),impulse: Int| Literal["first","all"] | Default = Default('all'),noise: Float = Default('1e-07'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply 2D convolution of video stream in frequency domain using second stream
 as impulse.
 
@@ -1996,7 +1996,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#convolve)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -2007,77 +2007,77 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='convolve', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _impulse,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "impulse": impulse,
-            
+
             "noise": noise,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def corr(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Obtain the correlation between two input videos.
 
 This filter takes two input videos.
@@ -2113,7 +2113,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#corr)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -2124,81 +2124,81 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='corr', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def decimate(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     cycle: Int = Default('5'),dupthresh: Double = Default('1.1'),scthresh: Double = Default('15'),blockx: Int = Default('32'),blocky: Int = Default('32'),ppsrc: Boolean = Default('false'),chroma: Boolean = Default('true'),mixed: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Drop duplicated frames at regular intervals.
 
 The filter accepts the following options:
@@ -2222,80 +2222,80 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#decimate)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='decimate', typings_input='[StreamType.video] + ([StreamType.video] if ppsrc else [])', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "cycle": cycle,
-            
+
             "dupthresh": dupthresh,
-            
+
             "scthresh": scthresh,
-            
+
             "blockx": blockx,
-            
+
             "blocky": blocky,
-            
+
             "ppsrc": ppsrc,
-            
+
             "chroma": chroma,
-            
+
             "mixed": mixed,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def deconvolve(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _impulse: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('7'),impulse: Int| Literal["first","all"] | Default = Default('all'),noise: Float = Default('1e-07'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply 2D deconvolution of video stream in frequency domain using second stream
 as impulse.
 
@@ -2317,7 +2317,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deconvolve)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -2328,106 +2328,106 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='deconvolve', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _impulse,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "impulse": impulse,
-            
+
             "noise": noise,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def displace(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _xmap: VideoStream,
-        
-    
-        
+
+
+
         _ymap: VideoStream,
-        
-    
+
+
 
 
     *,
     edge: Int| Literal["blank","smear","wrap","mirror"] | Default = Default('smear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Displace pixels as indicated by second and third input stream.
 
 It takes three input streams and outputs one stream, the first input is the
@@ -2456,7 +2456,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#displace)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -2464,125 +2464,125 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='displace', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _xmap,
-            
-        
-            
+
+
+
             _ymap,
-            
-        
+
+
 
 
         **merge({
-            
+
             "edge": edge,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def feedback(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _feedin: VideoStream,
-        
-    
+
+
 
 
     *,
     x: Int = Default('0'),w: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> tuple[
-    
-        
+
+
             VideoStream,
-        
-    
-        
+
+
+
             VideoStream,
-        
-    
+
+
 ]:
     """
-    
+
 Apply feedback video filter.
 
 This filter pass cropped input frames to 2nd output.
@@ -2609,79 +2609,79 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#feedback)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='feedback', typings_input=('video', 'video'), typings_output=('video', 'video')),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _feedin,
-            
-        
+
+
 
 
         **merge({
-            
+
             "x": x,
-            
+
             "w": w,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return (
-        
-            
+
+
                 filter_node.video(0),
-            
-        
-            
+
+
+
                 filter_node.video(1),
-            
-        
+
+
     )
 
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def fieldmatch(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     order: Int| Literal["auto","bff","tff"] | Default = Default('auto'),mode: Int| Literal["pc","pc_n","pc_u","pc_n_ub","pcn","pcn_ub"] | Default = Default('pc_n'),ppsrc: Boolean = Default('false'),field: Int| Literal["auto","bottom","top"] | Default = Default('auto'),mchroma: Boolean = Default('true'),y0: Int = Default('0'),scthresh: Double = Default('12'),combmatch: Int| Literal["none","sc","full"] | Default = Default('sc'),combdbg: Int| Literal["none","pcn","pcnub"] | Default = Default('none'),cthresh: Int = Default('9'),chroma: Boolean = Default('false'),blockx: Int = Default('16'),blocky: Int = Default('16'),combpel: Int = Default('80'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Field matching filter for inverse telecine. It is meant to reconstruct the
 progressive frames from a telecined stream. The filter does not drop duplicated
 frames, so to achieve a complete inverse telecine fieldmatch needs to be
@@ -2739,102 +2739,102 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fieldmatch)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='fieldmatch', typings_input='[StreamType.video] + [StreamType.video] if ppsrc else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "order": order,
-            
+
             "mode": mode,
-            
+
             "ppsrc": ppsrc,
-            
+
             "field": field,
-            
+
             "mchroma": mchroma,
-            
+
             "y0": y0,
-            
+
             "scthresh": scthresh,
-            
+
             "combmatch": combmatch,
-            
+
             "combdbg": combdbg,
-            
+
             "cthresh": cthresh,
-            
+
             "chroma": chroma,
-            
+
             "blockx": blockx,
-            
+
             "blocky": blocky,
-            
+
             "combpel": combpel,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
 def framepack(
-    
 
-    
-        
+
+
+
         _left: VideoStream,
-        
-    
-        
+
+
+
         _right: VideoStream,
-        
-    
+
+
 
 
     *,
     format: Int| Literal["sbs","tab","frameseq","lines","columns"] | Default = Default('sbs'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Pack two different video streams into a stereoscopic video, setting proper
 metadata on supported codecs. The two views should have the same size and
 framerate and processing will stop when the shorter video ends. Please note
@@ -2855,70 +2855,70 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#framepack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='framepack', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _left,
-            
-        
-            
+
+
+
             _right,
-            
-        
+
+
 
 
         **merge({
-            
+
             "format": format,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def freezeframes(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _replace: VideoStream,
-        
-    
+
+
 
 
     *,
     first: Int64 = Default('0'),last: Int64 = Default('0'),replace: Int64 = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Freeze video frames.
 
 This filter freezes video frames using frame from 2nd input.
@@ -2939,81 +2939,81 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#freezeframes)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='freezeframes', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _replace,
-            
-        
+
+
 
 
         **merge({
-            
+
             "first": first,
-            
+
             "last": last,
-            
+
             "replace": replace,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
 def guided(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     radius: Int = Default('3'),eps: Float = Default('0.01'),mode: Int| Literal["basic","fast"] | Default = Default('basic'),sub: Int = Default('4'),guidance: Int| Literal["off","on"] | Default = Default('off'),planes: Int = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply guided filter for edge-preserving smoothing, dehazing and so on.
 
 The filter accepts the following options:
@@ -3036,7 +3036,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#guided)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -3044,75 +3044,75 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='guided', typings_input='[StreamType.video] + [StreamType.video] if guidance else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "radius": radius,
-            
+
             "eps": eps,
-            
+
             "mode": mode,
-            
+
             "sub": sub,
-            
+
             "guidance": guidance,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def haldclut(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _clut: VideoStream,
-        
-    
+
+
 
 
     *,
     clut: Int| Literal["first","all"] | Default = Default('all'),interp: Int| Literal["nearest","trilinear","tetrahedral","pyramid","prism"] | Default = Default('tetrahedral'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply a Hald CLUT to a video stream.
 
 First input is the video stream to process, and second one is the Hald CLUT.
@@ -3135,7 +3135,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#haldclut)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -3146,63 +3146,63 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='haldclut', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _clut,
-            
-        
+
+
 
 
         **merge({
-            
+
             "clut": clut,
-            
+
             "interp": interp,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def headphone(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     map: String = Default(None),gain: Float = Default('0'),lfe: Float = Default('0'),type: Int| Literal["time","freq"] | Default = Default('freq'),size: Int = Default('1024'),hrir: Int| Literal["stereo","multich"] | Default = Default('stereo'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Apply head-related transfer functions (HRTFs) to create virtual
 loudspeakers around the user for binaural listening via headphones.
 The HRIRs are provided via additional streams, for each channel
@@ -3227,78 +3227,78 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#headphone)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='headphone', typings_input="[StreamType.audio] + [StreamType.audio] * (len(str(map).split('|')) - 1) if int(hrir) == 1 else []", typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "map": map,
-            
+
             "gain": gain,
-            
+
             "lfe": lfe,
-            
+
             "type": type,
-            
+
             "size": size,
-            
+
             "hrir": hrir,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
 def hstack(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),shortest: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos horizontally.
 
 All streams must be of same pixel format and of same height.
@@ -3321,54 +3321,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hstack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='hstack', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def hstack_vaapi(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Default('2'),shortest: Boolean = Default('false'),height: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos horizontally.
 
 This is the VA-API variant of the hstack filter, each input stream may
@@ -3391,84 +3391,84 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hstack_vaapi)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='hstack_vaapi', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
             "height": height,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
 def hysteresis(
-    
 
-    
-        
+
+
+
         _base: VideoStream,
-        
-    
-        
+
+
+
         _alt: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),threshold: Int = Default('0'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Grow first stream into second stream by connecting components.
 This makes it possible to build more robust edge masks.
 
@@ -3489,7 +3489,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hysteresis)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -3500,73 +3500,73 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='hysteresis', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _base,
-            
-        
-            
+
+
+
             _alt,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "threshold": threshold,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def identity(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Obtain the identity score between two input videos.
 
 This filter takes two input videos.
@@ -3602,7 +3602,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#identity)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -3613,63 +3613,63 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='identity', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def interleave(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     nb_inputs: Int = Auto('len(streams)'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Temporally interleave frames from several inputs.
 
 interleave works with video inputs, ainterleave with audio.
@@ -3708,54 +3708,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#interleave)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='interleave', typings_input='[StreamType.video] * int(nb_inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "nb_inputs": nb_inputs,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def join(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),channel_layout: String = Default('stereo'),map: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Join multiple input streams into one multi-channel stream.
 
 It accepts the following parameters:
@@ -3774,71 +3774,71 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#join)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='join', typings_input='[StreamType.audio] * int(inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "channel_layout": channel_layout,
-            
+
             "map": map,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
 def limitdiff(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     threshold: Float = Default('0.00392157'),elasticity: Float = Default('2'),reference: Boolean = Default('false'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply limited difference filter using second and optionally third video stream.
 
 The filter accepts the following options:
@@ -3859,7 +3859,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#limitdiff)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -3867,85 +3867,85 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='limitdiff', typings_input='[StreamType.video, StreamType.video] + ([StreamType.video] if reference else [])', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "threshold": threshold,
-            
+
             "elasticity": elasticity,
-            
+
             "reference": reference,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
 def lut2(
-    
 
-    
-        
+
+
+
         _srcx: VideoStream,
-        
-    
-        
+
+
+
         _srcy: VideoStream,
-        
-    
+
+
 
 
     *,
     c0: String = Default('x'),c1: String = Default('x'),c2: String = Default('x'),c3: String = Default('x'),d: Int = Default('0'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The lut2 filter takes two input streams and outputs one
 stream.
 
@@ -3972,7 +3972,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut2)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -3983,86 +3983,86 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='lut2', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _srcx,
-            
-        
-            
+
+
+
             _srcy,
-            
-        
+
+
 
 
         **merge({
-            
+
             "c0": c0,
-            
+
             "c1": c1,
-            
+
             "c2": c2,
-            
+
             "c3": c3,
-            
+
             "d": d,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def maskedclamp(
-    
 
-    
-        
+
+
+
         _base: VideoStream,
-        
-    
-        
+
+
+
         _dark: VideoStream,
-        
-    
-        
+
+
+
         _bright: VideoStream,
-        
-    
+
+
 
 
     *,
     undershoot: Int = Default('0'),overshoot: Int = Default('0'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Clamp the first input stream with the second input and third input stream.
 
 Returns the value of first stream to be between second input
@@ -4085,7 +4085,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedclamp)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4093,76 +4093,76 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='maskedclamp', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _base,
-            
-        
-            
+
+
+
             _dark,
-            
-        
-            
+
+
+
             _bright,
-            
-        
+
+
 
 
         **merge({
-            
+
             "undershoot": undershoot,
-            
+
             "overshoot": overshoot,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def maskedmax(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _filter1: VideoStream,
-        
-    
-        
+
+
+
         _filter2: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Merge the second and third input stream into output stream using absolute differences
 between second input stream and first input stream and absolute difference between
 third input stream and first input stream. The picked value will be from second input
@@ -4184,7 +4184,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedmax)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4192,72 +4192,72 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='maskedmax', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _filter1,
-            
-        
-            
+
+
+
             _filter2,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def maskedmerge(
-    
 
-    
-        
+
+
+
         _base: VideoStream,
-        
-    
-        
+
+
+
         _overlay: VideoStream,
-        
-    
-        
+
+
+
         _mask: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Merge the first input stream with the second input stream using per pixel
 weights in the third input stream.
 
@@ -4282,7 +4282,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedmerge)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4290,72 +4290,72 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='maskedmerge', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _base,
-            
-        
-            
+
+
+
             _overlay,
-            
-        
-            
+
+
+
             _mask,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def maskedmin(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _filter1: VideoStream,
-        
-    
-        
+
+
+
         _filter2: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Merge the second and third input stream into output stream using absolute differences
 between second input stream and first input stream and absolute difference between
 third input stream and first input stream. The picked value will be from second input
@@ -4377,7 +4377,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedmin)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4385,68 +4385,68 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='maskedmin', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _filter1,
-            
-        
-            
+
+
+
             _filter2,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def maskedthreshold(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     threshold: Int = Default('1'),planes: Int = Default('15'),mode: Int| Literal["abs","diff"] | Default = Default('abs'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Pick pixels comparing absolute difference of two video streams with fixed
 threshold.
 
@@ -4472,7 +4472,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedthreshold)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4480,67 +4480,67 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='maskedthreshold', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
             "threshold": threshold,
-            
+
             "planes": planes,
-            
+
             "mode": mode,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def mergeplanes(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     mapping: Int = Default('-1'),format: Pix_fmt = Default('yuva444p'),map0s: Int = Default('0'),map0p: Int = Default('0'),map1s: Int = Default('0'),map1p: Int = Default('0'),map2s: Int = Default('0'),map2p: Int = Default('0'),map3s: Int = Default('0'),map3p: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Merge color channel components from several video streams.
 
 The filter accepts up to 4 input streams, and merge selected input
@@ -4569,83 +4569,83 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mergeplanes)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='mergeplanes', typings_input='[StreamType.video] * int(max(hex(int(mapping))[2::2]))', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "mapping": mapping,
-            
+
             "format": format,
-            
+
             "map0s": map0s,
-            
+
             "map0p": map0p,
-            
+
             "map1s": map1s,
-            
+
             "map1p": map1p,
-            
+
             "map2s": map2s,
-            
+
             "map2p": map2p,
-            
+
             "map3s": map3s,
-            
+
             "map3p": map3p,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def midequalizer(
-    
 
-    
-        
+
+
+
         _in0: VideoStream,
-        
-    
-        
+
+
+
         _in1: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply Midway Image Equalization effect using two video streams.
 
 Midway Image Equalization adjusts a pair of images to have the same
@@ -4671,7 +4671,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#midequalizer)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4679,60 +4679,60 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='midequalizer', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _in0,
-            
-        
-            
+
+
+
             _in1,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def mix(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),weights: String = Default('1 1'),scale: Float = Default('0'),planes: Flags = Default('F'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Mix several video input streams into one video stream.
 
 A description of the accepted options follows.
@@ -4754,7 +4754,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mix)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4762,73 +4762,73 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='mix', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "weights": weights,
-            
+
             "scale": scale,
-            
+
             "planes": planes,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def morpho(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _structure: VideoStream,
-        
-    
+
+
 
 
     *,
     mode: Int| Literal["erode","dilate","open","close","gradient","tophat","blackhat"] | Default = Default('erode'),planes: Int = Default('7'),structure: Int| Literal["first","all"] | Default = Default('all'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 This filter allows to apply main morphological grayscale transforms,
 erode and dilate with arbitrary structures set in second input stream.
 
@@ -4854,7 +4854,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#morpho)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -4865,81 +4865,81 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='morpho', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _structure,
-            
-        
+
+
 
 
         **merge({
-            
+
             "mode": mode,
-            
+
             "planes": planes,
-            
+
             "structure": structure,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def msad(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Obtain the MSAD (Mean Sum of Absolute Differences) between two input videos.
 
 This filter takes two input videos.
@@ -4975,7 +4975,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#msad)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -4986,64 +4986,64 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='msad', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def multiply(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _factor: VideoStream,
-        
-    
+
+
 
 
     *,
     scale: Float = Default('1'),offset: Float = Default('0.5'),planes: Flags = Default('F'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Multiply first video stream pixels values with second video stream pixels values.
 
 The filter accepts the following options:
@@ -5063,7 +5063,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#multiply)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -5071,97 +5071,97 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='multiply', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _factor,
-            
-        
+
+
 
 
         **merge({
-            
+
             "scale": scale,
-            
+
             "offset": offset,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def overlay(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _overlay: VideoStream,
-        
-    
+
+
 
 
     *,
     x: String = Default('0'),y: String = Default('0'),eof_action: Int| Literal["repeat","endall","pass"] | Default = Default('repeat'),eval: Int| Literal["init","frame"] | Default = Default('frame'),shortest: Boolean = Default('false'),format: Int| Literal["yuv420","yuv420p10","yuv422","yuv422p10","yuv444","yuv444p10","rgb","gbrp","auto"] | Default = Default('yuv420'),repeatlast: Boolean = Default('true'),alpha: Int| Literal["straight","premultiplied"] | Default = Default('straight'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
-    
-    
-    
-    
-    
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Overlay one video on top of another.
 
 It takes two inputs and has one output. The first input is the "main"
@@ -5192,7 +5192,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -5200,77 +5200,77 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='overlay', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _overlay,
-            
-        
+
+
 
 
         **merge({
-            
+
             "x": x,
-            
+
             "y": y,
-            
+
             "eof_action": eof_action,
-            
+
             "eval": eval,
-            
+
             "shortest": shortest,
-            
+
             "format": format,
-            
+
             "repeatlast": repeatlast,
-            
+
             "alpha": alpha,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def overlay_opencl(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _overlay: VideoStream,
-        
-    
+
+
 
 
     *,
     x: Int = Default('0'),y: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Overlay one video on top of another.
 
 It takes two inputs and has one output. The first input is the "main" video on which the second input is overlaid.
@@ -5291,71 +5291,71 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay_opencl)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='overlay_opencl', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _overlay,
-            
-        
+
+
 
 
         **merge({
-            
+
             "x": x,
-            
+
             "y": y,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def overlay_vaapi(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _overlay: VideoStream,
-        
-    
+
+
 
 
     *,
     x: String = Default('0'),y: String = Default('0'),w: String = Default('overlay_iw'),h: String = Default('overlay_ih*w/overlay_iw'),alpha: Float = Default('1'),eof_action: Int| Literal["repeat","endall","pass"] | Default = Default('repeat'),shortest: Boolean = Default('false'),repeatlast: Boolean = Default('true'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
-    
-    
-    
-    
-    
+
+
+
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Overlay one video on the top of another.
 
 It takes two inputs and has one output. The first input is the "main" video on which the second input is overlaid.
@@ -5382,92 +5382,92 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay_vaapi)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='overlay_vaapi', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _overlay,
-            
-        
+
+
 
 
         **merge({
-            
+
             "x": x,
-            
+
             "y": y,
-            
+
             "w": w,
-            
+
             "h": h,
-            
+
             "alpha": alpha,
-            
+
             "eof_action": eof_action,
-            
+
             "shortest": shortest,
-            
+
             "repeatlast": repeatlast,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
 def paletteuse(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _palette: VideoStream,
-        
-    
+
+
 
 
     *,
     dither: Int| Literal["bayer","heckbert","floyd_steinberg","sierra2","sierra2_4a","sierra3","burkes","atkinson"] | Default = Default('sierra2_4a'),bayer_scale: Int = Default('2'),diff_mode: Int| Literal["rectangle"] | Default = Default('0'),new: Boolean = Default('false'),alpha_threshold: Int = Default('128'),debug_kdtree: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Use a palette to downsample an input video stream.
 
 The filter takes two inputs: one video stream and a palette. The palette must
@@ -5492,91 +5492,91 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#paletteuse)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='paletteuse', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _palette,
-            
-        
+
+
 
 
         **merge({
-            
+
             "dither": dither,
-            
+
             "bayer_scale": bayer_scale,
-            
+
             "diff_mode": diff_mode,
-            
+
             "new": new,
-            
+
             "alpha_threshold": alpha_threshold,
-            
+
             "debug_kdtree": debug_kdtree,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
 def premultiply(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     planes: Int = Default('15'),inplace: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply alpha premultiply effect to input video stream using first plane
 of second stream as alpha.
 
@@ -5598,7 +5598,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#premultiply)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -5606,62 +5606,62 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='premultiply', typings_input='[StreamType.video] + [StreamType.video] if inplace else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "inplace": inplace,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def program_opencl(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     source: String = Default(None),kernel: String = Default(None),inputs: Int = Default('1'),size: Image_size = Default(None),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Filter video using an OpenCL program.
 
 
@@ -5680,7 +5680,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#program_opencl)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -5688,71 +5688,71 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='program_opencl', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "source": source,
-            
+
             "kernel": kernel,
-            
+
             "inputs": inputs,
-            
+
             "size": size,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def psnr(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),stats_version: Int = Default('1'),output_max: Boolean = Default('false'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Obtain the average, maximum and minimum PSNR (Peak Signal to Noise
 Ratio) between two input videos.
 
@@ -5796,7 +5796,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#psnr)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -5807,83 +5807,83 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='psnr', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
             "stats_file": stats_file,
-            
+
             "stats_version": stats_version,
-            
+
             "output_max": output_max,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
 def remap(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _xmap: VideoStream,
-        
-    
-        
+
+
+
         _ymap: VideoStream,
-        
-    
+
+
 
 
     *,
     format: Int| Literal["color","gray"] | Default = Default('color'),fill: Color = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Remap pixels using 2nd: Xmap and 3rd: Ymap input video stream.
 
 Destination pixel at position (X, Y) will be picked from source (x, y) position
@@ -5907,74 +5907,74 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#remap)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='remap', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _xmap,
-            
-        
-            
+
+
+
             _ymap,
-            
-        
+
+
 
 
         **merge({
-            
+
             "format": format,
-            
+
             "fill": fill,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def remap_opencl(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _xmap: VideoStream,
-        
-    
-        
+
+
+
         _ymap: VideoStream,
-        
-    
+
+
 
 
     *,
     interp: Int| Literal["near","linear"] | Default = Default('linear'),fill: Color = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Remap pixels using 2nd: Xmap and 3rd: Ymap input video stream.
 
 Destination pixel at position (X, Y) will be picked from source (x, y) position
@@ -5998,104 +5998,104 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#remap_opencl)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='remap_opencl', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _xmap,
-            
-        
-            
+
+
+
             _ymap,
-            
-        
+
+
 
 
         **merge({
-            
+
             "interp": interp,
-            
+
             "fill": fill,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def scale2ref(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _ref: VideoStream,
-        
-    
+
+
 
 
     *,
     w: String = Default(None),h: String = Default(None),flags: String = Default(''),interl: Boolean = Default('false'),in_color_matrix: String| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default('auto'),out_color_matrix: String| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default(None),in_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),out_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),in_v_chr_pos: Int = Default('-513'),in_h_chr_pos: Int = Default('-513'),out_v_chr_pos: Int = Default('-513'),out_h_chr_pos: Int = Default('-513'),force_original_aspect_ratio: Int| Literal["disable","decrease","increase"] | Default = Default('disable'),force_divisible_by: Int = Default('1'),param0: Double = Default('DBL_MAX'),param1: Double = Default('DBL_MAX'),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> tuple[
-    
-        
+
+
             VideoStream,
-        
-    
-        
+
+
+
             VideoStream,
-        
-    
+
+
 ]:
     """
-    
+
 Scale (resize) the input video, based on a reference video.
 
 See the scale filter for available options, scale2ref supports the same but
@@ -6132,171 +6132,171 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#scale2ref)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='scale2ref', typings_input=('video', 'video'), typings_output=('video', 'video')),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _ref,
-            
-        
+
+
 
 
         **merge({
-            
+
             "w": w,
-            
+
             "h": h,
-            
+
             "flags": flags,
-            
+
             "interl": interl,
-            
+
             "in_color_matrix": in_color_matrix,
-            
+
             "out_color_matrix": out_color_matrix,
-            
+
             "in_range": in_range,
-            
+
             "out_range": out_range,
-            
+
             "in_v_chr_pos": in_v_chr_pos,
-            
+
             "in_h_chr_pos": in_h_chr_pos,
-            
+
             "out_v_chr_pos": out_v_chr_pos,
-            
+
             "out_h_chr_pos": out_h_chr_pos,
-            
+
             "force_original_aspect_ratio": force_original_aspect_ratio,
-            
+
             "force_divisible_by": force_divisible_by,
-            
+
             "param0": param0,
-            
+
             "param1": param1,
-            
+
             "eval": eval,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return (
-        
-            
+
+
                 filter_node.video(0),
-            
-        
-            
+
+
+
                 filter_node.video(1),
-            
-        
+
+
     )
 
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def sidechaincompress(
-    
 
-    
-        
+
+
+
         _main: AudioStream,
-        
-    
-        
+
+
+
         _sidechain: AudioStream,
-        
-    
+
+
 
 
     *,
     level_in: Double = Default('1'),mode: Int| Literal["downward","upward"] | Default = Default('downward'),threshold: Double = Default('0.125'),ratio: Double = Default('2'),attack: Double = Default('20'),release: Double = Default('250'),makeup: Double = Default('1'),knee: Double = Default('2.82843'),link: Int| Literal["average","maximum"] | Default = Default('average'),detection: Int| Literal["peak","rms"] | Default = Default('rms'),level_sc: Double = Default('1'),mix: Double = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 This filter acts like normal compressor but has the ability to compress
 detected signal using second input signal.
 It needs two input streams and returns one output stream.
@@ -6329,89 +6329,89 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sidechaincompress)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='sidechaincompress', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _sidechain,
-            
-        
+
+
 
 
         **merge({
-            
+
             "level_in": level_in,
-            
+
             "mode": mode,
-            
+
             "threshold": threshold,
-            
+
             "ratio": ratio,
-            
+
             "attack": attack,
-            
+
             "release": release,
-            
+
             "makeup": makeup,
-            
+
             "knee": knee,
-            
+
             "link": link,
-            
+
             "detection": detection,
-            
+
             "level_sc": level_sc,
-            
+
             "mix": mix,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
+
+
+
 def sidechaingate(
-    
 
-    
-        
+
+
+
         _main: AudioStream,
-        
-    
-        
+
+
+
         _sidechain: AudioStream,
-        
-    
+
+
 
 
     *,
     level_in: Double = Default('1'),mode: Int| Literal["downward","upward"] | Default = Default('downward'),range: Double = Default('0.06125'),threshold: Double = Default('0.125'),ratio: Double = Default('2'),attack: Double = Default('20'),release: Double = Default('250'),makeup: Double = Default('1'),knee: Double = Default('2.82843'),detection: Int| Literal["peak","rms"] | Default = Default('rms'),link: Int| Literal["average","maximum"] | Default = Default('average'),level_sc: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 A sidechain gate acts like a normal (wideband) gate but has the ability to
 filter the detected signal before sending it to the gain reduction stage.
 Normally a gate uses the full range signal to detect a level above the
@@ -6450,7 +6450,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sidechaingate)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -6458,83 +6458,83 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='sidechaingate', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _sidechain,
-            
-        
+
+
 
 
         **merge({
-            
+
             "level_in": level_in,
-            
+
             "mode": mode,
-            
+
             "range": range,
-            
+
             "threshold": threshold,
-            
+
             "ratio": ratio,
-            
+
             "attack": attack,
-            
+
             "release": release,
-            
+
             "makeup": makeup,
-            
+
             "knee": knee,
-            
+
             "detection": detection,
-            
+
             "link": link,
-            
+
             "level_sc": level_sc,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def signature(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     detectmode: Int| Literal["off","full","fast"] | Default = Default('off'),nb_inputs: Int = Auto('len(streams)'),filename: String = Default(''),format: Int| Literal["binary","xml"] | Default = Default('binary'),th_d: Int = Default('9000'),th_dc: Int = Default('60000'),th_xh: Int = Default('116'),th_di: Int = Default('0'),th_it: Double = Default('0.5'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Calculates the MPEG-7 Video Signature. The filter can handle more than one
 input. In this case the matching between the inputs can be calculated additionally.
 The filter always passes through the first input. The signature of each stream can
@@ -6562,94 +6562,94 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#signature)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='signature', typings_input='[StreamType.video] * int(nb_inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "detectmode": detectmode,
-            
+
             "nb_inputs": nb_inputs,
-            
+
             "filename": filename,
-            
+
             "format": format,
-            
+
             "th_d": th_d,
-            
+
             "th_dc": th_dc,
-            
+
             "th_xh": th_xh,
-            
+
             "th_di": th_di,
-            
+
             "th_it": th_it,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
 def spectrumsynth(
-    
 
-    
-        
+
+
+
         _magnitude: VideoStream,
-        
-    
-        
+
+
+
         _phase: VideoStream,
-        
-    
+
+
 
 
     *,
     sample_rate: Int = Default('44100'),channels: Int = Default('1'),scale: Int| Literal["lin","log"] | Default = Default('log'),slide: Int| Literal["replace","scroll","fullframe","rscroll"] | Default = Default('fullframe'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('rect'),overlap: Float = Default('1'),orientation: Int| Literal["vertical","horizontal"] | Default = Default('vertical'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Synthesize audio from 2 input video spectrums, first input stream represents
 magnitude across time and second represents phase across time.
 The filter will transform from frequency domain as displayed in videos back
@@ -6686,92 +6686,92 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#spectrumsynth)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='spectrumsynth', typings_input=('video', 'video'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _magnitude,
-            
-        
-            
+
+
+
             _phase,
-            
-        
+
+
 
 
         **merge({
-            
+
             "sample_rate": sample_rate,
-            
+
             "channels": channels,
-            
+
             "scale": scale,
-            
+
             "slide": slide,
-            
+
             "win_func": win_func,
-            
+
             "overlap": overlap,
-            
+
             "orientation": orientation,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def ssim(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Obtain the SSIM (Structural SImilarity Metric) between two input videos.
 
 This filter takes in input two input videos, the first input is
@@ -6801,7 +6801,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ssim)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -6812,68 +6812,68 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='ssim', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
             "stats_file": stats_file,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def ssim360(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),compute_chroma: Int = Default('1'),frame_skip_ratio: Int = Default('0'),ref_projection: Int| Literal["e","equirect","c3x2","c2x3","barrel","barrelsplit"] | Default = Default('e'),main_projection: Int| Literal["e","equirect","c3x2","c2x3","barrel","barrelsplit"] | Default = Default('5'),ref_stereo: Int| Literal["mono","tb","lr"] | Default = Default('mono'),main_stereo: Int| Literal["mono","tb","lr"] | Default = Default('3'),ref_pad: Float = Default('0'),main_pad: Float = Default('0'),use_tape: Int = Default('0'),heatmap_str: String = Default(None),default_heatmap_width: Int = Default('32'),default_heatmap_height: Int = Default('16'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Calculate the SSIM between two 360 video streams.
 
 
@@ -6901,7 +6901,7 @@ References:
     [FFmpeg Documentation](None)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -6909,85 +6909,85 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='ssim360', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
             "stats_file": stats_file,
-            
+
             "compute_chroma": compute_chroma,
-            
+
             "frame_skip_ratio": frame_skip_ratio,
-            
+
             "ref_projection": ref_projection,
-            
+
             "main_projection": main_projection,
-            
+
             "ref_stereo": ref_stereo,
-            
+
             "main_stereo": main_stereo,
-            
+
             "ref_pad": ref_pad,
-            
+
             "main_pad": main_pad,
-            
+
             "use_tape": use_tape,
-            
+
             "heatmap_str": heatmap_str,
-            
+
             "default_heatmap_width": default_heatmap_width,
-            
+
             "default_heatmap_height": default_heatmap_height,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def streamselect(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),map: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Select video or audio streams.
 
 The filter accepts the following options:
@@ -7006,94 +7006,94 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#streamselect)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='streamselect', typings_input='[StreamType.video] * int(inputs)', typings_output="[StreamType.video] * len(re.findall(r'\\d+', str(map)))"),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "map": map,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def threshold(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _threshold: VideoStream,
-        
-    
-        
+
+
+
         _min: VideoStream,
-        
-    
-        
+
+
+
         _max: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply threshold effect to video stream.
 
 This filter needs four video streams to perform thresholding.
@@ -7116,7 +7116,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#threshold)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -7124,102 +7124,102 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='threshold', typings_input=('video', 'video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _threshold,
-            
-        
-            
+
+
+
             _min,
-            
-        
-            
+
+
+
             _max,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def unpremultiply(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     planes: Int = Default('15'),inplace: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply alpha unpremultiply effect to input video stream using first plane
 of second stream as alpha.
 
@@ -7241,7 +7241,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#unpremultiply)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -7249,77 +7249,77 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='unpremultiply', typings_input='[StreamType.video] + ([StreamType.video] if inplace else [])', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "inplace": inplace,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
 def varblur(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _radius: VideoStream,
-        
-    
+
+
 
 
     *,
     min_r: Int = Default('0'),max_r: Int = Default('8'),planes: Int = Default('15'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply variable blur filter by using 2nd video stream to set blur radius.
 The 2nd stream must have the same dimensions.
 
@@ -7341,7 +7341,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#varblur)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -7352,89 +7352,89 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='varblur', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _radius,
-            
-        
+
+
 
 
         **merge({
-            
+
             "min_r": min_r,
-            
+
             "max_r": max_r,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
 def vif(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Obtain the average VIF (Visual Information Fidelity) between two input videos.
 
 This filter takes two input videos.
@@ -7471,7 +7471,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vif)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -7482,65 +7482,65 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='vif', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
 def vstack(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),shortest: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos vertically.
 
 All streams must be of same pixel format and of same width.
@@ -7563,54 +7563,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vstack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='vstack', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def vstack_vaapi(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Default('2'),shortest: Boolean = Default('false'),width: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos vertically.
 
 This is the VA-API variant of the vstack filter, each input stream may
@@ -7633,78 +7633,78 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vstack_vaapi)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='vstack_vaapi', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
             "width": width,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def xcorrelate(
-    
 
-    
-        
+
+
+
         _primary: VideoStream,
-        
-    
-        
+
+
+
         _secondary: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('7'),secondary: Int| Literal["first","all"] | Default = Default('all'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply normalized cross-correlation between first and second input video stream.
 
 Second input video stream dimensions must be lower than first input video stream.
@@ -7726,7 +7726,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xcorrelate)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -7737,65 +7737,65 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xcorrelate', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _primary,
-            
-        
-            
+
+
+
             _secondary,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "secondary": secondary,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xfade(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _xfade: VideoStream,
-        
-    
+
+
 
 
     *,
     transition: Int| Literal["custom","fade","wipeleft","wiperight","wipeup","wipedown","slideleft","slideright","slideup","slidedown","circlecrop","rectcrop","distance","fadeblack","fadewhite","radial","smoothleft","smoothright","smoothup","smoothdown","circleopen","circleclose","vertopen","vertclose","horzopen","horzclose","dissolve","pixelize","diagtl","diagtr","diagbl","diagbr","hlslice","hrslice","vuslice","vdslice","hblur","fadegrays","wipetl","wipetr","wipebl","wipebr","squeezeh","squeezev","zoomin","fadefast","fadeslow","hlwind","hrwind","vuwind","vdwind","coverleft","coverright","coverup","coverdown","revealleft","revealright","revealup","revealdown"] | Default = Default('fade'),duration: Duration = Default('1'),offset: Duration = Default('0'),expr: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply cross fade from one input video stream to another input video stream.
 The cross fade is applied for specified duration.
 
@@ -7819,70 +7819,70 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xfade)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xfade', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _xfade,
-            
-        
+
+
 
 
         **merge({
-            
+
             "transition": transition,
-            
+
             "duration": duration,
-            
+
             "offset": offset,
-            
+
             "expr": expr,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xfade_opencl(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _xfade: VideoStream,
-        
-    
+
+
 
 
     *,
     transition: Int| Literal["custom","fade","wipeleft","wiperight","wipeup","wipedown","slideleft","slideright","slideup","slidedown"] | Default = Default('fade'),source: String = Default(None),kernel: String = Default(None),duration: Duration = Default('1'),offset: Duration = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Cross fade two videos with custom transition effect by using OpenCL.
 
 It accepts the following options:
@@ -7903,74 +7903,74 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xfade_opencl)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xfade_opencl', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _xfade,
-            
-        
+
+
 
 
         **merge({
-            
+
             "transition": transition,
-            
+
             "source": source,
-            
+
             "kernel": kernel,
-            
+
             "duration": duration,
-            
+
             "offset": offset,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xmedian(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),planes: Int = Default('15'),percentile: Float = Default('0.5'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Pick median pixels from several input videos.
 
 The filter accepts the following options:
@@ -7991,7 +7991,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xmedian)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -8002,55 +8002,55 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xmedian', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "planes": planes,
-            
+
             "percentile": percentile,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xstack(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),layout: String = Default(None),grid: Image_size = Default(None),shortest: Boolean = Default('false'),fill: String = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack video inputs into custom layout.
 
 All streams must be of same pixel format.
@@ -8073,60 +8073,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xstack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xstack', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "layout": layout,
-            
+
             "grid": grid,
-            
+
             "shortest": shortest,
-            
+
             "fill": fill,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xstack_vaapi(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Default('2'),shortest: Boolean = Default('false'),layout: String = Default(None),grid: Image_size = Default(None),grid_tile_size: Image_size = Default(None),fill: String = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack video inputs into custom layout.
 
 This is the VA-API variant of the xstack filter,  each input stream may
@@ -8152,53 +8152,36 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xstack_vaapi)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xstack_vaapi', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
             "layout": layout,
-            
+
             "grid": grid,
-            
+
             "grid_tile_size": grid_tile_size,
-            
+
             "fill": fill,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
-
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    

--- a/packages/v6/src/ffmpeg/formats/demuxers.py
+++ b/packages/v6/src/ffmpeg/formats/demuxers.py
@@ -398,45 +398,45 @@ from ..streams.audio import AudioStream
 
 
 def _3dostr(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     3DO STR
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def _4xm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     4X Technologies
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def aa(
-    
+
     aa_fixed_key: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Audible AA format files
-    
+
     Args:
         aa_fixed_key: Fixed key used for handling Audible AA files
 
@@ -444,53 +444,53 @@ def aa(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "aa_fixed_key": aa_fixed_key,
-        
+
     }))
 
 
 
 def aac(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw ADTS AAC (Advanced Audio Coding)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def aax(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CRI AAX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ac3(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw AC-3
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -498,53 +498,53 @@ def ac3(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def ac4(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw AC-4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ace(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     tri-Ace Audio Container
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def acm(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Interplay ACM
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -552,41 +552,41 @@ def acm(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def act(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     ACT Voice file format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def adf(
-    
+
     linespeed: int | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Artworx Data Format
-    
+
     Args:
         linespeed: set simulated line speed (bytes per second) (from 1 to INT_MAX) (default 6000)
         video_size: set video size, such as 640x480 or hd720.
@@ -596,185 +596,185 @@ def adf(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "linespeed": linespeed,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def adp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     ADP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ads(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony PS2 ADS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def adx(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CRI ADX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def aea(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MD STUDIO audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def afc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AFC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def aiff(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Audio IFF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def aix(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CRI AIX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def alaw(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM A-law
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def alias_pix(
-    
+
     pattern_type: int | None| Literal["glob_sequence", "glob", "sequence", "none"] = None,
-    
+
     start_number: int | None = None,
-    
+
     start_number_range: int | None = None,
-    
+
     ts_from_file: int | None| Literal["none", "sec", "ns"] = None,
-    
+
     export_path_metadata: bool | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Alias/Wavefront PIX image
-    
+
     Args:
         pattern_type: set pattern type (from 0 to INT_MAX) (default 4)
         start_number: set first number in the sequence (from INT_MIN to INT_MAX) (default 0)
@@ -790,53 +790,53 @@ def alias_pix(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "pattern_type": pattern_type,
-        
+
         "start_number": start_number,
-        
+
         "start_number_range": start_number_range,
-        
+
         "ts_from_file": ts_from_file,
-        
+
         "export_path_metadata": export_path_metadata,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def alp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     LEGO Racers ALP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def amr(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     3GPP AMR
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -844,21 +844,21 @@ def amr(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def amrnb(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw AMR-NB
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -866,21 +866,21 @@ def amrnb(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def amrwb(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw AMR-WB
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -888,37 +888,37 @@ def amrwb(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def anm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Deluxe Paint Animation
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def apac(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw APAC
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -926,73 +926,73 @@ def apac(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def apc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CRYO APC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ape(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Monkey's Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def apm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Ubisoft Rayman 2 APM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def apng(
-    
+
     ignore_loop: bool | None = None,
-    
+
     max_fps: int | None = None,
-    
+
     default_fps: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Animated Portable Network Graphics
-    
+
     Args:
         ignore_loop: ignore loop setting (default true)
         max_fps: maximum framerate (0 is no limit) (from 0 to INT_MAX) (default 0)
@@ -1002,25 +1002,25 @@ def apng(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "ignore_loop": ignore_loop,
-        
+
         "max_fps": max_fps,
-        
+
         "default_fps": default_fps,
-        
+
     }))
 
 
 
 def aptx(
-    
+
     sample_rate: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw aptX
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 48000)
 
@@ -1028,21 +1028,21 @@ def aptx(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
     }))
 
 
 
 def aptx_hd(
-    
+
     sample_rate: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw aptX HD
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 48000)
 
@@ -1050,21 +1050,21 @@ def aptx_hd(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
     }))
 
 
 
 def aqtitle(
-    
+
     subfps: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AQTitle subtitles
-    
+
     Args:
         subfps: set the movie frame rate (from 0 to INT_MAX) (default 25/1)
 
@@ -1072,71 +1072,71 @@ def aqtitle(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "subfps": subfps,
-        
+
     }))
 
 
 
 def argo_asf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Argonaut Games ASF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def argo_brp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Argonaut Games BRP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def argo_cvg(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Argonaut Games CVG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def asf(
-    
+
     no_resync_search: bool | None = None,
-    
+
     export_xmp: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     ASF (Advanced / Active Streaming Format)
-    
+
     Args:
         no_resync_search: Don't try to resynchronize by looking for a certain optional start code (default false)
         export_xmp: Export full XMP metadata (default false)
@@ -1145,87 +1145,87 @@ def asf(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "no_resync_search": no_resync_search,
-        
+
         "export_xmp": export_xmp,
-        
+
     }))
 
 
 
 def asf_o(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     ASF (Advanced / Active Streaming Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ass(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SSA (SubStation Alpha) subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ast(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AST (Audio Stream)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def au(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sun AU
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def av1(
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AV1 Annex B
-    
+
     Args:
         framerate: (default "25")
 
@@ -1233,21 +1233,21 @@ def av1(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def avi(
-    
+
     use_odml: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AVI (Audio Video Interleaved)
-    
+
     Args:
         use_odml: use odml index (default true)
 
@@ -1255,55 +1255,55 @@ def avi(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "use_odml": use_odml,
-        
+
     }))
 
 
 
 def avr(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AVR (Audio Visual Research)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def avs(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Argonaut Games Creature Shock
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def avs2(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw AVS2-P2/IEEE1857.4
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -1312,25 +1312,25 @@ def avs2(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def avs3(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw AVS3-P2/IEEE1857.10
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -1339,75 +1339,75 @@ def avs3(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def bethsoftvid(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Bethesda Softworks VID
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def bfi(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Brute Force & Ignorance
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def bfstm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     BFSTM (Binary Cafe Stream)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def bin(
-    
+
     linespeed: int | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Binary text
-    
+
     Args:
         linespeed: set simulated line speed (bytes per second) (from 1 to INT_MAX) (default 6000)
         video_size: set video size, such as 640x480 or hd720.
@@ -1417,77 +1417,77 @@ def bin(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "linespeed": linespeed,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def bink(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Bink
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def binka(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Bink Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def bit(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     G.729 BIT file format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def bitpacked(
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Bitpacked
-    
+
     Args:
         pixel_format: set pixel format (default "yuv420p")
         video_size: set frame size
@@ -1497,33 +1497,33 @@ def bitpacked(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def bmp_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped bmp sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -1535,61 +1535,61 @@ def bmp_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def bmv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Discworld II BMV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def boa(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Black Ops Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def bonk(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw Bonk
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -1597,37 +1597,37 @@ def bonk(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def brender_pix(
-    
+
     pattern_type: int | None| Literal["glob_sequence", "glob", "sequence", "none"] = None,
-    
+
     start_number: int | None = None,
-    
+
     start_number_range: int | None = None,
-    
+
     ts_from_file: int | None| Literal["none", "sec", "ns"] = None,
-    
+
     export_path_metadata: bool | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     BRender PIX image
-    
+
     Args:
         pattern_type: set pattern type (from 0 to INT_MAX) (default 4)
         start_number: set first number in the sequence (from INT_MIN to INT_MAX) (default 0)
@@ -1643,87 +1643,87 @@ def brender_pix(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "pattern_type": pattern_type,
-        
+
         "start_number": start_number,
-        
+
         "start_number_range": start_number_range,
-        
+
         "ts_from_file": ts_from_file,
-        
+
         "export_path_metadata": export_path_metadata,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def brstm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     BRSTM (Binary Revolution Stream)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def c93(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Interplay C93
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def caf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Apple CAF (Core Audio Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def cavsvideo(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw Chinese AVS (Audio Video Standard)
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -1732,41 +1732,41 @@ def cavsvideo(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def cdg(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CD Graphics
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def cdxl(
-    
+
     sample_rate: int | None = None,
-    
+
     frame_rate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Commodore CDXL video
-    
+
     Args:
         sample_rate: (from 8000 to INT_MAX) (default 11025)
         frame_rate: (default "15")
@@ -1775,39 +1775,39 @@ def cdxl(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "frame_rate": frame_rate,
-        
+
     }))
 
 
 
 def cine(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Phantom Cine
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def codec2(
-    
+
     frames_per_packet: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     codec2 .c2 demuxer
-    
+
     Args:
         frames_per_packet: Number of frames to read at a time. Higher = faster decoding, lower granularity (from 1 to INT_MAX) (default 1)
 
@@ -1815,23 +1815,23 @@ def codec2(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frames_per_packet": frames_per_packet,
-        
+
     }))
 
 
 
 def codec2raw(
-    
+
     mode: int | None| Literal["3200", "2400", "1600", "1400", "1300", "1200", "700", "700B", "700C"] = None,
-    
+
     frames_per_packet: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw codec2 demuxer
-    
+
     Args:
         mode: codec2 mode [mandatory] (from -1 to 8) (default -1)
         frames_per_packet: Number of frames to read at a time. Higher = faster decoding, lower granularity (from 1 to INT_MAX) (default 1)
@@ -1840,27 +1840,27 @@ def codec2raw(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "mode": mode,
-        
+
         "frames_per_packet": frames_per_packet,
-        
+
     }))
 
 
 
 def concat(
-    
+
     safe: bool | None = None,
-    
+
     auto_convert: bool | None = None,
-    
+
     segment_time_metadata: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Virtual concatenation script
-    
+
     Args:
         safe: enable safe mode (default true)
         auto_convert: automatically convert bitstream format (default true)
@@ -1870,33 +1870,33 @@ def concat(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "safe": safe,
-        
+
         "auto_convert": auto_convert,
-        
+
         "segment_time_metadata": segment_time_metadata,
-        
+
     }))
 
 
 
 def cri_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped cri sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -1908,29 +1908,29 @@ def cri_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def data(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw data
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -1938,61 +1938,61 @@ def data(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def daud(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     D-Cinema audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dcstr(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sega DC STR
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dds_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped dds sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -2004,111 +2004,111 @@ def dds_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def derf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Xilam DERF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dfa(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Chronomaster DFA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dfpwm(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw DFPWM1a
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 48000)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def dhav(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Video DAV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dirac(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw Dirac
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -2117,25 +2117,25 @@ def dirac(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def dnxhd(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw DNxHD (SMPTE VC-3)
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -2144,31 +2144,31 @@ def dnxhd(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def dpx_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped dpx sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -2180,77 +2180,77 @@ def dpx_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def dsf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     DSD Stream File (DSF)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dsicin(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Delphine Software International CIN
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dss(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Digital Speech Standard (DSS)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dts(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw DTS
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -2258,53 +2258,53 @@ def dts(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def dtshd(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw DTS-HD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     DV (Digital Video)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dvbsub(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw dvbsub
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -2312,21 +2312,21 @@ def dvbsub(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def dvbtxt(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     dvbtxt
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -2334,37 +2334,37 @@ def dvbtxt(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def dxa(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     DXA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ea(
-    
+
     merge_alpha: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Electronic Arts Multimedia
-    
+
     Args:
         merge_alpha: return VP6 alpha in the main video stream (default false)
 
@@ -2372,37 +2372,37 @@ def ea(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "merge_alpha": merge_alpha,
-        
+
     }))
 
 
 
 def ea_cdata(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Electronic Arts cdata
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def eac3(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw E-AC-3
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -2410,37 +2410,37 @@ def eac3(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def epaf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Ensoniq Paris Audio File
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def evc(
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     EVC Annex B
-    
+
     Args:
         framerate: (default "25")
 
@@ -2448,29 +2448,29 @@ def evc(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def exr_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped exr sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -2482,157 +2482,157 @@ def exr_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def f32be(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM 32-bit floating-point big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def f32le(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM 32-bit floating-point little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def f64be(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM 64-bit floating-point big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def f64le(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM 64-bit floating-point little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def fbdev(
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Linux framebuffer
-    
+
     Args:
         framerate: (default "25")
 
@@ -2640,69 +2640,69 @@ def fbdev(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def ffmetadata(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     FFmpeg metadata in text
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def film_cpk(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sega FILM / CPK
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def filmstrip(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Adobe Filmstrip
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def fits(
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Flexible Image Transport System
-    
+
     Args:
         framerate: set the framerate (default "1")
 
@@ -2710,21 +2710,21 @@ def fits(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def flac(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw FLAC
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -2732,43 +2732,43 @@ def flac(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def flic(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     FLI/FLC/FLX animation
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def flv(
-    
+
     flv_metadata: bool | None = None,
-    
+
     flv_full_metadata: bool | None = None,
-    
+
     flv_ignore_prevtag: bool | None = None,
-    
+
     missing_streams: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     FLV (Flash Video)
-    
+
     Args:
         flv_metadata: Allocate streams according to the onMetaData array (default false)
         flv_full_metadata: Dump full metadata of the onMetadata (default false)
@@ -2779,75 +2779,75 @@ def flv(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "flv_metadata": flv_metadata,
-        
+
         "flv_full_metadata": flv_full_metadata,
-        
+
         "flv_ignore_prevtag": flv_ignore_prevtag,
-        
+
         "missing_streams": missing_streams,
-        
+
     }))
 
 
 
 def frm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Megalux Frame
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def fsb(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     FMOD Sample Bank
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def fwse(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Capcom's MT Framework sound
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def g722(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw G.722
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -2855,39 +2855,39 @@ def g722(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def g723_1(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     G.723.1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def g726(
-    
+
     code_size: int | None = None,
-    
+
     sample_rate: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw big-endian G.726 ("left aligned")
-    
+
     Args:
         code_size: Bits per G.726 code (from 2 to 5) (default 4)
         sample_rate: (from 0 to INT_MAX) (default 8000)
@@ -2896,25 +2896,25 @@ def g726(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "code_size": code_size,
-        
+
         "sample_rate": sample_rate,
-        
+
     }))
 
 
 
 def g726le(
-    
+
     code_size: int | None = None,
-    
+
     sample_rate: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw little-endian G.726 ("right aligned")
-    
+
     Args:
         code_size: Bits per G.726 code (from 2 to 5) (default 4)
         sample_rate: (from 0 to INT_MAX) (default 8000)
@@ -2923,23 +2923,23 @@ def g726le(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "code_size": code_size,
-        
+
         "sample_rate": sample_rate,
-        
+
     }))
 
 
 
 def g729(
-    
+
     bit_rate: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     G.729 raw format demuxer
-    
+
     Args:
         bit_rate: (from 0 to INT_MAX) (default 8000)
 
@@ -2947,45 +2947,45 @@ def g729(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "bit_rate": bit_rate,
-        
+
     }))
 
 
 
 def gdv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Gremlin Digital Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def gem_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped gem sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -2997,51 +2997,51 @@ def gem_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def genh(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     GENeric Header
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def gif(
-    
+
     min_delay: int | None = None,
-    
+
     max_gif_delay: int | None = None,
-    
+
     default_delay: int | None = None,
-    
+
     ignore_loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CompuServe Graphics Interchange Format (GIF)
-    
+
     Args:
         min_delay: minimum valid delay between frames (in hundredths of second) (from 0 to 6000) (default 2)
         max_gif_delay: maximum valid delay between frames (in hundredths of seconds) (from 0 to 65535) (default 65535)
@@ -3052,35 +3052,35 @@ def gif(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "min_delay": min_delay,
-        
+
         "max_gif_delay": max_gif_delay,
-        
+
         "default_delay": default_delay,
-        
+
         "ignore_loop": ignore_loop,
-        
+
     }))
 
 
 
 def gif_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped gif sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3092,29 +3092,29 @@ def gif_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def gsm(
-    
+
     sample_rate: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw GSM
-    
+
     Args:
         sample_rate: (from 1 to 6.50753e+07) (default 8000)
 
@@ -3122,39 +3122,39 @@ def gsm(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
     }))
 
 
 
 def gxf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     GXF (General eXchange Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def h261(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw H.261
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -3163,25 +3163,25 @@ def h261(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def h263(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw H.263
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -3190,25 +3190,25 @@ def h263(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def h264(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw H.264 video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -3217,27 +3217,27 @@ def h264(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def hca(
-    
+
     hca_lowkey: int | None = None,
-    
+
     hca_highkey: int | None = None,
-    
+
     hca_subkey: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CRI HCA
-    
+
     Args:
         hca_lowkey: Low key used for handling CRI HCA files (from 0 to UINT32_MAX) (default 0)
         hca_highkey: High key used for handling CRI HCA files (from 0 to UINT32_MAX) (default 0)
@@ -3247,49 +3247,49 @@ def hca(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "hca_lowkey": hca_lowkey,
-        
+
         "hca_highkey": hca_highkey,
-        
+
         "hca_subkey": hca_subkey,
-        
+
     }))
 
 
 
 def hcom(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Macintosh HCOM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def hdr_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped hdr sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3301,31 +3301,31 @@ def hdr_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def hevc(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw HEVC video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -3334,45 +3334,45 @@ def hevc(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def hls(
-    
+
     live_start_index: int | None = None,
-    
+
     prefer_x_start: bool | None = None,
-    
+
     allowed_extensions: str | None = None,
-    
+
     allowed_segment_extensions: str | None = None,
-    
+
     extension_picky: bool | None = None,
-    
+
     max_reload: int | None = None,
-    
+
     m3u8_hold_counters: int | None = None,
-    
+
     http_persistent: bool | None = None,
-    
+
     http_multiple: bool | None = None,
-    
+
     http_seekable: bool | None = None,
-    
+
     seg_format_options: str | None = None,
-    
+
     seg_max_retry: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Apple HTTP Live Streaming
-    
+
     Args:
         live_start_index: segment index to start live streams at (negative values are from the end) (from INT_MIN to INT_MAX) (default -3)
         prefer_x_start: prefer to use #EXT-X-START if it's in playlist instead of live_start_index (default false)
@@ -3391,95 +3391,95 @@ def hls(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "live_start_index": live_start_index,
-        
+
         "prefer_x_start": prefer_x_start,
-        
+
         "allowed_extensions": allowed_extensions,
-        
+
         "allowed_segment_extensions": allowed_segment_extensions,
-        
+
         "extension_picky": extension_picky,
-        
+
         "max_reload": max_reload,
-        
+
         "m3u8_hold_counters": m3u8_hold_counters,
-        
+
         "http_persistent": http_persistent,
-        
+
         "http_multiple": http_multiple,
-        
+
         "http_seekable": http_seekable,
-        
+
         "seg_format_options": seg_format_options,
-        
+
         "seg_max_retry": seg_max_retry,
-        
+
     }))
 
 
 
 def hnm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Cryo HNM v4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ico(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Microsoft Windows ICO
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def idcin(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     id Cinematic
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def idf(
-    
+
     linespeed: int | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     iCE Draw File
-    
+
     Args:
         linespeed: set simulated line speed (bytes per second) (from 1 to INT_MAX) (default 6000)
         video_size: set video size, such as 640x480 or hd720.
@@ -3489,89 +3489,89 @@ def idf(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "linespeed": linespeed,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def iff(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     IFF (Interchange File Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ifv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     IFV CCTV DVR
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ilbc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     iLBC storage
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def image2(
-    
+
     pattern_type: int | None| Literal["glob_sequence", "glob", "sequence", "none"] = None,
-    
+
     start_number: int | None = None,
-    
+
     start_number_range: int | None = None,
-    
+
     ts_from_file: int | None| Literal["none", "sec", "ns"] = None,
-    
+
     export_path_metadata: bool | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     image2 sequence
-    
+
     Args:
         pattern_type: set pattern type (from 0 to INT_MAX) (default 4)
         start_number: set first number in the sequence (from INT_MIN to INT_MAX) (default 0)
@@ -3587,45 +3587,45 @@ def image2(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "pattern_type": pattern_type,
-        
+
         "start_number": start_number,
-        
+
         "start_number_range": start_number_range,
-        
+
         "ts_from_file": ts_from_file,
-        
+
         "export_path_metadata": export_path_metadata,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def image2pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped image2 sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3637,31 +3637,31 @@ def image2pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def ingenient(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw Ingenient MJPEG
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -3670,39 +3670,39 @@ def ingenient(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def ipmovie(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Interplay MVE
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ipu(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw IPU Video
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -3710,109 +3710,109 @@ def ipu(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def ircam(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Berkeley/IRCAM/CARL Sound Format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def iss(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Funcom ISS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def iv8(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     IndigoVision 8000 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ivf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     On2 IVF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ivr(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     IVR (Internet Video Recording)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def j2k_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped j2k sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3824,53 +3824,53 @@ def j2k_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def jacosub(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     JACOsub subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def jpeg_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped jpeg sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3882,37 +3882,37 @@ def jpeg_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def jpegls_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped jpegls sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3924,53 +3924,53 @@ def jpegls_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def jpegxl_anim(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Animated JPEG XL
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def jpegxl_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped jpegxl sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3982,51 +3982,51 @@ def jpegxl_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def jv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Bitmap Brothers JV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def kux(
-    
+
     flv_metadata: bool | None = None,
-    
+
     flv_full_metadata: bool | None = None,
-    
+
     flv_ignore_prevtag: bool | None = None,
-    
+
     missing_streams: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     KUX (YouKu)
-    
+
     Args:
         flv_metadata: Allocate streams according to the onMetaData array (default false)
         flv_full_metadata: Dump full metadata of the onMetadata (default false)
@@ -4037,63 +4037,63 @@ def kux(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "flv_metadata": flv_metadata,
-        
+
         "flv_full_metadata": flv_full_metadata,
-        
+
         "flv_ignore_prevtag": flv_ignore_prevtag,
-        
+
         "missing_streams": missing_streams,
-        
+
     }))
 
 
 
 def kvag(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Simon & Schuster Interactive VAG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def laf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     LAF (Limitless Audio Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def lavfi(
-    
+
     graph: str | None = None,
-    
+
     graph_file: str | None = None,
-    
+
     dumpgraph: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Libavfilter virtual input device
-    
+
     Args:
         graph: set libavfilter graph
         graph_file: set libavfilter graph filename
@@ -4103,31 +4103,31 @@ def lavfi(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "graph": graph,
-        
+
         "graph_file": graph_file,
-        
+
         "dumpgraph": dumpgraph,
-        
+
     }))
 
 
 
 def live_flv(
-    
+
     flv_metadata: bool | None = None,
-    
+
     flv_full_metadata: bool | None = None,
-    
+
     flv_ignore_prevtag: bool | None = None,
-    
+
     missing_streams: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     live RTMP FLV (Flash Video)
-    
+
     Args:
         flv_metadata: Allocate streams according to the onMetaData array (default false)
         flv_full_metadata: Dump full metadata of the onMetadata (default false)
@@ -4138,43 +4138,43 @@ def live_flv(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "flv_metadata": flv_metadata,
-        
+
         "flv_full_metadata": flv_full_metadata,
-        
+
         "flv_ignore_prevtag": flv_ignore_prevtag,
-        
+
         "missing_streams": missing_streams,
-        
+
     }))
 
 
 
 def lmlm4(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw lmlm4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def loas(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     LOAS AudioSyncStream
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -4182,87 +4182,87 @@ def loas(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def lrc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     LRC lyrics
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def luodat(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Video CCTV DAT
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def lvf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     LVF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def lxf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     VR native stream (LXF)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def m4v(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw MPEG-4 video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -4271,71 +4271,71 @@ def m4v(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def mca(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MCA Audio Format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mcc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MacCaption
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mgsts(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Metal Gear Solid: The Twin Snakes
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def microdvd(
-    
+
     subfps: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MicroDVD subtitle format
-    
+
     Args:
         subfps: set the movie frame rate fallback (from 0 to INT_MAX) (default 0/1)
 
@@ -4343,23 +4343,23 @@ def microdvd(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "subfps": subfps,
-        
+
     }))
 
 
 
 def mjpeg(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw MJPEG video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -4368,25 +4368,25 @@ def mjpeg(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def mjpeg_2000(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw MJPEG 2000 video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -4395,23 +4395,23 @@ def mjpeg_2000(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def mlp(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw MLP
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -4419,101 +4419,101 @@ def mlp(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def mlv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Magic Lantern Video (MLV)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     American Laser Games MM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mmf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Yamaha SMAF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mods(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MobiClip MODS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def moflex(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MobiClip MOFLEX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mp3(
-    
+
     usetoc: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MP2/3 (MPEG audio layer 2/3)
-    
+
     Args:
         usetoc: use table of contents (default false)
 
@@ -4521,81 +4521,81 @@ def mp3(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "usetoc": usetoc,
-        
+
     }))
 
 
 
 def mpc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Musepack
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mpc8(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Musepack SV8
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mpeg(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MPEG-PS (MPEG-2 Program Stream)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mpegts(
-    
+
     resync_size: int | None = None,
-    
+
     fix_teletext_pts: bool | None = None,
-    
+
     ts_packetsize: int | None = None,
-    
+
     scan_all_pmts: bool | None = None,
-    
+
     skip_unknown_pmt: bool | None = None,
-    
+
     merge_pmt_versions: bool | None = None,
-    
+
     max_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MPEG-TS (MPEG-2 Transport Stream)
-    
+
     Args:
         resync_size: set size limit for looking up a new synchronization (from 0 to INT_MAX) (default 65536)
         fix_teletext_pts: try to fix pts values of dvb teletext streams (default true)
@@ -4609,37 +4609,37 @@ def mpegts(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "resync_size": resync_size,
-        
+
         "fix_teletext_pts": fix_teletext_pts,
-        
+
         "ts_packetsize": ts_packetsize,
-        
+
         "scan_all_pmts": scan_all_pmts,
-        
+
         "skip_unknown_pmt": skip_unknown_pmt,
-        
+
         "merge_pmt_versions": merge_pmt_versions,
-        
+
         "max_packet_size": max_packet_size,
-        
+
     }))
 
 
 
 def mpegtsraw(
-    
+
     resync_size: int | None = None,
-    
+
     compute_pcr: bool | None = None,
-    
+
     ts_packetsize: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw MPEG-TS (MPEG-2 Transport Stream)
-    
+
     Args:
         resync_size: set size limit for looking up a new synchronization (from 0 to INT_MAX) (default 65536)
         compute_pcr: compute exact PCR for each transport stream packet (default false)
@@ -4649,27 +4649,27 @@ def mpegtsraw(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "resync_size": resync_size,
-        
+
         "compute_pcr": compute_pcr,
-        
+
         "ts_packetsize": ts_packetsize,
-        
+
     }))
 
 
 
 def mpegvideo(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw MPEG video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -4678,23 +4678,23 @@ def mpegvideo(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def mpjpeg(
-    
+
     strict_mime_boundary: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MIME multipart JPEG
-    
+
     Args:
         strict_mime_boundary: require MIME boundaries match (default false)
 
@@ -4702,213 +4702,213 @@ def mpjpeg(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "strict_mime_boundary": strict_mime_boundary,
-        
+
     }))
 
 
 
 def mpl2(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MPL2 subtitles
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mpsub(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MPlayer subtitles
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def msf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony PS3 MSF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def msnwctcp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MSN TCP Webcam stream
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def msp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Microsoft Paint (MSP))
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mtaf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Konami PS2 MTAF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mtv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MTV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mulaw(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM mu-law
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def musx(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Eurocom MUSX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Silicon Graphics Movie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mvi(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Motion Pixels MVI
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mxf(
-    
+
     eia608_extract: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MXF (Material eXchange Format)
-    
+
     Args:
         eia608_extract: extract eia 608 captions from s436m track (default false)
 
@@ -4916,133 +4916,133 @@ def mxf(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "eia608_extract": eia608_extract,
-        
+
     }))
 
 
 
 def mxg(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MxPEG clip
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def nc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     NC camera feed
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def nistsphere(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     NIST SPeech HEader REsources
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def nsp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Computerized Speech Lab NSP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def nsv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Nullsoft Streaming Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def nut(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     NUT
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def nuv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     NuppelVideo
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def obu(
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AV1 low overhead OBU
-    
+
     Args:
         framerate: (default "25")
 
@@ -5050,53 +5050,53 @@ def obu(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def ogg(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Ogg
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def oma(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony OpenMG audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def osq(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw OSQ
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -5104,23 +5104,23 @@ def osq(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def oss(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     OSS (Open Sound System) capture
-    
+
     Args:
         sample_rate: (from 1 to INT_MAX) (default 48000)
         channels: (from 1 to INT_MAX) (default 2)
@@ -5129,47 +5129,47 @@ def oss(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
     }))
 
 
 
 def paf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Amazing Studio Packed Animation File
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def pam_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pam sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5181,37 +5181,37 @@ def pam_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pbm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pbm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5223,37 +5223,37 @@ def pbm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pcx_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pcx sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5265,53 +5265,53 @@ def pcx_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pdv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PlayDate Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def pfm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pfm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5323,37 +5323,37 @@ def pfm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pgm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pgm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5365,37 +5365,37 @@ def pgm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pgmyuv_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pgmyuv sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5407,37 +5407,37 @@ def pgmyuv_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pgx_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pgx sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5449,37 +5449,37 @@ def pgx_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def phm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped phm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5491,37 +5491,37 @@ def phm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def photocd_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped photocd sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5533,37 +5533,37 @@ def photocd_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pictor_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pictor sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5575,69 +5575,69 @@ def pictor_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pjs(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PJS (Phoenix Japanimation Society) subtitles
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def pmp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Playstation Portable PMP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def png_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped png sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5649,53 +5649,53 @@ def png_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pp_bnk(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Pro Pinball Series Soundbank
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ppm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped ppm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5707,37 +5707,37 @@ def ppm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def psd_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped psd sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5749,101 +5749,101 @@ def psd_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def psxstr(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony Playstation STR
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def pva(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     TechnoTrend PVA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def pvf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PVF (Portable Voice Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def qcp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     QCP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def qdraw_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped qdraw sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5855,37 +5855,37 @@ def qdraw_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def qoi_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped qoi sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5897,49 +5897,49 @@ def qoi_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def r3d(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     REDCODE R3D
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rawvideo(
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw video
-    
+
     Args:
         pixel_format: set pixel format (default "yuv420p")
         video_size: set frame size
@@ -5949,179 +5949,179 @@ def rawvideo(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def realtext(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RealText subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def redspark(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RedSpark
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rka(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RKA (RK Audio)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rl2(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RL2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RealMedia
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def roq(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     id RoQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rpl(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RPL / ARMovie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rsd(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     GameCube RSD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rso(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Lego Mindstorms RSO
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rtp(
-    
+
     rtp_flags: str | None = None,
-    
+
     listen_timeout: str | None = None,
-    
+
     localaddr: str | None = None,
-    
+
     allowed_media_types: str | None = None,
-    
+
     reorder_queue_size: int | None = None,
-    
+
     buffer_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RTP input
-    
+
     Args:
         rtp_flags: set RTP flags (default 0)
         listen_timeout: set maximum timeout (in seconds) to wait for incoming connections (default 10)
@@ -6134,51 +6134,51 @@ def rtp(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "rtp_flags": rtp_flags,
-        
+
         "listen_timeout": listen_timeout,
-        
+
         "localaddr": localaddr,
-        
+
         "allowed_media_types": allowed_media_types,
-        
+
         "reorder_queue_size": reorder_queue_size,
-        
+
         "buffer_size": buffer_size,
-        
+
     }))
 
 
 
 def rtsp(
-    
+
     initial_pause: bool | None = None,
-    
+
     rtsp_transport: str | None = None,
-    
+
     rtsp_flags: str | None = None,
-    
+
     allowed_media_types: str | None = None,
-    
+
     min_port: int | None = None,
-    
+
     max_port: int | None = None,
-    
+
     listen_timeout: int | None = None,
-    
+
     timeout: int | None = None,
-    
+
     reorder_queue_size: int | None = None,
-    
+
     buffer_size: int | None = None,
-    
+
     user_agent: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RTSP input
-    
+
     Args:
         initial_pause: do not start playing the stream immediately (default false)
         rtsp_transport: set RTSP transport protocols (default 0)
@@ -6196,313 +6196,313 @@ def rtsp(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "initial_pause": initial_pause,
-        
+
         "rtsp_transport": rtsp_transport,
-        
+
         "rtsp_flags": rtsp_flags,
-        
+
         "allowed_media_types": allowed_media_types,
-        
+
         "min_port": min_port,
-        
+
         "max_port": max_port,
-        
+
         "listen_timeout": listen_timeout,
-        
+
         "timeout": timeout,
-        
+
         "reorder_queue_size": reorder_queue_size,
-        
+
         "buffer_size": buffer_size,
-        
+
         "user_agent": user_agent,
-        
+
     }))
 
 
 
 def s16be(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 16-bit big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def s16le(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 16-bit little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def s24be(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 24-bit big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def s24le(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 24-bit little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def s32be(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 32-bit big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def s32le(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 32-bit little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def s337m(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SMPTE 337M
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def s8(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 8-bit
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def sami(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SAMI subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sap(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SAP input
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sbc(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw SBC (low-complexity subband codec)
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -6510,23 +6510,23 @@ def sbc(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def sbg(
-    
+
     sample_rate: int | None = None,
-    
+
     max_file_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SBaGen binaural beats script
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 0)
         max_file_size: (from 0 to INT_MAX) (default 5000000)
@@ -6535,81 +6535,81 @@ def sbg(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "max_file_size": max_file_size,
-        
+
     }))
 
 
 
 def scc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Scenarist Closed Captions
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def scd(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Square Enix SCD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sdns(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Xbox SDNS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sdp(
-    
+
     sdp_flags: str | None = None,
-    
+
     listen_timeout: str | None = None,
-    
+
     localaddr: str | None = None,
-    
+
     allowed_media_types: str | None = None,
-    
+
     reorder_queue_size: int | None = None,
-    
+
     buffer_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SDP
-    
+
     Args:
         sdp_flags: SDP flags (default 0)
         listen_timeout: set maximum timeout (in seconds) to wait for incoming connections (default 10)
@@ -6622,79 +6622,79 @@ def sdp(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sdp_flags": sdp_flags,
-        
+
         "listen_timeout": listen_timeout,
-        
+
         "localaddr": localaddr,
-        
+
         "allowed_media_types": allowed_media_types,
-        
+
         "reorder_queue_size": reorder_queue_size,
-        
+
         "buffer_size": buffer_size,
-        
+
     }))
 
 
 
 def sdr2(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SDR2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sds(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MIDI Sample Dump Standard
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sdx(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sample Dump eXchange
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ser(
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SER (Simple uncompressed video format for astronomical capturing)
-    
+
     Args:
         framerate: set frame rate (default "25")
 
@@ -6702,45 +6702,45 @@ def ser(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def sga(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Digital Pictures SGA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sgi_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped sgi sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -6752,29 +6752,29 @@ def sgi_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def shn(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw Shorten
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -6782,253 +6782,253 @@ def shn(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def siff(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Beam Software SIFF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def simbiosis_imx(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Simbiosis Interactive IMX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sln(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Asterisk raw pcm
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 8000)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def smjpeg(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Loki SDL MJPEG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def smk(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Smacker
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def smush(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     LucasArts Smush
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sol(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sierra SOL
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sox(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SoX (Sound eXchange) native
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def spdif(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     IEC 61937 (compressed data in S/PDIF)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def srt(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SubRip subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def stl(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Spruce subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def subviewer(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SubViewer subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def subviewer1(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SubViewer v1 subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sunrast_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped sunrast sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -7040,69 +7040,69 @@ def sunrast_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def sup(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw HDMV Presentation Graphic Stream subtitles
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def svag(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Konami PS2 SVAG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def svg_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped svg sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -7114,61 +7114,61 @@ def svg_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def svs(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Square SVS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def swf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SWF (ShockWave Flash)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def tak(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw TAK
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -7176,21 +7176,21 @@ def tak(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def tedcaptions(
-    
+
     start_time: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     TED Talks captions
-    
+
     Args:
         start_time: set the start time (offset) of the subtitles, in ms (from I64_MIN to I64_MAX) (default 15000)
 
@@ -7198,61 +7198,61 @@ def tedcaptions(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "start_time": start_time,
-        
+
     }))
 
 
 
 def thp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     THP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def tiertexseq(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Tiertex Limited SEQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def tiff_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped tiff sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -7264,45 +7264,45 @@ def tiff_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def tmv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     8088flex TMV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def truehd(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw TrueHD
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -7310,41 +7310,41 @@ def truehd(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def tta(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     TTA (True Audio)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def tty(
-    
+
     chars_per_frame: int | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Tele-typewriter
-    
+
     Args:
         chars_per_frame: (from 1 to INT_MAX) (default 6000)
         video_size: A string describing frame size, such as 640x480 or hd720.
@@ -7354,299 +7354,299 @@ def tty(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "chars_per_frame": chars_per_frame,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def txd(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Renderware TeXture Dictionary
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ty(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     TiVo TY Stream
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def u16be(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 16-bit big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def u16le(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 16-bit little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def u24be(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 24-bit big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def u24le(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 24-bit little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def u32be(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 32-bit big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def u32le(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 32-bit little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def u8(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 8-bit
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def usm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CRI USM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def v210(
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Uncompressed 4:2:2 10-bit
-    
+
     Args:
         video_size: set frame size
         framerate: set frame rate (default "25")
@@ -7655,25 +7655,25 @@ def v210(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def v210x(
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Uncompressed 4:2:2 10-bit
-    
+
     Args:
         video_size: set frame size
         framerate: set frame rate (default "25")
@@ -7682,47 +7682,47 @@ def v210x(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def vag(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony PS2 VAG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vbn_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped vbn sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -7734,31 +7734,31 @@ def vbn_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def vc1(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw VC-1
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -7767,119 +7767,119 @@ def vc1(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def vc1test(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     VC-1 test bitstream
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vidc(
-    
+
     sample_rate: int | None = None,
-    
+
     channels: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM Archimedes VIDC
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         channels: (from 0 to INT_MAX) (default 1)
-        ch_layout: 
+        ch_layout:
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "channels": channels,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def vividas(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Vividas VIV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vivo(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Vivo
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vmd(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sierra VMD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vobsub(
-    
+
     sub_name: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     VobSub subtitle format
-    
+
     Args:
         sub_name: URI for .sub file
 
@@ -7887,87 +7887,87 @@ def vobsub(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sub_name": sub_name,
-        
+
     }))
 
 
 
 def voc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Creative Voice
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vpk(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony PS2 VPK
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vplayer(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     VPlayer subtitles
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vqf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Nippon Telegraph and Telephone Corporation (NTT) TwinVQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vvc(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw H.266/VVC video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -7976,23 +7976,23 @@ def vvc(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def w64(
-    
+
     max_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony Wave64
-    
+
     Args:
         max_size: max size of single packet (from 1024 to 4.1943e+06) (default 4096)
 
@@ -8000,39 +8000,39 @@ def w64(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "max_size": max_size,
-        
+
     }))
 
 
 
 def wady(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Marble WADY
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def wav(
-    
+
     ignore_length: bool | None = None,
-    
+
     max_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     WAV / WAVE (Waveform Audio)
-    
+
     Args:
         ignore_length: Ignore length (default false)
         max_size: max size of single packet (from 1024 to 4.1943e+06) (default 4096)
@@ -8041,57 +8041,57 @@ def wav(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "ignore_length": ignore_length,
-        
+
         "max_size": max_size,
-        
+
     }))
 
 
 
 def wavarc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Waveform Archiver
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def wc3movie(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Wing Commander III movie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def webm_dash_manifest(
-    
+
     live: bool | None = None,
-    
+
     bandwidth: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     WebM DASH Manifest
-    
+
     Args:
         live: flag indicating that the input is a live file that only has the headers. (default false)
         bandwidth: bandwidth of this stream to be specified in the DASH manifest. (from 0 to INT_MAX) (default 0)
@@ -8100,31 +8100,31 @@ def webm_dash_manifest(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "live": live,
-        
+
         "bandwidth": bandwidth,
-        
+
     }))
 
 
 
 def webp_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped webp sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -8136,29 +8136,29 @@ def webp_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def webvtt(
-    
+
     kind: int | None| Literal["subtitles", "captions", "descriptions", "metadata"] = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     WebVTT subtitle
-    
+
     Args:
         kind: Set kind of WebVTT track (from 0 to INT_MAX) (default subtitles)
 
@@ -8166,37 +8166,37 @@ def webvtt(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "kind": kind,
-        
+
     }))
 
 
 
 def wsaud(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Westwood Studios audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def wsd(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Wideband Single-bit Data (WSD)
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -8204,107 +8204,107 @@ def wsd(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def wsvqa(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Westwood Studios VQA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def wtv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Windows Television (WTV)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def wv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     WavPack
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def wve(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Psion 3 audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def x11grab(
-    
+
     window_id: int | None = None,
-    
+
     x: int | None = None,
-    
+
     y: int | None = None,
-    
+
     grab_x: int | None = None,
-    
+
     grab_y: int | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
     draw_mouse: int | None = None,
-    
+
     follow_mouse: int | None| Literal["centered"] = None,
-    
+
     show_region: int | None = None,
-    
+
     region_border: int | None = None,
-    
+
     select_region: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     X11 screen capture, using XCB
-    
+
     Args:
         window_id: Window to capture. (from 0 to UINT32_MAX) (default 0)
         x: Initial x coordinate. (from 0 to INT_MAX) (default 0)
@@ -8323,63 +8323,63 @@ def x11grab(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "window_id": window_id,
-        
+
         "x": x,
-        
+
         "y": y,
-        
+
         "grab_x": grab_x,
-        
+
         "grab_y": grab_y,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
         "draw_mouse": draw_mouse,
-        
+
         "follow_mouse": follow_mouse,
-        
+
         "show_region": show_region,
-        
+
         "region_border": region_border,
-        
+
         "select_region": select_region,
-        
+
     }))
 
 
 
 def xa(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Maxis XA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def xbin(
-    
+
     linespeed: int | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     eXtended BINary text (XBIN)
-    
+
     Args:
         linespeed: set simulated line speed (bytes per second) (from 1 to INT_MAX) (default 6000)
         video_size: set video size, such as 640x480 or hd720.
@@ -8389,33 +8389,33 @@ def xbin(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "linespeed": linespeed,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def xbm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped xbm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -8427,69 +8427,69 @@ def xbm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def xmd(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Konami XMD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def xmv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Microsoft XMV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def xpm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped xpm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -8501,53 +8501,53 @@ def xpm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def xvag(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony PS3 XVAG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def xwd_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped xwd sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -8559,64 +8559,63 @@ def xwd_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def xwma(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Microsoft xWMA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def yop(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Psygnosis YOP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def yuv4mpegpipe(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     YUV4MPEG pipe
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
-    }))
 
+    }))

--- a/packages/v6/src/ffmpeg/formats/muxers.py
+++ b/packages/v6/src/ffmpeg/formats/muxers.py
@@ -44,61 +44,61 @@ from ..streams.audio import AudioStream
 
 
 def _3g2(
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     brand: str | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
     write_prft: int | None| Literal["wallclock", "pts"] = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     3GP2 (3GPP2 file format)
-    
+
     Args:
         movflags: MOV muxer flags (default 0)
         moov_size: maximum moov size so it can be placed at the begin (from 0 to INT_MAX) (default 0)
@@ -130,117 +130,117 @@ def _3g2(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "frag_duration": frag_duration,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "frag_size": frag_size,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "brand": brand,
-        
+
         "use_editlist": use_editlist,
-        
+
         "fragment_index": fragment_index,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_tmcd": write_tmcd,
-        
+
         "write_prft": write_prft,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "movie_timescale": movie_timescale,
-        
+
     }))
 
 
 
 def _3gp(
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     brand: str | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
     write_prft: int | None| Literal["wallclock", "pts"] = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     3GP (3GPP file format)
-    
+
     Args:
         movflags: MOV muxer flags (default 0)
         moov_size: maximum moov size so it can be placed at the begin (from 0 to INT_MAX) (default 0)
@@ -272,101 +272,101 @@ def _3gp(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "frag_duration": frag_duration,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "frag_size": frag_size,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "brand": brand,
-        
+
         "use_editlist": use_editlist,
-        
+
         "fragment_index": fragment_index,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_tmcd": write_tmcd,
-        
+
         "write_prft": write_prft,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "movie_timescale": movie_timescale,
-        
+
     }))
 
 
 
 def a64(
-    
+
 ) -> FFMpegMuxerOption:
     """
     a64 - video for Commodore 64
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ac3(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw AC-3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ac4(
-    
+
     write_crc: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw AC-4
-    
+
     Args:
         write_crc: enable checksum (default false)
 
@@ -374,25 +374,25 @@ def ac4(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "write_crc": write_crc,
-        
+
     }))
 
 
 
 def adts(
-    
+
     write_id3v2: bool | None = None,
-    
+
     write_apetag: bool | None = None,
-    
+
     write_mpeg2: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     ADTS AAC (Advanced Audio Coding)
-    
+
     Args:
         write_id3v2: Enable ID3v2 tag writing (default false)
         write_apetag: Enable APE tag writing (default false)
@@ -402,43 +402,43 @@ def adts(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "write_id3v2": write_id3v2,
-        
+
         "write_apetag": write_apetag,
-        
+
         "write_mpeg2": write_mpeg2,
-        
+
     }))
 
 
 
 def adx(
-    
+
 ) -> FFMpegMuxerOption:
     """
     CRI ADX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def aiff(
-    
+
     write_id3v2: bool | None = None,
-    
+
     id3v2_version: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Audio IFF
-    
+
     Args:
         write_id3v2: Enable ID3 tags writing. (default false)
         id3v2_version: Select ID3v2 version to write. Currently 3 and 4 are supported. (from 3 to 4) (default 4)
@@ -447,39 +447,39 @@ def aiff(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "write_id3v2": write_id3v2,
-        
+
         "id3v2_version": id3v2_version,
-        
+
     }))
 
 
 
 def alaw(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM A-law
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def alp(
-    
+
     type: int | None| Literal["auto", "tun", "pcm"] = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     LEGO Racers ALP
-    
+
     Args:
         type: set file type (from 0 to 2) (default auto)
 
@@ -487,71 +487,71 @@ def alp(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "type": type,
-        
+
     }))
 
 
 
 def amr(
-    
+
 ) -> FFMpegMuxerOption:
     """
     3GPP AMR
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def amv(
-    
+
 ) -> FFMpegMuxerOption:
     """
     AMV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def apm(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Ubisoft Rayman 2 APM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def apng(
-    
+
     plays: int | None = None,
-    
+
     final_delay: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Animated Portable Network Graphics
-    
+
     Args:
         plays: Number of times to play the output: 0 - infinite loop, 1 - no loop (from 0 to 65535) (default 1)
         final_delay: Force delay after the last frame (from 0 to 65535) (default 0/1)
@@ -560,59 +560,59 @@ def apng(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "plays": plays,
-        
+
         "final_delay": final_delay,
-        
+
     }))
 
 
 
 def aptx(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw aptX (Audio Processing Technology for Bluetooth)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def aptx_hd(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw aptX HD (Audio Processing Technology for Bluetooth)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def argo_asf(
-    
+
     version_major: int | None = None,
-    
+
     version_minor: int | None = None,
-    
+
     name: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Argonaut Games ASF
-    
+
     Args:
         version_major: override file major version (from 0 to 65535) (default 2)
         version_minor: override file minor version (from 0 to 65535) (default 1)
@@ -622,29 +622,29 @@ def argo_asf(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "version_major": version_major,
-        
+
         "version_minor": version_minor,
-        
+
         "name": name,
-        
+
     }))
 
 
 
 def argo_cvg(
-    
+
     skip_rate_check: bool | None = None,
-    
+
     loop: bool | None = None,
-    
+
     reverb: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Argonaut Games CVG
-    
+
     Args:
         skip_rate_check: skip sample rate check (default false)
         loop: set loop flag (default false)
@@ -654,25 +654,25 @@ def argo_cvg(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "skip_rate_check": skip_rate_check,
-        
+
         "loop": loop,
-        
+
         "reverb": reverb,
-        
+
     }))
 
 
 
 def asf(
-    
+
     packet_size: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     ASF (Advanced / Active Streaming Format)
-    
+
     Args:
         packet_size: Packet size (from 100 to 65536) (default 3200)
 
@@ -680,21 +680,21 @@ def asf(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "packet_size": packet_size,
-        
+
     }))
 
 
 
 def asf_stream(
-    
+
     packet_size: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     ASF (Advanced / Active Streaming Format)
-    
+
     Args:
         packet_size: Packet size (from 100 to 65536) (default 3200)
 
@@ -702,21 +702,21 @@ def asf_stream(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "packet_size": packet_size,
-        
+
     }))
 
 
 
 def ass(
-    
+
     ignore_readorder: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     SSA (SubStation Alpha) subtitle
-    
+
     Args:
         ignore_readorder: write events immediately, even if they're out-of-order (default false)
 
@@ -724,23 +724,23 @@ def ass(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "ignore_readorder": ignore_readorder,
-        
+
     }))
 
 
 
 def ast(
-    
+
     loopstart: int | None = None,
-    
+
     loopend: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     AST (Audio Stream)
-    
+
     Args:
         loopstart: Loopstart position in milliseconds. (from -1 to INT_MAX) (default -1)
         loopend: Loopend position in milliseconds. (from 0 to INT_MAX) (default 0)
@@ -749,43 +749,43 @@ def ast(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "loopstart": loopstart,
-        
+
         "loopend": loopend,
-        
+
     }))
 
 
 
 def au(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Sun AU
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def avi(
-    
+
     reserve_index_space: int | None = None,
-    
+
     write_channel_mask: bool | None = None,
-    
+
     flipped_raw_rgb: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     AVI (Audio Video Interleaved)
-    
+
     Args:
         reserve_index_space: reserve space (in bytes) at the beginning of the file for each stream index (from 0 to INT_MAX) (default 0)
         write_channel_mask: write channel mask into wave format header (default true)
@@ -795,27 +795,27 @@ def avi(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "reserve_index_space": reserve_index_space,
-        
+
         "write_channel_mask": write_channel_mask,
-        
+
         "flipped_raw_rgb": flipped_raw_rgb,
-        
+
     }))
 
 
 
 def avif(
-    
+
     movie_timescale: int | None = None,
-    
+
     loop: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     AVIF
-    
+
     Args:
         movie_timescale: set movie timescale (from 1 to INT_MAX) (default 1000)
         loop: Number of times to loop animated AVIF: 0 - infinite loop (from 0 to INT_MAX) (default 0)
@@ -824,237 +824,237 @@ def avif(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "movie_timescale": movie_timescale,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def avm2(
-    
+
 ) -> FFMpegMuxerOption:
     """
     SWF (ShockWave Flash) (AVM2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def avs2(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw AVS2-P2/IEEE1857.4 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def avs3(
-    
+
 ) -> FFMpegMuxerOption:
     """
     AVS3-P2/IEEE1857.10
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def bit(
-    
+
 ) -> FFMpegMuxerOption:
     """
     G.729 BIT file format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def caf(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Apple CAF (Core Audio Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def cavsvideo(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw Chinese AVS (Audio Video Standard) video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def codec2(
-    
+
 ) -> FFMpegMuxerOption:
     """
     codec2 .c2 muxer
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def codec2raw(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw codec2 muxer
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def crc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     CRC testing
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dash(
-    
+
     adaptation_sets: str | None = None,
-    
+
     window_size: int | None = None,
-    
+
     extra_window_size: int | None = None,
-    
+
     seg_duration: str | None = None,
-    
+
     frag_duration: str | None = None,
-    
+
     frag_type: int | None| Literal["none", "every_frame", "duration", "pframes"] = None,
-    
+
     remove_at_exit: bool | None = None,
-    
+
     use_template: bool | None = None,
-    
+
     use_timeline: bool | None = None,
-    
+
     single_file: bool | None = None,
-    
+
     single_file_name: str | None = None,
-    
+
     init_seg_name: str | None = None,
-    
+
     media_seg_name: str | None = None,
-    
+
     utc_timing_url: str | None = None,
-    
+
     method: str | None = None,
-    
+
     http_user_agent: str | None = None,
-    
+
     http_persistent: bool | None = None,
-    
+
     hls_playlist: bool | None = None,
-    
+
     hls_master_name: str | None = None,
-    
+
     streaming: bool | None = None,
-    
+
     timeout: str | None = None,
-    
+
     index_correction: bool | None = None,
-    
+
     format_options: str | None = None,
-    
+
     global_sidx: bool | None = None,
-    
+
     dash_segment_type: int | None| Literal["auto", "mp4", "webm"] = None,
-    
+
     ignore_io_errors: bool | None = None,
-    
+
     lhls: bool | None = None,
-    
+
     ldash: bool | None = None,
-    
+
     master_m3u8_publish_rate: int | None = None,
-    
+
     write_prft: bool | None = None,
-    
+
     mpd_profile: str | None = None,
-    
+
     http_opts: str | None = None,
-    
+
     target_latency: str | None = None,
-    
+
     min_playback_rate: str | None = None,
-    
+
     max_playback_rate: str | None = None,
-    
+
     update_period: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     DASH Muxer
-    
+
     Args:
         adaptation_sets: Adaptation sets. Syntax: id=0,streams=0,1,2 id=1,streams=3,4 and so on
         window_size: number of segments kept in the manifest (from 0 to INT_MAX) (default 0)
@@ -1097,205 +1097,205 @@ def dash(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "adaptation_sets": adaptation_sets,
-        
+
         "window_size": window_size,
-        
+
         "extra_window_size": extra_window_size,
-        
+
         "seg_duration": seg_duration,
-        
+
         "frag_duration": frag_duration,
-        
+
         "frag_type": frag_type,
-        
+
         "remove_at_exit": remove_at_exit,
-        
+
         "use_template": use_template,
-        
+
         "use_timeline": use_timeline,
-        
+
         "single_file": single_file,
-        
+
         "single_file_name": single_file_name,
-        
+
         "init_seg_name": init_seg_name,
-        
+
         "media_seg_name": media_seg_name,
-        
+
         "utc_timing_url": utc_timing_url,
-        
+
         "method": method,
-        
+
         "http_user_agent": http_user_agent,
-        
+
         "http_persistent": http_persistent,
-        
+
         "hls_playlist": hls_playlist,
-        
+
         "hls_master_name": hls_master_name,
-        
+
         "streaming": streaming,
-        
+
         "timeout": timeout,
-        
+
         "index_correction": index_correction,
-        
+
         "format_options": format_options,
-        
+
         "global_sidx": global_sidx,
-        
+
         "dash_segment_type": dash_segment_type,
-        
+
         "ignore_io_errors": ignore_io_errors,
-        
+
         "lhls": lhls,
-        
+
         "ldash": ldash,
-        
+
         "master_m3u8_publish_rate": master_m3u8_publish_rate,
-        
+
         "write_prft": write_prft,
-        
+
         "mpd_profile": mpd_profile,
-        
+
         "http_opts": http_opts,
-        
+
         "target_latency": target_latency,
-        
+
         "min_playback_rate": min_playback_rate,
-        
+
         "max_playback_rate": max_playback_rate,
-        
+
         "update_period": update_period,
-        
+
     }))
 
 
 
 def data(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw data
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def daud(
-    
+
 ) -> FFMpegMuxerOption:
     """
     D-Cinema audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dfpwm(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw DFPWM1a
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dirac(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw Dirac
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dnxhd(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw DNxHD (SMPTE VC-3)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dts(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw DTS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dv(
-    
+
 ) -> FFMpegMuxerOption:
     """
     DV (Digital Video)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dvd(
-    
+
     muxrate: int | None = None,
-    
+
     preload: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MPEG-2 PS (DVD VOB)
-    
+
     Args:
         muxrate: (from 0 to 1.67772e+09) (default 0)
         preload: Initial demux-decode delay in microseconds. (from 0 to INT_MAX) (default 500000)
@@ -1304,135 +1304,135 @@ def dvd(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "muxrate": muxrate,
-        
+
         "preload": preload,
-        
+
     }))
 
 
 
 def eac3(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw E-AC-3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def evc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw EVC video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def f32be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM 32-bit floating-point big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def f32le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM 32-bit floating-point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def f4v(
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     brand: str | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
     write_prft: int | None| Literal["wallclock", "pts"] = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     F4V Adobe Flash Video
-    
+
     Args:
         movflags: MOV muxer flags (default 0)
         moov_size: maximum moov size so it can be placed at the begin (from 0 to INT_MAX) (default 0)
@@ -1464,103 +1464,103 @@ def f4v(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "frag_duration": frag_duration,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "frag_size": frag_size,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "brand": brand,
-        
+
         "use_editlist": use_editlist,
-        
+
         "fragment_index": fragment_index,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_tmcd": write_tmcd,
-        
+
         "write_prft": write_prft,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "movie_timescale": movie_timescale,
-        
+
     }))
 
 
 
 def f64be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM 64-bit floating-point big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def f64le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM 64-bit floating-point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def fbdev(
-    
+
     xoffset: int | None = None,
-    
+
     yoffset: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Linux framebuffer
-    
+
     Args:
         xoffset: set x coordinate of top left corner (from INT_MIN to INT_MAX) (default 0)
         yoffset: set y coordinate of top left corner (from INT_MIN to INT_MAX) (default 0)
@@ -1569,59 +1569,59 @@ def fbdev(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "xoffset": xoffset,
-        
+
         "yoffset": yoffset,
-        
+
     }))
 
 
 
 def ffmetadata(
-    
+
 ) -> FFMpegMuxerOption:
     """
     FFmpeg metadata in text
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def fifo(
-    
+
     fifo_format: str | None = None,
-    
+
     queue_size: int | None = None,
-    
+
     format_opts: str | None = None,
-    
+
     drop_pkts_on_overflow: bool | None = None,
-    
+
     restart_with_keyframe: bool | None = None,
-    
+
     attempt_recovery: bool | None = None,
-    
+
     max_recovery_attempts: int | None = None,
-    
+
     recovery_wait_time: str | None = None,
-    
+
     recovery_wait_streamtime: bool | None = None,
-    
+
     recover_any_error: bool | None = None,
-    
+
     timeshift: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     FIFO queue pseudo-muxer
-    
+
     Args:
         fifo_format: Target muxer
         queue_size: Size of fifo queue (from 1 to INT_MAX) (default 60)
@@ -1639,45 +1639,45 @@ def fifo(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "fifo_format": fifo_format,
-        
+
         "queue_size": queue_size,
-        
+
         "format_opts": format_opts,
-        
+
         "drop_pkts_on_overflow": drop_pkts_on_overflow,
-        
+
         "restart_with_keyframe": restart_with_keyframe,
-        
+
         "attempt_recovery": attempt_recovery,
-        
+
         "max_recovery_attempts": max_recovery_attempts,
-        
+
         "recovery_wait_time": recovery_wait_time,
-        
+
         "recovery_wait_streamtime": recovery_wait_streamtime,
-        
+
         "recover_any_error": recover_any_error,
-        
+
         "timeshift": timeshift,
-        
+
     }))
 
 
 
 def fifo_test(
-    
+
     write_header_ret: int | None = None,
-    
+
     write_trailer_ret: int | None = None,
-    
+
     print_deinit_summary: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Fifo test muxer
-    
+
     Args:
         write_header_ret: write_header() return value (from INT_MIN to INT_MAX) (default 0)
         write_trailer_ret: write_trailer() return value (from INT_MIN to INT_MAX) (default 0)
@@ -1687,73 +1687,73 @@ def fifo_test(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "write_header_ret": write_header_ret,
-        
+
         "write_trailer_ret": write_trailer_ret,
-        
+
         "print_deinit_summary": print_deinit_summary,
-        
+
     }))
 
 
 
 def film_cpk(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Sega FILM / CPK
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def filmstrip(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Adobe Filmstrip
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def fits(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Flexible Image Transport System
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def flac(
-    
+
     write_header: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw FLAC
-    
+
     Args:
         write_header: Write the file header (default true)
 
@@ -1761,21 +1761,21 @@ def flac(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "write_header": write_header,
-        
+
     }))
 
 
 
 def flv(
-    
+
     flvflags: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     FLV (Flash Video)
-    
+
     Args:
         flvflags: FLV muxer flags (default 0)
 
@@ -1783,39 +1783,39 @@ def flv(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "flvflags": flvflags,
-        
+
     }))
 
 
 
 def framecrc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     framecrc testing
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def framehash(
-    
+
     hash: str | None = None,
-    
+
     format_version: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Per-frame hash testing
-    
+
     Args:
         hash: set hash to use (default "sha256")
         format_version: file format version (from 1 to 2) (default 2)
@@ -1824,25 +1824,25 @@ def framehash(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "hash": hash,
-        
+
         "format_version": format_version,
-        
+
     }))
 
 
 
 def framemd5(
-    
+
     hash: str | None = None,
-    
+
     format_version: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Per-frame MD5 testing
-    
+
     Args:
         hash: set hash to use (default "md5")
         format_version: file format version (from 1 to 2) (default 2)
@@ -1851,89 +1851,89 @@ def framemd5(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "hash": hash,
-        
+
         "format_version": format_version,
-        
+
     }))
 
 
 
 def g722(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw G.722
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def g723_1(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw G.723.1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def g726(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw big-endian G.726 ("left-justified")
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def g726le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw little-endian G.726 ("right-justified")
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def gif(
-    
+
     loop: int | None = None,
-    
+
     final_delay: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     CompuServe Graphics Interchange Format (GIF)
-    
+
     Args:
         loop: Number of times to loop the output: -1 - no loop, 0 - infinite loop (from -1 to 65535) (default 0)
         final_delay: Force delay (in centiseconds) after the last frame (from -1 to 65535) (default -1)
@@ -1942,103 +1942,103 @@ def gif(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "loop": loop,
-        
+
         "final_delay": final_delay,
-        
+
     }))
 
 
 
 def gsm(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw GSM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def gxf(
-    
+
 ) -> FFMpegMuxerOption:
     """
     GXF (General eXchange Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def h261(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw H.261
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def h263(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw H.263
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def h264(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw H.264 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def hash(
-    
+
     hash: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Hash testing
-    
+
     Args:
         hash: set hash to use (default "sha256")
 
@@ -2046,27 +2046,27 @@ def hash(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "hash": hash,
-        
+
     }))
 
 
 
 def hds(
-    
+
     window_size: int | None = None,
-    
+
     extra_window_size: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     remove_at_exit: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     HDS Muxer
-    
+
     Args:
         window_size: number of fragments kept in the manifest (from 0 to INT_MAX) (default 0)
         extra_window_size: number of fragments kept outside of the manifest before removing from disk (from 0 to INT_MAX) (default 5)
@@ -2077,111 +2077,111 @@ def hds(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "window_size": window_size,
-        
+
         "extra_window_size": extra_window_size,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "remove_at_exit": remove_at_exit,
-        
+
     }))
 
 
 
 def hevc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw HEVC video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def hls(
-    
+
     start_number: int | None = None,
-    
+
     hls_time: str | None = None,
-    
+
     hls_init_time: str | None = None,
-    
+
     hls_list_size: int | None = None,
-    
+
     hls_delete_threshold: int | None = None,
-    
+
     hls_vtt_options: str | None = None,
-    
+
     hls_allow_cache: int | None = None,
-    
+
     hls_base_url: str | None = None,
-    
+
     hls_segment_filename: str | None = None,
-    
+
     hls_segment_options: str | None = None,
-    
+
     hls_segment_size: int | None = None,
-    
+
     hls_key_info_file: str | None = None,
-    
+
     hls_enc: bool | None = None,
-    
+
     hls_enc_key: str | None = None,
-    
+
     hls_enc_key_url: str | None = None,
-    
+
     hls_enc_iv: str | None = None,
-    
+
     hls_subtitle_path: str | None = None,
-    
+
     hls_segment_type: int | None| Literal["mpegts", "fmp4"] = None,
-    
+
     hls_fmp4_init_filename: str | None = None,
-    
+
     hls_fmp4_init_resend: bool | None = None,
-    
+
     hls_flags: str | None = None,
-    
+
     strftime: bool | None = None,
-    
+
     strftime_mkdir: bool | None = None,
-    
+
     hls_playlist_type: int | None| Literal["event", "vod"] = None,
-    
+
     method: str | None = None,
-    
+
     hls_start_number_source: int | None| Literal["generic", "epoch", "epoch_us", "datetime"] = None,
-    
+
     http_user_agent: str | None = None,
-    
+
     var_stream_map: str | None = None,
-    
+
     cc_stream_map: str | None = None,
-    
+
     master_pl_name: str | None = None,
-    
+
     master_pl_publish_rate: int | None = None,
-    
+
     http_persistent: bool | None = None,
-    
+
     timeout: str | None = None,
-    
+
     ignore_io_errors: bool | None = None,
-    
+
     headers: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Apple HTTP Live Streaming
-    
+
     Args:
         start_number: set first number in the sequence (from 0 to I64_MAX) (default 0)
         hls_time: set segment length (default 2)
@@ -2223,131 +2223,131 @@ def hls(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "start_number": start_number,
-        
+
         "hls_time": hls_time,
-        
+
         "hls_init_time": hls_init_time,
-        
+
         "hls_list_size": hls_list_size,
-        
+
         "hls_delete_threshold": hls_delete_threshold,
-        
+
         "hls_vtt_options": hls_vtt_options,
-        
+
         "hls_allow_cache": hls_allow_cache,
-        
+
         "hls_base_url": hls_base_url,
-        
+
         "hls_segment_filename": hls_segment_filename,
-        
+
         "hls_segment_options": hls_segment_options,
-        
+
         "hls_segment_size": hls_segment_size,
-        
+
         "hls_key_info_file": hls_key_info_file,
-        
+
         "hls_enc": hls_enc,
-        
+
         "hls_enc_key": hls_enc_key,
-        
+
         "hls_enc_key_url": hls_enc_key_url,
-        
+
         "hls_enc_iv": hls_enc_iv,
-        
+
         "hls_subtitle_path": hls_subtitle_path,
-        
+
         "hls_segment_type": hls_segment_type,
-        
+
         "hls_fmp4_init_filename": hls_fmp4_init_filename,
-        
+
         "hls_fmp4_init_resend": hls_fmp4_init_resend,
-        
+
         "hls_flags": hls_flags,
-        
+
         "strftime": strftime,
-        
+
         "strftime_mkdir": strftime_mkdir,
-        
+
         "hls_playlist_type": hls_playlist_type,
-        
+
         "method": method,
-        
+
         "hls_start_number_source": hls_start_number_source,
-        
+
         "http_user_agent": http_user_agent,
-        
+
         "var_stream_map": var_stream_map,
-        
+
         "cc_stream_map": cc_stream_map,
-        
+
         "master_pl_name": master_pl_name,
-        
+
         "master_pl_publish_rate": master_pl_publish_rate,
-        
+
         "http_persistent": http_persistent,
-        
+
         "timeout": timeout,
-        
+
         "ignore_io_errors": ignore_io_errors,
-        
+
         "headers": headers,
-        
+
     }))
 
 
 
 def ico(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Microsoft Windows ICO
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ilbc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     iLBC storage
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def image2(
-    
+
     update: bool | None = None,
-    
+
     start_number: int | None = None,
-    
+
     strftime: bool | None = None,
-    
+
     frame_pts: bool | None = None,
-    
+
     atomic_writing: bool | None = None,
-    
+
     protocol_opts: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     image2 sequence
-    
+
     Args:
         update: continuously overwrite one file (default false)
         start_number: set first number in the sequence (from 0 to INT_MAX) (default 1)
@@ -2360,95 +2360,95 @@ def image2(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "update": update,
-        
+
         "start_number": start_number,
-        
+
         "strftime": strftime,
-        
+
         "frame_pts": frame_pts,
-        
+
         "atomic_writing": atomic_writing,
-        
+
         "protocol_opts": protocol_opts,
-        
+
     }))
 
 
 
 def image2pipe(
-    
+
 ) -> FFMpegMuxerOption:
     """
     piped image2 sequence
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ipod(
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     brand: str | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
     write_prft: int | None| Literal["wallclock", "pts"] = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     iPod H.264 MP4 (MPEG-4 Part 14)
-    
+
     Args:
         movflags: MOV muxer flags (default 0)
         moov_size: maximum moov size so it can be placed at the begin (from 0 to INT_MAX) (default 0)
@@ -2480,133 +2480,133 @@ def ipod(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "frag_duration": frag_duration,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "frag_size": frag_size,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "brand": brand,
-        
+
         "use_editlist": use_editlist,
-        
+
         "fragment_index": fragment_index,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_tmcd": write_tmcd,
-        
+
         "write_prft": write_prft,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "movie_timescale": movie_timescale,
-        
+
     }))
 
 
 
 def ircam(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Berkeley/IRCAM/CARL Sound Format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ismv(
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     brand: str | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
     write_prft: int | None| Literal["wallclock", "pts"] = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     ISMV/ISMA (Smooth Streaming)
-    
+
     Args:
         movflags: MOV muxer flags (default 0)
         moov_size: maximum moov size so it can be placed at the begin (from 0 to INT_MAX) (default 0)
@@ -2638,117 +2638,117 @@ def ismv(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "frag_duration": frag_duration,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "frag_size": frag_size,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "brand": brand,
-        
+
         "use_editlist": use_editlist,
-        
+
         "fragment_index": fragment_index,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_tmcd": write_tmcd,
-        
+
         "write_prft": write_prft,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "movie_timescale": movie_timescale,
-        
+
     }))
 
 
 
 def ivf(
-    
+
 ) -> FFMpegMuxerOption:
     """
     On2 IVF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def jacosub(
-    
+
 ) -> FFMpegMuxerOption:
     """
     JACOsub subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def kvag(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Simon & Schuster Interactive VAG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def latm(
-    
+
     smc_interval: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     LOAS/LATM
-    
+
     Args:
         smc_interval: StreamMuxConfig interval. (from 1 to 65535) (default 20)
 
@@ -2756,73 +2756,73 @@ def latm(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "smc-interval": smc_interval,
-        
+
     }))
 
 
 
 def lrc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     LRC lyrics
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def m4v(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw MPEG-4 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def matroska(
-    
+
     reserve_index_space: int | None = None,
-    
+
     cues_to_front: bool | None = None,
-    
+
     cluster_size_limit: int | None = None,
-    
+
     cluster_time_limit: int | None = None,
-    
+
     dash: bool | None = None,
-    
+
     dash_track_number: int | None = None,
-    
+
     live: bool | None = None,
-    
+
     allow_raw_vfw: bool | None = None,
-    
+
     flipped_raw_rgb: bool | None = None,
-    
+
     write_crc32: bool | None = None,
-    
+
     default_mode: int | None| Literal["infer", "infer_no_subs", "passthrough"] = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Matroska
-    
+
     Args:
         reserve_index_space: Reserve a given amount of space (in bytes) at the beginning of the file for the index (cues). (from 0 to INT_MAX) (default 0)
         cues_to_front: Move Cues (the index) to the front by shifting data if necessary (default false)
@@ -2840,41 +2840,41 @@ def matroska(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "reserve_index_space": reserve_index_space,
-        
+
         "cues_to_front": cues_to_front,
-        
+
         "cluster_size_limit": cluster_size_limit,
-        
+
         "cluster_time_limit": cluster_time_limit,
-        
+
         "dash": dash,
-        
+
         "dash_track_number": dash_track_number,
-        
+
         "live": live,
-        
+
         "allow_raw_vfw": allow_raw_vfw,
-        
+
         "flipped_raw_rgb": flipped_raw_rgb,
-        
+
         "write_crc32": write_crc32,
-        
+
         "default_mode": default_mode,
-        
+
     }))
 
 
 
 def md5(
-    
+
     hash: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MD5 testing
-    
+
     Args:
         hash: set hash to use (default "md5")
 
@@ -2882,149 +2882,149 @@ def md5(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "hash": hash,
-        
+
     }))
 
 
 
 def microdvd(
-    
+
 ) -> FFMpegMuxerOption:
     """
     MicroDVD subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mjpeg(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw MJPEG video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mkvtimestamp_v2(
-    
+
 ) -> FFMpegMuxerOption:
     """
     extract pts as timecode v2 format, as defined by mkvtoolnix
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mlp(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw MLP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mmf(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Yamaha SMAF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mov(
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     brand: str | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
     write_prft: int | None| Literal["wallclock", "pts"] = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     QuickTime / MOV
-    
+
     Args:
         movflags: MOV muxer flags (default 0)
         moov_size: maximum moov size so it can be placed at the begin (from 0 to INT_MAX) (default 0)
@@ -3056,89 +3056,89 @@ def mov(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "frag_duration": frag_duration,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "frag_size": frag_size,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "brand": brand,
-        
+
         "use_editlist": use_editlist,
-        
+
         "fragment_index": fragment_index,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_tmcd": write_tmcd,
-        
+
         "write_prft": write_prft,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "movie_timescale": movie_timescale,
-        
+
     }))
 
 
 
 def mp2(
-    
+
 ) -> FFMpegMuxerOption:
     """
     MP2 (MPEG audio layer 2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mp3(
-    
+
     id3v2_version: int | None = None,
-    
+
     write_id3v1: bool | None = None,
-    
+
     write_xing: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MP3 (MPEG audio layer 3)
-    
+
     Args:
         id3v2_version: Select ID3v2 version to write. Currently 3 and 4 are supported. (from 0 to 4) (default 4)
         write_id3v1: Enable ID3v1 writing. ID3v1 tags are written in UTF-8 which may not be supported by most software. (default false)
@@ -3148,73 +3148,73 @@ def mp3(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "id3v2_version": id3v2_version,
-        
+
         "write_id3v1": write_id3v1,
-        
+
         "write_xing": write_xing,
-        
+
     }))
 
 
 
 def mp4(
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     brand: str | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
     write_prft: int | None| Literal["wallclock", "pts"] = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MP4 (MPEG-4 Part 14)
-    
+
     Args:
         movflags: MOV muxer flags (default 0)
         moov_size: maximum moov size so it can be placed at the begin (from 0 to INT_MAX) (default 0)
@@ -3246,71 +3246,71 @@ def mp4(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "frag_duration": frag_duration,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "frag_size": frag_size,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "brand": brand,
-        
+
         "use_editlist": use_editlist,
-        
+
         "fragment_index": fragment_index,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_tmcd": write_tmcd,
-        
+
         "write_prft": write_prft,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "movie_timescale": movie_timescale,
-        
+
     }))
 
 
 
 def mpeg(
-    
+
     muxrate: int | None = None,
-    
+
     preload: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MPEG-1 Systems / MPEG program stream
-    
+
     Args:
         muxrate: (from 0 to 1.67772e+09) (default 0)
         preload: Initial demux-decode delay in microseconds. (from 0 to INT_MAX) (default 500000)
@@ -3319,87 +3319,87 @@ def mpeg(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "muxrate": muxrate,
-        
+
         "preload": preload,
-        
+
     }))
 
 
 
 def mpeg1video(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw MPEG-1 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mpeg2video(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw MPEG-2 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mpegts(
-    
+
     mpegts_transport_stream_id: int | None = None,
-    
+
     mpegts_original_network_id: int | None = None,
-    
+
     mpegts_service_id: int | None = None,
-    
+
     mpegts_service_type: int | None| Literal["digital_tv", "digital_radio", "teletext", "advanced_codec_digital_radio", "mpeg2_digital_hdtv", "advanced_codec_digital_sdtv", "advanced_codec_digital_hdtv", "hevc_digital_hdtv"] = None,
-    
+
     mpegts_pmt_start_pid: int | None = None,
-    
+
     mpegts_start_pid: int | None = None,
-    
+
     mpegts_m2ts_mode: bool | None = None,
-    
+
     muxrate: int | None = None,
-    
+
     pes_payload_size: int | None = None,
-    
+
     mpegts_flags: str | None = None,
-    
+
     mpegts_copyts: bool | None = None,
-    
+
     tables_version: int | None = None,
-    
+
     omit_video_pes_length: bool | None = None,
-    
+
     pcr_period: int | None = None,
-    
+
     pat_period: str | None = None,
-    
+
     sdt_period: str | None = None,
-    
+
     nit_period: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MPEG-TS (MPEG-2 Transport Stream)
-    
+
     Args:
         mpegts_transport_stream_id: Set transport_stream_id field. (from 1 to 65535) (default 1)
         mpegts_original_network_id: Set original_network_id field. (from 1 to 65535) (default 65281)
@@ -3423,53 +3423,53 @@ def mpegts(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "mpegts_transport_stream_id": mpegts_transport_stream_id,
-        
+
         "mpegts_original_network_id": mpegts_original_network_id,
-        
+
         "mpegts_service_id": mpegts_service_id,
-        
+
         "mpegts_service_type": mpegts_service_type,
-        
+
         "mpegts_pmt_start_pid": mpegts_pmt_start_pid,
-        
+
         "mpegts_start_pid": mpegts_start_pid,
-        
+
         "mpegts_m2ts_mode": mpegts_m2ts_mode,
-        
+
         "muxrate": muxrate,
-        
+
         "pes_payload_size": pes_payload_size,
-        
+
         "mpegts_flags": mpegts_flags,
-        
+
         "mpegts_copyts": mpegts_copyts,
-        
+
         "tables_version": tables_version,
-        
+
         "omit_video_pes_length": omit_video_pes_length,
-        
+
         "pcr_period": pcr_period,
-        
+
         "pat_period": pat_period,
-        
+
         "sdt_period": sdt_period,
-        
+
         "nit_period": nit_period,
-        
+
     }))
 
 
 
 def mpjpeg(
-    
+
     boundary_tag: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MIME multipart JPEG
-    
+
     Args:
         boundary_tag: Boundary tag (default "ffmpeg")
 
@@ -3477,39 +3477,39 @@ def mpjpeg(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "boundary_tag": boundary_tag,
-        
+
     }))
 
 
 
 def mulaw(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM mu-law
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mxf(
-    
+
     signal_standard: int | None| Literal["bt601", "bt1358", "smpte347m", "smpte274m", "smpte296m", "smpte349m", "smpte428"] = None,
-    
+
     store_user_comments: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MXF (Material eXchange Format)
-    
+
     Args:
         signal_standard: Force/set Signal Standard (from -1 to 7) (default -1)
         store_user_comments: (default true)
@@ -3518,27 +3518,27 @@ def mxf(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "signal_standard": signal_standard,
-        
+
         "store_user_comments": store_user_comments,
-        
+
     }))
 
 
 
 def mxf_d10(
-    
+
     d10_channelcount: int | None = None,
-    
+
     signal_standard: int | None| Literal["bt601", "bt1358", "smpte347m", "smpte274m", "smpte296m", "smpte349m", "smpte428"] = None,
-    
+
     store_user_comments: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MXF (Material eXchange Format) D-10 Mapping
-    
+
     Args:
         d10_channelcount: Force/set channelcount in generic sound essence descriptor (from -1 to 8) (default -1)
         signal_standard: Force/set Signal Standard (from -1 to 7) (default -1)
@@ -3548,29 +3548,29 @@ def mxf_d10(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "d10_channelcount": d10_channelcount,
-        
+
         "signal_standard": signal_standard,
-        
+
         "store_user_comments": store_user_comments,
-        
+
     }))
 
 
 
 def mxf_opatom(
-    
+
     mxf_audio_edit_rate: str | None = None,
-    
+
     signal_standard: int | None| Literal["bt601", "bt1358", "smpte347m", "smpte274m", "smpte296m", "smpte349m", "smpte428"] = None,
-    
+
     store_user_comments: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MXF (Material eXchange Format) Operational Pattern Atom
-    
+
     Args:
         mxf_audio_edit_rate: Audio edit rate for timecode (from 0 to INT_MAX) (default 25/1)
         signal_standard: Force/set Signal Standard (from -1 to 7) (default -1)
@@ -3580,43 +3580,43 @@ def mxf_opatom(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "mxf_audio_edit_rate": mxf_audio_edit_rate,
-        
+
         "signal_standard": signal_standard,
-        
+
         "store_user_comments": store_user_comments,
-        
+
     }))
 
 
 
 def null(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw null video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def nut(
-    
+
     syncpoints: str | None = None,
-    
+
     write_index: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     NUT
-    
+
     Args:
         syncpoints: NUT syncpoint behaviour (default 0)
         write_index: Write index (default true)
@@ -3625,45 +3625,45 @@ def nut(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "syncpoints": syncpoints,
-        
+
         "write_index": write_index,
-        
+
     }))
 
 
 
 def obu(
-    
+
 ) -> FFMpegMuxerOption:
     """
     AV1 low overhead OBU
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def oga(
-    
+
     serial_offset: int | None = None,
-    
+
     oggpagesize: int | None = None,
-    
+
     pagesize: int | None = None,
-    
+
     page_duration: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Ogg Audio
-    
+
     Args:
         serial_offset: serial number offset (from 0 to INT_MAX) (default 0)
         oggpagesize: Set preferred Ogg page size. (from 0 to 65025) (default 0)
@@ -3674,33 +3674,33 @@ def oga(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "serial_offset": serial_offset,
-        
+
         "oggpagesize": oggpagesize,
-        
+
         "pagesize": pagesize,
-        
+
         "page_duration": page_duration,
-        
+
     }))
 
 
 
 def ogg(
-    
+
     serial_offset: int | None = None,
-    
+
     oggpagesize: int | None = None,
-    
+
     pagesize: int | None = None,
-    
+
     page_duration: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Ogg
-    
+
     Args:
         serial_offset: serial number offset (from 0 to INT_MAX) (default 0)
         oggpagesize: Set preferred Ogg page size. (from 0 to 65025) (default 0)
@@ -3711,33 +3711,33 @@ def ogg(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "serial_offset": serial_offset,
-        
+
         "oggpagesize": oggpagesize,
-        
+
         "pagesize": pagesize,
-        
+
         "page_duration": page_duration,
-        
+
     }))
 
 
 
 def ogv(
-    
+
     serial_offset: int | None = None,
-    
+
     oggpagesize: int | None = None,
-    
+
     pagesize: int | None = None,
-    
+
     page_duration: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Ogg Video
-    
+
     Args:
         serial_offset: serial number offset (from 0 to INT_MAX) (default 0)
         oggpagesize: Set preferred Ogg page size. (from 0 to 65025) (default 0)
@@ -3748,49 +3748,49 @@ def ogv(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "serial_offset": serial_offset,
-        
+
         "oggpagesize": oggpagesize,
-        
+
         "pagesize": pagesize,
-        
+
         "page_duration": page_duration,
-        
+
     }))
 
 
 
 def oma(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Sony OpenMG audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def opus(
-    
+
     serial_offset: int | None = None,
-    
+
     oggpagesize: int | None = None,
-    
+
     pagesize: int | None = None,
-    
+
     page_duration: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Ogg Opus
-    
+
     Args:
         serial_offset: serial number offset (from 0 to INT_MAX) (default 0)
         oggpagesize: Set preferred Ogg page size. (from 0 to 65025) (default 0)
@@ -3801,91 +3801,91 @@ def opus(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "serial_offset": serial_offset,
-        
+
         "oggpagesize": oggpagesize,
-        
+
         "pagesize": pagesize,
-        
+
         "page_duration": page_duration,
-        
+
     }))
 
 
 
 def oss(
-    
+
 ) -> FFMpegMuxerOption:
     """
     OSS (Open Sound System) playback
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def psp(
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     brand: str | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
     write_prft: int | None| Literal["wallclock", "pts"] = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     PSP MP4 (MPEG-4 Part 14)
-    
+
     Args:
         movflags: MOV muxer flags (default 0)
         moov_size: maximum moov size so it can be placed at the begin (from 0 to INT_MAX) (default 0)
@@ -3917,141 +3917,141 @@ def psp(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "frag_duration": frag_duration,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "frag_size": frag_size,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "brand": brand,
-        
+
         "use_editlist": use_editlist,
-        
+
         "fragment_index": fragment_index,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_tmcd": write_tmcd,
-        
+
         "write_prft": write_prft,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "movie_timescale": movie_timescale,
-        
+
     }))
 
 
 
 def rawvideo(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def rm(
-    
+
 ) -> FFMpegMuxerOption:
     """
     RealMedia
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def roq(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw id RoQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def rso(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Lego Mindstorms RSO
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def rtp(
-    
+
     rtpflags: str | None = None,
-    
+
     payload_type: int | None = None,
-    
+
     ssrc: int | None = None,
-    
+
     cname: str | None = None,
-    
+
     seq: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     RTP output
-    
+
     Args:
         rtpflags: RTP muxer flags (default 0)
         payload_type: Specify RTP payload type (from -1 to 127) (default -1)
@@ -4063,31 +4063,31 @@ def rtp(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "rtpflags": rtpflags,
-        
+
         "payload_type": payload_type,
-        
+
         "ssrc": ssrc,
-        
+
         "cname": cname,
-        
+
         "seq": seq,
-        
+
     }))
 
 
 
 def rtp_mpegts(
-    
+
     mpegts_muxer_options: str | None = None,
-    
+
     rtp_muxer_options: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     RTP/mpegts output format
-    
+
     Args:
         mpegts_muxer_options: set list of options for the MPEG-TS muxer
         rtp_muxer_options: set list of options for the RTP muxer
@@ -4096,33 +4096,33 @@ def rtp_mpegts(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "mpegts_muxer_options": mpegts_muxer_options,
-        
+
         "rtp_muxer_options": rtp_muxer_options,
-        
+
     }))
 
 
 
 def rtsp(
-    
+
     rtpflags: str | None = None,
-    
+
     rtsp_transport: str | None = None,
-    
+
     min_port: int | None = None,
-    
+
     max_port: int | None = None,
-    
+
     buffer_size: int | None = None,
-    
+
     pkt_size: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     RTSP output
-    
+
     Args:
         rtpflags: RTP muxer flags (default 0)
         rtsp_transport: set RTSP transport protocols (default 0)
@@ -4135,245 +4135,245 @@ def rtsp(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "rtpflags": rtpflags,
-        
+
         "rtsp_transport": rtsp_transport,
-        
+
         "min_port": min_port,
-        
+
         "max_port": max_port,
-        
+
         "buffer_size": buffer_size,
-        
+
         "pkt_size": pkt_size,
-        
+
     }))
 
 
 
 def s16be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 16-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def s16le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 16-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def s24be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 24-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def s24le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 24-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def s32be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 32-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def s32le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 32-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def s8(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 8-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def sap(
-    
+
 ) -> FFMpegMuxerOption:
     """
     SAP output
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def sbc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw SBC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def scc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Scenarist Closed Captions
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def segment(
-    
+
     reference_stream: str | None = None,
-    
+
     segment_format: str | None = None,
-    
+
     segment_format_options: str | None = None,
-    
+
     segment_list: str | None = None,
-    
+
     segment_header_filename: str | None = None,
-    
+
     segment_list_flags: str | None = None,
-    
+
     segment_list_size: int | None = None,
-    
+
     segment_list_type: int | None| Literal["flat", "csv", "ext", "ffconcat", "m3u8", "hls"] = None,
-    
+
     segment_atclocktime: bool | None = None,
-    
+
     segment_clocktime_offset: str | None = None,
-    
+
     segment_clocktime_wrap_duration: str | None = None,
-    
+
     segment_time: str | None = None,
-    
+
     segment_time_delta: str | None = None,
-    
+
     min_seg_duration: str | None = None,
-    
+
     segment_times: str | None = None,
-    
+
     segment_frames: str | None = None,
-    
+
     segment_wrap: int | None = None,
-    
+
     segment_list_entry_prefix: str | None = None,
-    
+
     segment_start_number: int | None = None,
-    
+
     segment_wrap_number: int | None = None,
-    
+
     strftime: bool | None = None,
-    
+
     increment_tc: bool | None = None,
-    
+
     break_non_keyframes: bool | None = None,
-    
+
     individual_header_trailer: bool | None = None,
-    
+
     write_header_trailer: bool | None = None,
-    
+
     reset_timestamps: bool | None = None,
-    
+
     initial_offset: str | None = None,
-    
+
     write_empty_segments: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     segment
-    
+
     Args:
         reference_stream: set reference stream (default "auto")
         segment_format: set container format used for the segments
@@ -4408,99 +4408,99 @@ def segment(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "reference_stream": reference_stream,
-        
+
         "segment_format": segment_format,
-        
+
         "segment_format_options": segment_format_options,
-        
+
         "segment_list": segment_list,
-        
+
         "segment_header_filename": segment_header_filename,
-        
+
         "segment_list_flags": segment_list_flags,
-        
+
         "segment_list_size": segment_list_size,
-        
+
         "segment_list_type": segment_list_type,
-        
+
         "segment_atclocktime": segment_atclocktime,
-        
+
         "segment_clocktime_offset": segment_clocktime_offset,
-        
+
         "segment_clocktime_wrap_duration": segment_clocktime_wrap_duration,
-        
+
         "segment_time": segment_time,
-        
+
         "segment_time_delta": segment_time_delta,
-        
+
         "min_seg_duration": min_seg_duration,
-        
+
         "segment_times": segment_times,
-        
+
         "segment_frames": segment_frames,
-        
+
         "segment_wrap": segment_wrap,
-        
+
         "segment_list_entry_prefix": segment_list_entry_prefix,
-        
+
         "segment_start_number": segment_start_number,
-        
+
         "segment_wrap_number": segment_wrap_number,
-        
+
         "strftime": strftime,
-        
+
         "increment_tc": increment_tc,
-        
+
         "break_non_keyframes": break_non_keyframes,
-        
+
         "individual_header_trailer": individual_header_trailer,
-        
+
         "write_header_trailer": write_header_trailer,
-        
+
         "reset_timestamps": reset_timestamps,
-        
+
         "initial_offset": initial_offset,
-        
+
         "write_empty_segments": write_empty_segments,
-        
+
     }))
 
 
 
 def smjpeg(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Loki SDL MJPEG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def smoothstreaming(
-    
+
     window_size: int | None = None,
-    
+
     extra_window_size: int | None = None,
-    
+
     lookahead_count: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     remove_at_exit: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Smooth Streaming Muxer
-    
+
     Args:
         window_size: number of fragments kept in the manifest (from 0 to INT_MAX) (default 0)
         extra_window_size: number of fragments kept outside of the manifest before removing from disk (from 0 to INT_MAX) (default 5)
@@ -4512,49 +4512,49 @@ def smoothstreaming(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "window_size": window_size,
-        
+
         "extra_window_size": extra_window_size,
-        
+
         "lookahead_count": lookahead_count,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "remove_at_exit": remove_at_exit,
-        
+
     }))
 
 
 
 def sox(
-    
+
 ) -> FFMpegMuxerOption:
     """
     SoX (Sound eXchange) native
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def spdif(
-    
+
     spdif_flags: str | None = None,
-    
+
     dtshd_rate: int | None = None,
-    
+
     dtshd_fallback_time: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     IEC 61937 (used on S/PDIF - IEC958)
-    
+
     Args:
         spdif_flags: IEC 61937 encapsulation flags (default 0)
         dtshd_rate: mux complete DTS frames in HD mode at the specified IEC958 rate (in Hz, default 0=disabled) (from 0 to 768000) (default 0)
@@ -4564,31 +4564,31 @@ def spdif(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "spdif_flags": spdif_flags,
-        
+
         "dtshd_rate": dtshd_rate,
-        
+
         "dtshd_fallback_time": dtshd_fallback_time,
-        
+
     }))
 
 
 
 def spx(
-    
+
     serial_offset: int | None = None,
-    
+
     oggpagesize: int | None = None,
-    
+
     pagesize: int | None = None,
-    
+
     page_duration: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Ogg Speex
-    
+
     Args:
         serial_offset: serial number offset (from 0 to INT_MAX) (default 0)
         oggpagesize: Set preferred Ogg page size. (from 0 to 65025) (default 0)
@@ -4599,43 +4599,43 @@ def spx(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "serial_offset": serial_offset,
-        
+
         "oggpagesize": oggpagesize,
-        
+
         "pagesize": pagesize,
-        
+
         "page_duration": page_duration,
-        
+
     }))
 
 
 
 def srt(
-    
+
 ) -> FFMpegMuxerOption:
     """
     SubRip subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def streamhash(
-    
+
     hash: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Per-stream hash testing
-    
+
     Args:
         hash: set hash to use (default "sha256")
 
@@ -4643,39 +4643,39 @@ def streamhash(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "hash": hash,
-        
+
     }))
 
 
 
 def sup(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw HDMV Presentation Graphic Stream subtitles
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def svcd(
-    
+
     muxrate: int | None = None,
-    
+
     preload: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MPEG-2 PS (SVCD)
-    
+
     Args:
         muxrate: (from 0 to 1.67772e+09) (default 0)
         preload: Initial demux-decode delay in microseconds. (from 0 to INT_MAX) (default 500000)
@@ -4684,41 +4684,41 @@ def svcd(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "muxrate": muxrate,
-        
+
         "preload": preload,
-        
+
     }))
 
 
 
 def swf(
-    
+
 ) -> FFMpegMuxerOption:
     """
     SWF (ShockWave Flash)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def tee(
-    
+
     use_fifo: bool | None = None,
-    
+
     fifo_options: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Multiple muxer tee
-    
+
     Args:
         use_fifo: Use fifo pseudo-muxer to separate actual muxers from encoder (default false)
         fifo_options: fifo pseudo-muxer options
@@ -4727,233 +4727,233 @@ def tee(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "use_fifo": use_fifo,
-        
+
         "fifo_options": fifo_options,
-        
+
     }))
 
 
 
 def truehd(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw TrueHD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def tta(
-    
+
 ) -> FFMpegMuxerOption:
     """
     TTA (True Audio)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ttml(
-    
+
 ) -> FFMpegMuxerOption:
     """
     TTML subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u16be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 16-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u16le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 16-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u24be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 24-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u24le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 24-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u32be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 32-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u32le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 32-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u8(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 8-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def uncodedframecrc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     uncoded framecrc testing
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def vc1(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw VC-1 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def vc1test(
-    
+
 ) -> FFMpegMuxerOption:
     """
     VC-1 test bitstream
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def vcd(
-    
+
     muxrate: int | None = None,
-    
+
     preload: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MPEG-1 Systems / MPEG program stream (VCD)
-    
+
     Args:
         muxrate: (from 0 to 1.67772e+09) (default 0)
         preload: Initial demux-decode delay in microseconds. (from 0 to INT_MAX) (default 500000)
@@ -4962,41 +4962,41 @@ def vcd(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "muxrate": muxrate,
-        
+
         "preload": preload,
-        
+
     }))
 
 
 
 def vidc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM Archimedes VIDC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def vob(
-    
+
     muxrate: int | None = None,
-    
+
     preload: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MPEG-2 PS (VOB)
-    
+
     Args:
         muxrate: (from 0 to 1.67772e+09) (default 0)
         preload: Initial demux-decode delay in microseconds. (from 0 to INT_MAX) (default 500000)
@@ -5005,81 +5005,81 @@ def vob(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "muxrate": muxrate,
-        
+
         "preload": preload,
-        
+
     }))
 
 
 
 def voc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Creative Voice
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def vvc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw H.266/VVC video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def w64(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Sony Wave64
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def wav(
-    
+
     write_bext: bool | None = None,
-    
+
     write_peak: int | None| Literal["off", "on", "only"] = None,
-    
+
     rf64: int | None| Literal["auto", "always", "never"] = None,
-    
+
     peak_block_size: int | None = None,
-    
+
     peak_format: int | None = None,
-    
+
     peak_ppv: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     WAV / WAVE (Waveform Audio)
-    
+
     Args:
         write_bext: Write BEXT chunk. (default false)
         write_peak: Write Peak Envelope chunk. (from 0 to 2) (default off)
@@ -5092,51 +5092,51 @@ def wav(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "write_bext": write_bext,
-        
+
         "write_peak": write_peak,
-        
+
         "rf64": rf64,
-        
+
         "peak_block_size": peak_block_size,
-        
+
         "peak_format": peak_format,
-        
+
         "peak_ppv": peak_ppv,
-        
+
     }))
 
 
 
 def webm(
-    
+
     reserve_index_space: int | None = None,
-    
+
     cues_to_front: bool | None = None,
-    
+
     cluster_size_limit: int | None = None,
-    
+
     cluster_time_limit: int | None = None,
-    
+
     dash: bool | None = None,
-    
+
     dash_track_number: int | None = None,
-    
+
     live: bool | None = None,
-    
+
     allow_raw_vfw: bool | None = None,
-    
+
     flipped_raw_rgb: bool | None = None,
-    
+
     write_crc32: bool | None = None,
-    
+
     default_mode: int | None| Literal["infer", "infer_no_subs", "passthrough"] = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     WebM
-    
+
     Args:
         reserve_index_space: Reserve a given amount of space (in bytes) at the beginning of the file for the index (cues). (from 0 to INT_MAX) (default 0)
         cues_to_front: Move Cues (the index) to the front by shifting data if necessary (default false)
@@ -5154,47 +5154,47 @@ def webm(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "reserve_index_space": reserve_index_space,
-        
+
         "cues_to_front": cues_to_front,
-        
+
         "cluster_size_limit": cluster_size_limit,
-        
+
         "cluster_time_limit": cluster_time_limit,
-        
+
         "dash": dash,
-        
+
         "dash_track_number": dash_track_number,
-        
+
         "live": live,
-        
+
         "allow_raw_vfw": allow_raw_vfw,
-        
+
         "flipped_raw_rgb": flipped_raw_rgb,
-        
+
         "write_crc32": write_crc32,
-        
+
         "default_mode": default_mode,
-        
+
     }))
 
 
 
 def webm_chunk(
-    
+
     chunk_start_index: int | None = None,
-    
+
     header: str | None = None,
-    
+
     audio_chunk_duration: int | None = None,
-    
+
     method: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     WebM Chunk Muxer
-    
+
     Args:
         chunk_start_index: start index of the chunk (from 0 to INT_MAX) (default 0)
         header: filename of the header where the initialization data will be written
@@ -5205,39 +5205,39 @@ def webm_chunk(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "chunk_start_index": chunk_start_index,
-        
+
         "header": header,
-        
+
         "audio_chunk_duration": audio_chunk_duration,
-        
+
         "method": method,
-        
+
     }))
 
 
 
 def webm_dash_manifest(
-    
+
     adaptation_sets: str | None = None,
-    
+
     live: bool | None = None,
-    
+
     chunk_start_index: int | None = None,
-    
+
     chunk_duration_ms: int | None = None,
-    
+
     utc_timing_url: str | None = None,
-    
+
     time_shift_buffer_depth: float | None = None,
-    
+
     minimum_update_period: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     WebM DASH Manifest
-    
+
     Args:
         adaptation_sets: Adaptation sets. Syntax: id=0,streams=0,1,2 id=1,streams=3,4 and so on
         live: create a live stream manifest (default false)
@@ -5251,33 +5251,33 @@ def webm_dash_manifest(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "adaptation_sets": adaptation_sets,
-        
+
         "live": live,
-        
+
         "chunk_start_index": chunk_start_index,
-        
+
         "chunk_duration_ms": chunk_duration_ms,
-        
+
         "utc_timing_url": utc_timing_url,
-        
+
         "time_shift_buffer_depth": time_shift_buffer_depth,
-        
+
         "minimum_update_period": minimum_update_period,
-        
+
     }))
 
 
 
 def webp(
-    
+
     loop: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     WebP
-    
+
     Args:
         loop: Number of times to loop the output: 0 - infinite loop (from 0 to 65535) (default 1)
 
@@ -5285,792 +5285,87 @@ def webp(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def webvtt(
-    
+
 ) -> FFMpegMuxerOption:
     """
     WebVTT subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def wsaud(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Westwood Studios audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def wtv(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Windows Television (WTV)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def wv(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw WavPack
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def yuv4mpegpipe(
-    
+
 ) -> FFMpegMuxerOption:
     """
     YUV4MPEG pipe
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/packages/v6/src/ffmpeg/sources.py
+++ b/packages/v6/src/ffmpeg/sources.py
@@ -43,29 +43,29 @@ from .streams.audio import AudioStream
 import re
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def abuffer(
-    
 
-    
+
+
 
 
     *,
     time_base: Rational = Default('0/1'),sample_rate: Int = Default('0'),sample_fmt: Sample_fmt = Default('none'),channel_layout: String = Default(None),channels: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Buffer audio frames, and make them available to the filter chain.
 
 This source is mainly intended for a programmatic use, in particular
@@ -89,100 +89,100 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#abuffer)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='abuffer', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "time_base": time_base,
-            
+
             "sample_rate": sample_rate,
-            
+
             "sample_fmt": sample_fmt,
-            
+
             "channel_layout": channel_layout,
-            
+
             "channels": channels,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def aevalsrc(
-    
 
-    
+
+
 
 
     *,
     exprs: String = Default(None),nb_samples: Int = Default('1024'),sample_rate: String = Default('44100'),duration: Duration = Default('-0.000001'),channel_layout: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate an audio signal specified by an expression.
 
 This source accepts in input one or more expressions (one for each
@@ -207,60 +207,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aevalsrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='aevalsrc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "exprs": exprs,
-            
+
             "nb_samples": nb_samples,
-            
+
             "sample_rate": sample_rate,
-            
+
             "duration": duration,
-            
+
             "channel_layout": channel_layout,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def afdelaysrc(
-    
 
-    
+
+
 
 
     *,
     delay: Double = Default('0'),sample_rate: Int = Default('44100'),nb_samples: Int = Default('1024'),taps: Int = Default('0'),channel_layout: String = Default('stereo'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate a fractional delay FIR coefficients.
 
 The resulting stream can be used with afir filter for filtering the audio signal.
@@ -283,62 +283,62 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afdelaysrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='afdelaysrc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "delay": delay,
-            
+
             "sample_rate": sample_rate,
-            
+
             "nb_samples": nb_samples,
-            
+
             "taps": taps,
-            
+
             "channel_layout": channel_layout,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def afireqsrc(
-    
 
-    
+
+
 
 
     *,
     preset: Int| Literal["custom","flat","acoustic","bass","beats","classic","clear","deep bass","dubstep","electronic","hardstyle","hip-hop","jazz","metal","movie","pop","r&b","rock","vocal booster"] | Default = Default('flat'),gains: String = Default('0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'),bands: String = Default('25 40 63 100 160 250 400 630 1000 1600 2500 4000 6300 10000 16000 24000'),taps: Int = Default('4096'),sample_rate: Int = Default('44100'),nb_samples: Int = Default('1024'),interp: Int| Literal["linear","cubic"] | Default = Default('linear'),phase: Int| Literal["linear","min"] | Default = Default('min'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate a FIR equalizer coefficients.
 
 The resulting stream can be used with afir filter for filtering the audio signal.
@@ -364,62 +364,62 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afireqsrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='afireqsrc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "preset": preset,
-            
+
             "gains": gains,
-            
+
             "bands": bands,
-            
+
             "taps": taps,
-            
+
             "sample_rate": sample_rate,
-            
+
             "nb_samples": nb_samples,
-            
+
             "interp": interp,
-            
+
             "phase": phase,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
+
+
+
 def afirsrc(
-    
 
-    
+
+
 
 
     *,
     taps: Int = Default('1025'),frequency: String = Default('0 1'),magnitude: String = Default('1 1'),phase: String = Default('0 0'),sample_rate: Int = Default('44100'),nb_samples: Int = Default('1024'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('blackman'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate a FIR coefficients using frequency sampling method.
 
 The resulting stream can be used with afir filter for filtering the audio signal.
@@ -444,78 +444,78 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afirsrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='afirsrc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "taps": taps,
-            
+
             "frequency": frequency,
-            
+
             "magnitude": magnitude,
-            
+
             "phase": phase,
-            
+
             "sample_rate": sample_rate,
-            
+
             "nb_samples": nb_samples,
-            
+
             "win_func": win_func,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
 def ainterleave(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     nb_inputs: Int = Auto('len(streams)'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Temporally interleave frames from several inputs.
 
 interleave works with video inputs, ainterleave with audio.
@@ -554,58 +554,58 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#interleave)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='ainterleave', typings_input='[StreamType.audio] * int(nb_inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "nb_inputs": nb_inputs,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def allrgb(
-    
 
-    
+
+
 
 
     *,
     rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -666,52 +666,52 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='allrgb', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def allyuv(
-    
 
-    
+
+
 
 
     *,
     rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -772,60 +772,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='allyuv', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def amerge(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Merge two or more audio streams into a single multi-channel stream.
 
 The filter accepts the following options:
@@ -842,54 +842,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amerge)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='amerge', typings_input='[StreamType.audio] * int(inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def amix(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),dropout_transition: Float = Default('2'),weights: String = Default('1 1'),normalize: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Mixes multiple audio inputs into a single output.
 
 Note that this filter only supports float samples (the amerge
@@ -915,64 +915,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amix)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='amix', typings_input='[StreamType.audio] * int(inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "duration": duration,
-            
+
             "dropout_transition": dropout_transition,
-            
+
             "weights": weights,
-            
+
             "normalize": normalize,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
+
+
+
 def amovie(
-    
 
-    
+
+
 
 
     *,
     filename: String = Default(None),format_name: String = Default(None),stream_index: Int = Default('-1'),seek_point: Double = Default('0'),streams: String = Default(None),loop: Int = Default('1'),discontinuity: Duration = Default('0'),dec_threads: Int = Default('0'),format_opts: Dictionary = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 This is the same as movie source, except it selects an audio
 stream by default.
 
 
 Args:
-    filename: 
+    filename:
     format_name: set format name
     stream_index: set stream index (from -1 to INT_MAX) (default -1)
     seek_point: set seekpoint (seconds) (from 0 to 9.22337e+12) (default 0)
@@ -991,77 +991,77 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amovie)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='amovie', typings_input="[StreamType.audio] * len(streams.split('+'))", typings_output="[StreamType.audio] * len(streams.split('+'))"),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "filename": filename,
-            
+
             "format_name": format_name,
-            
+
             "stream_index": stream_index,
-            
+
             "seek_point": seek_point,
-            
+
             "streams": streams,
-            
+
             "loop": loop,
-            
+
             "discontinuity": discontinuity,
-            
+
             "dec_threads": dec_threads,
-            
+
             "format_opts": format_opts,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
 def anoisesrc(
-    
 
-    
+
+
 
 
     *,
     sample_rate: Int = Default('48000'),amplitude: Double = Default('1'),duration: Duration = Default('0'),color: Int| Literal["white","pink","brown","blue","violet","velvet"] | Default = Default('white'),seed: Int64 = Default('-1'),nb_samples: Int = Default('1024'),density: Double = Default('0.05'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate a noise audio signal.
 
 The filter accepts the following options:
@@ -1084,64 +1084,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anoisesrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='anoisesrc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "sample_rate": sample_rate,
-            
+
             "amplitude": amplitude,
-            
+
             "duration": duration,
-            
+
             "color": color,
-            
+
             "seed": seed,
-            
+
             "nb_samples": nb_samples,
-            
+
             "density": density,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def anullsrc(
-    
 
-    
+
+
 
 
     *,
     channel_layout: String = Default('stereo'),sample_rate: String = Default('44100'),nb_samples: Int = Default('1024'),duration: Duration = Default('-0.000001'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 The null audio source, return unprocessed audio frames. It is mainly useful
 as a template and to be employed in analysis / debugging tools, or as
 the source for filters which ignore the input data (for example the sox
@@ -1164,114 +1164,114 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anullsrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='anullsrc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "channel_layout": channel_layout,
-            
+
             "sample_rate": sample_rate,
-            
+
             "nb_samples": nb_samples,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def astreamselect(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),map: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Select video or audio streams.
 
 The filter accepts the following options:
@@ -1290,87 +1290,87 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#streamselect)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='astreamselect', typings_input='[StreamType.audio] * int(inputs)', typings_output="[StreamType.audio] * len(re.findall(r'\\d+', str(map)))"),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "map": map,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def avsynctest(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('hd720'),framerate: Video_rate = Default('30'),samplerate: Int = Default('44100'),amplitude: Float = Default('0.7'),period: Int = Default('3'),delay: Int = Default('0'),cycle: Boolean = Default('false'),duration: Duration = Default('0'),fg: Color = Default('white'),bg: Color = Default('black'),ag: Color = Default('gray'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> tuple[
-    
-        
+
+
             AudioStream,
-        
-    
-        
+
+
+
             VideoStream,
-        
-    
+
+
 ]:
     """
-    
+
 Generate an Audio/Video Sync Test.
 
 Generated stream periodically shows flash video frame and emits beep in audio.
@@ -1401,116 +1401,116 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#avsynctest)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='avsynctest', typings_input=(), typings_output=('audio', 'video')),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "framerate": framerate,
-            
+
             "samplerate": samplerate,
-            
+
             "amplitude": amplitude,
-            
+
             "period": period,
-            
+
             "delay": delay,
-            
+
             "cycle": cycle,
-            
+
             "duration": duration,
-            
+
             "fg": fg,
-            
+
             "bg": bg,
-            
+
             "ag": ag,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return (
-        
-            
+
+
                 filter_node.audio(0),
-            
-        
-            
+
+
+
                 filter_node.video(0),
-            
-        
+
+
     )
 
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def bm3d(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     sigma: Float = Default('1'),block: Int = Default('16'),bstep: Int = Default('4'),group: Int = Default('1'),range: Int = Default('9'),mstep: Int = Default('1'),thmse: Float = Default('0'),hdthr: Float = Default('2.7'),estim: Int| Literal["basic","final"] | Default = Default('basic'),ref: Boolean = Default('false'),planes: Int = Default('7'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Denoise frames using Block-Matching 3D algorithm.
 
 The filter accepts the following options.
@@ -1538,7 +1538,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bm3d)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -1546,71 +1546,71 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='bm3d', typings_input='[StreamType.video] + [StreamType.video] if ref else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "sigma": sigma,
-            
+
             "block": block,
-            
+
             "bstep": bstep,
-            
+
             "group": group,
-            
+
             "range": range,
-            
+
             "mstep": mstep,
-            
+
             "thmse": thmse,
-            
+
             "hdthr": hdthr,
-            
+
             "estim": estim,
-            
+
             "ref": ref,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def buffer(
-    
 
-    
+
+
 
 
     *,
     width: Int = Default('0'),video_size: Image_size = Default(None),height: Int = Default('0'),pix_fmt: Pix_fmt = Default('none'),sar: Rational = Default('0/1'),time_base: Rational = Default('0/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Buffer video frames, and make them available to the filter chain.
 
 This source is mainly intended for a programmatic use, in particular
@@ -1635,66 +1635,66 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#buffer)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='buffer', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "width": width,
-            
+
             "video_size": video_size,
-            
+
             "height": height,
-            
+
             "pix_fmt": pix_fmt,
-            
+
             "sar": sar,
-            
+
             "time_base": time_base,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def cellauto(
-    
 
-    
+
+
 
 
     *,
     filename: String = Default(None),pattern: String = Default(None),rate: Video_rate = Default('25'),size: Image_size = Default(None),rule: Int = Default('110'),random_fill_ratio: Double = Default('0.618034'),random_seed: Int64 = Default('-1'),scroll: Boolean = Default('true'),start_full: Boolean = Default('false'),full: Boolean = Default('true'),stitch: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Create a pattern generated by an elementary cellular automaton.
 
 The initial state of the cellular automaton can be defined through the
@@ -1729,86 +1729,86 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#cellauto)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='cellauto', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "filename": filename,
-            
+
             "pattern": pattern,
-            
+
             "rate": rate,
-            
+
             "size": size,
-            
+
             "rule": rule,
-            
+
             "random_fill_ratio": random_fill_ratio,
-            
+
             "random_seed": random_seed,
-            
+
             "scroll": scroll,
-            
+
             "start_full": start_full,
-            
+
             "full": full,
-            
+
             "stitch": stitch,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
 def color(
-    
 
-    
+
+
 
 
     *,
     color: Color = Default('black'),size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -1871,60 +1871,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='color', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "color": color,
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def colorchart(
-    
 
-    
+
+
 
 
     *,
     rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),patch_size: Image_size = Default('64x64'),preset: Int| Literal["reference","skintones"] | Default = Default('reference'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -1987,76 +1987,76 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='colorchart', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
             "patch_size": patch_size,
-            
+
             "preset": preset,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
 def colorspectrum(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),type: Int| Literal["black","white","all"] | Default = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -2119,64 +2119,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='colorspectrum', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
             "type": type,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def concat(
-    
 
-    
+
+
     *streams: FilterableStream,
-    
 
 
-    
+
+
     n: Int = Auto('len(streams) // (int(v) + int(a))'),v: Int = Default('1'),a: Int = Default('0'),unsafe: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Concatenate audio and video streams, joining them together one after the
 other.
 
@@ -2202,95 +2202,95 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#concat)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='concat', typings_input='([StreamType.video]*int(v) + [StreamType.audio]*int(a))*int(n)', typings_output='[StreamType.video]*int(v) + [StreamType.audio]*int(a)'),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "n": n,
-            
+
             "v": v,
-            
+
             "a": a,
-            
+
             "unsafe": unsafe,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def decimate(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     cycle: Int = Default('5'),dupthresh: Double = Default('1.1'),scthresh: Double = Default('15'),blockx: Int = Default('32'),blocky: Int = Default('32'),ppsrc: Boolean = Default('false'),chroma: Boolean = Default('true'),mixed: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Drop duplicated frames at regular intervals.
 
 The filter accepts the following options:
@@ -2314,162 +2314,162 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#decimate)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='decimate', typings_input='[StreamType.video] + ([StreamType.video] if ppsrc else [])', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "cycle": cycle,
-            
+
             "dupthresh": dupthresh,
-            
+
             "scthresh": scthresh,
-            
+
             "blockx": blockx,
-            
+
             "blocky": blocky,
-            
+
             "ppsrc": ppsrc,
-            
+
             "chroma": chroma,
-            
+
             "mixed": mixed,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def fieldmatch(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     order: Int| Literal["auto","bff","tff"] | Default = Default('auto'),mode: Int| Literal["pc","pc_n","pc_u","pc_n_ub","pcn","pcn_ub"] | Default = Default('pc_n'),ppsrc: Boolean = Default('false'),field: Int| Literal["auto","bottom","top"] | Default = Default('auto'),mchroma: Boolean = Default('true'),y0: Int = Default('0'),scthresh: Double = Default('12'),combmatch: Int| Literal["none","sc","full"] | Default = Default('sc'),combdbg: Int| Literal["none","pcn","pcnub"] | Default = Default('none'),cthresh: Int = Default('9'),chroma: Boolean = Default('false'),blockx: Int = Default('16'),blocky: Int = Default('16'),combpel: Int = Default('80'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Field matching filter for inverse telecine. It is meant to reconstruct the
 progressive frames from a telecined stream. The filter does not drop duplicated
 frames, so to achieve a complete inverse telecine fieldmatch needs to be
@@ -2527,112 +2527,112 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fieldmatch)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='fieldmatch', typings_input='[StreamType.video] + [StreamType.video] if ppsrc else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "order": order,
-            
+
             "mode": mode,
-            
+
             "ppsrc": ppsrc,
-            
+
             "field": field,
-            
+
             "mchroma": mchroma,
-            
+
             "y0": y0,
-            
+
             "scthresh": scthresh,
-            
+
             "combmatch": combmatch,
-            
+
             "combdbg": combdbg,
-            
+
             "cthresh": cthresh,
-            
+
             "chroma": chroma,
-            
+
             "blockx": blockx,
-            
+
             "blocky": blocky,
-            
+
             "combpel": combpel,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def gradients(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('640x480'),rate: Video_rate = Default('25'),c0: Color = Default('random'),c1: Color = Default('random'),c2: Color = Default('random'),c3: Color = Default('random'),c4: Color = Default('random'),c5: Color = Default('random'),c6: Color = Default('random'),c7: Color = Default('random'),x0: Int = Default('-1'),y0: Int = Default('-1'),x1: Int = Default('-1'),y1: Int = Default('-1'),nb_colors: Int = Default('2'),seed: Int64 = Default('-1'),duration: Duration = Default('-0.000001'),speed: Float = Default('0.01'),type: Int| Literal["linear","radial","circular","spiral"] | Default = Default('linear'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate several gradients.
 
 
@@ -2665,95 +2665,95 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#gradients)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='gradients', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "c0": c0,
-            
+
             "c1": c1,
-            
+
             "c2": c2,
-            
+
             "c3": c3,
-            
+
             "c4": c4,
-            
+
             "c5": c5,
-            
+
             "c6": c6,
-            
+
             "c7": c7,
-            
+
             "x0": x0,
-            
+
             "y0": y0,
-            
+
             "x1": x1,
-            
+
             "y1": y1,
-            
+
             "nb_colors": nb_colors,
-            
+
             "seed": seed,
-            
+
             "duration": duration,
-            
+
             "speed": speed,
-            
+
             "type": type,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def guided(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     radius: Int = Default('3'),eps: Float = Default('0.01'),mode: Int| Literal["basic","fast"] | Default = Default('basic'),sub: Int = Default('4'),guidance: Int| Literal["off","on"] | Default = Default('off'),planes: Int = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply guided filter for edge-preserving smoothing, dehazing and so on.
 
 The filter accepts the following options:
@@ -2776,7 +2776,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#guided)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -2784,61 +2784,61 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='guided', typings_input='[StreamType.video] + [StreamType.video] if guidance else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "radius": radius,
-            
+
             "eps": eps,
-            
+
             "mode": mode,
-            
+
             "sub": sub,
-            
+
             "guidance": guidance,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def haldclutsrc(
-    
 
-    
+
+
 
 
     *,
     level: Int = Default('6'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -2900,58 +2900,58 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='haldclutsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "level": level,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def headphone(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     map: String = Default(None),gain: Float = Default('0'),lfe: Float = Default('0'),type: Int| Literal["time","freq"] | Default = Default('freq'),size: Int = Default('1024'),hrir: Int| Literal["stereo","multich"] | Default = Default('stereo'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Apply head-related transfer functions (HRTFs) to create virtual
 loudspeakers around the user for binaural listening via headphones.
 The HRIRs are provided via additional streams, for each channel
@@ -2976,66 +2976,66 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#headphone)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='headphone', typings_input="[StreamType.audio] + [StreamType.audio] * (len(str(map).split('|')) - 1) if int(hrir) == 1 else []", typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "map": map,
-            
+
             "gain": gain,
-            
+
             "lfe": lfe,
-            
+
             "type": type,
-            
+
             "size": size,
-            
+
             "hrir": hrir,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def hilbert(
-    
 
-    
+
+
 
 
     *,
     sample_rate: Int = Default('44100'),taps: Int = Default('22051'),nb_samples: Int = Default('1024'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('blackman'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate odd-tap Hilbert transform FIR coefficients.
 
 The resulting stream can be used with afir filter for phase-shifting
@@ -3061,64 +3061,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hilbert)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='hilbert', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "sample_rate": sample_rate,
-            
+
             "taps": taps,
-            
+
             "nb_samples": nb_samples,
-            
+
             "win_func": win_func,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def hstack(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),shortest: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos horizontally.
 
 All streams must be of same pixel format and of same height.
@@ -3141,54 +3141,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hstack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='hstack', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def hstack_vaapi(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Default('2'),shortest: Boolean = Default('false'),height: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos horizontally.
 
 This is the VA-API variant of the hstack filter, each input stream may
@@ -3211,82 +3211,82 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hstack_vaapi)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='hstack_vaapi', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
             "height": height,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def interleave(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     nb_inputs: Int = Auto('len(streams)'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Temporally interleave frames from several inputs.
 
 interleave works with video inputs, ainterleave with audio.
@@ -3325,54 +3325,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#interleave)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='interleave', typings_input='[StreamType.video] * int(nb_inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "nb_inputs": nb_inputs,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def join(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),channel_layout: String = Default('stereo'),map: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Join multiple input streams into one multi-channel stream.
 
 It accepts the following parameters:
@@ -3391,64 +3391,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#join)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='join', typings_input='[StreamType.audio] * int(inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "channel_layout": channel_layout,
-            
+
             "map": map,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
 def life(
-    
 
-    
+
+
 
 
     *,
     filename: String = Default(None),size: Image_size = Default(None),rate: Video_rate = Default('25'),rule: String = Default('B3/S23'),random_fill_ratio: Double = Default('0.618034'),random_seed: Int64 = Default('-1'),stitch: Boolean = Default('true'),mold: Int = Default('0'),life_color: Color = Default('white'),death_color: Color = Default('black'),mold_color: Color = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate a life pattern.
 
 This source is based on a generalization of John Conway's life game.
@@ -3487,73 +3487,73 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#life)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='life', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "filename": filename,
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "rule": rule,
-            
+
             "random_fill_ratio": random_fill_ratio,
-            
+
             "random_seed": random_seed,
-            
+
             "stitch": stitch,
-            
+
             "mold": mold,
-            
+
             "life_color": life_color,
-            
+
             "death_color": death_color,
-            
+
             "mold_color": mold_color,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def limitdiff(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     threshold: Float = Default('0.00392157'),elasticity: Float = Default('2'),reference: Boolean = Default('false'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply limited difference filter using second and optionally third video stream.
 
 The filter accepts the following options:
@@ -3574,7 +3574,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#limitdiff)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -3582,77 +3582,77 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='limitdiff', typings_input='[StreamType.video, StreamType.video] + ([StreamType.video] if reference else [])', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "threshold": threshold,
-            
+
             "elasticity": elasticity,
-            
+
             "reference": reference,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def mandelbrot(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('640x480'),rate: Video_rate = Default('25'),maxiter: Int = Default('7189'),start_x: Double = Default('-0.743644'),start_y: Double = Default('-0.131826'),start_scale: Double = Default('3'),end_scale: Double = Default('0.3'),end_pts: Double = Default('400'),bailout: Double = Default('10'),morphxf: Double = Default('0.01'),morphyf: Double = Default('0.0123'),morphamp: Double = Default('0'),outer: Int| Literal["iteration_count","normalized_iteration_count","white","outz"] | Default = Default('normalized_iteration_count'),inner: Int| Literal["black","period","convergence","mincol"] | Default = Default('mincol'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate a Mandelbrot set fractal, and progressively zoom towards the
 point specified with start_x and start_y.
 
@@ -3683,94 +3683,94 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mandelbrot)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='mandelbrot', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "maxiter": maxiter,
-            
+
             "start_x": start_x,
-            
+
             "start_y": start_y,
-            
+
             "start_scale": start_scale,
-            
+
             "end_scale": end_scale,
-            
+
             "end_pts": end_pts,
-            
+
             "bailout": bailout,
-            
+
             "morphxf": morphxf,
-            
+
             "morphyf": morphyf,
-            
+
             "morphamp": morphamp,
-            
+
             "outer": outer,
-            
+
             "inner": inner,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
 def mergeplanes(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     mapping: Int = Default('-1'),format: Pix_fmt = Default('yuva444p'),map0s: Int = Default('0'),map0p: Int = Default('0'),map1s: Int = Default('0'),map1p: Int = Default('0'),map2s: Int = Default('0'),map2p: Int = Default('0'),map3s: Int = Default('0'),map3p: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Merge color channel components from several video streams.
 
 The filter accepts up to 4 input streams, and merge selected input
@@ -3799,81 +3799,81 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mergeplanes)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='mergeplanes', typings_input='[StreamType.video] * int(max(hex(int(mapping))[2::2]))', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "mapping": mapping,
-            
+
             "format": format,
-            
+
             "map0s": map0s,
-            
+
             "map0p": map0p,
-            
+
             "map1s": map1s,
-            
+
             "map1p": map1p,
-            
+
             "map2s": map2s,
-            
+
             "map2p": map2p,
-            
+
             "map3s": map3s,
-            
+
             "map3p": map3p,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def mix(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),weights: String = Default('1 1'),scale: Float = Default('0'),planes: Flags = Default('F'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Mix several video input streams into one video stream.
 
 A description of the accepted options follows.
@@ -3895,7 +3895,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mix)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -3903,59 +3903,59 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='mix', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "weights": weights,
-            
+
             "scale": scale,
-            
+
             "planes": planes,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def movie(
-    
 
-    
+
+
 
 
     *,
     filename: String = Default(None),format_name: String = Default(None),stream_index: Int = Default('-1'),seek_point: Double = Default('0'),streams: String = Default(None),loop: Int = Default('1'),discontinuity: Duration = Default('0'),dec_threads: Int = Default('0'),format_opts: Dictionary = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Read audio and/or video stream(s) from a movie container.
 
 It accepts the following parameters:
@@ -3981,67 +3981,67 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#movie)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='movie', typings_input="[StreamType.video] * len(streams.split('+'))", typings_output="[StreamType.video] * len(streams.split('+'))"),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "filename": filename,
-            
+
             "format_name": format_name,
-            
+
             "stream_index": stream_index,
-            
+
             "seek_point": seek_point,
-            
+
             "streams": streams,
-            
+
             "loop": loop,
-            
+
             "discontinuity": discontinuity,
-            
+
             "dec_threads": dec_threads,
-            
+
             "format_opts": format_opts,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def mptestsrc(
-    
 
-    
+
+
 
 
     *,
     rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),test: Int| Literal["dc_luma","dc_chroma","freq_luma","freq_chroma","amp_luma","amp_chroma","cbp","mv","ring1","ring2","all"] | Default = Default('all'),max_frames: Int64 = Default('30'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate various test patterns, as generated by the MPlayer test filter.
 
 The size of the generated video is fixed, and is 256x256.
@@ -4064,76 +4064,76 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mptestsrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='mptestsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "test": test,
-            
+
             "max_frames": max_frames,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def nullsrc(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -4195,54 +4195,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='nullsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def openclsrc(
-    
 
-    
+
+
 
 
     *,
     source: String = Default(None),kernel: String = Default(None),size: Image_size = Default(None),format: Pix_fmt = Default('none'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate video using an OpenCL program.
 
 
@@ -4261,70 +4261,70 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#openclsrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='openclsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "source": source,
-            
+
             "kernel": kernel,
-            
+
             "size": size,
-            
+
             "format": format,
-            
+
             "rate": rate,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
 def pal100bars(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -4386,54 +4386,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='pal100bars', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def pal75bars(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -4495,83 +4495,83 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='pal75bars', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def premultiply(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     planes: Int = Default('15'),inplace: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply alpha premultiply effect to input video stream using first plane
 of second stream as alpha.
 
@@ -4593,7 +4593,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#premultiply)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4601,62 +4601,62 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='premultiply', typings_input='[StreamType.video] + [StreamType.video] if inplace else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "inplace": inplace,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def program_opencl(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     source: String = Default(None),kernel: String = Default(None),inputs: Int = Default('1'),size: Image_size = Default(None),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Filter video using an OpenCL program.
 
 
@@ -4675,7 +4675,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#program_opencl)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -4683,85 +4683,85 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='program_opencl', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "source": source,
-            
+
             "kernel": kernel,
-            
+
             "inputs": inputs,
-            
+
             "size": size,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def rgbtestsrc(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),complement: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -4824,138 +4824,138 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='rgbtestsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
             "complement": complement,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def sierpinski(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('640x480'),rate: Video_rate = Default('25'),seed: Int64 = Default('-1'),jump: Int = Default('100'),type: Int| Literal["carpet","triangle"] | Default = Default('carpet'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate a Sierpinski carpet/triangle fractal, and randomly pan around.
 
 This source accepts the following options:
@@ -4976,60 +4976,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sierpinski)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='sierpinski', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "seed": seed,
-            
+
             "jump": jump,
-            
+
             "type": type,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def signature(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     detectmode: Int| Literal["off","full","fast"] | Default = Default('off'),nb_inputs: Int = Auto('len(streams)'),filename: String = Default(''),format: Int| Literal["binary","xml"] | Default = Default('binary'),th_d: Int = Default('9000'),th_dc: Int = Default('60000'),th_xh: Int = Default('116'),th_di: Int = Default('0'),th_it: Double = Default('0.5'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Calculates the MPEG-7 Video Signature. The filter can handle more than one
 input. In this case the matching between the inputs can be calculated additionally.
 The filter always passes through the first input. The signature of each stream can
@@ -5057,70 +5057,70 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#signature)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='signature', typings_input='[StreamType.video] * int(nb_inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "detectmode": detectmode,
-            
+
             "nb_inputs": nb_inputs,
-            
+
             "filename": filename,
-            
+
             "format": format,
-            
+
             "th_d": th_d,
-            
+
             "th_dc": th_dc,
-            
+
             "th_xh": th_xh,
-            
+
             "th_di": th_di,
-            
+
             "th_it": th_it,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def sinc(
-    
 
-    
+
+
 
 
     *,
     sample_rate: Int = Default('44100'),nb_samples: Int = Default('1024'),hp: Float = Default('0'),lp: Float = Default('0'),phase: Float = Default('50'),beta: Float = Default('-1'),att: Float = Default('120'),round: Boolean = Default('false'),hptaps: Int = Default('0'),lptaps: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate a sinc kaiser-windowed low-pass, high-pass, band-pass, or band-reject FIR coefficients.
 
 The resulting stream can be used with afir filter for filtering the audio signal.
@@ -5148,66 +5148,66 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sinc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='sinc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "sample_rate": sample_rate,
-            
+
             "nb_samples": nb_samples,
-            
+
             "hp": hp,
-            
+
             "lp": lp,
-            
+
             "phase": phase,
-            
+
             "beta": beta,
-            
+
             "att": att,
-            
+
             "round": round,
-            
+
             "hptaps": hptaps,
-            
+
             "lptaps": lptaps,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
+
+
+
 def sine(
-    
 
-    
+
+
 
 
     *,
     frequency: Double = Default('440'),beep_factor: Double = Default('0'),sample_rate: Int = Default('44100'),duration: Duration = Default('0'),samples_per_frame: String = Default('1024'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate an audio signal made of a sine wave with amplitude 1/8.
 
 The audio signal is bit-exact.
@@ -5230,60 +5230,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sine)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='sine', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "frequency": frequency,
-            
+
             "beep_factor": beep_factor,
-            
+
             "sample_rate": sample_rate,
-            
+
             "duration": duration,
-            
+
             "samples_per_frame": samples_per_frame,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def smptebars(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -5345,54 +5345,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='smptebars', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def smptehdbars(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -5454,80 +5454,80 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='smptehdbars', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def streamselect(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),map: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Select video or audio streams.
 
 The filter accepts the following options:
@@ -5546,69 +5546,69 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#streamselect)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='streamselect', typings_input='[StreamType.video] * int(inputs)', typings_output="[StreamType.video] * len(re.findall(r'\\d+', str(map)))"),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "map": map,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
 def testsrc(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),decimals: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -5671,56 +5671,56 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='testsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
             "decimals": decimals,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def testsrc2(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),alpha: Int = Default('255'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -5783,101 +5783,101 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='testsrc2', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
             "alpha": alpha,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def unpremultiply(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     planes: Int = Default('15'),inplace: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply alpha unpremultiply effect to input video stream using first plane
 of second stream as alpha.
 
@@ -5899,7 +5899,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#unpremultiply)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -5907,91 +5907,91 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='unpremultiply', typings_input='[StreamType.video] + ([StreamType.video] if inplace else [])', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "inplace": inplace,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def vstack(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),shortest: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos vertically.
 
 All streams must be of same pixel format and of same width.
@@ -6014,54 +6014,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vstack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='vstack', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def vstack_vaapi(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Default('2'),shortest: Boolean = Default('false'),width: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos vertically.
 
 This is the VA-API variant of the vstack filter, each input stream may
@@ -6084,78 +6084,78 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vstack_vaapi)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='vstack_vaapi', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
             "width": width,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
 def xmedian(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),planes: Int = Default('15'),percentile: Float = Default('0.5'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Pick median pixels from several input videos.
 
 The filter accepts the following options:
@@ -6176,7 +6176,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xmedian)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -6187,55 +6187,55 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xmedian', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "planes": planes,
-            
+
             "percentile": percentile,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xstack(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),layout: String = Default(None),grid: Image_size = Default(None),shortest: Boolean = Default('false'),fill: String = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack video inputs into custom layout.
 
 All streams must be of same pixel format.
@@ -6258,60 +6258,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xstack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xstack', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "layout": layout,
-            
+
             "grid": grid,
-            
+
             "shortest": shortest,
-            
+
             "fill": fill,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xstack_vaapi(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Default('2'),shortest: Boolean = Default('false'),layout: String = Default(None),grid: Image_size = Default(None),grid_tile_size: Image_size = Default(None),fill: String = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack video inputs into custom layout.
 
 This is the VA-API variant of the xstack filter,  each input stream may
@@ -6337,64 +6337,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xstack_vaapi)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xstack_vaapi', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
             "layout": layout,
-            
+
             "grid": grid,
-            
+
             "grid_tile_size": grid_tile_size,
-            
+
             "fill": fill,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def yuvtestsrc(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -6456,56 +6456,56 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='yuvtestsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def zoneplate(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),precision: Int = Default('10'),xo: Int = Default('0'),yo: Int = Default('0'),to: Int = Default('0'),k0: Int = Default('0'),kx: Int = Default('0'),ky: Int = Default('0'),kt: Int = Default('0'),kxt: Int = Default('0'),kyt: Int = Default('0'),kxy: Int = Default('0'),kx2: Int = Default('0'),ky2: Int = Default('0'),kt2: Int = Default('0'),ku: Int = Default('0'),kv: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate a zoneplate test video pattern.
 
 This source accepts the following options:
@@ -6541,69 +6541,62 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#zoneplate)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='zoneplate', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
             "precision": precision,
-            
+
             "xo": xo,
-            
+
             "yo": yo,
-            
+
             "to": to,
-            
+
             "k0": k0,
-            
+
             "kx": kx,
-            
+
             "ky": ky,
-            
+
             "kt": kt,
-            
+
             "kxt": kxt,
-            
+
             "kyt": kyt,
-            
+
             "kxy": kxy,
-            
+
             "kx2": kx2,
-            
+
             "ky2": ky2,
-            
+
             "kt2": kt2,
-            
+
             "ku": ku,
-            
+
             "kv": kv,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
-
-
-    
-
-    
-
-    

--- a/packages/v6/src/ffmpeg/streams/audio.py
+++ b/packages/v6/src/ffmpeg/streams/audio.py
@@ -48,12 +48,12 @@ class AudioStream(FilterableStream):
     Audio stream.
     """
 
-    
-        
-    
-    
+
+
+
+
     def a3dscope(
-    
+
     self,
 
 
@@ -61,12 +61,12 @@ class AudioStream(FilterableStream):
 
     *,
     rate: Video_rate = Default('25'),size: Image_size = Default('hd720'),fov: Float = Default('90'),roll: Float = Default('0'),pitch: Float = Default('0'),yaw: Float = Default('0'),xzoom: Float = Default('1'),xpos: Float = Default('0'),length: Int = Default('15'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to 3d scope video output.
 
 The filter accepts the following options:
@@ -91,53 +91,53 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#a3dscope)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='a3dscope', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rate": rate,
-                
+
                 "size": size,
-                
+
                 "fov": fov,
-                
+
                 "roll": roll,
-                
+
                 "pitch": pitch,
-                
+
                 "yaw": yaw,
-                
+
                 "xzoom": xzoom,
-                
+
                 "xpos": xpos,
-                
+
                 "length": length,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def abench(
-    
+
     self,
 
 
@@ -145,12 +145,12 @@ References:
 
     *,
     action: Int| Literal["start","stop"] | Default = Default('start'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Benchmark part of a filtergraph.
 
 The filter accepts the following options:
@@ -167,37 +167,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bench)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='abench', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "action": action,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def abitscope(
-    
+
     self,
 
 
@@ -205,12 +205,12 @@ References:
 
     *,
     rate: Video_rate = Default('25'),size: Image_size = Default('1024x256'),colors: String = Default('red|green|blue|yellow|orange|lime|pink|magenta|brown'),mode: Int| Literal["bars","trace"] | Default = Default('bars'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a video output, displaying the audio bit scope.
 
 The filter accepts the following options:
@@ -230,47 +230,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#abitscope)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='abitscope', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rate": rate,
-                
+
                 "size": size,
-                
+
                 "colors": colors,
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def acompressor(
-    
+
     self,
 
 
@@ -278,12 +278,12 @@ References:
 
     *,
     level_in: Double = Default('1'),mode: Int| Literal["downward","upward"] | Default = Default('downward'),threshold: Double = Default('0.125'),ratio: Double = Default('2'),attack: Double = Default('20'),release: Double = Default('250'),makeup: Double = Default('1'),knee: Double = Default('2.82843'),link: Int| Literal["average","maximum"] | Default = Default('average'),detection: Int| Literal["peak","rms"] | Default = Default('rms'),level_sc: Double = Default('1'),mix: Double = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 A compressor is mainly used to reduce the dynamic range of a signal.
 Especially modern music is mostly compressed at a high ratio to
 improve the overall loudness. It's done to get the highest attention
@@ -336,59 +336,59 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acompressor)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acompressor', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "mode": mode,
-                
+
                 "threshold": threshold,
-                
+
                 "ratio": ratio,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "makeup": makeup,
-                
+
                 "knee": knee,
-                
+
                 "link": link,
-                
+
                 "detection": detection,
-                
+
                 "level_sc": level_sc,
-                
+
                 "mix": mix,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def acontrast(
-    
+
     self,
 
 
@@ -396,12 +396,12 @@ References:
 
     *,
     contrast: Float = Default('33'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Simple audio dynamic range compression/expansion filter.
 
 The filter accepts the following options:
@@ -418,50 +418,50 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acontrast)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acontrast', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "contrast": contrast,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def acopy(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Copy the input audio source unchanged to the output. This is mainly useful for
 testing purposes.
 
@@ -476,56 +476,56 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acopy)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acopy', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def acrossfade(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _crossfade1: AudioStream,
-        
-    
+
+
 
 
     *,
     nb_samples: Int = Default('44100'),duration: Duration = Default('0'),overlap: Boolean = Default('true'),curve1: Int| Literal["nofade","tri","qsin","esin","hsin","log","ipar","qua","cub","squ","cbr","par","exp","iqsin","ihsin","dese","desi","losi","sinc","isinc","quat","quatr","qsin2","hsin2"] | Default = Default('tri'),curve2: Int| Literal["nofade","tri","qsin","esin","hsin","log","ipar","qua","cub","squ","cbr","par","exp","iqsin","ihsin","dese","desi","losi","sinc","isinc","quat","quatr","qsin2","hsin2"] | Default = Default('tri'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply cross fade from one input audio stream to another input audio stream.
 The cross fade is applied for specified duration near the end of first stream.
 
@@ -547,53 +547,53 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acrossfade)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acrossfade', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _crossfade1,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "nb_samples": nb_samples,
-                
+
                 "duration": duration,
-                
+
                 "overlap": overlap,
-                
+
                 "curve1": curve1,
-                
+
                 "curve2": curve2,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def acrossover(
-    
+
     self,
 
 
@@ -601,12 +601,12 @@ References:
 
     *,
     split: String = Default('500'),order: Int| Literal["2nd","4th","6th","8th","10th","12th","14th","16th","18th","20th"] | Default = Default('4th'),level: Float = Default('1'),gain: String = Default('1.f'),precision: Int| Literal["auto","float","double"] | Default = Default('auto'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Split audio stream into several bands.
 
 This filter splits audio stream into two or more frequency ranges.
@@ -631,46 +631,46 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acrossover)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acrossover', typings_input=('audio',), typings_output="[StreamType.audio] * len(re.split(r'[ |]+', str(split)))"),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "split": split,
-                
+
                 "order": order,
-                
+
                 "level": level,
-                
+
                 "gain": gain,
-                
+
                 "precision": precision,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def acrusher(
-    
+
     self,
 
 
@@ -678,15 +678,15 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),bits: Double = Default('8'),mix: Double = Default('0.5'),mode: Int| Literal["lin","log"] | Default = Default('lin'),dc: Double = Default('1'),aa: Double = Default('0.5'),samples: Double = Default('1'),lfo: Boolean = Default('false'),lforange: Double = Default('20'),lforate: Double = Default('0.3'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Reduce audio bit resolution.
 
 This filter is bit crusher with enhanced functionality. A bit crusher
@@ -731,7 +731,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acrusher)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -739,54 +739,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acrusher', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "bits": bits,
-                
+
                 "mix": mix,
-                
+
                 "mode": mode,
-                
+
                 "dc": dc,
-                
+
                 "aa": aa,
-                
+
                 "samples": samples,
-                
+
                 "lfo": lfo,
-                
+
                 "lforange": lforange,
-                
+
                 "lforate": lforate,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def acue(
-    
+
     self,
 
 
@@ -794,12 +794,12 @@ References:
 
     *,
     cue: Int64 = Default('0'),preroll: Duration = Default('0'),buffer: Duration = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Delay audio filtering until a given wallclock timestamp. See the cue
 filter.
 
@@ -817,43 +817,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acue)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acue', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cue": cue,
-                
+
                 "preroll": preroll,
-                
+
                 "buffer": buffer,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def adeclick(
-    
+
     self,
 
 
@@ -861,15 +861,15 @@ References:
 
     *,
     window: Double = Default('55'),overlap: Double = Default('75'),arorder: Double = Default('2'),threshold: Double = Default('2'),burst: Double = Default('2'),method: Int| Literal["add","a","save","s"] | Default = Default('add'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Remove impulsive noise from input audio.
 
 Samples detected as impulsive noise are replaced by interpolated samples using
@@ -893,7 +893,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adeclick)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -901,44 +901,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adeclick', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "window": window,
-                
+
                 "overlap": overlap,
-                
+
                 "arorder": arorder,
-                
+
                 "threshold": threshold,
-                
+
                 "burst": burst,
-                
+
                 "method": method,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adeclip(
-    
+
     self,
 
 
@@ -946,15 +946,15 @@ References:
 
     *,
     window: Double = Default('55'),overlap: Double = Default('75'),arorder: Double = Default('8'),threshold: Double = Default('10'),hsize: Int = Default('1000'),method: Int| Literal["add","a","save","s"] | Default = Default('add'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Remove clipped samples from input audio.
 
 Samples detected as clipped are replaced by interpolated samples using
@@ -978,7 +978,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adeclip)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -986,44 +986,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adeclip', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "window": window,
-                
+
                 "overlap": overlap,
-                
+
                 "arorder": arorder,
-                
+
                 "threshold": threshold,
-                
+
                 "hsize": hsize,
-                
+
                 "method": method,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adecorrelate(
-    
+
     self,
 
 
@@ -1031,15 +1031,15 @@ References:
 
     *,
     stages: Int = Default('6'),seed: Int64 = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply decorrelation to input audio stream.
 
 The filter accepts the following options:
@@ -1058,7 +1058,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adecorrelate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1066,36 +1066,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adecorrelate', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "stages": stages,
-                
+
                 "seed": seed,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adelay(
-    
+
     self,
 
 
@@ -1103,15 +1103,15 @@ References:
 
     *,
     delays: String = Default(None),all: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Delay one or more audio channels.
 
 Samples in delayed channel are filled with silence.
@@ -1132,7 +1132,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adelay)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1140,36 +1140,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adelay', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "delays": delays,
-                
+
                 "all": all,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adenorm(
-    
+
     self,
 
 
@@ -1177,15 +1177,15 @@ References:
 
     *,
     level: Double = Default('-351'),type: Int| Literal["dc","ac","square","pulse"] | Default = Default('dc'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Remedy denormals in audio by adding extremely low-level noise.
 
 This filter shall be placed before any filter that can produce denormals.
@@ -1206,7 +1206,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adenorm)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1214,52 +1214,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adenorm', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level": level,
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aderivative(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Compute derivative/integral of audio stream.
 
 Applying both filters one after another produces original audio.
@@ -1276,7 +1276,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aderivative)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1284,32 +1284,32 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aderivative', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adrawgraph(
-    
+
     self,
 
 
@@ -1317,12 +1317,12 @@ References:
 
     *,
     m1: String = Default(''),fg1: String = Default('0xffff0000'),m2: String = Default(''),fg2: String = Default('0xff00ff00'),m3: String = Default(''),fg3: String = Default('0xffff00ff'),m4: String = Default(''),fg4: String = Default('0xffffff00'),bg: Color = Default('white'),min: Float = Default('-1'),max: Float = Default('1'),mode: Int| Literal["bar","dot","line"] | Default = Default('line'),slide: Int| Literal["frame","replace","scroll","rscroll","picture"] | Default = Default('frame'),size: Image_size = Default('900x256'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw a graph using input audio metadata.
 
 See drawgraph
@@ -1353,65 +1353,65 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adrawgraph)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adrawgraph', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "m1": m1,
-                
+
                 "fg1": fg1,
-                
+
                 "m2": m2,
-                
+
                 "fg2": fg2,
-                
+
                 "m3": m3,
-                
+
                 "fg3": fg3,
-                
+
                 "m4": m4,
-                
+
                 "fg4": fg4,
-                
+
                 "bg": bg,
-                
+
                 "min": min,
-                
+
                 "max": max,
-                
+
                 "mode": mode,
-                
+
                 "slide": slide,
-                
+
                 "size": size,
-                
+
                 "rate": rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adrc(
-    
+
     self,
 
 
@@ -1419,15 +1419,15 @@ References:
 
     *,
     transfer: String = Default('p'),attack: Double = Default('50'),release: Double = Default('100'),channels: String = Default('all'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply spectral dynamic range controller filter to input audio stream.
 
 A description of the accepted options follows.
@@ -1448,7 +1448,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adrc)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1456,40 +1456,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adrc', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "transfer": transfer,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "channels": channels,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adynamicequalizer(
-    
+
     self,
 
 
@@ -1497,15 +1497,15 @@ References:
 
     *,
     threshold: Double = Default('0'),dfrequency: Double = Default('1000'),dqfactor: Double = Default('1'),tfrequency: Double = Default('1000'),tqfactor: Double = Default('1'),attack: Double = Default('20'),release: Double = Default('200'),ratio: Double = Default('1'),makeup: Double = Default('0'),range: Double = Default('50'),mode: Int| Literal["listen","cut","boost"] | Default = Default('cut'),dftype: Int| Literal["bandpass","lowpass","highpass","peak"] | Default = Default('bandpass'),tftype: Int| Literal["bell","lowshelf","highshelf"] | Default = Default('bell'),direction: Int| Literal["downward","upward"] | Default = Default('downward'),auto: Int| Literal["disabled","off","on"] | Default = Default('disabled'),precision: Int| Literal["auto","float","double"] | Default = Default('auto'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply dynamic equalization to input audio stream.
 
 A description of the accepted options follows.
@@ -1538,7 +1538,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adynamicequalizer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1546,64 +1546,64 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adynamicequalizer', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold": threshold,
-                
+
                 "dfrequency": dfrequency,
-                
+
                 "dqfactor": dqfactor,
-                
+
                 "tfrequency": tfrequency,
-                
+
                 "tqfactor": tqfactor,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "ratio": ratio,
-                
+
                 "makeup": makeup,
-                
+
                 "range": range,
-                
+
                 "mode": mode,
-                
+
                 "dftype": dftype,
-                
+
                 "tftype": tftype,
-                
+
                 "direction": direction,
-                
+
                 "auto": auto,
-                
+
                 "precision": precision,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adynamicsmooth(
-    
+
     self,
 
 
@@ -1611,15 +1611,15 @@ References:
 
     *,
     sensitivity: Double = Default('2'),basefreq: Double = Default('22050'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply dynamic smoothing to input audio stream.
 
 A description of the accepted options follows.
@@ -1638,7 +1638,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adynamicsmooth)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1646,36 +1646,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adynamicsmooth', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sensitivity": sensitivity,
-                
+
                 "basefreq": basefreq,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aecho(
-    
+
     self,
 
 
@@ -1683,12 +1683,12 @@ References:
 
     *,
     in_gain: Float = Default('0.6'),out_gain: Float = Default('0.3'),delays: String = Default('1000'),decays: String = Default('0.5'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply echoing to the input audio.
 
 Echoes are reflected sound and can occur naturally amongst mountains
@@ -1716,43 +1716,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aecho)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aecho', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "in_gain": in_gain,
-                
+
                 "out_gain": out_gain,
-                
+
                 "delays": delays,
-                
+
                 "decays": decays,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aemphasis(
-    
+
     self,
 
 
@@ -1760,15 +1760,15 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),mode: Int| Literal["reproduction","production"] | Default = Default('reproduction'),type: Int| Literal["col","emi","bsi","riaa","cd","50fm","75fm","50kf","75kf"] | Default = Default('cd'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Audio emphasis filter creates or restores material directly taken from LPs or
 emphased CDs with different filter curves. E.g. to store music on vinyl the
 signal has to be altered by a filter first to even out the disadvantages of
@@ -1794,7 +1794,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aemphasis)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1802,40 +1802,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aemphasis', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "mode": mode,
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aeval(
-    
+
     self,
 
 
@@ -1843,15 +1843,15 @@ References:
 
     *,
     exprs: String = Default(None),channel_layout: String = Default(None),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Modify an audio signal according to the specified expressions.
 
 This filter accepts one or more expressions (one for each channel),
@@ -1873,7 +1873,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aeval)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1881,38 +1881,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aeval', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "exprs": exprs,
-                
+
                 "channel_layout": channel_layout,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def aexciter(
-    
+
     self,
 
 
@@ -1920,15 +1920,15 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),amount: Double = Default('1'),drive: Double = Default('8.5'),blend: Double = Default('0'),freq: Double = Default('7500'),ceil: Double = Default('9999'),listen: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 An exciter is used to produce high sound that is not present in the
 original signal. This is done by creating harmonic distortions of the
 signal which are restricted in range and added to the original signal.
@@ -1958,7 +1958,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aexciter)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1966,48 +1966,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aexciter', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "amount": amount,
-                
+
                 "drive": drive,
-                
+
                 "blend": blend,
-                
+
                 "freq": freq,
-                
+
                 "ceil": ceil,
-                
+
                 "listen": listen,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def afade(
-    
+
     self,
 
 
@@ -2015,15 +2015,15 @@ References:
 
     *,
     type: Int| Literal["in","out"] | Default = Default('in'),start_sample: Int64 = Default('0'),nb_samples: Int64 = Default('44100'),start_time: Duration = Default('0'),duration: Duration = Default('0'),curve: Int| Literal["nofade","tri","qsin","esin","hsin","log","ipar","qua","cub","squ","cbr","par","exp","iqsin","ihsin","dese","desi","losi","sinc","isinc","quat","quatr","qsin2","hsin2"] | Default = Default('tri'),silence: Double = Default('0'),unity: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply fade-in/out effect to input audio.
 
 A description of the accepted parameters follows.
@@ -2048,7 +2048,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afade)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2056,50 +2056,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='afade', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "type": type,
-                
+
                 "start_sample": start_sample,
-                
+
                 "nb_samples": nb_samples,
-                
+
                 "start_time": start_time,
-                
+
                 "duration": duration,
-                
+
                 "curve": curve,
-                
+
                 "silence": silence,
-                
+
                 "unity": unity,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def afftdn(
-    
+
     self,
 
 
@@ -2107,15 +2107,15 @@ References:
 
     *,
     noise_reduction: Float = Default('12'),noise_floor: Float = Default('-50'),noise_type: Int| Literal["white","w","vinyl","v","shellac","s","custom","c"] | Default = Default('white'),band_noise: String = Default(None),residual_floor: Float = Default('-38'),track_noise: Boolean = Default('false'),track_residual: Boolean = Default('false'),output_mode: Int| Literal["input","i","output","o","noise","n"] | Default = Default('output'),adaptivity: Float = Default('0.5'),floor_offset: Float = Default('1'),noise_link: Int| Literal["none","min","max","average"] | Default = Default('min'),band_multiplier: Float = Default('1.25'),sample_noise: Int| Literal["none","start","begin","stop","end"] | Default = Default('none'),gain_smooth: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Denoise audio samples with FFT.
 
 A description of the accepted parameters follows.
@@ -2146,7 +2146,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afftdn)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2154,60 +2154,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='afftdn', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "noise_reduction": noise_reduction,
-                
+
                 "noise_floor": noise_floor,
-                
+
                 "noise_type": noise_type,
-                
+
                 "band_noise": band_noise,
-                
+
                 "residual_floor": residual_floor,
-                
+
                 "track_noise": track_noise,
-                
+
                 "track_residual": track_residual,
-                
+
                 "output_mode": output_mode,
-                
+
                 "adaptivity": adaptivity,
-                
+
                 "floor_offset": floor_offset,
-                
+
                 "noise_link": noise_link,
-                
+
                 "band_multiplier": band_multiplier,
-                
+
                 "sample_noise": sample_noise,
-                
+
                 "gain_smooth": gain_smooth,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def afftfilt(
-    
+
     self,
 
 
@@ -2215,15 +2215,15 @@ References:
 
     *,
     real: String = Default('re'),imag: String = Default('im'),win_size: Int = Default('4096'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('hann'),overlap: Float = Default('0.75'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply arbitrary expressions to samples in frequency domain.
 
 
@@ -2243,7 +2243,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afftfilt)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2251,55 +2251,55 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='afftfilt', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "real": real,
-                
+
                 "imag": imag,
-                
+
                 "win_size": win_size,
-                
+
                 "win_func": win_func,
-                
+
                 "overlap": overlap,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def afifo(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Buffer input images and send them when they are requested.
 
 It is mainly useful when auto-inserted by the libavfilter
@@ -2318,39 +2318,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fifo)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='afifo', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def aformat(
-    
+
     self,
 
 
@@ -2358,12 +2358,12 @@ References:
 
     *,
     sample_fmts: String = Default(None),sample_rates: String = Default(None),channel_layouts: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Set output format constraints for the input audio. The framework will
 negotiate the most appropriate format to minimize conversions.
 
@@ -2383,41 +2383,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aformat)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aformat', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sample_fmts": sample_fmts,
-                
+
                 "sample_rates": sample_rates,
-                
+
                 "channel_layouts": channel_layouts,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def afreqshift(
-    
+
     self,
 
 
@@ -2425,15 +2425,15 @@ References:
 
     *,
     shift: Double = Default('0'),level: Double = Default('1'),order: Int = Default('8'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply frequency shift to input audio samples.
 
 The filter accepts the following options:
@@ -2453,7 +2453,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afreqshift)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2461,38 +2461,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='afreqshift', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "shift": shift,
-                
+
                 "level": level,
-                
+
                 "order": order,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def afwtdn(
-    
+
     self,
 
 
@@ -2500,15 +2500,15 @@ References:
 
     *,
     sigma: Double = Default('0'),levels: Int = Default('10'),wavet: Int| Literal["sym2","sym4","rbior68","deb10","sym10","coif5","bl3"] | Default = Default('sym10'),percent: Double = Default('85'),profile: Boolean = Default('false'),adaptive: Boolean = Default('false'),samples: Int = Default('8192'),softness: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Reduce broadband noise from input samples using Wavelets.
 
 A description of the accepted options follows.
@@ -2533,7 +2533,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afwtdn)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2541,48 +2541,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='afwtdn', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sigma": sigma,
-                
+
                 "levels": levels,
-                
+
                 "wavet": wavet,
-                
+
                 "percent": percent,
-                
+
                 "profile": profile,
-                
+
                 "adaptive": adaptive,
-                
+
                 "samples": samples,
-                
+
                 "softness": softness,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def agate(
-    
+
     self,
 
 
@@ -2590,15 +2590,15 @@ References:
 
     *,
     level_in: Double = Default('1'),mode: Int| Literal["downward","upward"] | Default = Default('downward'),range: Double = Default('0.06125'),threshold: Double = Default('0.125'),ratio: Double = Default('2'),attack: Double = Default('20'),release: Double = Default('250'),makeup: Double = Default('1'),knee: Double = Default('2.82843'),detection: Int| Literal["peak","rms"] | Default = Default('rms'),link: Int| Literal["average","maximum"] | Default = Default('average'),level_sc: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 A gate is mainly used to reduce lower parts of a signal. This kind of signal
 processing reduces disturbing noise between useful signals.
 
@@ -2637,7 +2637,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#agate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2645,56 +2645,56 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='agate', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "mode": mode,
-                
+
                 "range": range,
-                
+
                 "threshold": threshold,
-                
+
                 "ratio": ratio,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "makeup": makeup,
-                
+
                 "knee": knee,
-                
+
                 "detection": detection,
-                
+
                 "link": link,
-                
+
                 "level_sc": level_sc,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def agraphmonitor(
-    
+
     self,
 
 
@@ -2702,12 +2702,12 @@ References:
 
     *,
     size: Image_size = Default('hd720'),opacity: Float = Default('0.9'),mode: Flags| Literal["full","compact","nozero","noeof","nodisabled"] | Default = Default('0'),flags: Flags| Literal["none","all","queue","frame_count_in","frame_count_out","frame_count_delta","pts","pts_delta","time","time_delta","timebase","format","size","rate","eof","sample_count_in","sample_count_out","sample_count_delta","disabled"] | Default = Default('all+queue'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 See graphmonitor.
 
 
@@ -2726,45 +2726,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#agraphmonitor)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='agraphmonitor', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "opacity": opacity,
-                
+
                 "mode": mode,
-                
+
                 "flags": flags,
-                
+
                 "rate": rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ahistogram(
-    
+
     self,
 
 
@@ -2772,12 +2772,12 @@ References:
 
     *,
     dmode: Int| Literal["single","separate"] | Default = Default('single'),rate: Video_rate = Default('25'),size: Image_size = Default('hd720'),scale: Int| Literal["log","sqrt","cbrt","lin","rlog"] | Default = Default('log'),ascale: Int| Literal["log","lin"] | Default = Default('log'),acount: Int = Default('1'),rheight: Float = Default('0.1'),slide: Int| Literal["replace","scroll"] | Default = Default('replace'),hmode: Int| Literal["abs","sign"] | Default = Default('abs'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a video output, displaying the volume histogram.
 
 The filter accepts the following options:
@@ -2802,53 +2802,53 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ahistogram)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ahistogram', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dmode": dmode,
-                
+
                 "rate": rate,
-                
+
                 "size": size,
-                
+
                 "scale": scale,
-                
+
                 "ascale": ascale,
-                
+
                 "acount": acount,
-                
+
                 "rheight": rheight,
-                
+
                 "slide": slide,
-                
+
                 "hmode": hmode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aiir(
-    
+
     self,
 
 
@@ -2856,12 +2856,12 @@ References:
 
     *,
     zeros: String = Default('1+0i 1-0i'),poles: String = Default('1+0i 1-0i'),gains: String = Default('1|1'),dry: Double = Default('1'),wet: Double = Default('1'),format: Int| Literal["ll","sf","tf","zp","pr","pd","sp"] | Default = Default('zp'),process: Int| Literal["d","s","p"] | Default = Default('s'),precision: Int| Literal["dbl","flt","i32","i16"] | Default = Default('dbl'),e: Int| Literal["dbl","flt","i32","i16"] | Default = Default('dbl'),normalize: Boolean = Default('true'),mix: Double = Default('1'),response: Boolean = Default('false'),channel: Int = Default('0'),size: Image_size = Default('hd720'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Apply an arbitrary Infinite Impulse Response filter.
 
 It accepts the following parameters:
@@ -2893,82 +2893,82 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aiir)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aiir', typings_input=('audio',), typings_output='[StreamType.audio] + [StreamType.video] if response else []'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "zeros": zeros,
-                
+
                 "poles": poles,
-                
+
                 "gains": gains,
-                
+
                 "dry": dry,
-                
+
                 "wet": wet,
-                
+
                 "format": format,
-                
+
                 "process": process,
-                
+
                 "precision": precision,
-                
+
                 "e": e,
-                
+
                 "normalize": normalize,
-                
+
                 "mix": mix,
-                
+
                 "response": response,
-                
+
                 "channel": channel,
-                
+
                 "size": size,
-                
+
                 "rate": rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aintegral(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Compute derivative/integral of audio stream.
 
 Applying both filters one after another produces original audio.
@@ -2985,7 +2985,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aderivative)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2993,50 +2993,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aintegral', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def alatency(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Measure filtering latency.
 
 Report previous filter filtering latency, delay in number of audio samples for audio filters
@@ -3057,7 +3057,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#latency)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3065,32 +3065,32 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='alatency', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def alimiter(
-    
+
     self,
 
 
@@ -3098,15 +3098,15 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),limit: Double = Default('1'),attack: Double = Default('5'),release: Double = Default('50'),asc: Boolean = Default('false'),asc_level: Double = Default('0.5'),level: Boolean = Default('true'),latency: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 The limiter prevents an input signal from rising over a desired threshold.
 This limiter uses lookahead technology to prevent your signal from distorting.
 It means that there is a small delay after the signal is processed. Keep in mind
@@ -3135,7 +3135,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#alimiter)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3143,50 +3143,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='alimiter', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "limit": limit,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "asc": asc,
-                
+
                 "asc_level": asc_level,
-                
+
                 "level": level,
-                
+
                 "latency": latency,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def allpass(
-    
+
     self,
 
 
@@ -3194,15 +3194,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.707'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),order: Int = Default('2'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a two-pole all-pass filter with central frequency (in Hz)
 frequency, and filter-width width.
 An all-pass filter changes the audio's frequency to phase relationship
@@ -3231,7 +3231,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allpass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3239,54 +3239,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='allpass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "order": order,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def aloop(
-    
+
     self,
 
 
@@ -3294,12 +3294,12 @@ References:
 
     *,
     loop: Int = Default('0'),size: Int64 = Default('0'),start: Int64 = Default('0'),time: Duration = Default('INT64_MAX'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Loop audio samples.
 
 The filter accepts the following options:
@@ -3319,49 +3319,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aloop)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aloop', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "loop": loop,
-                
+
                 "size": size,
-                
+
                 "start": start,
-                
+
                 "time": time,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def ametadata(
-    
+
     self,
 
 
@@ -3369,15 +3369,15 @@ References:
 
     *,
     mode: Int| Literal["select","add","modify","delete","print"] | Default = Default('select'),key: String = Default(None),value: String = Default(None),function: Int| Literal["same_str","starts_with","less","equal","greater","expr","ends_with"] | Default = Default('same_str'),expr: String = Default(None),file: String = Default(None),direct: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Manipulate frame metadata.
 
 This filter accepts the following options:
@@ -3401,7 +3401,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#metadata)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3409,73 +3409,73 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ametadata', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "key": key,
-                
+
                 "value": value,
-                
+
                 "function": function,
-                
+
                 "expr": expr,
-                
+
                 "file": file,
-                
+
                 "direct": direct,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def amultiply(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _multiply1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Multiply first audio stream with second audio stream and store result
 in output audio stream. Multiplication is done by multiplying each
 sample from first stream with sample at same position from second stream.
@@ -3494,43 +3494,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amultiply)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='amultiply', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _multiply1,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def anequalizer(
-    
+
     self,
 
 
@@ -3538,15 +3538,15 @@ References:
 
     *,
     params: String = Default(''),curves: Boolean = Default('false'),size: Image_size = Default('hd720'),mgain: Double = Default('60'),fscale: Int| Literal["lin","log"] | Default = Default('log'),colors: String = Default('red|green|blue|yellow|orange|lime|pink|magenta|brown'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 High-order parametric multiband equalizer for each channel.
 
 It accepts the following parameters:
@@ -3570,7 +3570,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anequalizer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3578,45 +3578,45 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='anequalizer', typings_input=('audio',), typings_output='[StreamType.audio] + [StreamType.video] if curves else []'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "params": params,
-                
+
                 "curves": curves,
-                
+
                 "size": size,
-                
+
                 "mgain": mgain,
-                
+
                 "fscale": fscale,
-                
+
                 "colors": colors,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def anlmdn(
-    
+
     self,
 
 
@@ -3624,15 +3624,15 @@ References:
 
     *,
     strength: Float = Default('1e-05'),patch: Duration = Default('0.002'),research: Duration = Default('0.006'),output: Int| Literal["i","o","n"] | Default = Default('o'),smooth: Float = Default('11'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Reduce broadband noise in audio samples using Non-Local Means algorithm.
 
 Each sample is adjusted by looking for other samples with similar contexts. This
@@ -3658,7 +3658,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anlmdn)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3666,66 +3666,66 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='anlmdn', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "strength": strength,
-                
+
                 "patch": patch,
-                
+
                 "research": research,
-                
+
                 "output": output,
-                
+
                 "smooth": smooth,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def anlmf(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('256'),mu: Float = Default('0.75'),eps: Float = Default('1'),leakage: Float = Default('0'),out_mode: Int| Literal["i","d","o","n","e"] | Default = Default('o'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply Normalized Least-Mean-(Squares|Fourth) algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to mimic a desired filter by finding the filter coefficients that
@@ -3751,7 +3751,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anlmf)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3759,74 +3759,74 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='anlmf', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _desired,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "order": order,
-                
+
                 "mu": mu,
-                
+
                 "eps": eps,
-                
+
                 "leakage": leakage,
-                
+
                 "out_mode": out_mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def anlms(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('256'),mu: Float = Default('0.75'),eps: Float = Default('1'),leakage: Float = Default('0'),out_mode: Int| Literal["i","d","o","n","e"] | Default = Default('o'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply Normalized Least-Mean-(Squares|Fourth) algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to mimic a desired filter by finding the filter coefficients that
@@ -3852,7 +3852,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anlmf)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3860,65 +3860,65 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='anlms', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _desired,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "order": order,
-                
+
                 "mu": mu,
-                
+
                 "eps": eps,
-                
+
                 "leakage": leakage,
-                
+
                 "out_mode": out_mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def anull(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Pass the audio source unchanged to the output.
 
 
@@ -3932,39 +3932,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anull)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='anull', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def apad(
-    
+
     self,
 
 
@@ -3972,15 +3972,15 @@ References:
 
     *,
     packet_size: Int = Default('4096'),pad_len: Int64 = Default('-1'),whole_len: Int64 = Default('-1'),pad_dur: Duration = Default('-0.000001'),whole_dur: Duration = Default('-0.000001'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Pad the end of an audio stream with silence.
 
 This can be used together with ffmpeg -shortest to
@@ -4005,7 +4005,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#apad)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4013,42 +4013,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='apad', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "packet_size": packet_size,
-                
+
                 "pad_len": pad_len,
-                
+
                 "whole_len": whole_len,
-                
+
                 "pad_dur": pad_dur,
-                
+
                 "whole_dur": whole_dur,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aperms(
-    
+
     self,
 
 
@@ -4056,15 +4056,15 @@ References:
 
     *,
     mode: Int| Literal["none","ro","rw","toggle","random"] | Default = Default('none'),seed: Int64 = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Set read/write permissions for the output frames.
 
 These filters are mainly aimed at developers to test direct path in the
@@ -4086,7 +4086,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#perms)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4094,36 +4094,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aperms', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "seed": seed,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aphasemeter(
-    
+
     self,
 
 
@@ -4131,12 +4131,12 @@ References:
 
     *,
     rate: Video_rate = Default('25'),size: Image_size = Default('800x400'),rc: Int = Default('2'),gc: Int = Default('7'),bc: Int = Default('1'),mpc: String = Default('none'),video: Boolean = Default('true'),phasing: Boolean = Default('false'),tolerance: Float = Default('0'),angle: Float = Default('170'),duration: Duration = Default('2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Measures phase of input audio, which is exported as metadata lavfi.aphasemeter.phase,
 representing mean phase of current audio frame. A video output can also be produced and is
 enabled by default. The audio is passed through as first output.
@@ -4170,58 +4170,58 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aphasemeter)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aphasemeter', typings_input=('audio',), typings_output='[StreamType.audio] + ([StreamType.video] if video else [])'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rate": rate,
-                
+
                 "size": size,
-                
+
                 "rc": rc,
-                
+
                 "gc": gc,
-                
+
                 "bc": bc,
-                
+
                 "mpc": mpc,
-                
+
                 "video": video,
-                
+
                 "phasing": phasing,
-                
+
                 "tolerance": tolerance,
-                
+
                 "angle": angle,
-                
+
                 "duration": duration,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aphaser(
-    
+
     self,
 
 
@@ -4229,12 +4229,12 @@ References:
 
     *,
     in_gain: Double = Default('0.4'),out_gain: Double = Default('0.74'),delay: Double = Default('3'),decay: Double = Default('0.4'),speed: Double = Default('0.5'),type: Int| Literal["triangular","t","sinusoidal","s"] | Default = Default('triangular'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Add a phasing effect to the input audio.
 
 A phaser filter creates series of peaks and troughs in the frequency spectrum.
@@ -4259,47 +4259,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aphaser)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aphaser', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "in_gain": in_gain,
-                
+
                 "out_gain": out_gain,
-                
+
                 "delay": delay,
-                
+
                 "decay": decay,
-                
+
                 "speed": speed,
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aphaseshift(
-    
+
     self,
 
 
@@ -4307,15 +4307,15 @@ References:
 
     *,
     shift: Double = Default('0'),level: Double = Default('1'),order: Int = Default('8'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply phase shift to input audio samples.
 
 The filter accepts the following options:
@@ -4335,7 +4335,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aphaseshift)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4343,62 +4343,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aphaseshift', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "shift": shift,
-                
+
                 "level": level,
-                
+
                 "order": order,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def apsnr(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _input1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Measure Audio Peak Signal-to-Noise Ratio.
 
 This filter takes two audio streams for input, and outputs first
@@ -4417,7 +4417,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#apsnr)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4425,40 +4425,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='apsnr', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _input1,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def apsyclip(
-    
+
     self,
 
 
@@ -4466,15 +4466,15 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),clip: Double = Default('1'),diff: Boolean = Default('false'),adaptive: Double = Default('0.5'),iterations: Int = Default('10'),level: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply Psychoacoustic clipper to input audio stream.
 
 The filter accepts the following options:
@@ -4498,7 +4498,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#apsyclip)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4506,46 +4506,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='apsyclip', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "clip": clip,
-                
+
                 "diff": diff,
-                
+
                 "adaptive": adaptive,
-                
+
                 "iterations": iterations,
-                
+
                 "level": level,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def apulsator(
-    
+
     self,
 
 
@@ -4553,12 +4553,12 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),mode: Int| Literal["sine","triangle","square","sawup","sawdown"] | Default = Default('sine'),amount: Double = Default('1'),offset_l: Double = Default('0'),offset_r: Double = Default('0.5'),width: Double = Default('1'),timing: Int| Literal["bpm","ms","hz"] | Default = Default('hz'),bpm: Double = Default('120'),ms: Int = Default('500'),hz: Double = Default('2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Audio pulsator is something between an autopanner and a tremolo.
 But it can produce funny stereo effects as well. Pulsator changes the volume
 of the left and right channel based on a LFO (low frequency oscillator) with
@@ -4597,57 +4597,57 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#apulsator)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='apulsator', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "mode": mode,
-                
+
                 "amount": amount,
-                
+
                 "offset_l": offset_l,
-                
+
                 "offset_r": offset_r,
-                
+
                 "width": width,
-                
+
                 "timing": timing,
-                
+
                 "bpm": bpm,
-                
+
                 "ms": ms,
-                
+
                 "hz": hz,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def arealtime(
-    
+
     self,
 
 
@@ -4655,12 +4655,12 @@ References:
 
     *,
     limit: Duration = Default('2'),speed: Double = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Slow down filtering to match real time approximately.
 
 These filters will pause the filtering for a variable amount of time to
@@ -4682,39 +4682,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#realtime)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='arealtime', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "limit": limit,
-                
+
                 "speed": speed,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aresample(
-    
+
     self,
 
 
@@ -4722,12 +4722,12 @@ References:
 
     *,
     sample_rate: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Resample the input audio to the specified parameters, using the
 libswresample library. If none are specified then the filter will
 automatically convert between its input and output.
@@ -4756,50 +4756,50 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aresample)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aresample', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sample_rate": sample_rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def areverse(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Reverse an audio clip.
 
 Warning: This filter requires memory to buffer the entire clip, so trimming
@@ -4816,59 +4816,59 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#areverse)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='areverse', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def arls(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('16'),_lambda: Float = Default('1'),delta: Float = Default('2'),out_mode: Int| Literal["i","d","o","n","e"] | Default = Default('o'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply Recursive Least Squares algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to mimic a desired filter by recursively finding the filter coefficients that
@@ -4893,7 +4893,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#arls)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4901,48 +4901,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='arls', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _desired,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "order": order,
-                
+
                 "lambda": _lambda,
-                
+
                 "delta": delta,
-                
+
                 "out_mode": out_mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def arnndn(
-    
+
     self,
 
 
@@ -4950,15 +4950,15 @@ References:
 
     *,
     model: String = Default(None),mix: Float = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Reduce noise from speech using Recurrent Neural Networks.
 
 This filter accepts the following options:
@@ -4977,7 +4977,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#arnndn)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4985,60 +4985,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='arnndn', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "model": model,
-                
+
                 "mix": mix,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asdr(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _input1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Measure Audio Signal-to-Distortion Ratio.
 
 This filter takes two audio streams for input, and outputs first
@@ -5057,7 +5057,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asdr)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5065,40 +5065,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asdr', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _input1,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asegment(
-    
+
     self,
 
 
@@ -5106,12 +5106,12 @@ References:
 
     *,
     timestamps: String = Default(None),samples: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Split single input stream into multiple streams.
 
 This filter does opposite of concat filters.
@@ -5134,40 +5134,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#segment)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asegment', typings_input=('audio',), typings_output="[StreamType.audio] * len(str(timestamps or samples).split('|'))"),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "timestamps": timestamps,
-                
+
                 "samples": samples,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aselect(
-    
+
     self,
 
 
@@ -5175,12 +5175,12 @@ References:
 
     *,
     expr: String = Default('1'),outputs: Int = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Select frames to pass in output.
 
 This filter accepts the following options:
@@ -5199,40 +5199,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#select)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aselect', typings_input=('audio',), typings_output='[StreamType.audio] * int(outputs)'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "expr": expr,
-                
+
                 "outputs": outputs,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asendcmd(
-    
+
     self,
 
 
@@ -5240,12 +5240,12 @@ References:
 
     *,
     commands: String = Default(None),filename: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Send commands to filters in the filtergraph.
 
 These filters read commands to be sent to other filters in the
@@ -5274,39 +5274,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sendcmd)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asendcmd', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "commands": commands,
-                
+
                 "filename": filename,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asetnsamples(
-    
+
     self,
 
 
@@ -5314,15 +5314,15 @@ References:
 
     *,
     nb_out_samples: Int = Default('1024'),pad: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Set the number of samples per each output audio frame.
 
 The last output packet may contain a different number of samples, as
@@ -5345,7 +5345,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asetnsamples)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5353,36 +5353,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asetnsamples', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "nb_out_samples": nb_out_samples,
-                
+
                 "pad": pad,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asetpts(
-    
+
     self,
 
 
@@ -5390,12 +5390,12 @@ References:
 
     *,
     expr: String = Default('PTS'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Change the PTS (presentation timestamp) of the input frames.
 
 setpts works on video frames, asetpts on audio frames.
@@ -5414,37 +5414,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setpts)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asetpts', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "expr": expr,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asetrate(
-    
+
     self,
 
 
@@ -5452,12 +5452,12 @@ References:
 
     *,
     sample_rate: Int = Default('44100'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Set the sample rate without altering the PCM data.
 This will result in a change of speed and pitch.
 
@@ -5475,37 +5475,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asetrate)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asetrate', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sample_rate": sample_rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asettb(
-    
+
     self,
 
 
@@ -5513,12 +5513,12 @@ References:
 
     *,
     expr: String = Default('intb'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Set the timebase to use for the output frames timestamps.
 It is mainly useful for testing timebase configuration.
 
@@ -5536,50 +5536,50 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#settb)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asettb', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "expr": expr,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ashowinfo(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Show a line containing various information for each input audio frame.
 The input audio is not modified.
 
@@ -5599,35 +5599,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ashowinfo)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ashowinfo', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asidedata(
-    
+
     self,
 
 
@@ -5635,15 +5635,15 @@ References:
 
     *,
     mode: Int| Literal["select","delete"] | Default = Default('select'),type: Int| Literal["PANSCAN","A53_CC","STEREO3D","MATRIXENCODING","DOWNMIX_INFO","REPLAYGAIN","DISPLAYMATRIX","AFD","MOTION_VECTORS","SKIP_SAMPLES","AUDIO_SERVICE_TYPE","MASTERING_DISPLAY_METADATA","GOP_TIMECODE","SPHERICAL","CONTENT_LIGHT_LEVEL","ICC_PROFILE","S12M_TIMECOD","DYNAMIC_HDR_PLUS","REGIONS_OF_INTEREST","DETECTION_BOUNDING_BOXES","SEI_UNREGISTERED"] | Default = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Delete frame side data, or select frames based on it.
 
 This filter accepts the following options:
@@ -5662,7 +5662,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sidedata)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5670,60 +5670,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asidedata', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asisdr(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _input1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Measure Audio Scaled-Invariant Signal-to-Distortion Ratio.
 
 This filter takes two audio streams for input, and outputs first
@@ -5742,7 +5742,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asisdr)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5750,40 +5750,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asisdr', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _input1,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asoftclip(
-    
+
     self,
 
 
@@ -5791,15 +5791,15 @@ References:
 
     *,
     type: Int| Literal["hard","tanh","atan","cubic","exp","alg","quintic","sin","erf"] | Default = Default('tanh'),threshold: Double = Default('1'),output: Double = Default('1'),param: Double = Default('1'),oversample: Int = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply audio soft clipping.
 
 Soft clipping is a type of distortion effect where the amplitude of a signal is saturated
@@ -5824,7 +5824,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asoftclip)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5832,42 +5832,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asoftclip', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "type": type,
-                
+
                 "threshold": threshold,
-                
+
                 "output": output,
-                
+
                 "param": param,
-                
+
                 "oversample": oversample,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aspectralstats(
-    
+
     self,
 
 
@@ -5875,12 +5875,12 @@ References:
 
     *,
     win_size: Int = Default('2048'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('hann'),overlap: Float = Default('0.5'),measure: Flags| Literal["none","all","mean","variance","centroid","spread","skewness","kurtosis","entropy","flatness","crest","flux","slope","decrease","rolloff"] | Default = Default('all+mean+variance+centroid+spread+skewness+kurtosis+entropy+flatness+crest+flux+slope+decrease+rolloff'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Display frequency domain statistical information about the audio channels.
 Statistics are calculated and stored as metadata for each audio channel and for each audio frame.
 
@@ -5901,43 +5901,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aspectralstats)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aspectralstats', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "win_size": win_size,
-                
+
                 "win_func": win_func,
-                
+
                 "overlap": overlap,
-                
+
                 "measure": measure,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asplit(
-    
+
     self,
 
 
@@ -5945,12 +5945,12 @@ References:
 
     *,
     outputs: Int = Default('2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Split input into several identical outputs.
 
 asplit works with audio input, split with video.
@@ -5971,40 +5971,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#split)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asplit', typings_input=('audio',), typings_output='[StreamType.audio] * int(outputs)'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "outputs": outputs,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def astats(
-    
+
     self,
 
 
@@ -6012,12 +6012,12 @@ References:
 
     *,
     length: Double = Default('0.05'),metadata: Boolean = Default('false'),reset: Int = Default('0'),measure_perchannel: Flags| Literal["none","all","Bit_depth","Crest_factor","DC_offset","Dynamic_range","Entropy","Flat_factor","Max_difference","Max_level","Mean_difference","Min_difference","Min_level","Noise_floor","Noise_floor_count","Number_of_Infs","Number_of_NaNs","Number_of_denormals","Number_of_samples","Peak_count","Peak_level","RMS_difference","RMS_level","RMS_peak","RMS_trough","Zero_crossings","Zero_crossings_rate","Abs_Peak_count"] | Default = Default('all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate+Abs_Peak_count'),measure_overall: Flags| Literal["none","all","Bit_depth","Crest_factor","DC_offset","Dynamic_range","Entropy","Flat_factor","Max_difference","Max_level","Mean_difference","Min_difference","Min_level","Noise_floor","Noise_floor_count","Number_of_Infs","Number_of_NaNs","Number_of_denormals","Number_of_samples","Peak_count","Peak_level","RMS_difference","RMS_level","RMS_peak","RMS_trough","Zero_crossings","Zero_crossings_rate","Abs_Peak_count"] | Default = Default('all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate+Abs_Peak_count'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Display time domain statistical information about the audio channels.
 Statistics are calculated and displayed for each audio channel and,
 where applicable, an overall figure is also given.
@@ -6040,47 +6040,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#astats)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='astats', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "length": length,
-                
+
                 "metadata": metadata,
-                
+
                 "reset": reset,
-                
+
                 "measure_perchannel": measure_perchannel,
-                
+
                 "measure_overall": measure_overall,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def asubboost(
-    
+
     self,
 
 
@@ -6088,15 +6088,15 @@ References:
 
     *,
     dry: Double = Default('1'),wet: Double = Default('1'),boost: Double = Default('2'),decay: Double = Default('0'),feedback: Double = Default('0.9'),cutoff: Double = Default('100'),slope: Double = Default('0.5'),delay: Double = Default('20'),channels: String = Default('all'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Boost subwoofer frequencies.
 
 The filter accepts the following options:
@@ -6122,7 +6122,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asubboost)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6130,50 +6130,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asubboost', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dry": dry,
-                
+
                 "wet": wet,
-                
+
                 "boost": boost,
-                
+
                 "decay": decay,
-                
+
                 "feedback": feedback,
-                
+
                 "cutoff": cutoff,
-                
+
                 "slope": slope,
-                
+
                 "delay": delay,
-                
+
                 "channels": channels,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asubcut(
-    
+
     self,
 
 
@@ -6181,15 +6181,15 @@ References:
 
     *,
     cutoff: Double = Default('20'),order: Int = Default('10'),level: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Cut subwoofer frequencies.
 
 This filter allows to set custom, steeper
@@ -6213,7 +6213,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asubcut)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6221,38 +6221,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asubcut', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cutoff": cutoff,
-                
+
                 "order": order,
-                
+
                 "level": level,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asupercut(
-    
+
     self,
 
 
@@ -6260,15 +6260,15 @@ References:
 
     *,
     cutoff: Double = Default('20000'),order: Int = Default('10'),level: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Cut super frequencies.
 
 The filter accepts the following options:
@@ -6288,7 +6288,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asupercut)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6296,38 +6296,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asupercut', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cutoff": cutoff,
-                
+
                 "order": order,
-                
+
                 "level": level,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asuperpass(
-    
+
     self,
 
 
@@ -6335,15 +6335,15 @@ References:
 
     *,
     centerf: Double = Default('1000'),order: Int = Default('4'),qfactor: Double = Default('1'),level: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply high order Butterworth band-pass filter.
 
 The filter accepts the following options:
@@ -6364,7 +6364,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asuperpass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6372,40 +6372,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asuperpass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "centerf": centerf,
-                
+
                 "order": order,
-                
+
                 "qfactor": qfactor,
-                
+
                 "level": level,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asuperstop(
-    
+
     self,
 
 
@@ -6413,15 +6413,15 @@ References:
 
     *,
     centerf: Double = Default('1000'),order: Int = Default('4'),qfactor: Double = Default('1'),level: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply high order Butterworth band-stop filter.
 
 The filter accepts the following options:
@@ -6442,7 +6442,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asuperstop)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6450,42 +6450,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asuperstop', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "centerf": centerf,
-                
+
                 "order": order,
-                
+
                 "qfactor": qfactor,
-                
+
                 "level": level,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def atempo(
-    
+
     self,
 
 
@@ -6493,12 +6493,12 @@ References:
 
     *,
     tempo: Double = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Adjust audio tempo.
 
 The filter accepts exactly one parameter, the audio tempo. If not
@@ -6522,37 +6522,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#atempo)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='atempo', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "tempo": tempo,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def atilt(
-    
+
     self,
 
 
@@ -6560,15 +6560,15 @@ References:
 
     *,
     freq: Double = Default('10000'),slope: Double = Default('0'),width: Double = Default('1000'),order: Int = Default('5'),level: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply spectral tilt filter to audio stream.
 
 This filter apply any spectral roll-off slope over any specified frequency band.
@@ -6592,7 +6592,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#atilt)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6600,42 +6600,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='atilt', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "freq": freq,
-                
+
                 "slope": slope,
-                
+
                 "width": width,
-                
+
                 "order": order,
-                
+
                 "level": level,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def atrim(
-    
+
     self,
 
 
@@ -6643,12 +6643,12 @@ References:
 
     *,
     start: Duration = Default('INT64_MAX'),end: Duration = Default('INT64_MAX'),start_pts: Int64 = Default('I64_MIN'),end_pts: Int64 = Default('I64_MIN'),duration: Duration = Default('0'),start_sample: Int64 = Default('-1'),end_sample: Int64 = Default('I64_MAX'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Trim the input so that the output contains one continuous subpart of the input.
 
 It accepts the following parameters:
@@ -6671,49 +6671,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#atrim)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='atrim', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "start": start,
-                
+
                 "end": end,
-                
+
                 "start_pts": start_pts,
-                
+
                 "end_pts": end_pts,
-                
+
                 "duration": duration,
-                
+
                 "start_sample": start_sample,
-                
+
                 "end_sample": end_sample,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def avectorscope(
-    
+
     self,
 
 
@@ -6721,12 +6721,12 @@ References:
 
     *,
     mode: Int| Literal["lissajous","lissajous_xy","polar"] | Default = Default('lissajous'),rate: Video_rate = Default('25'),size: Image_size = Default('400x400'),rc: Int = Default('40'),gc: Int = Default('160'),bc: Int = Default('80'),ac: Int = Default('255'),rf: Int = Default('15'),gf: Int = Default('10'),bf: Int = Default('5'),af: Int = Default('5'),zoom: Double = Default('1'),draw: Int| Literal["dot","line","aaline"] | Default = Default('dot'),scale: Int| Literal["lin","sqrt","cbrt","log"] | Default = Default('lin'),swap: Boolean = Default('true'),mirror: Int| Literal["none","x","y","xy"] | Default = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a video output, representing the audio vector
 scope.
 
@@ -6766,94 +6766,94 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#avectorscope)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='avectorscope', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "rate": rate,
-                
+
                 "size": size,
-                
+
                 "rc": rc,
-                
+
                 "gc": gc,
-                
+
                 "bc": bc,
-                
+
                 "ac": ac,
-                
+
                 "rf": rf,
-                
+
                 "gf": gf,
-                
+
                 "bf": bf,
-                
+
                 "af": af,
-                
+
                 "zoom": zoom,
-                
+
                 "draw": draw,
-                
+
                 "scale": scale,
-                
+
                 "swap": swap,
-                
+
                 "mirror": mirror,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def axcorrelate(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _axcorrelate1: AudioStream,
-        
-    
+
+
 
 
     *,
     size: Int = Default('256'),algo: Int| Literal["slow","fast","best"] | Default = Default('best'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Calculate normalized windowed cross-correlation between two input audio streams.
 
 Resulted samples are always between -1 and 1 inclusive.
@@ -6877,47 +6877,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#axcorrelate)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='axcorrelate', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _axcorrelate1,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "algo": algo,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def azmq(
-    
+
     self,
 
 
@@ -6925,12 +6925,12 @@ References:
 
     *,
     bind_address: String = Default('tcp://*:5555'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Receive commands sent through a libzmq client, and forward them to
 filters in the filtergraph.
 
@@ -6989,39 +6989,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#zmq)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='azmq', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "bind_address": bind_address,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def bandpass(
-    
+
     self,
 
 
@@ -7029,15 +7029,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),csg: Boolean = Default('false'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a two-pole Butterworth band-pass filter with central
 frequency frequency, and (3dB-point) band-width width.
 The csg option selects a constant skirt gain (peak gain = Q)
@@ -7068,7 +7068,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bandpass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7076,52 +7076,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bandpass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "csg": csg,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def bandreject(
-    
+
     self,
 
 
@@ -7129,15 +7129,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a two-pole Butterworth band-reject filter with central
 frequency frequency, and (3dB-point) band-width width.
 The filter roll off at 6dB per octave (20dB per decade).
@@ -7165,7 +7165,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bandreject)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7173,50 +7173,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bandreject', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def bass(
-    
+
     self,
 
 
@@ -7224,15 +7224,15 @@ References:
 
     *,
     frequency: Double = Default('100'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),gain: Double = Default('0'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Boost or cut the bass (lower) frequencies of the audio using a two-pole
 shelving filter with a response similar to that of a standard
 hi-fi's tone-controls. This is also known as shelving equalisation (EQ).
@@ -7262,7 +7262,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7270,60 +7270,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "gain": gain,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def biquad(
-    
+
     self,
 
 
@@ -7331,15 +7331,15 @@ References:
 
     *,
     a0: Double = Default('1'),a1: Double = Default('0'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a biquad IIR filter with the given coefficients.
 Where b0, b1, b2 and a0, a1, a2
 are the numerator and denominator coefficients respectively.
@@ -7366,7 +7366,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#biquad)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7374,78 +7374,78 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='biquad', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "a0": a0,
-                
+
                 "a1": a1,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def channelmap(
-    
+
     self,
 
 
@@ -7453,12 +7453,12 @@ References:
 
     *,
     map: String = Default(None),channel_layout: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Remap input channels to new locations.
 
 It accepts the following parameters:
@@ -7476,39 +7476,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#channelmap)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='channelmap', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "map": map,
-                
+
                 "channel_layout": channel_layout,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def channelsplit(
-    
+
     self,
 
 
@@ -7516,12 +7516,12 @@ References:
 
     *,
     channel_layout: String = Default('stereo'),channels: String = Default('all'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Split each channel from an input audio stream into a separate output stream.
 
 It accepts the following parameters:
@@ -7540,40 +7540,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#channelsplit)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='channelsplit', typings_input=('audio',), typings_output='[StreamType.audio] * CHANNEL_LAYOUT[str(channel_layout)]'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "channel_layout": channel_layout,
-                
+
                 "channels": channels,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def chorus(
-    
+
     self,
 
 
@@ -7581,12 +7581,12 @@ References:
 
     *,
     in_gain: Float = Default('0.4'),out_gain: Float = Default('0.4'),delays: String = Default(None),decays: String = Default(None),speeds: String = Default(None),depths: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Add a chorus effect to the audio.
 
 Can make a single vocal sound like a chorus, but can also be applied to instrumentation.
@@ -7617,91 +7617,91 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#chorus)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='chorus', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "in_gain": in_gain,
-                
+
                 "out_gain": out_gain,
-                
+
                 "delays": delays,
-                
+
                 "decays": decays,
-                
+
                 "speeds": speeds,
-                
+
                 "depths": depths,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def compand(
-    
+
     self,
 
 
@@ -7709,12 +7709,12 @@ References:
 
     *,
     attacks: String = Default('0'),decays: String = Default('0.8'),points: String = Default('-70/-70|-60/-20|1/0'),soft_knee: Double = Default('0.01'),gain: Double = Default('0'),volume: Double = Default('0'),delay: Double = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Compress or expand the audio's dynamic range.
 
 It accepts the following parameters:
@@ -7737,49 +7737,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#compand)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='compand', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "attacks": attacks,
-                
+
                 "decays": decays,
-                
+
                 "points": points,
-                
+
                 "soft-knee": soft_knee,
-                
+
                 "gain": gain,
-                
+
                 "volume": volume,
-                
+
                 "delay": delay,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def compensationdelay(
-    
+
     self,
 
 
@@ -7787,15 +7787,15 @@ References:
 
     *,
     mm: Int = Default('0'),cm: Int = Default('0'),m: Int = Default('0'),dry: Double = Default('0'),wet: Double = Default('1'),temp: Int = Default('20'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Compensation Delay Line is a metric based delay to compensate differing
 positions of microphones or speakers.
 
@@ -7834,7 +7834,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#compensationdelay)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7842,62 +7842,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='compensationdelay', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mm": mm,
-                
+
                 "cm": cm,
-                
+
                 "m": m,
-                
+
                 "dry": dry,
-                
+
                 "wet": wet,
-                
+
                 "temp": temp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def crossfeed(
-    
+
     self,
 
 
@@ -7905,15 +7905,15 @@ References:
 
     *,
     strength: Double = Default('0.2'),range: Double = Default('0.5'),slope: Double = Default('0.5'),level_in: Double = Default('0.9'),level_out: Double = Default('1'),block_size: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply headphone crossfeed filter.
 
 Crossfeed is the process of blending the left and right channels of stereo
@@ -7942,7 +7942,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#crossfeed)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7950,44 +7950,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='crossfeed', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "strength": strength,
-                
+
                 "range": range,
-                
+
                 "slope": slope,
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "block_size": block_size,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def crystalizer(
-    
+
     self,
 
 
@@ -7995,15 +7995,15 @@ References:
 
     *,
     i: Float = Default('2'),c: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Simple algorithm for audio noise sharpening.
 
 This filter linearly increases differences betweeen each audio sample.
@@ -8024,7 +8024,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#crystalizer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8032,44 +8032,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='crystalizer', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "i": i,
-                
+
                 "c": c,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def dcshift(
-    
+
     self,
 
 
@@ -8077,15 +8077,15 @@ References:
 
     *,
     shift: Double = Default('0'),limitergain: Double = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a DC shift to the audio.
 
 This can be useful to remove a DC offset (caused perhaps by a hardware problem
@@ -8107,7 +8107,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dcshift)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8115,48 +8115,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dcshift', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "shift": shift,
-                
+
                 "limitergain": limitergain,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def deesser(
-    
+
     self,
 
 
@@ -8164,15 +8164,15 @@ References:
 
     *,
     i: Double = Default('0'),m: Double = Default('0.5'),f: Double = Default('0.5'),s: Int| Literal["i","o","e"] | Default = Default('o'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply de-essing to the audio samples.
 
 
@@ -8191,7 +8191,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deesser)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8199,62 +8199,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deesser', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "i": i,
-                
+
                 "m": m,
-                
+
                 "f": f,
-                
+
                 "s": s,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def dialoguenhance(
-    
+
     self,
 
 
@@ -8262,15 +8262,15 @@ References:
 
     *,
     original: Double = Default('1'),enhance: Double = Default('1'),voice: Double = Default('2'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Enhance dialogue in stereo audio.
 
 This filter accepts stereo input and produce surround (3.0) channels output.
@@ -8295,7 +8295,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dialoguenhance)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8303,60 +8303,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dialoguenhance', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "original": original,
-                
+
                 "enhance": enhance,
-                
+
                 "voice": voice,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def drmeter(
-    
+
     self,
 
 
@@ -8364,12 +8364,12 @@ References:
 
     *,
     length: Double = Default('3'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Measure audio dynamic range.
 
 DR values of 14 and higher is found in very dynamic material. DR of 8 to 13
@@ -8390,37 +8390,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#drmeter)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='drmeter', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "length": length,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dynaudnorm(
-    
+
     self,
 
 
@@ -8428,15 +8428,15 @@ References:
 
     *,
     framelen: Int = Default('500'),gausssize: Int = Default('31'),peak: Double = Default('0.95'),maxgain: Double = Default('10'),targetrms: Double = Default('0'),coupling: Boolean = Default('true'),correctdc: Boolean = Default('false'),altboundary: Boolean = Default('false'),compress: Double = Default('0'),threshold: Double = Default('0'),channels: String = Default('all'),overlap: Double = Default('0'),curve: String = Default(None),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Dynamic Audio Normalizer.
 
 This filter applies a certain amount of gain to the input audio in order
@@ -8476,7 +8476,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dynaudnorm)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8484,71 +8484,71 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dynaudnorm', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "framelen": framelen,
-                
+
                 "gausssize": gausssize,
-                
+
                 "peak": peak,
-                
+
                 "maxgain": maxgain,
-                
+
                 "targetrms": targetrms,
-                
+
                 "coupling": coupling,
-                
+
                 "correctdc": correctdc,
-                
+
                 "altboundary": altboundary,
-                
+
                 "compress": compress,
-                
+
                 "threshold": threshold,
-                
+
                 "channels": channels,
-                
+
                 "overlap": overlap,
-                
+
                 "curve": curve,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def earwax(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Make audio easier to listen to on headphones.
 
 This filter adds `cues' to 44.1kHz stereo (i.e. audio CD format) audio
@@ -8569,35 +8569,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#earwax)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='earwax', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ebur128(
-    
+
     self,
 
 
@@ -8605,12 +8605,12 @@ References:
 
     *,
     video: Boolean = Default('false'),size: Image_size = Default('640x480'),meter: Int = Default('9'),framelog: Int| Literal["quiet","info","verbose"] | Default = Default('-1'),metadata: Boolean = Default('false'),peak: Flags| Literal["none","sample","true"] | Default = Default('0'),dualmono: Boolean = Default('false'),panlaw: Double = Default('-3.0103'),target: Int = Default('-23'),gauge: Int| Literal["momentary","m","shortterm","s"] | Default = Default('momentary'),scale: Int| Literal["absolute","LUFS","relative","LU"] | Default = Default('absolute'),integrated: Double = Default('0'),range: Double = Default('0'),lra_low: Double = Default('0'),lra_high: Double = Default('0'),sample_peak: Double = Default('0'),true_peak: Double = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 EBU R128 scanner filter. This filter takes an audio stream and analyzes its loudness
 level. By default, it logs a message at a frequency of 10Hz with the
 Momentary loudness (identified by M), Short-term loudness (S),
@@ -8666,80 +8666,80 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ebur128)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ebur128', typings_input=('audio',), typings_output='[StreamType.video] if video else [] + [StreamType.audio]'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "video": video,
-                
+
                 "size": size,
-                
+
                 "meter": meter,
-                
+
                 "framelog": framelog,
-                
+
                 "metadata": metadata,
-                
+
                 "peak": peak,
-                
+
                 "dualmono": dualmono,
-                
+
                 "panlaw": panlaw,
-                
+
                 "target": target,
-                
+
                 "gauge": gauge,
-                
+
                 "scale": scale,
-                
+
                 "integrated": integrated,
-                
+
                 "range": range,
-                
+
                 "lra_low": lra_low,
-                
+
                 "lra_high": lra_high,
-                
+
                 "sample_peak": sample_peak,
-                
+
                 "true_peak": true_peak,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def equalizer(
-    
+
     self,
 
 
@@ -8747,15 +8747,15 @@ References:
 
     *,
     frequency: Double = Default('0'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('1'),gain: Double = Default('0'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a two-pole peaking equalisation (EQ) filter. With this
 filter, the signal-level at and around a selected frequency can
 be increased or decreased, whilst (unlike bandpass and bandreject
@@ -8788,7 +8788,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#equalizer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8796,62 +8796,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='equalizer', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "gain": gain,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def extrastereo(
-    
+
     self,
 
 
@@ -8859,15 +8859,15 @@ References:
 
     *,
     m: Float = Default('2.5'),c: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Linearly increases the difference between left and right channels which
 adds some sort of "live" effect to playback.
 
@@ -8887,7 +8887,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#extrastereo)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8895,58 +8895,58 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='extrastereo', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "m": m,
-                
+
                 "c": c,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def firequalizer(
-    
+
     self,
 
 
@@ -8954,12 +8954,12 @@ References:
 
     *,
     gain: String = Default('gain_interpolate(f)'),gain_entry: String = Default(None),delay: Double = Default('0.01'),accuracy: Double = Default('5'),wfunc: Int| Literal["rectangular","hann","hamming","blackman","nuttall3","mnuttall3","nuttall","bnuttall","bharris","tukey"] | Default = Default('hann'),fixed: Boolean = Default('false'),multi: Boolean = Default('false'),zero_phase: Boolean = Default('false'),scale: Int| Literal["linlin","linlog","loglin","loglog"] | Default = Default('linlog'),dumpfile: String = Default(None),dumpscale: Int| Literal["linlin","linlog","loglin","loglog"] | Default = Default('linlog'),fft2: Boolean = Default('false'),min_phase: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply FIR Equalization using arbitrary frequency response.
 
 The filter accepts the following option:
@@ -8988,61 +8988,61 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#firequalizer)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='firequalizer', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "gain": gain,
-                
+
                 "gain_entry": gain_entry,
-                
+
                 "delay": delay,
-                
+
                 "accuracy": accuracy,
-                
+
                 "wfunc": wfunc,
-                
+
                 "fixed": fixed,
-                
+
                 "multi": multi,
-                
+
                 "zero_phase": zero_phase,
-                
+
                 "scale": scale,
-                
+
                 "dumpfile": dumpfile,
-                
+
                 "dumpscale": dumpscale,
-                
+
                 "fft2": fft2,
-                
+
                 "min_phase": min_phase,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def flanger(
-    
+
     self,
 
 
@@ -9050,12 +9050,12 @@ References:
 
     *,
     delay: Double = Default('0'),depth: Double = Default('2'),regen: Double = Default('0'),width: Double = Default('71'),speed: Double = Default('0.5'),shape: Int| Literal["triangular","t","sinusoidal","s"] | Default = Default('sinusoidal'),phase: Double = Default('25'),interp: Int| Literal["linear","quadratic"] | Default = Default('linear'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a flanging effect to the audio.
 
 The filter accepts the following options:
@@ -9079,85 +9079,85 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#flanger)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='flanger', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "delay": delay,
-                
+
                 "depth": depth,
-                
+
                 "regen": regen,
-                
+
                 "width": width,
-                
+
                 "speed": speed,
-                
+
                 "shape": shape,
-                
+
                 "phase": phase,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def haas(
-    
+
     self,
 
 
@@ -9165,12 +9165,12 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),side_gain: Double = Default('1'),middle_source: Int| Literal["left","right","mid","side"] | Default = Default('mid'),middle_phase: Boolean = Default('false'),left_delay: Double = Default('2.05'),left_balance: Double = Default('-1'),left_gain: Double = Default('1'),left_phase: Boolean = Default('false'),right_delay: Double = Default('2.12'),right_balance: Double = Default('1'),right_gain: Double = Default('1'),right_phase: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply Haas effect to audio.
 
 Note that this makes most sense to apply on mono signals.
@@ -9203,65 +9203,65 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#haas)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='haas', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "side_gain": side_gain,
-                
+
                 "middle_source": middle_source,
-                
+
                 "middle_phase": middle_phase,
-                
+
                 "left_delay": left_delay,
-                
+
                 "left_balance": left_balance,
-                
+
                 "left_gain": left_gain,
-                
+
                 "left_phase": left_phase,
-                
+
                 "right_delay": right_delay,
-                
+
                 "right_balance": right_balance,
-                
+
                 "right_gain": right_gain,
-                
+
                 "right_phase": right_phase,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def hdcd(
-    
+
     self,
 
 
@@ -9269,12 +9269,12 @@ References:
 
     *,
     disable_autoconvert: Boolean = Default('true'),process_stereo: Boolean = Default('true'),cdt_ms: Int = Default('2000'),force_pe: Boolean = Default('false'),analyze_mode: Int| Literal["off","lle","pe","cdt","tgm"] | Default = Default('off'),bits_per_sample: Int| Literal["16","20","24"] | Default = Default('16'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Decodes High Definition Compatible Digital (HDCD) data. A 16-bit PCM stream with
 embedded HDCD codes is expanded into a 20-bit PCM stream.
 
@@ -9312,51 +9312,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hdcd)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hdcd', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "disable_autoconvert": disable_autoconvert,
-                
+
                 "process_stereo": process_stereo,
-                
+
                 "cdt_ms": cdt_ms,
-                
+
                 "force_pe": force_pe,
-                
+
                 "analyze_mode": analyze_mode,
-                
+
                 "bits_per_sample": bits_per_sample,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def highpass(
-    
+
     self,
 
 
@@ -9364,15 +9364,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.707'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a high-pass filter with 3dB point frequency.
 The filter can be either single-pole, or double-pole (the default).
 The filter roll off at 6dB per pole per octave (20dB per pole per decade).
@@ -9401,7 +9401,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#highpass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9409,52 +9409,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='highpass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def highshelf(
-    
+
     self,
 
 
@@ -9462,15 +9462,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),gain: Double = Default('0'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Boost or cut treble (upper) frequencies of the audio using a two-pole
 shelving filter with a response similar to that of a standard
 hi-fi's tone-controls. This is also known as shelving equalisation (EQ).
@@ -9500,7 +9500,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#treble)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9508,116 +9508,116 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='highshelf', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "gain": gain,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def loudnorm(
-    
+
     self,
 
 
@@ -9625,12 +9625,12 @@ References:
 
     *,
     I: Double = Default('-24'),LRA: Double = Default('7'),TP: Double = Default('-2'),measured_I: Double = Default('0'),measured_LRA: Double = Default('0'),measured_TP: Double = Default('99'),measured_thresh: Double = Default('-70'),offset: Double = Default('0'),linear: Boolean = Default('true'),dual_mono: Boolean = Default('false'),print_format: Int| Literal["none","json","summary"] | Default = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 EBU R128 loudness normalization. Includes both dynamic and linear normalization modes.
 Support for both single pass (livestreams, files) and double pass (files) modes.
 This algorithm can target IL, LRA, and maximum true peak. In dynamic mode, to accurately
@@ -9661,57 +9661,57 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#loudnorm)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='loudnorm', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "I": I,
-                
+
                 "LRA": LRA,
-                
+
                 "TP": TP,
-                
+
                 "measured_I": measured_I,
-                
+
                 "measured_LRA": measured_LRA,
-                
+
                 "measured_TP": measured_TP,
-                
+
                 "measured_thresh": measured_thresh,
-                
+
                 "offset": offset,
-                
+
                 "linear": linear,
-                
+
                 "dual_mono": dual_mono,
-                
+
                 "print_format": print_format,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lowpass(
-    
+
     self,
 
 
@@ -9719,15 +9719,15 @@ References:
 
     *,
     frequency: Double = Default('500'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.707'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a low-pass filter with 3dB point frequency.
 The filter can be either single-pole or double-pole (the default).
 The filter roll off at 6dB per pole per octave (20dB per pole per decade).
@@ -9756,7 +9756,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lowpass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9764,52 +9764,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lowpass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lowshelf(
-    
+
     self,
 
 
@@ -9817,15 +9817,15 @@ References:
 
     *,
     frequency: Double = Default('100'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),gain: Double = Default('0'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Boost or cut the bass (lower) frequencies of the audio using a two-pole
 shelving filter with a response similar to that of a standard
 hi-fi's tone-controls. This is also known as shelving equalisation (EQ).
@@ -9855,7 +9855,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9863,84 +9863,84 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lowshelf', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "gain": gain,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def mcompand(
-    
+
     self,
 
 
@@ -9948,12 +9948,12 @@ References:
 
     *,
     args: String = Default('0.005,0.1 6 -47/-40,-34/-34,-17/-33 100 | 0.003,0.05 6 -47/-40,-34/-34,-17/-33 400 | 0.000625,0.0125 6 -47/-40,-34/-34,-15/-33 1600 | 0.0001,0.025 6 -47/-40,-34/-34,-31/-31,-0/-30 6400 | 0,0.025 6 -38/-31,-28/-28,-0/-25 22000'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Multiband Compress or expand the audio's dynamic range.
 
 The input audio is divided into bands using 4th order Linkwitz-Riley IIRs.
@@ -9974,109 +9974,109 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mcompand)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='mcompand', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "args": args,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def pan(
-    
+
     self,
 
 
@@ -10084,12 +10084,12 @@ References:
 
     *,
     args: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Mix channels with specific gain levels. The filter accepts the output
 channel layout followed by a set of channels definitions.
 
@@ -10101,7 +10101,7 @@ The filter accepts parameters of the form:
 
 
 Args:
-    args: 
+    args:
     extra_options: Extra options for the filter
 
 Returns:
@@ -10111,91 +10111,91 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pan)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pan', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "args": args,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def replaygain(
-    
+
     self,
 
 
@@ -10203,12 +10203,12 @@ References:
 
     *,
     track_gain: Float = Default('0'),track_peak: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 ReplayGain scanner filter. This filter takes an audio stream as an input and
 outputs it unchanged.
 At end of filtering it displays track_gain and track_peak.
@@ -10228,93 +10228,93 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#replaygain)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='replaygain', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "track_gain": track_gain,
-                
+
                 "track_peak": track_peak,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def showcqt(
-    
+
     self,
 
 
@@ -10322,12 +10322,12 @@ References:
 
     *,
     size: Image_size = Default('1920x1080'),fps: Video_rate = Default('25'),bar_h: Int = Default('-1'),axis_h: Int = Default('-1'),sono_h: Int = Default('-1'),fullhd: Boolean = Default('true'),sono_v: String = Default('16'),bar_v: String = Default('sono_v'),sono_g: Float = Default('3'),bar_g: Float = Default('1'),bar_t: Float = Default('1'),timeclamp: Double = Default('0.17'),attack: Double = Default('0'),basefreq: Double = Default('20.0152'),endfreq: Double = Default('20495.6'),coeffclamp: Float = Default('1'),tlength: String = Default('384*tc/(384+tc*f)'),count: Int = Default('6'),fcount: Int = Default('0'),fontfile: String = Default(None),font: String = Default(None),fontcolor: String = Default('st(0, (midi(f)-59.5)/12);st(1, if(between(ld(0),0,1), 0.5-0.5*cos(2*PI*ld(0)), 0));r(1-ld(1)) + b(ld(1))'),axisfile: String = Default(None),axis: Boolean = Default('true'),csp: Int| Literal["unspecified","bt709","fcc","bt470bg","smpte170m","smpte240m","bt2020ncl"] | Default = Default('unspecified'),cscheme: String = Default('1|0.5|0|0|0.5|1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a video output representing frequency spectrum
 logarithmically using Brown-Puckette constant Q transform algorithm with
 direct frequency domain coefficient calculation (but the transform itself
@@ -10373,87 +10373,87 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showcqt)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showcqt', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "fps": fps,
-                
+
                 "bar_h": bar_h,
-                
+
                 "axis_h": axis_h,
-                
+
                 "sono_h": sono_h,
-                
+
                 "fullhd": fullhd,
-                
+
                 "sono_v": sono_v,
-                
+
                 "bar_v": bar_v,
-                
+
                 "sono_g": sono_g,
-                
+
                 "bar_g": bar_g,
-                
+
                 "bar_t": bar_t,
-                
+
                 "timeclamp": timeclamp,
-                
+
                 "attack": attack,
-                
+
                 "basefreq": basefreq,
-                
+
                 "endfreq": endfreq,
-                
+
                 "coeffclamp": coeffclamp,
-                
+
                 "tlength": tlength,
-                
+
                 "count": count,
-                
+
                 "fcount": fcount,
-                
+
                 "fontfile": fontfile,
-                
+
                 "font": font,
-                
+
                 "fontcolor": fontcolor,
-                
+
                 "axisfile": axisfile,
-                
+
                 "axis": axis,
-                
+
                 "csp": csp,
-                
+
                 "cscheme": cscheme,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showcwt(
-    
+
     self,
 
 
@@ -10461,12 +10461,12 @@ References:
 
     *,
     size: Image_size = Default('640x512'),rate: String = Default('25'),scale: Int| Literal["linear","log","bark","mel","erbs","sqrt","cbrt","qdrt"] | Default = Default('linear'),iscale: Int| Literal["linear","log","sqrt","cbrt","qdrt"] | Default = Default('log'),min: Float = Default('20'),max: Float = Default('20000'),imin: Float = Default('0'),imax: Float = Default('1'),logb: Float = Default('0.0001'),deviation: Float = Default('1'),pps: Int = Default('64'),mode: Int| Literal["magnitude","phase","magphase","channel","stereo"] | Default = Default('magnitude'),slide: Int| Literal["replace","scroll","frame"] | Default = Default('replace'),direction: Int| Literal["lr","rl","ud","du"] | Default = Default('lr'),bar: Float = Default('0'),rotation: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to video output representing frequency spectrum
 using Continuous Wavelet Transform and Morlet wavelet.
 
@@ -10499,67 +10499,67 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showcwt)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showcwt', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "rate": rate,
-                
+
                 "scale": scale,
-                
+
                 "iscale": iscale,
-                
+
                 "min": min,
-                
+
                 "max": max,
-                
+
                 "imin": imin,
-                
+
                 "imax": imax,
-                
+
                 "logb": logb,
-                
+
                 "deviation": deviation,
-                
+
                 "pps": pps,
-                
+
                 "mode": mode,
-                
+
                 "slide": slide,
-                
+
                 "direction": direction,
-                
+
                 "bar": bar,
-                
+
                 "rotation": rotation,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showfreqs(
-    
+
     self,
 
 
@@ -10567,12 +10567,12 @@ References:
 
     *,
     size: Image_size = Default('1024x512'),rate: Video_rate = Default('25'),mode: Int| Literal["line","bar","dot"] | Default = Default('bar'),ascale: Int| Literal["lin","sqrt","cbrt","log"] | Default = Default('log'),fscale: Int| Literal["lin","log","rlog"] | Default = Default('lin'),win_size: Int = Default('2048'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('hann'),overlap: Float = Default('1'),averaging: Int = Default('1'),colors: String = Default('red|green|blue|yellow|orange|lime|pink|magenta|brown'),cmode: Int| Literal["combined","separate"] | Default = Default('combined'),minamp: Float = Default('1e-06'),data: Int| Literal["magnitude","phase","delay"] | Default = Default('magnitude'),channels: String = Default('all'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to video output representing the audio power spectrum.
 Audio amplitude is on Y-axis while frequency is on X-axis.
 
@@ -10603,67 +10603,67 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showfreqs)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showfreqs', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "rate": rate,
-                
+
                 "mode": mode,
-                
+
                 "ascale": ascale,
-                
+
                 "fscale": fscale,
-                
+
                 "win_size": win_size,
-                
+
                 "win_func": win_func,
-                
+
                 "overlap": overlap,
-                
+
                 "averaging": averaging,
-                
+
                 "colors": colors,
-                
+
                 "cmode": cmode,
-                
+
                 "minamp": minamp,
-                
+
                 "data": data,
-                
+
                 "channels": channels,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def showspatial(
-    
+
     self,
 
 
@@ -10671,12 +10671,12 @@ References:
 
     *,
     size: Image_size = Default('512x512'),win_size: Int = Default('4096'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('hann'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert stereo input audio to a video output, representing the spatial relationship
 between two channels.
 
@@ -10697,43 +10697,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showspatial)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showspatial', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "win_size": win_size,
-                
+
                 "win_func": win_func,
-                
+
                 "rate": rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showspectrum(
-    
+
     self,
 
 
@@ -10741,12 +10741,12 @@ References:
 
     *,
     size: Image_size = Default('640x512'),slide: Int| Literal["replace","scroll","fullframe","rscroll","lreplace"] | Default = Default('replace'),mode: Int| Literal["combined","separate"] | Default = Default('combined'),color: Int| Literal["channel","intensity","rainbow","moreland","nebulae","fire","fiery","fruit","cool","magma","green","viridis","plasma","cividis","terrain"] | Default = Default('channel'),scale: Int| Literal["lin","sqrt","cbrt","log","4thrt","5thrt"] | Default = Default('sqrt'),fscale: Int| Literal["lin","log"] | Default = Default('lin'),saturation: Float = Default('1'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('hann'),orientation: Int| Literal["vertical","horizontal"] | Default = Default('vertical'),overlap: Float = Default('0'),gain: Float = Default('1'),data: Int| Literal["magnitude","phase","uphase"] | Default = Default('magnitude'),rotation: Float = Default('0'),start: Int = Default('0'),stop: Int = Default('0'),fps: String = Default('auto'),legend: Boolean = Default('false'),drange: Float = Default('120'),limit: Float = Default('0'),opacity: Float = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a video output, representing the audio frequency
 spectrum.
 
@@ -10783,75 +10783,75 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showspectrum)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showspectrum', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "slide": slide,
-                
+
                 "mode": mode,
-                
+
                 "color": color,
-                
+
                 "scale": scale,
-                
+
                 "fscale": fscale,
-                
+
                 "saturation": saturation,
-                
+
                 "win_func": win_func,
-                
+
                 "orientation": orientation,
-                
+
                 "overlap": overlap,
-                
+
                 "gain": gain,
-                
+
                 "data": data,
-                
+
                 "rotation": rotation,
-                
+
                 "start": start,
-                
+
                 "stop": stop,
-                
+
                 "fps": fps,
-                
+
                 "legend": legend,
-                
+
                 "drange": drange,
-                
+
                 "limit": limit,
-                
+
                 "opacity": opacity,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showspectrumpic(
-    
+
     self,
 
 
@@ -10859,12 +10859,12 @@ References:
 
     *,
     size: Image_size = Default('4096x2048'),mode: Int| Literal["combined","separate"] | Default = Default('combined'),color: Int| Literal["channel","intensity","rainbow","moreland","nebulae","fire","fiery","fruit","cool","magma","green","viridis","plasma","cividis","terrain"] | Default = Default('intensity'),scale: Int| Literal["lin","sqrt","cbrt","log","4thrt","5thrt"] | Default = Default('log'),fscale: Int| Literal["lin","log"] | Default = Default('lin'),saturation: Float = Default('1'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('hann'),orientation: Int| Literal["vertical","horizontal"] | Default = Default('vertical'),gain: Float = Default('1'),legend: Boolean = Default('true'),rotation: Float = Default('0'),start: Int = Default('0'),stop: Int = Default('0'),drange: Float = Default('120'),limit: Float = Default('0'),opacity: Float = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a single video frame, representing the audio frequency
 spectrum.
 
@@ -10897,67 +10897,67 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showspectrumpic)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showspectrumpic', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "mode": mode,
-                
+
                 "color": color,
-                
+
                 "scale": scale,
-                
+
                 "fscale": fscale,
-                
+
                 "saturation": saturation,
-                
+
                 "win_func": win_func,
-                
+
                 "orientation": orientation,
-                
+
                 "gain": gain,
-                
+
                 "legend": legend,
-                
+
                 "rotation": rotation,
-                
+
                 "start": start,
-                
+
                 "stop": stop,
-                
+
                 "drange": drange,
-                
+
                 "limit": limit,
-                
+
                 "opacity": opacity,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showvolume(
-    
+
     self,
 
 
@@ -10965,12 +10965,12 @@ References:
 
     *,
     rate: Video_rate = Default('25'),b: Int = Default('1'),w: Int = Default('400'),h: Int = Default('20'),f: Double = Default('0.95'),c: String = Default('PEAK*255+floor((1-PEAK)*255)*256+0xff000000'),t: Boolean = Default('true'),v: Boolean = Default('true'),dm: Double = Default('0'),dmc: Color = Default('orange'),o: Int| Literal["h","v"] | Default = Default('h'),s: Int = Default('0'),p: Float = Default('0'),m: Int| Literal["p","r"] | Default = Default('p'),ds: Int| Literal["lin","log"] | Default = Default('lin'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio volume to a video output.
 
 The filter accepts the following options:
@@ -11001,65 +11001,65 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showvolume)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showvolume', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rate": rate,
-                
+
                 "b": b,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "f": f,
-                
+
                 "c": c,
-                
+
                 "t": t,
-                
+
                 "v": v,
-                
+
                 "dm": dm,
-                
+
                 "dmc": dmc,
-                
+
                 "o": o,
-                
+
                 "s": s,
-                
+
                 "p": p,
-                
+
                 "m": m,
-                
+
                 "ds": ds,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showwaves(
-    
+
     self,
 
 
@@ -11067,12 +11067,12 @@ References:
 
     *,
     size: Image_size = Default('600x240'),mode: Int| Literal["point","line","p2p","cline"] | Default = Default('point'),n: Rational = Default('0/1'),rate: Video_rate = Default('25'),split_channels: Boolean = Default('false'),colors: String = Default('red|green|blue|yellow|orange|lime|pink|magenta|brown'),scale: Int| Literal["lin","log","sqrt","cbrt"] | Default = Default('lin'),draw: Int| Literal["scale","full"] | Default = Default('scale'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a video output, representing the samples waves.
 
 The filter accepts the following options:
@@ -11096,51 +11096,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showwaves)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showwaves', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "mode": mode,
-                
+
                 "n": n,
-                
+
                 "rate": rate,
-                
+
                 "split_channels": split_channels,
-                
+
                 "colors": colors,
-                
+
                 "scale": scale,
-                
+
                 "draw": draw,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showwavespic(
-    
+
     self,
 
 
@@ -11148,12 +11148,12 @@ References:
 
     *,
     size: Image_size = Default('600x240'),split_channels: Boolean = Default('false'),colors: String = Default('red|green|blue|yellow|orange|lime|pink|magenta|brown'),scale: Int| Literal["lin","log","sqrt","cbrt"] | Default = Default('lin'),draw: Int| Literal["scale","full"] | Default = Default('scale'),filter: Int| Literal["average","peak"] | Default = Default('average'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a single video frame, representing the samples waves.
 
 The filter accepts the following options:
@@ -11175,74 +11175,74 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showwavespic)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showwavespic', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "split_channels": split_channels,
-                
+
                 "colors": colors,
-                
+
                 "scale": scale,
-                
+
                 "draw": draw,
-                
+
                 "filter": filter,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def sidechaincompress(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _sidechain: AudioStream,
-        
-    
+
+
 
 
     *,
     level_in: Double = Default('1'),mode: Int| Literal["downward","upward"] | Default = Default('downward'),threshold: Double = Default('0.125'),ratio: Double = Default('2'),attack: Double = Default('20'),release: Double = Default('250'),makeup: Double = Default('1'),knee: Double = Default('2.82843'),link: Int| Literal["average","maximum"] | Default = Default('average'),detection: Int| Literal["peak","rms"] | Default = Default('rms'),level_sc: Double = Default('1'),mix: Double = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 This filter acts like normal compressor but has the ability to compress
 detected signal using second input signal.
 It needs two input streams and returns one output stream.
@@ -11275,91 +11275,91 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sidechaincompress)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sidechaincompress', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _sidechain,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "mode": mode,
-                
+
                 "threshold": threshold,
-                
+
                 "ratio": ratio,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "makeup": makeup,
-                
+
                 "knee": knee,
-                
+
                 "link": link,
-                
+
                 "detection": detection,
-                
+
                 "level_sc": level_sc,
-                
+
                 "mix": mix,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def sidechaingate(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _sidechain: AudioStream,
-        
-    
+
+
 
 
     *,
     level_in: Double = Default('1'),mode: Int| Literal["downward","upward"] | Default = Default('downward'),range: Double = Default('0.06125'),threshold: Double = Default('0.125'),ratio: Double = Default('2'),attack: Double = Default('20'),release: Double = Default('250'),makeup: Double = Default('1'),knee: Double = Default('2.82843'),detection: Int| Literal["peak","rms"] | Default = Default('rms'),link: Int| Literal["average","maximum"] | Default = Default('average'),level_sc: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 A sidechain gate acts like a normal (wideband) gate but has the ability to
 filter the detected signal before sending it to the gain reduction stage.
 Normally a gate uses the full range signal to detect a level above the
@@ -11398,7 +11398,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sidechaingate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11406,72 +11406,72 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sidechaingate', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _sidechain,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "mode": mode,
-                
+
                 "range": range,
-                
+
                 "threshold": threshold,
-                
+
                 "ratio": ratio,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "makeup": makeup,
-                
+
                 "knee": knee,
-                
+
                 "detection": detection,
-                
+
                 "link": link,
-                
+
                 "level_sc": level_sc,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def silencedetect(
-    
+
     self,
 
 
@@ -11479,12 +11479,12 @@ References:
 
     *,
     n: Double = Default('0.001'),d: Duration = Default('2'),mono: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Detect silence in an audio stream.
 
 This filter logs a message when it detects that the input audio volume is less
@@ -11518,41 +11518,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#silencedetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='silencedetect', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "n": n,
-                
+
                 "d": d,
-                
+
                 "mono": mono,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def silenceremove(
-    
+
     self,
 
 
@@ -11560,15 +11560,15 @@ References:
 
     *,
     start_periods: Int = Default('0'),start_duration: Duration = Default('0'),start_threshold: Double = Default('0'),start_silence: Duration = Default('0'),start_mode: Int| Literal["any","all"] | Default = Default('any'),stop_periods: Int = Default('0'),stop_duration: Duration = Default('0'),stop_threshold: Double = Default('0'),stop_silence: Duration = Default('0'),stop_mode: Int| Literal["any","all"] | Default = Default('all'),detection: Int| Literal["avg","rms","peak","median","ptp","dev"] | Default = Default('rms'),window: Duration = Default('0.02'),timestamp: Int| Literal["write","copy"] | Default = Default('write'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Remove silence from the beginning, middle or end of the audio.
 
 The filter accepts the following options:
@@ -11598,7 +11598,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#silenceremove)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11606,76 +11606,76 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='silenceremove', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "start_periods": start_periods,
-                
+
                 "start_duration": start_duration,
-                
+
                 "start_threshold": start_threshold,
-                
+
                 "start_silence": start_silence,
-                
+
                 "start_mode": start_mode,
-                
+
                 "stop_periods": stop_periods,
-                
+
                 "stop_duration": stop_duration,
-                
+
                 "stop_threshold": stop_threshold,
-                
+
                 "stop_silence": stop_silence,
-                
+
                 "stop_mode": stop_mode,
-                
+
                 "detection": detection,
-                
+
                 "window": window,
-                
+
                 "timestamp": timestamp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def speechnorm(
-    
+
     self,
 
 
@@ -11683,15 +11683,15 @@ References:
 
     *,
     peak: Double = Default('0.95'),expansion: Double = Default('2'),compression: Double = Default('2'),threshold: Double = Default('0'),_raise: Double = Default('0.001'),fall: Double = Default('0.001'),channels: String = Default('all'),invert: Boolean = Default('false'),link: Boolean = Default('false'),rms: Double = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Speech Normalizer.
 
 This filter expands or compresses each half-cycle of audio samples
@@ -11722,7 +11722,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#speechnorm)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11730,64 +11730,64 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='speechnorm', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "peak": peak,
-                
+
                 "expansion": expansion,
-                
+
                 "compression": compression,
-                
+
                 "threshold": threshold,
-                
+
                 "raise": _raise,
-                
+
                 "fall": fall,
-                
+
                 "channels": channels,
-                
+
                 "invert": invert,
-                
+
                 "link": link,
-                
+
                 "rms": rms,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def stereotools(
-    
+
     self,
 
 
@@ -11795,15 +11795,15 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),balance_in: Double = Default('0'),balance_out: Double = Default('0'),softclip: Boolean = Default('false'),mutel: Boolean = Default('false'),muter: Boolean = Default('false'),phasel: Boolean = Default('false'),phaser: Boolean = Default('false'),mode: Int| Literal["lr>lr","lr>ms","ms>lr","lr>ll","lr>rr","lr>l+r","lr>rl","ms>ll","ms>rr","ms>rl","lr>l-r"] | Default = Default('lr>lr'),slev: Double = Default('1'),sbal: Double = Default('0'),mlev: Double = Default('1'),mpan: Double = Default('0'),base: Double = Default('0'),delay: Double = Default('0'),sclevel: Double = Default('1'),phase: Double = Default('0'),bmode_in: Int| Literal["balance","amplitude","power"] | Default = Default('balance'),bmode_out: Int| Literal["balance","amplitude","power"] | Default = Default('balance'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 This filter has some handy utilities to manage stereo signals, for converting
 M/S stereo recordings to L/R signal while having control over the parameters
 or spreading the stereo image of master track.
@@ -11842,7 +11842,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#stereotools)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11850,72 +11850,72 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='stereotools', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "balance_in": balance_in,
-                
+
                 "balance_out": balance_out,
-                
+
                 "softclip": softclip,
-                
+
                 "mutel": mutel,
-                
+
                 "muter": muter,
-                
+
                 "phasel": phasel,
-                
+
                 "phaser": phaser,
-                
+
                 "mode": mode,
-                
+
                 "slev": slev,
-                
+
                 "sbal": sbal,
-                
+
                 "mlev": mlev,
-                
+
                 "mpan": mpan,
-                
+
                 "base": base,
-                
+
                 "delay": delay,
-                
+
                 "sclevel": sclevel,
-                
+
                 "phase": phase,
-                
+
                 "bmode_in": bmode_in,
-                
+
                 "bmode_out": bmode_out,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def stereowiden(
-    
+
     self,
 
 
@@ -11923,15 +11923,15 @@ References:
 
     *,
     delay: Float = Default('20'),feedback: Float = Default('0.3'),crossfeed: Float = Default('0.3'),drymix: Float = Default('0.8'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 This filter enhance the stereo effect by suppressing signal common to both
 channels and by delaying the signal of left into right and vice versa,
 thereby widening the stereo effect.
@@ -11954,7 +11954,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#stereowiden)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11962,46 +11962,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='stereowiden', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "delay": delay,
-                
+
                 "feedback": feedback,
-                
+
                 "crossfeed": crossfeed,
-                
+
                 "drymix": drymix,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def superequalizer(
-    
+
     self,
 
 
@@ -12009,12 +12009,12 @@ References:
 
     *,
     _1b: Float = Default('1'),_2b: Float = Default('1'),_3b: Float = Default('1'),_4b: Float = Default('1'),_5b: Float = Default('1'),_6b: Float = Default('1'),_7b: Float = Default('1'),_8b: Float = Default('1'),_9b: Float = Default('1'),_10b: Float = Default('1'),_11b: Float = Default('1'),_12b: Float = Default('1'),_13b: Float = Default('1'),_14b: Float = Default('1'),_15b: Float = Default('1'),_16b: Float = Default('1'),_17b: Float = Default('1'),_18b: Float = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply 18 band equalizer.
 
 The filter accepts the following options:
@@ -12048,71 +12048,71 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#superequalizer)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='superequalizer', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "1b": _1b,
-                
+
                 "2b": _2b,
-                
+
                 "3b": _3b,
-                
+
                 "4b": _4b,
-                
+
                 "5b": _5b,
-                
+
                 "6b": _6b,
-                
+
                 "7b": _7b,
-                
+
                 "8b": _8b,
-                
+
                 "9b": _9b,
-                
+
                 "10b": _10b,
-                
+
                 "11b": _11b,
-                
+
                 "12b": _12b,
-                
+
                 "13b": _13b,
-                
+
                 "14b": _14b,
-                
+
                 "15b": _15b,
-                
+
                 "16b": _16b,
-                
+
                 "17b": _17b,
-                
+
                 "18b": _18b,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def surround(
-    
+
     self,
 
 
@@ -12120,12 +12120,12 @@ References:
 
     *,
     chl_out: String = Default('5.1'),chl_in: String = Default('stereo'),level_in: Float = Default('1'),level_out: Float = Default('1'),lfe: Boolean = Default('true'),lfe_low: Int = Default('128'),lfe_high: Int = Default('256'),lfe_mode: Int| Literal["add","sub"] | Default = Default('add'),smooth: Float = Default('0'),angle: Float = Default('90'),focus: Float = Default('0'),fc_in: Float = Default('1'),fc_out: Float = Default('1'),fl_in: Float = Default('1'),fl_out: Float = Default('1'),fr_in: Float = Default('1'),fr_out: Float = Default('1'),sl_in: Float = Default('1'),sl_out: Float = Default('1'),sr_in: Float = Default('1'),sr_out: Float = Default('1'),bl_in: Float = Default('1'),bl_out: Float = Default('1'),br_in: Float = Default('1'),br_out: Float = Default('1'),bc_in: Float = Default('1'),bc_out: Float = Default('1'),lfe_in: Float = Default('1'),lfe_out: Float = Default('1'),allx: Float = Default('-1'),ally: Float = Default('-1'),fcx: Float = Default('0.5'),flx: Float = Default('0.5'),frx: Float = Default('0.5'),blx: Float = Default('0.5'),brx: Float = Default('0.5'),slx: Float = Default('0.5'),srx: Float = Default('0.5'),bcx: Float = Default('0.5'),fcy: Float = Default('0.5'),fly: Float = Default('0.5'),fry: Float = Default('0.5'),bly: Float = Default('0.5'),bry: Float = Default('0.5'),sly: Float = Default('0.5'),sry: Float = Default('0.5'),bcy: Float = Default('0.5'),win_size: Int = Default('4096'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('hann'),overlap: Float = Default('0.5'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply audio surround upmix filter.
 
 This filter allows to produce multichannel output from audio stream.
@@ -12193,155 +12193,155 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#surround)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='surround', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "chl_out": chl_out,
-                
+
                 "chl_in": chl_in,
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "lfe": lfe,
-                
+
                 "lfe_low": lfe_low,
-                
+
                 "lfe_high": lfe_high,
-                
+
                 "lfe_mode": lfe_mode,
-                
+
                 "smooth": smooth,
-                
+
                 "angle": angle,
-                
+
                 "focus": focus,
-                
+
                 "fc_in": fc_in,
-                
+
                 "fc_out": fc_out,
-                
+
                 "fl_in": fl_in,
-                
+
                 "fl_out": fl_out,
-                
+
                 "fr_in": fr_in,
-                
+
                 "fr_out": fr_out,
-                
+
                 "sl_in": sl_in,
-                
+
                 "sl_out": sl_out,
-                
+
                 "sr_in": sr_in,
-                
+
                 "sr_out": sr_out,
-                
+
                 "bl_in": bl_in,
-                
+
                 "bl_out": bl_out,
-                
+
                 "br_in": br_in,
-                
+
                 "br_out": br_out,
-                
+
                 "bc_in": bc_in,
-                
+
                 "bc_out": bc_out,
-                
+
                 "lfe_in": lfe_in,
-                
+
                 "lfe_out": lfe_out,
-                
+
                 "allx": allx,
-                
+
                 "ally": ally,
-                
+
                 "fcx": fcx,
-                
+
                 "flx": flx,
-                
+
                 "frx": frx,
-                
+
                 "blx": blx,
-                
+
                 "brx": brx,
-                
+
                 "slx": slx,
-                
+
                 "srx": srx,
-                
+
                 "bcx": bcx,
-                
+
                 "fcy": fcy,
-                
+
                 "fly": fly,
-                
+
                 "fry": fry,
-                
+
                 "bly": bly,
-                
+
                 "bry": bry,
-                
+
                 "sly": sly,
-                
+
                 "sry": sry,
-                
+
                 "bcy": bcy,
-                
+
                 "win_size": win_size,
-                
+
                 "win_func": win_func,
-                
+
                 "overlap": overlap,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def tiltshelf(
-    
+
     self,
 
 
@@ -12349,15 +12349,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),gain: Double = Default('0'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Boost or cut the lower frequencies and cut or boost higher frequencies
 of the audio using a two-pole shelving filter with a response similar to
 that of a standard hi-fi's tone-controls.
@@ -12388,7 +12388,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tiltshelf)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12396,78 +12396,78 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tiltshelf', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "gain": gain,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def treble(
-    
+
     self,
 
 
@@ -12475,15 +12475,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),gain: Double = Default('0'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Boost or cut treble (upper) frequencies of the audio using a two-pole
 shelving filter with a response similar to that of a standard
 hi-fi's tone-controls. This is also known as shelving equalisation (EQ).
@@ -12513,7 +12513,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#treble)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12521,54 +12521,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='treble', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "gain": gain,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tremolo(
-    
+
     self,
 
 
@@ -12576,15 +12576,15 @@ References:
 
     *,
     f: Double = Default('5'),d: Double = Default('0.5'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Sinusoidal amplitude modulation.
 
 The filter accepts the following options:
@@ -12603,7 +12603,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tremolo)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12611,62 +12611,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tremolo', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "f": f,
-                
+
                 "d": d,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def vibrato(
-    
+
     self,
 
 
@@ -12674,15 +12674,15 @@ References:
 
     *,
     f: Double = Default('5'),d: Double = Default('0.5'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Sinusoidal phase modulation.
 
 The filter accepts the following options:
@@ -12701,7 +12701,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vibrato)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12709,44 +12709,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vibrato', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "f": f,
-                
+
                 "d": d,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def virtualbass(
-    
+
     self,
 
 
@@ -12754,15 +12754,15 @@ References:
 
     *,
     cutoff: Double = Default('250'),strength: Double = Default('3'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply audio Virtual Bass filter.
 
 This filter accepts stereo input and produce stereo with LFE (2.1) channels output.
@@ -12785,7 +12785,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#virtualbass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12793,38 +12793,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='virtualbass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cutoff": cutoff,
-                
+
                 "strength": strength,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def volume(
-    
+
     self,
 
 
@@ -12832,15 +12832,15 @@ References:
 
     *,
     volume: String = Default('1.0'),precision: Int| Literal["fixed","float","double"] | Default = Default('float'),eval: Int| Literal["once","frame"] | Default = Default('once'),replaygain: Int| Literal["drop","ignore","track","album"] | Default = Default('drop'),replaygain_preamp: Double = Default('0'),replaygain_noclip: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Adjust the input audio volume.
 
 It accepts the following parameters:
@@ -12863,7 +12863,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#volume)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12871,57 +12871,57 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='volume', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "volume": volume,
-                
+
                 "precision": precision,
-                
+
                 "eval": eval,
-                
+
                 "replaygain": replaygain,
-                
+
                 "replaygain_preamp": replaygain_preamp,
-                
+
                 "replaygain_noclip": replaygain_noclip,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def volumedetect(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Detect the volume of the input video.
 
 The filter has no parameters. It supports only 16-bit signed integer samples,
@@ -12946,65 +12946,23 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#volumedetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='volumedetect', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
-
-
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    

--- a/packages/v6/src/ffmpeg/streams/video.py
+++ b/packages/v6/src/ffmpeg/streams/video.py
@@ -48,36 +48,36 @@ class VideoStream(FilterableStream):
     Video stream.
     """
 
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def addroi(
-    
+
     self,
 
 
@@ -85,12 +85,12 @@ class VideoStream(FilterableStream):
 
     *,
     x: String = Default('0'),y: String = Default('0'),w: String = Default('0'),h: String = Default('0'),qoffset: Rational = Default('-1/10'),clear: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Mark a region of interest in a video frame.
 
 The frame data is passed through unchanged, but metadata is attached
@@ -115,134 +115,134 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#addroi)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='addroi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "qoffset": qoffset,
-                
+
                 "clear": clear,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def alphaextract(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Extract the alpha component from the input as a grayscale video. This
 is especially useful with the alphamerge filter.
 
@@ -257,64 +257,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#alphaextract)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='alphaextract', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def alphamerge(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _alpha: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Add or replace the alpha component of the primary input with the
 grayscale value of a second input. This is intended for use with
 alphaextract to allow the transmission or storage of frame
@@ -340,7 +340,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#alphamerge)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -351,50 +351,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='alphamerge', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _alpha,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def amplify(
-    
+
     self,
 
 
@@ -402,15 +402,15 @@ References:
 
     *,
     radius: Int = Default('2'),factor: Float = Default('2'),threshold: Float = Default('10'),tolerance: Float = Default('0'),low: Float = Default('65535'),high: Float = Default('65535'),planes: Flags = Default('7'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Amplify differences between current pixel and pixels of adjacent frames in
 same pixel location.
 
@@ -435,7 +435,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amplify)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -443,118 +443,118 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='amplify', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "radius": radius,
-                
+
                 "factor": factor,
-                
+
                 "threshold": threshold,
-                
+
                 "tolerance": tolerance,
-                
+
                 "low": low,
-                
+
                 "high": high,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def ass(
-    
+
     self,
 
 
@@ -562,12 +562,12 @@ References:
 
     *,
     filename: String = Default(None),original_size: Image_size = Default(None),fontsdir: String = Default(None),alpha: Boolean = Default('false'),shaping: Int| Literal["auto","simple","complex"] | Default = Default('auto'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Same as the subtitles filter, except that it doesn't require libavcodec
 and libavformat to work. On the other hand, it is limited to ASS (Advanced
 Substation Alpha) subtitles files.
@@ -591,59 +591,59 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ass)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ass', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "filename": filename,
-                
+
                 "original_size": original_size,
-                
+
                 "fontsdir": fontsdir,
-                
+
                 "alpha": alpha,
-                
+
                 "shaping": shaping,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def atadenoise(
-    
+
     self,
 
 
@@ -651,15 +651,15 @@ References:
 
     *,
     _0a: Float = Default('0.02'),_0b: Float = Default('0.04'),_1a: Float = Default('0.02'),_1b: Float = Default('0.04'),_2a: Float = Default('0.02'),_2b: Float = Default('0.04'),s: Int = Default('9'),p: Flags = Default('7'),a: Int| Literal["p","s"] | Default = Default('p'),_0s: Float = Default('32767'),_1s: Float = Default('32767'),_2s: Float = Default('32767'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply an Adaptive Temporal Averaging Denoiser to the video input.
 
 The filter accepts the following options:
@@ -688,7 +688,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#atadenoise)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -696,64 +696,64 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='atadenoise', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "0a": _0a,
-                
+
                 "0b": _0b,
-                
+
                 "1a": _1a,
-                
+
                 "1b": _1b,
-                
+
                 "2a": _2a,
-                
+
                 "2b": _2b,
-                
+
                 "s": s,
-                
+
                 "p": p,
-                
+
                 "a": a,
-                
+
                 "0s": _0s,
-                
+
                 "1s": _1s,
-                
+
                 "2s": _2s,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def avgblur(
-    
+
     self,
 
 
@@ -761,15 +761,15 @@ References:
 
     *,
     sizeX: Int = Default('1'),planes: Int = Default('15'),sizeY: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply average blur filter.
 
 The filter accepts the following options:
@@ -789,7 +789,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#avgblur)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -797,38 +797,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='avgblur', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sizeX": sizeX,
-                
+
                 "planes": planes,
-                
+
                 "sizeY": sizeY,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def avgblur_opencl(
-    
+
     self,
 
 
@@ -836,12 +836,12 @@ References:
 
     *,
     sizeX: Int = Default('1'),planes: Int = Default('15'),sizeY: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply average blur filter.
 
 The filter accepts the following options:
@@ -860,47 +860,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#avgblur_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='avgblur_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sizeX": sizeX,
-                
+
                 "planes": planes,
-                
+
                 "sizeY": sizeY,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def backgroundkey(
-    
+
     self,
 
 
@@ -908,15 +908,15 @@ References:
 
     *,
     threshold: Float = Default('0.08'),similarity: Float = Default('0.1'),blend: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Turns a static background into transparency.
 
 The filter accepts the following option:
@@ -936,7 +936,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#backgroundkey)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -944,44 +944,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='backgroundkey', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold": threshold,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def bbox(
-    
+
     self,
 
 
@@ -989,15 +989,15 @@ References:
 
     *,
     min_val: Int = Default('16'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Compute the bounding box for the non-black pixels in the input frame
 luma plane.
 
@@ -1021,7 +1021,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bbox)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1029,34 +1029,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bbox', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "min_val": min_val,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def bench(
-    
+
     self,
 
 
@@ -1064,12 +1064,12 @@ References:
 
     *,
     action: Int| Literal["start","stop"] | Default = Default('start'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Benchmark part of a filtergraph.
 
 The filter accepts the following options:
@@ -1086,37 +1086,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bench)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bench', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "action": action,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def bilateral(
-    
+
     self,
 
 
@@ -1124,15 +1124,15 @@ References:
 
     *,
     sigmaS: Float = Default('0.1'),sigmaR: Float = Default('0.1'),planes: Int = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply bilateral filter, spatial smoothing while preserving edges.
 
 The filter accepts the following options:
@@ -1152,7 +1152,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bilateral)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1160,40 +1160,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bilateral', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sigmaS": sigmaS,
-                
+
                 "sigmaR": sigmaR,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def bitplanenoise(
-    
+
     self,
 
 
@@ -1201,15 +1201,15 @@ References:
 
     *,
     bitplane: Int = Default('1'),filter: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Show and measure bit plane noise.
 
 The filter accepts the following options:
@@ -1228,7 +1228,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bitplanenoise)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1236,36 +1236,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bitplanenoise', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "bitplane": bitplane,
-                
+
                 "filter": filter,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def blackdetect(
-    
+
     self,
 
 
@@ -1273,12 +1273,12 @@ References:
 
     *,
     d: Double = Default('2'),picture_black_ratio_th: Double = Default('0.98'),pixel_black_th: Double = Default('0.1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect video intervals that are (almost) completely black. Can be
 useful to detect chapter transitions, commercials, or invalid
 recordings.
@@ -1312,41 +1312,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blackdetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='blackdetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "d": d,
-                
+
                 "picture_black_ratio_th": picture_black_ratio_th,
-                
+
                 "pixel_black_th": pixel_black_th,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def blackframe(
-    
+
     self,
 
 
@@ -1354,12 +1354,12 @@ References:
 
     *,
     amount: Int = Default('98'),threshold: Int = Default('32'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect frames that are (almost) completely black. Can be useful to
 detect chapter transitions or commercials. Output lines consist of
 the frame number of the detected frame, the percentage of blackness,
@@ -1387,68 +1387,68 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blackframe)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='blackframe', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "amount": amount,
-                
+
                 "threshold": threshold,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def blend(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _bottom: VideoStream,
-        
-    
+
+
 
 
     *,
     c0_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c1_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c2_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c3_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),all_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('-1'),c0_expr: String = Default(None),c1_expr: String = Default(None),c2_expr: String = Default(None),c3_expr: String = Default(None),all_expr: String = Default(None),c0_opacity: Double = Default('1'),c1_opacity: Double = Default('1'),c2_opacity: Double = Default('1'),c3_opacity: Double = Default('1'),all_opacity: Double = Default('1'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Blend two video frames into each other.
 
 The blend filter takes two input streams and outputs one
@@ -1489,7 +1489,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blend)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -1500,72 +1500,72 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='blend', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _bottom,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "c0_mode": c0_mode,
-                
+
                 "c1_mode": c1_mode,
-                
+
                 "c2_mode": c2_mode,
-                
+
                 "c3_mode": c3_mode,
-                
+
                 "all_mode": all_mode,
-                
+
                 "c0_expr": c0_expr,
-                
+
                 "c1_expr": c1_expr,
-                
+
                 "c2_expr": c2_expr,
-                
+
                 "c3_expr": c3_expr,
-                
+
                 "all_expr": all_expr,
-                
+
                 "c0_opacity": c0_opacity,
-                
+
                 "c1_opacity": c1_opacity,
-                
+
                 "c2_opacity": c2_opacity,
-                
+
                 "c3_opacity": c3_opacity,
-                
+
                 "all_opacity": all_opacity,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def blockdetect(
-    
+
     self,
 
 
@@ -1573,12 +1573,12 @@ References:
 
     *,
     period_min: Int = Default('3'),period_max: Int = Default('24'),planes: Int = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Determines blockiness of frames without altering the input frames.
 
 Based on Remco Muijs and Ihor Kirenko: "A no-reference blocking artifact measure for adaptive video processing." 2005 13th European signal processing conference.
@@ -1599,41 +1599,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blockdetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='blockdetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "period_min": period_min,
-                
+
                 "period_max": period_max,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def blurdetect(
-    
+
     self,
 
 
@@ -1641,12 +1641,12 @@ References:
 
     *,
     high: Float = Default('0.117647'),low: Float = Default('0.0588235'),radius: Int = Default('50'),block_pct: Int = Default('80'),block_width: Int = Default('-1'),planes: Int = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Determines blurriness of frames without altering the input frames.
 
 Based on Marziliano, Pina, et al. "A no-reference perceptual blur metric."
@@ -1671,49 +1671,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blurdetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='blurdetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "high": high,
-                
+
                 "low": low,
-                
+
                 "radius": radius,
-                
+
                 "block_pct": block_pct,
-                
+
                 "block_width": block_width,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def boxblur(
-    
+
     self,
 
 
@@ -1721,15 +1721,15 @@ References:
 
     *,
     luma_radius: String = Default('2'),luma_power: Int = Default('2'),chroma_radius: String = Default(None),chroma_power: Int = Default('-1'),alpha_radius: String = Default(None),alpha_power: Int = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a boxblur algorithm to the input video.
 
 It accepts the following parameters:
@@ -1752,7 +1752,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#boxblur)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1760,44 +1760,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='boxblur', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_radius": luma_radius,
-                
+
                 "luma_power": luma_power,
-                
+
                 "chroma_radius": chroma_radius,
-                
+
                 "chroma_power": chroma_power,
-                
+
                 "alpha_radius": alpha_radius,
-                
+
                 "alpha_power": alpha_power,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def boxblur_opencl(
-    
+
     self,
 
 
@@ -1805,12 +1805,12 @@ References:
 
     *,
     luma_radius: String = Default('2'),luma_power: Int = Default('2'),chroma_radius: String = Default(None),chroma_power: Int = Default('-1'),alpha_radius: String = Default(None),alpha_power: Int = Default('-1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a boxblur algorithm to the input video.
 
 It accepts the following parameters:
@@ -1832,51 +1832,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#boxblur_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='boxblur_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_radius": luma_radius,
-                
+
                 "luma_power": luma_power,
-                
+
                 "chroma_radius": chroma_radius,
-                
+
                 "chroma_power": chroma_power,
-                
+
                 "alpha_radius": alpha_radius,
-                
+
                 "alpha_power": alpha_power,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def bwdif(
-    
+
     self,
 
 
@@ -1884,15 +1884,15 @@ References:
 
     *,
     mode: Int| Literal["send_frame","send_field"] | Default = Default('send_field'),parity: Int| Literal["tff","bff","auto"] | Default = Default('auto'),deint: Int| Literal["all","interlaced"] | Default = Default('all'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlace the input video ("bwdif" stands for "Bob Weaver
 Deinterlacing Filter").
 
@@ -1915,7 +1915,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bwdif)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1923,38 +1923,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bwdif', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "parity": parity,
-                
+
                 "deint": deint,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def cas(
-    
+
     self,
 
 
@@ -1962,15 +1962,15 @@ References:
 
     *,
     strength: Float = Default('0'),planes: Flags = Default('7'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Contrast Adaptive Sharpen filter to video stream.
 
 The filter accepts the following options:
@@ -1989,7 +1989,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#cas)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1997,49 +1997,49 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='cas', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "strength": strength,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ccrepack(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Repack CEA-708 closed captioning side data
 
 This filter fixes various issues seen with commerical encoders
@@ -2059,43 +2059,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ccrepack)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ccrepack', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def chromahold(
-    
+
     self,
 
 
@@ -2103,15 +2103,15 @@ References:
 
     *,
     color: Color = Default('black'),similarity: Float = Default('0.01'),blend: Float = Default('0'),yuv: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove all color information for all colors except for certain one.
 
 The filter accepts the following options:
@@ -2132,7 +2132,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#chromahold)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2140,40 +2140,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='chromahold', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "color": color,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
                 "yuv": yuv,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def chromakey(
-    
+
     self,
 
 
@@ -2181,15 +2181,15 @@ References:
 
     *,
     color: Color = Default('black'),similarity: Float = Default('0.01'),blend: Float = Default('0'),yuv: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 YUV colorspace color/chroma keying.
 
 The filter accepts the following options:
@@ -2210,7 +2210,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#chromakey)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2218,40 +2218,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='chromakey', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "color": color,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
                 "yuv": yuv,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def chromanr(
-    
+
     self,
 
 
@@ -2259,15 +2259,15 @@ References:
 
     *,
     thres: Float = Default('30'),sizew: Int = Default('5'),sizeh: Int = Default('5'),stepw: Int = Default('1'),steph: Int = Default('1'),threy: Float = Default('200'),threu: Float = Default('200'),threv: Float = Default('200'),distance: Int| Literal["manhattan","euclidean"] | Default = Default('manhattan'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reduce chrominance noise.
 
 The filter accepts the following options:
@@ -2293,7 +2293,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#chromanr)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2301,50 +2301,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='chromanr', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "thres": thres,
-                
+
                 "sizew": sizew,
-                
+
                 "sizeh": sizeh,
-                
+
                 "stepw": stepw,
-                
+
                 "steph": steph,
-                
+
                 "threy": threy,
-                
+
                 "threu": threu,
-                
+
                 "threv": threv,
-                
+
                 "distance": distance,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def chromashift(
-    
+
     self,
 
 
@@ -2352,15 +2352,15 @@ References:
 
     *,
     cbh: Int = Default('0'),cbv: Int = Default('0'),crh: Int = Default('0'),crv: Int = Default('0'),edge: Int| Literal["smear","wrap"] | Default = Default('smear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Shift chroma pixels horizontally and/or vertically.
 
 The filter accepts the following options:
@@ -2382,7 +2382,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#chromashift)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2390,42 +2390,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='chromashift', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cbh": cbh,
-                
+
                 "cbv": cbv,
-                
+
                 "crh": crh,
-                
+
                 "crv": crv,
-                
+
                 "edge": edge,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ciescope(
-    
+
     self,
 
 
@@ -2433,12 +2433,12 @@ References:
 
     *,
     system: Int| Literal["ntsc","470m","ebu","470bg","smpte","240m","apple","widergb","cie1931","hdtv","rec709","uhdtv","rec2020","dcip3"] | Default = Default('hdtv'),cie: Int| Literal["xyy","ucs","luv"] | Default = Default('xyy'),gamuts: Flags| Literal["ntsc","470m","ebu","470bg","smpte","240m","apple","widergb","cie1931","hdtv","rec709","uhdtv","rec2020","dcip3"] | Default = Default('0'),size: Int = Default('512'),intensity: Float = Default('0.001'),contrast: Float = Default('0.75'),corrgamma: Boolean = Default('true'),showwhite: Boolean = Default('false'),gamma: Double = Default('2.6'),fill: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Display CIE color diagram with pixels overlaid onto it.
 
 The filter accepts the following options:
@@ -2464,55 +2464,55 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ciescope)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ciescope', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "system": system,
-                
+
                 "cie": cie,
-                
+
                 "gamuts": gamuts,
-                
+
                 "size": size,
-                
+
                 "intensity": intensity,
-                
+
                 "contrast": contrast,
-                
+
                 "corrgamma": corrgamma,
-                
+
                 "showwhite": showwhite,
-                
+
                 "gamma": gamma,
-                
+
                 "fill": fill,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def codecview(
-    
+
     self,
 
 
@@ -2520,15 +2520,15 @@ References:
 
     *,
     mv: Flags| Literal["pf","bf","bb"] | Default = Default('0'),qp: Boolean = Default('false'),mv_type: Flags| Literal["fp","bp"] | Default = Default('0'),frame_type: Flags| Literal["if","pf","bf"] | Default = Default('0'),block: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Visualize information exported by some codecs.
 
 Some codecs can export information through frames using side-data or other
@@ -2554,7 +2554,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#codecview)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2562,44 +2562,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='codecview', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mv": mv,
-                
+
                 "qp": qp,
-                
+
                 "mv_type": mv_type,
-                
+
                 "frame_type": frame_type,
-                
+
                 "block": block,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def colorbalance(
-    
+
     self,
 
 
@@ -2607,15 +2607,15 @@ References:
 
     *,
     rs: Float = Default('0'),gs: Float = Default('0'),bs: Float = Default('0'),rm: Float = Default('0'),gm: Float = Default('0'),bm: Float = Default('0'),rh: Float = Default('0'),gh: Float = Default('0'),bh: Float = Default('0'),pl: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Modify intensity of primary colors (red, green and blue) of input frames.
 
 The filter allows an input frame to be adjusted in the shadows, midtones or highlights
@@ -2648,7 +2648,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorbalance)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2656,52 +2656,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorbalance', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rs": rs,
-                
+
                 "gs": gs,
-                
+
                 "bs": bs,
-                
+
                 "rm": rm,
-                
+
                 "gm": gm,
-                
+
                 "bm": bm,
-                
+
                 "rh": rh,
-                
+
                 "gh": gh,
-                
+
                 "bh": bh,
-                
+
                 "pl": pl,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorchannelmixer(
-    
+
     self,
 
 
@@ -2709,15 +2709,15 @@ References:
 
     *,
     rr: Double = Default('1'),rg: Double = Default('0'),rb: Double = Default('0'),ra: Double = Default('0'),gr: Double = Default('0'),gg: Double = Default('1'),gb: Double = Default('0'),ga: Double = Default('0'),br: Double = Default('0'),bg: Double = Default('0'),bb: Double = Default('1'),ba: Double = Default('0'),ar: Double = Default('0'),ag: Double = Default('0'),ab: Double = Default('0'),aa: Double = Default('1'),pc: Int| Literal["none","lum","max","avg","sum","nrm","pwr"] | Default = Default('none'),pa: Double = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust video input frames by re-mixing color channels.
 
 This filter modifies a color channel by adding the values associated to
@@ -2759,7 +2759,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorchannelmixer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2767,70 +2767,70 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorchannelmixer', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rr": rr,
-                
+
                 "rg": rg,
-                
+
                 "rb": rb,
-                
+
                 "ra": ra,
-                
+
                 "gr": gr,
-                
+
                 "gg": gg,
-                
+
                 "gb": gb,
-                
+
                 "ga": ga,
-                
+
                 "br": br,
-                
+
                 "bg": bg,
-                
+
                 "bb": bb,
-                
+
                 "ba": ba,
-                
+
                 "ar": ar,
-                
+
                 "ag": ag,
-                
+
                 "ab": ab,
-                
+
                 "aa": aa,
-                
+
                 "pc": pc,
-                
+
                 "pa": pa,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def colorcontrast(
-    
+
     self,
 
 
@@ -2838,15 +2838,15 @@ References:
 
     *,
     rc: Float = Default('0'),gm: Float = Default('0'),by: Float = Default('0'),rcw: Float = Default('0'),gmw: Float = Default('0'),byw: Float = Default('0'),pl: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust color contrast between RGB components.
 
 The filter accepts the following options:
@@ -2870,7 +2870,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorcontrast)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2878,46 +2878,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorcontrast', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rc": rc,
-                
+
                 "gm": gm,
-                
+
                 "by": by,
-                
+
                 "rcw": rcw,
-                
+
                 "gmw": gmw,
-                
+
                 "byw": byw,
-                
+
                 "pl": pl,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorcorrect(
-    
+
     self,
 
 
@@ -2925,15 +2925,15 @@ References:
 
     *,
     rl: Float = Default('0'),bl: Float = Default('0'),rh: Float = Default('0'),bh: Float = Default('0'),saturation: Float = Default('1'),analyze: Int| Literal["manual","average","minmax","median"] | Default = Default('manual'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust color white balance selectively for blacks and whites.
 This filter operates in YUV colorspace.
 
@@ -2957,7 +2957,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorcorrect)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2965,44 +2965,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorcorrect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rl": rl,
-                
+
                 "bl": bl,
-                
+
                 "rh": rh,
-                
+
                 "bh": bh,
-                
+
                 "saturation": saturation,
-                
+
                 "analyze": analyze,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorhold(
-    
+
     self,
 
 
@@ -3010,15 +3010,15 @@ References:
 
     *,
     color: Color = Default('black'),similarity: Float = Default('0.01'),blend: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove all color information for all RGB colors except for certain one.
 
 The filter accepts the following options:
@@ -3038,7 +3038,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorhold)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3046,38 +3046,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorhold', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "color": color,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorize(
-    
+
     self,
 
 
@@ -3085,15 +3085,15 @@ References:
 
     *,
     hue: Float = Default('0'),saturation: Float = Default('0.5'),lightness: Float = Default('0.5'),mix: Float = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Overlay a solid color on the video stream.
 
 The filter accepts the following options:
@@ -3114,7 +3114,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorize)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3122,40 +3122,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorize', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "hue": hue,
-                
+
                 "saturation": saturation,
-                
+
                 "lightness": lightness,
-                
+
                 "mix": mix,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorkey(
-    
+
     self,
 
 
@@ -3163,15 +3163,15 @@ References:
 
     *,
     color: Color = Default('black'),similarity: Float = Default('0.01'),blend: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 RGB colorspace color keying.
 This filter operates on 8-bit RGB format frames by setting the alpha component of each pixel
 which falls within the similarity radius of the key color to 0. The alpha value for pixels outside
@@ -3194,7 +3194,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorkey)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3202,38 +3202,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorkey', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "color": color,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorkey_opencl(
-    
+
     self,
 
 
@@ -3241,12 +3241,12 @@ References:
 
     *,
     color: Color = Default('black'),similarity: Float = Default('0.01'),blend: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 RGB colorspace color keying.
 
 The filter accepts the following options:
@@ -3265,41 +3265,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorkey_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorkey_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "color": color,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorlevels(
-    
+
     self,
 
 
@@ -3307,15 +3307,15 @@ References:
 
     *,
     rimin: Double = Default('0'),gimin: Double = Default('0'),bimin: Double = Default('0'),aimin: Double = Default('0'),rimax: Double = Default('1'),gimax: Double = Default('1'),bimax: Double = Default('1'),aimax: Double = Default('1'),romin: Double = Default('0'),gomin: Double = Default('0'),bomin: Double = Default('0'),aomin: Double = Default('0'),romax: Double = Default('1'),gomax: Double = Default('1'),bomax: Double = Default('1'),aomax: Double = Default('1'),preserve: Int| Literal["none","lum","max","avg","sum","nrm","pwr"] | Default = Default('none'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust video input frames using levels.
 
 The filter accepts the following options:
@@ -3349,7 +3349,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorlevels)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3357,94 +3357,94 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorlevels', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rimin": rimin,
-                
+
                 "gimin": gimin,
-                
+
                 "bimin": bimin,
-                
+
                 "aimin": aimin,
-                
+
                 "rimax": rimax,
-                
+
                 "gimax": gimax,
-                
+
                 "bimax": bimax,
-                
+
                 "aimax": aimax,
-                
+
                 "romin": romin,
-                
+
                 "gomin": gomin,
-                
+
                 "bomin": bomin,
-                
+
                 "aomin": aomin,
-                
+
                 "romax": romax,
-                
+
                 "gomax": gomax,
-                
+
                 "bomax": bomax,
-                
+
                 "aomax": aomax,
-                
+
                 "preserve": preserve,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colormap(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _target: VideoStream,
-        
-    
+
+
 
 
     *,
     patch_size: Image_size = Default('64x64'),nb_patches: Int = Default('0'),type: Int| Literal["relative","absolute"] | Default = Default('absolute'),kernel: Int| Literal["euclidean","weuclidean"] | Default = Default('euclidean'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply custom color maps to video stream.
 
 This filter needs three input video streams.
@@ -3470,7 +3470,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colormap)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3478,52 +3478,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colormap', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _source,
-                
-            
-                
+
+
+
                 _target,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "patch_size": patch_size,
-                
+
                 "nb_patches": nb_patches,
-                
+
                 "type": type,
-                
+
                 "kernel": kernel,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colormatrix(
-    
+
     self,
 
 
@@ -3531,15 +3531,15 @@ References:
 
     *,
     src: Int| Literal["bt709","fcc","bt601","bt470","bt470bg","smpte170m","smpte240m","bt2020"] | Default = Default('-1'),dst: Int| Literal["bt709","fcc","bt601","bt470","bt470bg","smpte170m","smpte240m","bt2020"] | Default = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert color matrix.
 
 The filter accepts the following options:
@@ -3558,7 +3558,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colormatrix)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3566,36 +3566,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colormatrix', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "src": src,
-                
+
                 "dst": dst,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorspace(
-    
+
     self,
 
 
@@ -3603,15 +3603,15 @@ References:
 
     *,
     all: Int| Literal["bt470m","bt470bg","bt601-6-525","bt601-6-625","bt709","smpte170m","smpte240m","bt2020"] | Default = Default('0'),space: Int| Literal["bt709","fcc","bt470bg","smpte170m","smpte240m","ycgco","gbr","bt2020nc","bt2020ncl"] | Default = Default('2'),range: Int| Literal["tv","mpeg","pc","jpeg"] | Default = Default('0'),primaries: Int| Literal["bt709","bt470m","bt470bg","smpte170m","smpte240m","smpte428","film","smpte431","smpte432","bt2020","jedec-p22","ebu3213"] | Default = Default('2'),trc: Int| Literal["bt709","bt470m","gamma22","bt470bg","gamma28","smpte170m","smpte240m","linear","srgb","iec61966-2-1","xvycc","iec61966-2-4","bt2020-10","bt2020-12"] | Default = Default('2'),format: Int| Literal["yuv420p","yuv420p10","yuv420p12","yuv422p","yuv422p10","yuv422p12","yuv444p","yuv444p10","yuv444p12"] | Default = Default('-1'),fast: Boolean = Default('false'),dither: Int| Literal["none","fsb"] | Default = Default('none'),wpadapt: Int| Literal["bradford","vonkries","identity"] | Default = Default('bradford'),iall: Int| Literal["bt470m","bt470bg","bt601-6-525","bt601-6-625","bt709","smpte170m","smpte240m","bt2020"] | Default = Default('0'),ispace: Int| Literal["bt709","fcc","bt470bg","smpte170m","smpte240m","ycgco","gbr","bt2020nc","bt2020ncl"] | Default = Default('2'),irange: Int| Literal["tv","mpeg","pc","jpeg"] | Default = Default('0'),iprimaries: Int| Literal["bt709","bt470m","bt470bg","smpte170m","smpte240m","smpte428","film","smpte431","smpte432","bt2020","jedec-p22","ebu3213"] | Default = Default('2'),itrc: Int| Literal["bt709","bt470m","gamma22","bt470bg","gamma28","smpte170m","smpte240m","linear","srgb","iec61966-2-1","xvycc","iec61966-2-4","bt2020-10","bt2020-12"] | Default = Default('2'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert colorspace, transfer characteristics or color primaries.
 Input video needs to have an even size.
 
@@ -3643,7 +3643,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorspace)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3651,62 +3651,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorspace', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "all": all,
-                
+
                 "space": space,
-                
+
                 "range": range,
-                
+
                 "primaries": primaries,
-                
+
                 "trc": trc,
-                
+
                 "format": format,
-                
+
                 "fast": fast,
-                
+
                 "dither": dither,
-                
+
                 "wpadapt": wpadapt,
-                
+
                 "iall": iall,
-                
+
                 "ispace": ispace,
-                
+
                 "irange": irange,
-                
+
                 "iprimaries": iprimaries,
-                
+
                 "itrc": itrc,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def colortemperature(
-    
+
     self,
 
 
@@ -3714,15 +3714,15 @@ References:
 
     *,
     temperature: Float = Default('6500'),mix: Float = Default('1'),pl: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust color temperature in video to simulate variations in ambient color temperature.
 
 The filter accepts the following options:
@@ -3742,7 +3742,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colortemperature)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3750,44 +3750,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colortemperature', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "temperature": temperature,
-                
+
                 "mix": mix,
-                
+
                 "pl": pl,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def convolution(
-    
+
     self,
 
 
@@ -3795,15 +3795,15 @@ References:
 
     *,
     _0m: String = Default('0 0 0 0 1 0 0 0 0'),_1m: String = Default('0 0 0 0 1 0 0 0 0'),_2m: String = Default('0 0 0 0 1 0 0 0 0'),_3m: String = Default('0 0 0 0 1 0 0 0 0'),_0rdiv: Float = Default('0'),_1rdiv: Float = Default('0'),_2rdiv: Float = Default('0'),_3rdiv: Float = Default('0'),_0bias: Float = Default('0'),_1bias: Float = Default('0'),_2bias: Float = Default('0'),_3bias: Float = Default('0'),_0mode: Int| Literal["square","row","column"] | Default = Default('square'),_1mode: Int| Literal["square","row","column"] | Default = Default('square'),_2mode: Int| Literal["square","row","column"] | Default = Default('square'),_3mode: Int| Literal["square","row","column"] | Default = Default('square'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply convolution of 3x3, 5x5, 7x7 or horizontal/vertical up to 49 elements.
 
 The filter accepts the following options:
@@ -3836,7 +3836,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#convolution)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3844,64 +3844,64 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='convolution', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "0m": _0m,
-                
+
                 "1m": _1m,
-                
+
                 "2m": _2m,
-                
+
                 "3m": _3m,
-                
+
                 "0rdiv": _0rdiv,
-                
+
                 "1rdiv": _1rdiv,
-                
+
                 "2rdiv": _2rdiv,
-                
+
                 "3rdiv": _3rdiv,
-                
+
                 "0bias": _0bias,
-                
+
                 "1bias": _1bias,
-                
+
                 "2bias": _2bias,
-                
+
                 "3bias": _3bias,
-                
+
                 "0mode": _0mode,
-                
+
                 "1mode": _1mode,
-                
+
                 "2mode": _2mode,
-                
+
                 "3mode": _3mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def convolution_opencl(
-    
+
     self,
 
 
@@ -3909,12 +3909,12 @@ References:
 
     *,
     _0m: String = Default('0 0 0 0 1 0 0 0 0'),_2m: String = Default('0 0 0 0 1 0 0 0 0'),_3m: String = Default('0 0 0 0 1 0 0 0 0'),_0rdiv: Float = Default('1'),_1rdiv: Float = Default('1'),_2rdiv: Float = Default('1'),_3rdiv: Float = Default('1'),_0bias: Float = Default('0'),_1bias: Float = Default('0'),_2bias: Float = Default('0'),_3bias: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply convolution of 3x3, 5x5, 7x7 matrix.
 
 The filter accepts the following options:
@@ -3941,86 +3941,86 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#convolution_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='convolution_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "0m": _0m,
-                
+
                 "2m": _2m,
-                
+
                 "3m": _3m,
-                
+
                 "0rdiv": _0rdiv,
-                
+
                 "1rdiv": _1rdiv,
-                
+
                 "2rdiv": _2rdiv,
-                
+
                 "3rdiv": _3rdiv,
-                
+
                 "0bias": _0bias,
-                
+
                 "1bias": _1bias,
-                
+
                 "2bias": _2bias,
-                
+
                 "3bias": _3bias,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def convolve(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _impulse: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('7'),impulse: Int| Literal["first","all"] | Default = Default('all'),noise: Float = Default('1e-07'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply 2D convolution of video stream in frequency domain using second stream
 as impulse.
 
@@ -4042,7 +4042,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#convolve)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -4053,61 +4053,61 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='convolve', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _impulse,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "impulse": impulse,
-                
+
                 "noise": noise,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def copy(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Copy the input video source unchanged to the output. This is mainly useful for
 testing purposes.
 
@@ -4124,64 +4124,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#copy)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='copy', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def corr(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the correlation between two input videos.
 
 This filter takes two input videos.
@@ -4217,7 +4217,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#corr)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -4228,42 +4228,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='corr', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def cover_rect(
-    
+
     self,
 
 
@@ -4271,12 +4271,12 @@ References:
 
     *,
     cover: String = Default(None),mode: Int| Literal["cover","blur"] | Default = Default('blur'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Cover a rectangular object
 
 It accepts the following options:
@@ -4294,39 +4294,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#cover_rect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='cover_rect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cover": cover,
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def crop(
-    
+
     self,
 
 
@@ -4334,12 +4334,12 @@ References:
 
     *,
     out_w: String = Default('iw'),out_h: String = Default('ih'),x: String = Default('(in_w-out_w)/2'),y: String = Default('(in_h-out_h)/2'),keep_aspect: Boolean = Default('false'),exact: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Crop the input video to given dimensions.
 
 It accepts the following parameters:
@@ -4361,47 +4361,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#crop)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='crop', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "out_w": out_w,
-                
+
                 "out_h": out_h,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "keep_aspect": keep_aspect,
-                
+
                 "exact": exact,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def cropdetect(
-    
+
     self,
 
 
@@ -4409,15 +4409,15 @@ References:
 
     *,
     limit: Float = Default('0.0941176'),round: Int = Default('16'),reset: Int = Default('0'),skip: Int = Default('2'),reset_count: Int = Default('0'),max_outliers: Int = Default('0'),mode: Int| Literal["black","mvedges"] | Default = Default('black'),high: Float = Default('0.0980392'),low: Float = Default('0.0588235'),mv_threshold: Int = Default('8'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Auto-detect the crop size.
 
 It calculates the necessary cropping parameters and prints the
@@ -4448,7 +4448,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#cropdetect)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4456,56 +4456,56 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='cropdetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "limit": limit,
-                
+
                 "round": round,
-                
+
                 "reset": reset,
-                
+
                 "skip": skip,
-                
+
                 "reset_count": reset_count,
-                
+
                 "max_outliers": max_outliers,
-                
+
                 "mode": mode,
-                
+
                 "high": high,
-                
+
                 "low": low,
-                
+
                 "mv_threshold": mv_threshold,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def cue(
-    
+
     self,
 
 
@@ -4513,12 +4513,12 @@ References:
 
     *,
     cue: Int64 = Default('0'),preroll: Duration = Default('0'),buffer: Duration = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Delay video filtering until a given wallclock timestamp. The filter first
 passes on preroll amount of frames, then it buffers at most
 buffer amount of frames and waits for the cue. After reaching the cue
@@ -4547,41 +4547,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#cue)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='cue', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cue": cue,
-                
+
                 "preroll": preroll,
-                
+
                 "buffer": buffer,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def curves(
-    
+
     self,
 
 
@@ -4589,15 +4589,15 @@ References:
 
     *,
     preset: Int| Literal["none","color_negative","cross_process","darker","increase_contrast","lighter","linear_contrast","medium_contrast","negative","strong_contrast","vintage"] | Default = Default('none'),master: String = Default(None),red: String = Default(None),green: String = Default(None),blue: String = Default(None),all: String = Default(None),psfile: String = Default(None),plot: String = Default(None),interp: Int| Literal["natural","pchip"] | Default = Default('natural'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply color adjustments using curves.
 
 This filter is similar to the Adobe Photoshop and GIMP curves tools. Each
@@ -4644,7 +4644,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#curves)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4652,50 +4652,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='curves', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "preset": preset,
-                
+
                 "master": master,
-                
+
                 "red": red,
-                
+
                 "green": green,
-                
+
                 "blue": blue,
-                
+
                 "all": all,
-                
+
                 "psfile": psfile,
-                
+
                 "plot": plot,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def datascope(
-    
+
     self,
 
 
@@ -4703,12 +4703,12 @@ References:
 
     *,
     size: Image_size = Default('hd720'),x: Int = Default('0'),y: Int = Default('0'),mode: Int| Literal["mono","color","color2"] | Default = Default('mono'),axis: Boolean = Default('false'),opacity: Float = Default('0.75'),format: Int| Literal["hex","dec"] | Default = Default('hex'),components: Int = Default('15'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Video data analysis filter.
 
 This filter shows hexadecimal pixel values of part of video.
@@ -4734,51 +4734,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#datascope)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='datascope', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "mode": mode,
-                
+
                 "axis": axis,
-                
+
                 "opacity": opacity,
-                
+
                 "format": format,
-                
+
                 "components": components,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dblur(
-    
+
     self,
 
 
@@ -4786,15 +4786,15 @@ References:
 
     *,
     angle: Float = Default('45'),radius: Float = Default('5'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Directional blur filter.
 
 The filter accepts the following options:
@@ -4814,7 +4814,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dblur)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4822,40 +4822,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dblur', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "angle": angle,
-                
+
                 "radius": radius,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def dctdnoiz(
-    
+
     self,
 
 
@@ -4863,15 +4863,15 @@ References:
 
     *,
     sigma: Float = Default('0'),overlap: Int = Default('-1'),expr: String = Default(None),n: Int = Default('3'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Denoise frames using 2D DCT (frequency domain filtering).
 
 This filter is not designed for real time.
@@ -4894,7 +4894,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dctdnoiz)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4902,40 +4902,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dctdnoiz', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sigma": sigma,
-                
+
                 "overlap": overlap,
-                
+
                 "expr": expr,
-                
+
                 "n": n,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def deband(
-    
+
     self,
 
 
@@ -4943,15 +4943,15 @@ References:
 
     *,
     _1thr: Float = Default('0.02'),_2thr: Float = Default('0.02'),_3thr: Float = Default('0.02'),_4thr: Float = Default('0.02'),range: Int = Default('16'),direction: Float = Default('6.28319'),blur: Boolean = Default('true'),coupling: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove banding artifacts from input video.
 It works by replacing banded pixels with average value of referenced pixels.
 
@@ -4977,7 +4977,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deband)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4985,48 +4985,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deband', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "1thr": _1thr,
-                
+
                 "2thr": _2thr,
-                
+
                 "3thr": _3thr,
-                
+
                 "4thr": _4thr,
-                
+
                 "range": range,
-                
+
                 "direction": direction,
-                
+
                 "blur": blur,
-                
+
                 "coupling": coupling,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def deblock(
-    
+
     self,
 
 
@@ -5034,15 +5034,15 @@ References:
 
     *,
     filter: Int| Literal["weak","strong"] | Default = Default('strong'),block: Int = Default('8'),alpha: Float = Default('0.098'),beta: Float = Default('0.05'),gamma: Float = Default('0.05'),delta: Float = Default('0.05'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove blocking artifacts from input video.
 
 The filter accepts the following options:
@@ -5066,7 +5066,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deblock)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5074,77 +5074,77 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deblock', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "filter": filter,
-                
+
                 "block": block,
-                
+
                 "alpha": alpha,
-                
+
                 "beta": beta,
-                
+
                 "gamma": gamma,
-                
+
                 "delta": delta,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def deconvolve(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _impulse: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('7'),impulse: Int| Literal["first","all"] | Default = Default('all'),noise: Float = Default('1e-07'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply 2D deconvolution of video stream in frequency domain using second stream
 as impulse.
 
@@ -5166,7 +5166,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deconvolve)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -5177,48 +5177,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deconvolve', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _impulse,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "impulse": impulse,
-                
+
                 "noise": noise,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dedot(
-    
+
     self,
 
 
@@ -5226,15 +5226,15 @@ References:
 
     *,
     m: Flags| Literal["dotcrawl","rainbows"] | Default = Default('dotcrawl+rainbows'),lt: Float = Default('0.079'),tl: Float = Default('0.079'),tc: Float = Default('0.058'),ct: Float = Default('0.019'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reduce cross-luminance (dot-crawl) and cross-color (rainbows) from video.
 
 It accepts the following options:
@@ -5256,7 +5256,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dedot)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5264,44 +5264,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dedot', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "m": m,
-                
+
                 "lt": lt,
-                
+
                 "tl": tl,
-                
+
                 "tc": tc,
-                
+
                 "ct": ct,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def deflate(
-    
+
     self,
 
 
@@ -5309,15 +5309,15 @@ References:
 
     *,
     threshold0: Int = Default('65535'),threshold1: Int = Default('65535'),threshold2: Int = Default('65535'),threshold3: Int = Default('65535'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply deflate effect to the video.
 
 This filter replaces the pixel by the local(3x3) average by taking into account
@@ -5341,7 +5341,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deflate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5349,40 +5349,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deflate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold0": threshold0,
-                
+
                 "threshold1": threshold1,
-                
+
                 "threshold2": threshold2,
-                
+
                 "threshold3": threshold3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def deflicker(
-    
+
     self,
 
 
@@ -5390,12 +5390,12 @@ References:
 
     *,
     size: Int = Default('5'),mode: Int| Literal["am","gm","hm","qm","cm","pm","median"] | Default = Default('am'),bypass: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove temporal frame luminance variations.
 
 It accepts the following options:
@@ -5414,41 +5414,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deflicker)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deflicker', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "mode": mode,
-                
+
                 "bypass": bypass,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def deinterlace_vaapi(
-    
+
     self,
 
 
@@ -5456,12 +5456,12 @@ References:
 
     *,
     mode: Int| Literal["default","bob","weave","motion_adaptive","motion_compensated"] | Default = Default('default'),rate: Int| Literal["frame","field"] | Default = Default('frame'),auto: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlacing of VAAPI surfaces
 
 
@@ -5478,41 +5478,41 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deinterlace_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "rate": rate,
-                
+
                 "auto": auto,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dejudder(
-    
+
     self,
 
 
@@ -5520,12 +5520,12 @@ References:
 
     *,
     cycle: Int = Default('4'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove judder produced by partially interlaced telecined content.
 
 Judder can be introduced, for instance, by pullup filter. If the original
@@ -5548,37 +5548,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dejudder)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dejudder', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cycle": cycle,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def delogo(
-    
+
     self,
 
 
@@ -5586,15 +5586,15 @@ References:
 
     *,
     x: String = Default('-1'),y: String = Default('-1'),w: String = Default('-1'),h: String = Default('-1'),show: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Suppress a TV station logo by a simple interpolation of the surrounding
 pixels. Just set a rectangle covering the logo and watch it disappear
 (and sometimes something even uglier appear - your mileage may vary).
@@ -5618,7 +5618,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#delogo)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5626,42 +5626,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='delogo', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "show": show,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def denoise_vaapi(
-    
+
     self,
 
 
@@ -5669,12 +5669,12 @@ References:
 
     *,
     denoise: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 VAAPI VPP for de-noise
 
 
@@ -5689,37 +5689,37 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='denoise_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "denoise": denoise,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def derain(
-    
+
     self,
 
 
@@ -5727,15 +5727,15 @@ References:
 
     *,
     filter_type: Int| Literal["derain","dehaze"] | Default = Default('derain'),dnn_backend: Int = Default('1'),model: String = Default(None),input: String = Default('x'),output: String = Default('y'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove the rain in the input image/video by applying the derain methods based on
 convolutional neural networks. Supported models:
 
@@ -5756,7 +5756,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#derain)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5764,42 +5764,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='derain', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "filter_type": filter_type,
-                
+
                 "dnn_backend": dnn_backend,
-                
+
                 "model": model,
-                
+
                 "input": input,
-                
+
                 "output": output,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def deshake(
-    
+
     self,
 
 
@@ -5807,12 +5807,12 @@ References:
 
     *,
     x: Int = Default('-1'),y: Int = Default('-1'),w: Int = Default('-1'),h: Int = Default('-1'),rx: Int = Default('16'),ry: Int = Default('16'),edge: Int| Literal["blank","original","clamp","mirror"] | Default = Default('mirror'),blocksize: Int = Default('8'),contrast: Int = Default('125'),search: Int| Literal["exhaustive","less"] | Default = Default('exhaustive'),filename: String = Default(None),opencl: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Attempt to fix small changes in horizontal and/or vertical shift. This
 filter helps remove camera shake from hand-holding a camera, bumping a
 tripod, moving on a vehicle, etc.
@@ -5842,59 +5842,59 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deshake)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deshake', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "rx": rx,
-                
+
                 "ry": ry,
-                
+
                 "edge": edge,
-                
+
                 "blocksize": blocksize,
-                
+
                 "contrast": contrast,
-                
+
                 "search": search,
-                
+
                 "filename": filename,
-                
+
                 "opencl": opencl,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def deshake_opencl(
-    
+
     self,
 
 
@@ -5902,12 +5902,12 @@ References:
 
     *,
     tripod: Boolean = Default('false'),debug: Boolean = Default('false'),adaptive_crop: Boolean = Default('true'),refine_features: Boolean = Default('true'),smooth_strength: Float = Default('0'),smooth_window_multiplier: Float = Default('2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Feature-point based video stabilization filter.
 
 The filter accepts the following options:
@@ -5929,47 +5929,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deshake_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deshake_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "tripod": tripod,
-                
+
                 "debug": debug,
-                
+
                 "adaptive_crop": adaptive_crop,
-                
+
                 "refine_features": refine_features,
-                
+
                 "smooth_strength": smooth_strength,
-                
+
                 "smooth_window_multiplier": smooth_window_multiplier,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def despill(
-    
+
     self,
 
 
@@ -5977,15 +5977,15 @@ References:
 
     *,
     type: Int| Literal["green","blue"] | Default = Default('green'),mix: Float = Default('0.5'),expand: Float = Default('0'),red: Float = Default('0'),green: Float = Default('-1'),blue: Float = Default('0'),brightness: Float = Default('0'),alpha: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove unwanted contamination of foreground colors, caused by reflected color of
 greenscreen or bluescreen.
 
@@ -6011,7 +6011,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#despill)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6019,48 +6019,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='despill', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "type": type,
-                
+
                 "mix": mix,
-                
+
                 "expand": expand,
-                
+
                 "red": red,
-                
+
                 "green": green,
-                
+
                 "blue": blue,
-                
+
                 "brightness": brightness,
-                
+
                 "alpha": alpha,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def detelecine(
-    
+
     self,
 
 
@@ -6068,12 +6068,12 @@ References:
 
     *,
     first_field: Int| Literal["top","t","bottom","b"] | Default = Default('top'),pattern: String = Default('23'),start_frame: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply an exact inverse of the telecine operation. It requires a predefined
 pattern specified using the pattern option which must be the same as that passed
 to the telecine filter.
@@ -6094,43 +6094,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#detelecine)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='detelecine', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "first_field": first_field,
-                
+
                 "pattern": pattern,
-                
+
                 "start_frame": start_frame,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def dilation(
-    
+
     self,
 
 
@@ -6138,15 +6138,15 @@ References:
 
     *,
     coordinates: Int = Default('255'),threshold0: Int = Default('65535'),threshold1: Int = Default('65535'),threshold2: Int = Default('65535'),threshold3: Int = Default('65535'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply dilation effect to the video.
 
 This filter replaces the pixel by the local(3x3) maximum.
@@ -6170,7 +6170,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dilation)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6178,42 +6178,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dilation', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "coordinates": coordinates,
-                
+
                 "threshold0": threshold0,
-                
+
                 "threshold1": threshold1,
-                
+
                 "threshold2": threshold2,
-                
+
                 "threshold3": threshold3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dilation_opencl(
-    
+
     self,
 
 
@@ -6221,12 +6221,12 @@ References:
 
     *,
     threshold0: Float = Default('65535'),threshold1: Float = Default('65535'),threshold2: Float = Default('65535'),threshold3: Float = Default('65535'),coordinates: Int = Default('255'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply dilation effect to the video.
 
 This filter replaces the pixel by the local(3x3) maximum.
@@ -6249,73 +6249,73 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dilation_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dilation_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold0": threshold0,
-                
+
                 "threshold1": threshold1,
-                
+
                 "threshold2": threshold2,
-                
+
                 "threshold3": threshold3,
-                
+
                 "coordinates": coordinates,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def displace(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _xmap: VideoStream,
-        
-    
-        
+
+
+
         _ymap: VideoStream,
-        
-    
+
+
 
 
     *,
     edge: Int| Literal["blank","smear","wrap","mirror"] | Default = Default('smear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Displace pixels as indicated by second and third input stream.
 
 It takes three input streams and outputs one stream, the first input is the
@@ -6344,7 +6344,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#displace)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6352,46 +6352,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='displace', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _xmap,
-                
-            
-                
+
+
+
                 _ymap,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "edge": edge,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dnn_classify(
-    
+
     self,
 
 
@@ -6399,12 +6399,12 @@ References:
 
     *,
     dnn_backend: Int = Default('2'),model: String = Default(None),input: String = Default(None),output: String = Default(None),backend_configs: String = Default(None),options: String = Default(None),_async: Boolean = Default('true'),confidence: Float = Default('0.5'),labels: String = Default(None),target: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Do classification with deep neural networks based on bounding boxes.
 
 The filter accepts the following options:
@@ -6430,55 +6430,55 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dnn_classify)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dnn_classify', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dnn_backend": dnn_backend,
-                
+
                 "model": model,
-                
+
                 "input": input,
-                
+
                 "output": output,
-                
+
                 "backend_configs": backend_configs,
-                
+
                 "options": options,
-                
+
                 "async": _async,
-                
+
                 "confidence": confidence,
-                
+
                 "labels": labels,
-                
+
                 "target": target,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dnn_detect(
-    
+
     self,
 
 
@@ -6486,12 +6486,12 @@ References:
 
     *,
     dnn_backend: Int = Default('2'),model: String = Default(None),input: String = Default(None),output: String = Default(None),backend_configs: String = Default(None),options: String = Default(None),_async: Boolean = Default('true'),confidence: Float = Default('0.5'),labels: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Do object detection with deep neural networks.
 
 The filter accepts the following options:
@@ -6516,53 +6516,53 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dnn_detect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dnn_detect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dnn_backend": dnn_backend,
-                
+
                 "model": model,
-                
+
                 "input": input,
-                
+
                 "output": output,
-                
+
                 "backend_configs": backend_configs,
-                
+
                 "options": options,
-                
+
                 "async": _async,
-                
+
                 "confidence": confidence,
-                
+
                 "labels": labels,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dnn_processing(
-    
+
     self,
 
 
@@ -6570,12 +6570,12 @@ References:
 
     *,
     dnn_backend: Int = Default('1'),model: String = Default(None),input: String = Default(None),output: String = Default(None),backend_configs: String = Default(None),options: String = Default(None),_async: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Do image processing with deep neural networks. It works together with another filter
 which converts the pixel format of the Frame to what the dnn network requires.
 
@@ -6599,49 +6599,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dnn_processing)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dnn_processing', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dnn_backend": dnn_backend,
-                
+
                 "model": model,
-                
+
                 "input": input,
-                
+
                 "output": output,
-                
+
                 "backend_configs": backend_configs,
-                
+
                 "options": options,
-                
+
                 "async": _async,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def doubleweave(
-    
+
     self,
 
 
@@ -6649,12 +6649,12 @@ References:
 
     *,
     first_field: Int| Literal["top","t","bottom","b"] | Default = Default('top'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The weave takes a field-based video input and join
 each two sequential fields into single frame, producing a new double
 height clip with half the frame rate and half the frame count.
@@ -6676,37 +6676,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#weave)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='doubleweave', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "first_field": first_field,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def drawbox(
-    
+
     self,
 
 
@@ -6714,15 +6714,15 @@ References:
 
     *,
     x: String = Default('0'),y: String = Default('0'),width: String = Default('0'),height: String = Default('0'),color: String = Default('black'),thickness: String = Default('3'),replace: Boolean = Default('false'),box_source: String = Default(None),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw a colored box on the input image.
 
 It accepts the following parameters:
@@ -6747,7 +6747,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#drawbox)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6755,48 +6755,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='drawbox', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "color": color,
-                
+
                 "thickness": thickness,
-                
+
                 "replace": replace,
-                
+
                 "box_source": box_source,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def drawgraph(
-    
+
     self,
 
 
@@ -6804,12 +6804,12 @@ References:
 
     *,
     m1: String = Default(''),fg1: String = Default('0xffff0000'),m2: String = Default(''),fg2: String = Default('0xff00ff00'),m3: String = Default(''),fg3: String = Default('0xffff00ff'),m4: String = Default(''),fg4: String = Default('0xffffff00'),bg: Color = Default('white'),min: Float = Default('-1'),max: Float = Default('1'),mode: Int| Literal["bar","dot","line"] | Default = Default('line'),slide: Int| Literal["frame","replace","scroll","rscroll","picture"] | Default = Default('frame'),size: Image_size = Default('900x256'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw a graph using input video metadata.
 
 It accepts the following parameters:
@@ -6840,65 +6840,65 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#drawgraph)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='drawgraph', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "m1": m1,
-                
+
                 "fg1": fg1,
-                
+
                 "m2": m2,
-                
+
                 "fg2": fg2,
-                
+
                 "m3": m3,
-                
+
                 "fg3": fg3,
-                
+
                 "m4": m4,
-                
+
                 "fg4": fg4,
-                
+
                 "bg": bg,
-                
+
                 "min": min,
-                
+
                 "max": max,
-                
+
                 "mode": mode,
-                
+
                 "slide": slide,
-                
+
                 "size": size,
-                
+
                 "rate": rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def drawgrid(
-    
+
     self,
 
 
@@ -6906,15 +6906,15 @@ References:
 
     *,
     x: String = Default('0'),y: String = Default('0'),width: String = Default('0'),height: String = Default('0'),color: String = Default('black'),thickness: String = Default('1'),replace: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw a grid on the input image.
 
 It accepts the following parameters:
@@ -6938,7 +6938,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#drawgrid)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6946,46 +6946,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='drawgrid', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "color": color,
-                
+
                 "thickness": thickness,
-                
+
                 "replace": replace,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def drawtext(
-    
+
     self,
 
 
@@ -6993,15 +6993,15 @@ References:
 
     *,
     fontfile: String = Default(None),text: String = Default(None),textfile: String = Default(None),fontcolor: Color = Default('black'),fontcolor_expr: String = Default(''),boxcolor: Color = Default('white'),bordercolor: Color = Default('black'),shadowcolor: Color = Default('black'),box: Boolean = Default('false'),boxborderw: String = Default('0'),line_spacing: Int = Default('0'),fontsize: String = Default(None),text_align: Flags| Literal["left","L","right","R","center","C","top","T","bottom","B","middle","M"] | Default = Default('0'),x: String = Default('0'),y: String = Default('0'),boxw: Int = Default('0'),boxh: Int = Default('0'),shadowx: Int = Default('0'),shadowy: Int = Default('0'),borderw: Int = Default('0'),tabsize: Int = Default('4'),basetime: Int64 = Default('I64_MIN'),font: String = Default('Sans'),expansion: Int| Literal["none","normal","strftime"] | Default = Default('normal'),y_align: Int| Literal["text","baseline","font"] | Default = Default('text'),timecode: String = Default(None),tc24hmax: Boolean = Default('false'),timecode_rate: Rational = Default('0/1'),reload: Int = Default('0'),alpha: String = Default('1'),fix_bounds: Boolean = Default('false'),start_number: Int = Default('0'),text_source: String = Default(None),text_shaping: Boolean = Default('true'),ft_load_flags: Flags| Literal["default","no_scale","no_hinting","render","no_bitmap","vertical_layout","force_autohint","crop_bitmap","pedantic","ignore_global_advance_width","no_recurse","ignore_transform","monochrome","linear_design","no_autohint"] | Default = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw a text string or text from a specified file on top of a video, using the
 libfreetype library.
 
@@ -7059,7 +7059,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#drawtext)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7067,110 +7067,110 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='drawtext', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "fontfile": fontfile,
-                
+
                 "text": text,
-                
+
                 "textfile": textfile,
-                
+
                 "fontcolor": fontcolor,
-                
+
                 "fontcolor_expr": fontcolor_expr,
-                
+
                 "boxcolor": boxcolor,
-                
+
                 "bordercolor": bordercolor,
-                
+
                 "shadowcolor": shadowcolor,
-                
+
                 "box": box,
-                
+
                 "boxborderw": boxborderw,
-                
+
                 "line_spacing": line_spacing,
-                
+
                 "fontsize": fontsize,
-                
+
                 "text_align": text_align,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "boxw": boxw,
-                
+
                 "boxh": boxh,
-                
+
                 "shadowx": shadowx,
-                
+
                 "shadowy": shadowy,
-                
+
                 "borderw": borderw,
-                
+
                 "tabsize": tabsize,
-                
+
                 "basetime": basetime,
-                
+
                 "font": font,
-                
+
                 "expansion": expansion,
-                
+
                 "y_align": y_align,
-                
+
                 "timecode": timecode,
-                
+
                 "tc24hmax": tc24hmax,
-                
+
                 "timecode_rate": timecode_rate,
-                
+
                 "reload": reload,
-                
+
                 "alpha": alpha,
-                
+
                 "fix_bounds": fix_bounds,
-                
+
                 "start_number": start_number,
-                
+
                 "text_source": text_source,
-                
+
                 "text_shaping": text_shaping,
-                
+
                 "ft_load_flags": ft_load_flags,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def edgedetect(
-    
+
     self,
 
 
@@ -7178,15 +7178,15 @@ References:
 
     *,
     high: Double = Default('0.196078'),low: Double = Default('0.0784314'),mode: Int| Literal["wires","colormix","canny"] | Default = Default('wires'),planes: Flags| Literal["y","u","v","r","g","b"] | Default = Default('y+u+v+r+g+b'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect and draw edges. The filter uses the Canny Edge Detection algorithm.
 
 The filter accepts the following options:
@@ -7207,7 +7207,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#edgedetect)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7215,40 +7215,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='edgedetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "high": high,
-                
+
                 "low": low,
-                
+
                 "mode": mode,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def elbg(
-    
+
     self,
 
 
@@ -7256,12 +7256,12 @@ References:
 
     *,
     codebook_length: Int = Default('256'),nb_steps: Int = Default('1'),seed: Int64 = Default('-1'),pal8: Boolean = Default('false'),use_alpha: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a posterize effect using the ELBG (Enhanced LBG) algorithm.
 
 For each input image, the filter will compute the optimal mapping from
@@ -7286,45 +7286,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#elbg)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='elbg', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "codebook_length": codebook_length,
-                
+
                 "nb_steps": nb_steps,
-                
+
                 "seed": seed,
-                
+
                 "pal8": pal8,
-                
+
                 "use_alpha": use_alpha,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def entropy(
-    
+
     self,
 
 
@@ -7332,15 +7332,15 @@ References:
 
     *,
     mode: Int| Literal["normal","diff"] | Default = Default('normal'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Measure graylevel entropy in histogram of color channels of video frames.
 
 It accepts the following parameters:
@@ -7358,7 +7358,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#entropy)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7366,34 +7366,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='entropy', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def epx(
-    
+
     self,
 
 
@@ -7401,12 +7401,12 @@ References:
 
     *,
     n: Int = Default('3'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply the EPX magnification filter which is designed for pixel art.
 
 It accepts the following option:
@@ -7423,37 +7423,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#epx)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='epx', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "n": n,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def eq(
-    
+
     self,
 
 
@@ -7461,15 +7461,15 @@ References:
 
     *,
     contrast: String = Default('1.0'),brightness: String = Default('0.0'),saturation: String = Default('1.0'),gamma: String = Default('1.0'),gamma_r: String = Default('1.0'),gamma_g: String = Default('1.0'),gamma_b: String = Default('1.0'),gamma_weight: String = Default('1.0'),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Set brightness, contrast, saturation and approximate gamma adjustment.
 
 The filter accepts the following options:
@@ -7495,7 +7495,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#eq)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7503,52 +7503,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='eq', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "contrast": contrast,
-                
+
                 "brightness": brightness,
-                
+
                 "saturation": saturation,
-                
+
                 "gamma": gamma,
-                
+
                 "gamma_r": gamma_r,
-                
+
                 "gamma_g": gamma_g,
-                
+
                 "gamma_b": gamma_b,
-                
+
                 "gamma_weight": gamma_weight,
-                
+
                 "eval": eval,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def erosion(
-    
+
     self,
 
 
@@ -7556,15 +7556,15 @@ References:
 
     *,
     coordinates: Int = Default('255'),threshold0: Int = Default('65535'),threshold1: Int = Default('65535'),threshold2: Int = Default('65535'),threshold3: Int = Default('65535'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply erosion effect to the video.
 
 This filter replaces the pixel by the local(3x3) minimum.
@@ -7588,7 +7588,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#erosion)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7596,42 +7596,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='erosion', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "coordinates": coordinates,
-                
+
                 "threshold0": threshold0,
-                
+
                 "threshold1": threshold1,
-                
+
                 "threshold2": threshold2,
-                
+
                 "threshold3": threshold3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def erosion_opencl(
-    
+
     self,
 
 
@@ -7639,12 +7639,12 @@ References:
 
     *,
     threshold0: Float = Default('65535'),threshold1: Float = Default('65535'),threshold2: Float = Default('65535'),threshold3: Float = Default('65535'),coordinates: Int = Default('255'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply erosion effect to the video.
 
 This filter replaces the pixel by the local(3x3) minimum.
@@ -7667,45 +7667,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#erosion_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='erosion_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold0": threshold0,
-                
+
                 "threshold1": threshold1,
-                
+
                 "threshold2": threshold2,
-                
+
                 "threshold3": threshold3,
-                
+
                 "coordinates": coordinates,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def estdif(
-    
+
     self,
 
 
@@ -7713,15 +7713,15 @@ References:
 
     *,
     mode: Int| Literal["frame","field"] | Default = Default('field'),parity: Int| Literal["tff","bff","auto"] | Default = Default('auto'),deint: Int| Literal["all","interlaced"] | Default = Default('all'),rslope: Int = Default('1'),redge: Int = Default('2'),ecost: Int = Default('2'),mcost: Int = Default('1'),dcost: Int = Default('1'),interp: Int| Literal["2p","4p","6p"] | Default = Default('4p'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlace the input video ("estdif" stands for "Edge Slope
 Tracing Deinterlacing Filter").
 
@@ -7750,7 +7750,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#estdif)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7758,50 +7758,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='estdif', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "parity": parity,
-                
+
                 "deint": deint,
-                
+
                 "rslope": rslope,
-                
+
                 "redge": redge,
-                
+
                 "ecost": ecost,
-                
+
                 "mcost": mcost,
-                
+
                 "dcost": dcost,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def exposure(
-    
+
     self,
 
 
@@ -7809,15 +7809,15 @@ References:
 
     *,
     exposure: Float = Default('0'),black: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust exposure of the video stream.
 
 The filter accepts the following options:
@@ -7836,7 +7836,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#exposure)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7844,36 +7844,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='exposure', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "exposure": exposure,
-                
+
                 "black": black,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def extractplanes(
-    
+
     self,
 
 
@@ -7881,12 +7881,12 @@ References:
 
     *,
     planes: Flags| Literal["y","u","v","r","g","b","a"] | Default = Default('r'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Extract color channel components from input video stream into
 separate grayscale video streams.
 
@@ -7905,40 +7905,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#extractplanes)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='extractplanes', typings_input=('video',), typings_output="[StreamType.video] * len(planes.split('+'))"),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def fade(
-    
+
     self,
 
 
@@ -7946,15 +7946,15 @@ References:
 
     *,
     type: Int| Literal["in","out"] | Default = Default('in'),start_frame: Int = Default('0'),nb_frames: Int = Default('25'),alpha: Boolean = Default('false'),start_time: Duration = Default('0'),duration: Duration = Default('0'),color: Color = Default('black'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a fade-in/out effect to the input video.
 
 It accepts the following parameters:
@@ -7978,7 +7978,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fade)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7986,77 +7986,77 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fade', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "type": type,
-                
+
                 "start_frame": start_frame,
-                
+
                 "nb_frames": nb_frames,
-                
+
                 "alpha": alpha,
-                
+
                 "start_time": start_time,
-                
+
                 "duration": duration,
-                
+
                 "color": color,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def feedback(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _feedin: VideoStream,
-        
-    
+
+
 
 
     *,
     x: Int = Default('0'),w: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> tuple[
-    
-        
+
+
             VideoStream,
-        
-    
-        
+
+
+
             VideoStream,
-        
-    
+
+
 ]:
         """
-        
+
 Apply feedback video filter.
 
 This filter pass cropped input frames to 2nd output.
@@ -8083,58 +8083,58 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#feedback)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='feedback', typings_input=('video', 'video'), typings_output=('video', 'video')),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _feedin,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "w": w,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return (
-            
-                
+
+
                     filter_node.video(0),
-                
-            
-                
+
+
+
                     filter_node.video(1),
-                
-            
+
+
         )
 
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fftdnoiz(
-    
+
     self,
 
 
@@ -8142,15 +8142,15 @@ References:
 
     *,
     sigma: Float = Default('1'),amount: Float = Default('1'),block: Int = Default('32'),overlap: Float = Default('0.5'),method: Int| Literal["wiener","hard"] | Default = Default('wiener'),prev: Int = Default('0'),next: Int = Default('0'),planes: Int = Default('7'),window: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('hann'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Denoise frames using 3D FFT (frequency domain filtering).
 
 The filter accepts the following options:
@@ -8176,7 +8176,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fftdnoiz)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8184,50 +8184,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fftdnoiz', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sigma": sigma,
-                
+
                 "amount": amount,
-                
+
                 "block": block,
-                
+
                 "overlap": overlap,
-                
+
                 "method": method,
-                
+
                 "prev": prev,
-                
+
                 "next": next,
-                
+
                 "planes": planes,
-                
+
                 "window": window,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fftfilt(
-    
+
     self,
 
 
@@ -8235,15 +8235,15 @@ References:
 
     *,
     dc_Y: Int = Default('0'),dc_U: Int = Default('0'),dc_V: Int = Default('0'),weight_Y: String = Default('1'),weight_U: String = Default(None),weight_V: String = Default(None),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply arbitrary expressions to samples in frequency domain
 
 
@@ -8265,7 +8265,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fftfilt)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8273,46 +8273,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fftfilt', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dc_Y": dc_Y,
-                
+
                 "dc_U": dc_U,
-                
+
                 "dc_V": dc_V,
-                
+
                 "weight_Y": weight_Y,
-                
+
                 "weight_U": weight_U,
-                
+
                 "weight_V": weight_V,
-                
+
                 "eval": eval,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def field(
-    
+
     self,
 
 
@@ -8320,12 +8320,12 @@ References:
 
     *,
     type: Int| Literal["top","bottom"] | Default = Default('top'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Extract a single field from an interlaced image using stride
 arithmetic to avoid wasting CPU time. The output frames are marked as
 non-interlaced.
@@ -8344,37 +8344,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#field)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='field', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fieldhint(
-    
+
     self,
 
 
@@ -8382,12 +8382,12 @@ References:
 
     *,
     hint: String = Default(None),mode: Int| Literal["absolute","relative","pattern"] | Default = Default('absolute'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Create new frames by copying the top and bottom fields from surrounding frames
 supplied as numbers by the hint file.
 
@@ -8404,41 +8404,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fieldhint)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fieldhint', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "hint": hint,
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def fieldorder(
-    
+
     self,
 
 
@@ -8446,15 +8446,15 @@ References:
 
     *,
     order: Int| Literal["bff","tff"] | Default = Default('tff'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Transform the field order of the input video.
 
 It accepts the following parameters:
@@ -8472,7 +8472,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fieldorder)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8480,47 +8480,47 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fieldorder', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "order": order,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fifo(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Buffer input images and send them when they are requested.
 
 It is mainly useful when auto-inserted by the libavfilter
@@ -8539,35 +8539,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fifo)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fifo', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fillborders(
-    
+
     self,
 
 
@@ -8575,15 +8575,15 @@ References:
 
     *,
     left: Int = Default('0'),right: Int = Default('0'),top: Int = Default('0'),bottom: Int = Default('0'),mode: Int| Literal["smear","mirror","fixed","reflect","wrap","fade","margins"] | Default = Default('smear'),color: Color = Default('black'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Fill borders of the input video, without changing video stream dimensions.
 Sometimes video can have garbage at the four edges and you may not want to
 crop video input to keep size multiple of some number.
@@ -8608,7 +8608,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fillborders)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8616,44 +8616,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fillborders', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "left": left,
-                
+
                 "right": right,
-                
+
                 "top": top,
-                
+
                 "bottom": bottom,
-                
+
                 "mode": mode,
-                
+
                 "color": color,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def find_rect(
-    
+
     self,
 
 
@@ -8661,12 +8661,12 @@ References:
 
     *,
     object: String = Default(None),threshold: Float = Default('0.5'),mipmaps: Int = Default('3'),xmin: Int = Default('0'),discard: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Find a rectangular object in the input video.
 
 The object to search for must be specified as a gray8 image specified with the
@@ -8697,49 +8697,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#find_rect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='find_rect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "object": object,
-                
+
                 "threshold": threshold,
-                
+
                 "mipmaps": mipmaps,
-                
+
                 "xmin": xmin,
-                
+
                 "discard": discard,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def floodfill(
-    
+
     self,
 
 
@@ -8747,15 +8747,15 @@ References:
 
     *,
     x: Int = Default('0'),y: Int = Default('0'),s0: Int = Default('0'),s1: Int = Default('0'),s2: Int = Default('0'),s3: Int = Default('0'),d0: Int = Default('0'),d1: Int = Default('0'),d2: Int = Default('0'),d3: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Flood area with values of same pixel components with another values.
 
 It accepts the following options:
@@ -8782,7 +8782,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#floodfill)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8790,52 +8790,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='floodfill', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "s0": s0,
-                
+
                 "s1": s1,
-                
+
                 "s2": s2,
-                
+
                 "s3": s3,
-                
+
                 "d0": d0,
-                
+
                 "d1": d1,
-                
+
                 "d2": d2,
-                
+
                 "d3": d3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def format(
-    
+
     self,
 
 
@@ -8843,12 +8843,12 @@ References:
 
     *,
     pix_fmts: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert the input video to one of the specified pixel formats.
 Libavfilter will try to pick one that is suitable as input to
 the next filter.
@@ -8867,37 +8867,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#format)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='format', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "pix_fmts": pix_fmts,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fps(
-    
+
     self,
 
 
@@ -8905,12 +8905,12 @@ References:
 
     *,
     fps: String = Default('25'),start_time: Double = Default('DBL_MAX'),round: Int| Literal["zero","inf","down","up","near"] | Default = Default('near'),eof_action: Int| Literal["round","pass"] | Default = Default('round'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert the video to specified constant frame rate by duplicating or dropping
 frames as necessary.
 
@@ -8931,64 +8931,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fps)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fps', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "fps": fps,
-                
+
                 "start_time": start_time,
-                
+
                 "round": round,
-                
+
                 "eof_action": eof_action,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def framepack(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _right: VideoStream,
-        
-    
+
+
 
 
     *,
     format: Int| Literal["sbs","tab","frameseq","lines","columns"] | Default = Default('sbs'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pack two different video streams into a stereoscopic video, setting proper
 metadata on supported codecs. The two views should have the same size and
 framerate and processing will stop when the shorter video ends. Please note
@@ -9009,45 +9009,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#framepack)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='framepack', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _right,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "format": format,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def framerate(
-    
+
     self,
 
 
@@ -9055,12 +9055,12 @@ References:
 
     *,
     fps: Video_rate = Default('50'),interp_start: Int = Default('15'),interp_end: Int = Default('240'),scene: Double = Default('8.2'),flags: Flags| Literal["scene_change_detect","scd"] | Default = Default('scene_change_detect+scd'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Change the frame rate by interpolating new video output frames from the source
 frames.
 
@@ -9086,45 +9086,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#framerate)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='framerate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "fps": fps,
-                
+
                 "interp_start": interp_start,
-                
+
                 "interp_end": interp_end,
-                
+
                 "scene": scene,
-                
+
                 "flags": flags,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def framestep(
-    
+
     self,
 
 
@@ -9132,15 +9132,15 @@ References:
 
     *,
     step: Int = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Select one frame every N-th frame.
 
 This filter accepts the following option:
@@ -9158,7 +9158,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#framestep)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9166,34 +9166,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='framestep', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "step": step,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def freezedetect(
-    
+
     self,
 
 
@@ -9201,12 +9201,12 @@ References:
 
     *,
     n: Double = Default('0.001'),d: Duration = Default('2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect frozen video.
 
 This filter logs a message and sets frame metadata when it detects that the
@@ -9237,60 +9237,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#freezedetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='freezedetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "n": n,
-                
+
                 "d": d,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def freezeframes(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _replace: VideoStream,
-        
-    
+
+
 
 
     *,
     first: Int64 = Default('0'),last: Int64 = Default('0'),replace: Int64 = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Freeze video frames.
 
 This filter freezes video frames using frame from 2nd input.
@@ -9311,49 +9311,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#freezeframes)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='freezeframes', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _replace,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "first": first,
-                
+
                 "last": last,
-                
+
                 "replace": replace,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fspp(
-    
+
     self,
 
 
@@ -9361,15 +9361,15 @@ References:
 
     *,
     quality: Int = Default('4'),qp: Int = Default('0'),strength: Int = Default('0'),use_bframe_qp: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply fast and simple postprocessing. It is a faster version of spp.
 
 It splits (I)DCT into horizontal/vertical passes. Unlike the simple post-
@@ -9394,7 +9394,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fspp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9402,40 +9402,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fspp', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "quality": quality,
-                
+
                 "qp": qp,
-                
+
                 "strength": strength,
-                
+
                 "use_bframe_qp": use_bframe_qp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def gblur(
-    
+
     self,
 
 
@@ -9443,15 +9443,15 @@ References:
 
     *,
     sigma: Float = Default('0.5'),steps: Int = Default('1'),planes: Int = Default('15'),sigmaV: Float = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Gaussian blur filter.
 
 The filter accepts the following options:
@@ -9472,7 +9472,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#gblur)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9480,40 +9480,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='gblur', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sigma": sigma,
-                
+
                 "steps": steps,
-                
+
                 "planes": planes,
-                
+
                 "sigmaV": sigmaV,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def geq(
-    
+
     self,
 
 
@@ -9521,15 +9521,15 @@ References:
 
     *,
     lum_expr: String = Default(None),cb_expr: String = Default(None),cr_expr: String = Default(None),alpha_expr: String = Default(None),red_expr: String = Default(None),green_expr: String = Default(None),blue_expr: String = Default(None),interpolation: Int| Literal["nearest","n","bilinear","b"] | Default = Default('bilinear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply generic equation to each pixel.
 
 The filter accepts the following options:
@@ -9554,7 +9554,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#geq)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9562,48 +9562,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='geq', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "lum_expr": lum_expr,
-                
+
                 "cb_expr": cb_expr,
-                
+
                 "cr_expr": cr_expr,
-                
+
                 "alpha_expr": alpha_expr,
-                
+
                 "red_expr": red_expr,
-                
+
                 "green_expr": green_expr,
-                
+
                 "blue_expr": blue_expr,
-                
+
                 "interpolation": interpolation,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def gradfun(
-    
+
     self,
 
 
@@ -9611,15 +9611,15 @@ References:
 
     *,
     strength: Float = Default('1.2'),radius: Int = Default('16'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Fix the banding artifacts that are sometimes introduced into nearly flat
 regions by truncation to 8-bit color depth.
 Interpolate the gradients that should go where the bands are, and
@@ -9645,7 +9645,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#gradfun)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9653,38 +9653,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='gradfun', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "strength": strength,
-                
+
                 "radius": radius,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def graphmonitor(
-    
+
     self,
 
 
@@ -9692,12 +9692,12 @@ References:
 
     *,
     size: Image_size = Default('hd720'),opacity: Float = Default('0.9'),mode: Flags| Literal["full","compact","nozero","noeof","nodisabled"] | Default = Default('0'),flags: Flags| Literal["none","all","queue","frame_count_in","frame_count_out","frame_count_delta","pts","pts_delta","time","time_delta","timebase","format","size","rate","eof","sample_count_in","sample_count_out","sample_count_delta","disabled"] | Default = Default('all+queue'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Show various filtergraph stats.
 
 With this filter one can debug complete filtergraph.
@@ -9721,61 +9721,61 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#graphmonitor)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='graphmonitor', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "opacity": opacity,
-                
+
                 "mode": mode,
-                
+
                 "flags": flags,
-                
+
                 "rate": rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def grayworld(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 A color constancy filter that applies color correction based on the grayworld assumption
 
 See: https://www.researchgate.net/publication/275213614_A_New_Color_Correction_Method_for_Underwater_Imaging
@@ -9799,7 +9799,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#grayworld)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9807,32 +9807,32 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='grayworld', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def greyedge(
-    
+
     self,
 
 
@@ -9840,15 +9840,15 @@ References:
 
     *,
     difford: Int = Default('1'),minknorm: Int = Default('1'),sigma: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 A color constancy variation filter which estimates scene illumination via grey edge algorithm
 and corrects the scene colors accordingly.
 
@@ -9871,7 +9871,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#greyedge)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9879,71 +9879,71 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='greyedge', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "difford": difford,
-                
+
                 "minknorm": minknorm,
-                
+
                 "sigma": sigma,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def haldclut(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _clut: VideoStream,
-        
-    
+
+
 
 
     *,
     clut: Int| Literal["first","all"] | Default = Default('all'),interp: Int| Literal["nearest","trilinear","tetrahedral","pyramid","prism"] | Default = Default('tetrahedral'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a Hald CLUT to a video stream.
 
 First input is the video stream to process, and second one is the Hald CLUT.
@@ -9966,7 +9966,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#haldclut)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -9977,68 +9977,68 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='haldclut', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _clut,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "clut": clut,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def hflip(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Flip the input video horizontally.
 
 For example, to horizontally flip the input video with ffmpeg:
@@ -10058,7 +10058,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hflip)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -10066,38 +10066,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hflip', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def histeq(
-    
+
     self,
 
 
@@ -10105,15 +10105,15 @@ References:
 
     *,
     strength: Float = Default('0.2'),intensity: Float = Default('0.21'),antibanding: Int| Literal["none","weak","strong"] | Default = Default('none'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 This filter applies a global color histogram equalization on a
 per-frame basis.
 
@@ -10141,7 +10141,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#histeq)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -10149,38 +10149,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='histeq', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "strength": strength,
-                
+
                 "intensity": intensity,
-                
+
                 "antibanding": antibanding,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def histogram(
-    
+
     self,
 
 
@@ -10188,12 +10188,12 @@ References:
 
     *,
     level_height: Int = Default('200'),scale_height: Int = Default('12'),display_mode: Int| Literal["overlay","parade","stack"] | Default = Default('stack'),levels_mode: Int| Literal["linear","logarithmic"] | Default = Default('linear'),components: Int = Default('7'),fgopacity: Float = Default('0.7'),bgopacity: Float = Default('0.5'),colors_mode: Int| Literal["whiteonblack","blackonwhite","whiteongray","blackongray","coloronblack","coloronwhite","colorongray","blackoncolor","whiteoncolor","grayoncolor"] | Default = Default('whiteonblack'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Compute and draw a color distribution histogram for the input video.
 
 The computed histogram is a representation of the color component
@@ -10225,51 +10225,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#histogram)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='histogram', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_height": level_height,
-                
+
                 "scale_height": scale_height,
-                
+
                 "display_mode": display_mode,
-                
+
                 "levels_mode": levels_mode,
-                
+
                 "components": components,
-                
+
                 "fgopacity": fgopacity,
-                
+
                 "bgopacity": bgopacity,
-                
+
                 "colors_mode": colors_mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hqdn3d(
-    
+
     self,
 
 
@@ -10277,15 +10277,15 @@ References:
 
     *,
     luma_spatial: Double = Default('0'),chroma_spatial: Double = Default('0'),luma_tmp: Double = Default('0'),chroma_tmp: Double = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 This is a high precision/quality 3d denoise filter. It aims to reduce
 image noise, producing smooth images and making still images really
 still. It should enhance compressibility.
@@ -10308,7 +10308,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hqdn3d)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -10316,40 +10316,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hqdn3d', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_spatial": luma_spatial,
-                
+
                 "chroma_spatial": chroma_spatial,
-                
+
                 "luma_tmp": luma_tmp,
-                
+
                 "chroma_tmp": chroma_tmp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hqx(
-    
+
     self,
 
 
@@ -10357,12 +10357,12 @@ References:
 
     *,
     n: Int = Default('3'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a high-quality magnification filter designed for pixel art. This filter
 was originally created by Maxim Stepin.
 
@@ -10380,41 +10380,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hqx)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hqx', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "n": n,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def hsvhold(
-    
+
     self,
 
 
@@ -10422,15 +10422,15 @@ References:
 
     *,
     hue: Float = Default('0'),sat: Float = Default('0'),val: Float = Default('0'),similarity: Float = Default('0.01'),blend: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Turns a certain HSV range into gray values.
 
 This filter measures color difference between set HSV color in options
@@ -10456,7 +10456,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hsvhold)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -10464,42 +10464,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hsvhold', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "hue": hue,
-                
+
                 "sat": sat,
-                
+
                 "val": val,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hsvkey(
-    
+
     self,
 
 
@@ -10507,15 +10507,15 @@ References:
 
     *,
     hue: Float = Default('0'),sat: Float = Default('0'),val: Float = Default('0'),similarity: Float = Default('0.01'),blend: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Turns a certain HSV range into transparency.
 
 This filter measures color difference between set HSV color in options
@@ -10541,7 +10541,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hsvkey)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -10549,42 +10549,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hsvkey', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "hue": hue,
-                
+
                 "sat": sat,
-                
+
                 "val": val,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hue(
-    
+
     self,
 
 
@@ -10592,15 +10592,15 @@ References:
 
     *,
     h: String = Default(None),s: String = Default('1'),H: String = Default(None),b: String = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Modify the hue and/or the saturation of the input.
 
 It accepts the following parameters:
@@ -10621,7 +10621,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hue)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -10629,40 +10629,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hue', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "h": h,
-                
+
                 "s": s,
-                
+
                 "H": H,
-                
+
                 "b": b,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def huesaturation(
-    
+
     self,
 
 
@@ -10670,15 +10670,15 @@ References:
 
     *,
     hue: Float = Default('0'),saturation: Float = Default('0'),intensity: Float = Default('0'),colors: Flags| Literal["r","y","g","c","b","m","a"] | Default = Default('r+y+g+c+b+m+a'),strength: Float = Default('1'),rw: Float = Default('0.333'),gw: Float = Default('0.334'),bw: Float = Default('0.333'),lightness: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply hue-saturation-intensity adjustments to input video stream.
 
 This filter operates in RGB colorspace.
@@ -10706,7 +10706,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#huesaturation)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -10714,63 +10714,63 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='huesaturation', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "hue": hue,
-                
+
                 "saturation": saturation,
-                
+
                 "intensity": intensity,
-                
+
                 "colors": colors,
-                
+
                 "strength": strength,
-                
+
                 "rw": rw,
-                
+
                 "gw": gw,
-                
+
                 "bw": bw,
-                
+
                 "lightness": lightness,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hwdownload(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Download hardware frames to system memory.
 
 The input must be in hardware frames, and the output a non-hardware format.
@@ -10789,35 +10789,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hwdownload)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hwdownload', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hwmap(
-    
+
     self,
 
 
@@ -10825,12 +10825,12 @@ References:
 
     *,
     mode: Flags| Literal["read","write","overwrite","direct"] | Default = Default('read+write'),derive_device: String = Default(None),reverse: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Map hardware frames to system memory or to another device.
 
 This filter has several different modes of operation; which one is used depends
@@ -10850,41 +10850,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hwmap)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hwmap', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "derive_device": derive_device,
-                
+
                 "reverse": reverse,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hwupload(
-    
+
     self,
 
 
@@ -10892,12 +10892,12 @@ References:
 
     *,
     derive_device: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Upload system memory frames to hardware surfaces.
 
 The device to upload to must be supplied when the filter is initialised.  If
@@ -10921,66 +10921,66 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hwupload)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hwupload', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "derive_device": derive_device,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hysteresis(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _alt: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),threshold: Int = Default('0'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Grow first stream into second stream by connecting components.
 This makes it possible to build more robust edge masks.
 
@@ -11001,7 +11001,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hysteresis)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -11012,75 +11012,75 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hysteresis', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _alt,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "threshold": threshold,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def identity(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the identity score between two input videos.
 
 This filter takes two input videos.
@@ -11116,7 +11116,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#identity)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -11127,42 +11127,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='identity', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def idet(
-    
+
     self,
 
 
@@ -11170,12 +11170,12 @@ References:
 
     *,
     intl_thres: Float = Default('1.04'),prog_thres: Float = Default('1.5'),rep_thres: Float = Default('3'),half_life: Float = Default('0'),analyze_interlaced_flag: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect video interlacing type.
 
 This filter tries to detect if the input frames are interlaced, progressive,
@@ -11203,45 +11203,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#idet)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='idet', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "intl_thres": intl_thres,
-                
+
                 "prog_thres": prog_thres,
-                
+
                 "rep_thres": rep_thres,
-                
+
                 "half_life": half_life,
-                
+
                 "analyze_interlaced_flag": analyze_interlaced_flag,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def il(
-    
+
     self,
 
 
@@ -11249,15 +11249,15 @@ References:
 
     *,
     luma_mode: Int| Literal["none","interleave","i","deinterleave","d"] | Default = Default('none'),chroma_mode: Int| Literal["none","interleave","i","deinterleave","d"] | Default = Default('none'),alpha_mode: Int| Literal["none","interleave","i","deinterleave","d"] | Default = Default('none'),luma_swap: Boolean = Default('false'),chroma_swap: Boolean = Default('false'),alpha_swap: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterleave or interleave fields.
 
 This filter allows one to process interlaced images fields without
@@ -11286,7 +11286,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#il)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11294,44 +11294,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='il', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_mode": luma_mode,
-                
+
                 "chroma_mode": chroma_mode,
-                
+
                 "alpha_mode": alpha_mode,
-                
+
                 "luma_swap": luma_swap,
-                
+
                 "chroma_swap": chroma_swap,
-                
+
                 "alpha_swap": alpha_swap,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def inflate(
-    
+
     self,
 
 
@@ -11339,15 +11339,15 @@ References:
 
     *,
     threshold0: Int = Default('65535'),threshold1: Int = Default('65535'),threshold2: Int = Default('65535'),threshold3: Int = Default('65535'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply inflate effect to the video.
 
 This filter replaces the pixel by the local(3x3) average by taking into account
@@ -11371,7 +11371,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#inflate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11379,40 +11379,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='inflate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold0": threshold0,
-                
+
                 "threshold1": threshold1,
-                
+
                 "threshold2": threshold2,
-                
+
                 "threshold3": threshold3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def interlace(
-    
+
     self,
 
 
@@ -11420,12 +11420,12 @@ References:
 
     *,
     scan: Int| Literal["tff","bff"] | Default = Default('tff'),lowpass: Int| Literal["off","linear","complex"] | Default = Default('linear'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Simple interlacing filter from progressive contents. This interleaves upper (or
 lower) lines from odd frames with lower (or upper) lines from even frames,
 halving the frame rate and preserving image height.
@@ -11457,43 +11457,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#interlace)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='interlace', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "scan": scan,
-                
+
                 "lowpass": lowpass,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def kerndeint(
-    
+
     self,
 
 
@@ -11501,12 +11501,12 @@ References:
 
     *,
     thresh: Int = Default('10'),map: Boolean = Default('false'),order: Boolean = Default('false'),sharp: Boolean = Default('false'),twoway: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlace input video by applying Donald Graft's adaptive kernel
 deinterling. Work on interlaced parts of a video to produce
 progressive frames.
@@ -11529,45 +11529,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#kerndeint)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='kerndeint', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "thresh": thresh,
-                
+
                 "map": map,
-                
+
                 "order": order,
-                
+
                 "sharp": sharp,
-                
+
                 "twoway": twoway,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def kirsch(
-    
+
     self,
 
 
@@ -11575,15 +11575,15 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply kirsch operator to input video stream.
 
 The filter accepts the following option:
@@ -11603,7 +11603,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#kirsch)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11611,38 +11611,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='kirsch', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lagfun(
-    
+
     self,
 
 
@@ -11650,15 +11650,15 @@ References:
 
     *,
     decay: Float = Default('0.95'),planes: Flags = Default('F'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Slowly update darker pixels.
 
 This filter makes short flashes of light appear longer.
@@ -11678,7 +11678,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lagfun)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11686,52 +11686,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lagfun', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "decay": decay,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def latency(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Measure filtering latency.
 
 Report previous filter filtering latency, delay in number of audio samples for audio filters
@@ -11752,7 +11752,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#latency)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11760,32 +11760,32 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='latency', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lenscorrection(
-    
+
     self,
 
 
@@ -11793,15 +11793,15 @@ References:
 
     *,
     cx: Double = Default('0.5'),cy: Double = Default('0.5'),k1: Double = Default('0'),k2: Double = Default('0'),i: Int| Literal["nearest","bilinear"] | Default = Default('nearest'),fc: Color = Default('black@0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Correct radial lens distortion
 
 This filter can be used to correct for radial distortion as can result from the use
@@ -11837,7 +11837,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lenscorrection)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11845,48 +11845,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lenscorrection', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cx": cx,
-                
+
                 "cy": cy,
-                
+
                 "k1": k1,
-                
+
                 "k2": k2,
-                
+
                 "i": i,
-                
+
                 "fc": fc,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def limiter(
-    
+
     self,
 
 
@@ -11894,15 +11894,15 @@ References:
 
     *,
     min: Int = Default('0'),max: Int = Default('65535'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Limits the pixel components values to the specified range [min, max].
 
 The filter accepts the following options:
@@ -11922,7 +11922,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#limiter)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11930,38 +11930,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='limiter', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "min": min,
-                
+
                 "max": max,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def loop(
-    
+
     self,
 
 
@@ -11969,12 +11969,12 @@ References:
 
     *,
     loop: Int = Default('0'),size: Int64 = Default('0'),start: Int64 = Default('0'),time: Duration = Default('INT64_MAX'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Loop video frames.
 
 The filter accepts the following options:
@@ -11994,49 +11994,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#loop)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='loop', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "loop": loop,
-                
+
                 "size": size,
-                
+
                 "start": start,
-                
+
                 "time": time,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def lumakey(
-    
+
     self,
 
 
@@ -12044,15 +12044,15 @@ References:
 
     *,
     threshold: Double = Default('0'),tolerance: Double = Default('0.01'),softness: Double = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Turn certain luma values into transparency.
 
 The filter accepts the following options:
@@ -12072,7 +12072,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lumakey)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12080,38 +12080,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lumakey', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold": threshold,
-                
+
                 "tolerance": tolerance,
-                
+
                 "softness": softness,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lut(
-    
+
     self,
 
 
@@ -12119,15 +12119,15 @@ References:
 
     *,
     c0: String = Default('clipval'),c1: String = Default('clipval'),c2: String = Default('clipval'),c3: String = Default('clipval'),y: String = Default('clipval'),u: String = Default('clipval'),v: String = Default('clipval'),r: String = Default('clipval'),g: String = Default('clipval'),b: String = Default('clipval'),a: String = Default('clipval'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Compute a look-up table for binding each pixel component input value
 to an output value, and apply it to the input video.
 
@@ -12159,7 +12159,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12167,54 +12167,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lut', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "c0": c0,
-                
+
                 "c1": c1,
-                
+
                 "c2": c2,
-                
+
                 "c3": c3,
-                
+
                 "y": y,
-                
+
                 "u": u,
-                
+
                 "v": v,
-                
+
                 "r": r,
-                
+
                 "g": g,
-                
+
                 "b": b,
-                
+
                 "a": a,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lut1d(
-    
+
     self,
 
 
@@ -12222,15 +12222,15 @@ References:
 
     *,
     file: String = Default(None),interp: Int| Literal["nearest","linear","cosine","cubic","spline"] | Default = Default('linear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a 1D LUT to an input video.
 
 The filter accepts the following options:
@@ -12249,7 +12249,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut1d)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12257,65 +12257,65 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lut1d', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "file": file,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lut2(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _srcy: VideoStream,
-        
-    
+
+
 
 
     *,
     c0: String = Default('x'),c1: String = Default('x'),c2: String = Default('x'),c3: String = Default('x'),d: Int = Default('0'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The lut2 filter takes two input streams and outputs one
 stream.
 
@@ -12342,7 +12342,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut2)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -12353,52 +12353,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lut2', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _srcy,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "c0": c0,
-                
+
                 "c1": c1,
-                
+
                 "c2": c2,
-                
+
                 "c3": c3,
-                
+
                 "d": d,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lut3d(
-    
+
     self,
 
 
@@ -12406,15 +12406,15 @@ References:
 
     *,
     file: String = Default(None),clut: Int| Literal["first","all"] | Default = Default('all'),interp: Int| Literal["nearest","trilinear","tetrahedral","pyramid","prism"] | Default = Default('tetrahedral'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a 3D LUT to an input video.
 
 The filter accepts the following options:
@@ -12434,7 +12434,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut3d)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12442,38 +12442,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lut3d', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "file": file,
-                
+
                 "clut": clut,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lutrgb(
-    
+
     self,
 
 
@@ -12481,15 +12481,15 @@ References:
 
     *,
     c0: String = Default('clipval'),c1: String = Default('clipval'),c2: String = Default('clipval'),c3: String = Default('clipval'),y: String = Default('clipval'),u: String = Default('clipval'),v: String = Default('clipval'),r: String = Default('clipval'),g: String = Default('clipval'),b: String = Default('clipval'),a: String = Default('clipval'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Compute a look-up table for binding each pixel component input value
 to an output value, and apply it to the input video.
 
@@ -12521,7 +12521,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12529,54 +12529,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lutrgb', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "c0": c0,
-                
+
                 "c1": c1,
-                
+
                 "c2": c2,
-                
+
                 "c3": c3,
-                
+
                 "y": y,
-                
+
                 "u": u,
-                
+
                 "v": v,
-                
+
                 "r": r,
-                
+
                 "g": g,
-                
+
                 "b": b,
-                
+
                 "a": a,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lutyuv(
-    
+
     self,
 
 
@@ -12584,15 +12584,15 @@ References:
 
     *,
     c0: String = Default('clipval'),c1: String = Default('clipval'),c2: String = Default('clipval'),c3: String = Default('clipval'),y: String = Default('clipval'),u: String = Default('clipval'),v: String = Default('clipval'),r: String = Default('clipval'),g: String = Default('clipval'),b: String = Default('clipval'),a: String = Default('clipval'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Compute a look-up table for binding each pixel component input value
 to an output value, and apply it to the input video.
 
@@ -12624,7 +12624,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12632,84 +12632,84 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lutyuv', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "c0": c0,
-                
+
                 "c1": c1,
-                
+
                 "c2": c2,
-                
+
                 "c3": c3,
-                
+
                 "y": y,
-                
+
                 "u": u,
-                
+
                 "v": v,
-                
+
                 "r": r,
-                
+
                 "g": g,
-                
+
                 "b": b,
-                
+
                 "a": a,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def maskedclamp(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _dark: VideoStream,
-        
-    
-        
+
+
+
         _bright: VideoStream,
-        
-    
+
+
 
 
     *,
     undershoot: Int = Default('0'),overshoot: Int = Default('0'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Clamp the first input stream with the second input and third input stream.
 
 Returns the value of first stream to be between second input
@@ -12732,7 +12732,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedclamp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12740,78 +12740,78 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='maskedclamp', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _dark,
-                
-            
-                
+
+
+
                 _bright,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "undershoot": undershoot,
-                
+
                 "overshoot": overshoot,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def maskedmax(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _filter1: VideoStream,
-        
-    
-        
+
+
+
         _filter2: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Merge the second and third input stream into output stream using absolute differences
 between second input stream and first input stream and absolute difference between
 third input stream and first input stream. The picked value will be from second input
@@ -12833,7 +12833,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedmax)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12841,74 +12841,74 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='maskedmax', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _filter1,
-                
-            
-                
+
+
+
                 _filter2,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def maskedmerge(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _overlay: VideoStream,
-        
-    
-        
+
+
+
         _mask: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Merge the first input stream with the second input stream using per pixel
 weights in the third input stream.
 
@@ -12933,7 +12933,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedmerge)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12941,74 +12941,74 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='maskedmerge', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _overlay,
-                
-            
-                
+
+
+
                 _mask,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def maskedmin(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _filter1: VideoStream,
-        
-    
-        
+
+
+
         _filter2: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Merge the second and third input stream into output stream using absolute differences
 between second input stream and first input stream and absolute difference between
 third input stream and first input stream. The picked value will be from second input
@@ -13030,7 +13030,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedmin)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -13038,70 +13038,70 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='maskedmin', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _filter1,
-                
-            
-                
+
+
+
                 _filter2,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def maskedthreshold(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     threshold: Int = Default('1'),planes: Int = Default('15'),mode: Int| Literal["abs","diff"] | Default = Default('abs'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pick pixels comparing absolute difference of two video streams with fixed
 threshold.
 
@@ -13127,7 +13127,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedthreshold)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -13135,46 +13135,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='maskedthreshold', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "threshold": threshold,
-                
+
                 "planes": planes,
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def maskfun(
-    
+
     self,
 
 
@@ -13182,15 +13182,15 @@ References:
 
     *,
     low: Int = Default('10'),high: Int = Default('10'),planes: Int = Default('15'),fill: Int = Default('0'),sum: Int = Default('10'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Create mask from input video.
 
 For example it is useful to create motion masks after tblend filter.
@@ -13214,7 +13214,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskfun)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -13222,42 +13222,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='maskfun', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "low": low,
-                
+
                 "high": high,
-                
+
                 "planes": planes,
-                
+
                 "fill": fill,
-                
+
                 "sum": sum,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def mcdeint(
-    
+
     self,
 
 
@@ -13265,12 +13265,12 @@ References:
 
     *,
     mode: Int| Literal["fast","medium","slow","extra_slow"] | Default = Default('fast'),parity: Int| Literal["tff","bff"] | Default = Default('bff'),qp: Int = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply motion-compensation deinterlacing.
 
 It needs one field per frame as input and must thus be used together
@@ -13292,43 +13292,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mcdeint)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='mcdeint', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "parity": parity,
-                
+
                 "qp": qp,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def median(
-    
+
     self,
 
 
@@ -13336,15 +13336,15 @@ References:
 
     *,
     radius: Int = Default('1'),planes: Int = Default('15'),radiusV: Int = Default('0'),percentile: Float = Default('0.5'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pick median pixel from certain rectangle defined by radius.
 
 This filter accepts the following options:
@@ -13365,7 +13365,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#median)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -13373,42 +13373,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='median', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "radius": radius,
-                
+
                 "planes": planes,
-                
+
                 "radiusV": radiusV,
-                
+
                 "percentile": percentile,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def mestimate(
-    
+
     self,
 
 
@@ -13416,12 +13416,12 @@ References:
 
     *,
     method: Int| Literal["esa","tss","tdls","ntss","fss","ds","hexbs","epzs","umh"] | Default = Default('esa'),mb_size: Int = Default('16'),search_param: Int = Default('7'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Estimate and export motion vectors using block matching algorithms.
 Motion vectors are stored in frame side data to be used by other filters.
 
@@ -13441,41 +13441,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mestimate)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='mestimate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "method": method,
-                
+
                 "mb_size": mb_size,
-                
+
                 "search_param": search_param,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def metadata(
-    
+
     self,
 
 
@@ -13483,15 +13483,15 @@ References:
 
     *,
     mode: Int| Literal["select","add","modify","delete","print"] | Default = Default('select'),key: String = Default(None),value: String = Default(None),function: Int| Literal["same_str","starts_with","less","equal","greater","expr","ends_with"] | Default = Default('same_str'),expr: String = Default(None),file: String = Default(None),direct: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Manipulate frame metadata.
 
 This filter accepts the following options:
@@ -13515,7 +13515,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#metadata)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -13523,70 +13523,70 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='metadata', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "key": key,
-                
+
                 "value": value,
-                
+
                 "function": function,
-                
+
                 "expr": expr,
-                
+
                 "file": file,
-                
+
                 "direct": direct,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def midequalizer(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _in1: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Midway Image Equalization effect using two video streams.
 
 Midway Image Equalization adjusts a pair of images to have the same
@@ -13612,7 +13612,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#midequalizer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -13620,42 +13620,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='midequalizer', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _in1,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def minterpolate(
-    
+
     self,
 
 
@@ -13663,12 +13663,12 @@ References:
 
     *,
     fps: Video_rate = Default('60'),mi_mode: Int| Literal["dup","blend","mci"] | Default = Default('mci'),mc_mode: Int| Literal["obmc","aobmc"] | Default = Default('obmc'),me_mode: Int| Literal["bidir","bilat"] | Default = Default('bilat'),me: Int| Literal["esa","tss","tdls","ntss","fss","ds","hexbs","epzs","umh"] | Default = Default('epzs'),mb_size: Int = Default('16'),search_param: Int = Default('32'),vsbmc: Int = Default('0'),scd: Int| Literal["none","fdiff"] | Default = Default('fdiff'),scd_threshold: Double = Default('10'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert the video to specified frame rate using motion interpolation.
 
 This filter accepts the following options:
@@ -13694,57 +13694,57 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#minterpolate)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='minterpolate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "fps": fps,
-                
+
                 "mi_mode": mi_mode,
-                
+
                 "mc_mode": mc_mode,
-                
+
                 "me_mode": me_mode,
-                
+
                 "me": me,
-                
+
                 "mb_size": mb_size,
-                
+
                 "search_param": search_param,
-                
+
                 "vsbmc": vsbmc,
-                
+
                 "scd": scd,
-                
+
                 "scd_threshold": scd_threshold,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def monochrome(
-    
+
     self,
 
 
@@ -13752,15 +13752,15 @@ References:
 
     *,
     cb: Float = Default('0'),cr: Float = Default('0'),size: Float = Default('1'),high: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert video to gray using custom color filter.
 
 A description of the accepted options follows.
@@ -13781,7 +13781,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#monochrome)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -13789,69 +13789,69 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='monochrome', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cb": cb,
-                
+
                 "cr": cr,
-                
+
                 "size": size,
-                
+
                 "high": high,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def morpho(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _structure: VideoStream,
-        
-    
+
+
 
 
     *,
     mode: Int| Literal["erode","dilate","open","close","gradient","tophat","blackhat"] | Default = Default('erode'),planes: Int = Default('7'),structure: Int| Literal["first","all"] | Default = Default('all'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 This filter allows to apply main morphological grayscale transforms,
 erode and dilate with arbitrary structures set in second input stream.
 
@@ -13877,7 +13877,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#morpho)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -13888,50 +13888,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='morpho', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _structure,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "planes": planes,
-                
+
                 "structure": structure,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def mpdecimate(
-    
+
     self,
 
 
@@ -13939,12 +13939,12 @@ References:
 
     *,
     max: Int = Default('0'),keep: Int = Default('0'),hi: Int = Default('768'),lo: Int = Default('320'),frac: Float = Default('0.33'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Drop frames that do not differ greatly from the previous frame in
 order to reduce frame rate.
 
@@ -13970,76 +13970,76 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mpdecimate)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='mpdecimate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "max": max,
-                
+
                 "keep": keep,
-                
+
                 "hi": hi,
-                
+
                 "lo": lo,
-                
+
                 "frac": frac,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def msad(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the MSAD (Mean Sum of Absolute Differences) between two input videos.
 
 This filter takes two input videos.
@@ -14075,7 +14075,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#msad)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -14086,66 +14086,66 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='msad', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def multiply(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _factor: VideoStream,
-        
-    
+
+
 
 
     *,
     scale: Float = Default('1'),offset: Float = Default('0.5'),planes: Flags = Default('F'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Multiply first video stream pixels values with second video stream pixels values.
 
 The filter accepts the following options:
@@ -14165,7 +14165,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#multiply)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14173,46 +14173,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='multiply', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _factor,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "scale": scale,
-                
+
                 "offset": offset,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def negate(
-    
+
     self,
 
 
@@ -14220,15 +14220,15 @@ References:
 
     *,
     components: Flags| Literal["y","u","v","r","g","b","a"] | Default = Default('y+u+v+r+g+b'),negate_alpha: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Negate (invert) the input video.
 
 It accepts the following option:
@@ -14247,7 +14247,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#negate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14255,36 +14255,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='negate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "components": components,
-                
+
                 "negate_alpha": negate_alpha,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def nlmeans(
-    
+
     self,
 
 
@@ -14292,15 +14292,15 @@ References:
 
     *,
     s: Double = Default('1'),p: Int = Default('7'),pc: Int = Default('0'),r: Int = Default('15'),rc: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Denoise frames using Non-Local Means algorithm.
 
 Each pixel is adjusted by looking for other pixels with similar contexts. This
@@ -14330,7 +14330,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#nlmeans)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14338,42 +14338,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='nlmeans', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "s": s,
-                
+
                 "p": p,
-                
+
                 "pc": pc,
-                
+
                 "r": r,
-                
+
                 "rc": rc,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def nlmeans_opencl(
-    
+
     self,
 
 
@@ -14381,12 +14381,12 @@ References:
 
     *,
     s: Double = Default('1'),p: Int = Default('7'),pc: Int = Default('0'),r: Int = Default('15'),rc: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Non-local Means denoise filter through OpenCL, this filter accepts same options as nlmeans.
 
 
@@ -14405,45 +14405,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#nlmeans_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='nlmeans_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "s": s,
-                
+
                 "p": p,
-                
+
                 "pc": pc,
-                
+
                 "r": r,
-                
+
                 "rc": rc,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def nnedi(
-    
+
     self,
 
 
@@ -14451,15 +14451,15 @@ References:
 
     *,
     weights: String = Default('nnedi3_weights.bin'),deint: Int| Literal["all","interlaced"] | Default = Default('all'),field: Int| Literal["af","a","t","b","tf","bf"] | Default = Default('a'),planes: Int = Default('7'),nsize: Int| Literal["s8x6","s16x6","s32x6","s48x6","s8x4","s16x4","s32x4"] | Default = Default('s32x4'),nns: Int| Literal["n16","n32","n64","n128","n256"] | Default = Default('n32'),qual: Int| Literal["fast","slow"] | Default = Default('fast'),etype: Int| Literal["a","abs","s","mse"] | Default = Default('a'),pscrn: Int| Literal["none","original","new","new2","new3"] | Default = Default('new'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlace video using neural network edge directed interpolation.
 
 This filter accepts the following options:
@@ -14485,7 +14485,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#nnedi)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14493,50 +14493,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='nnedi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "weights": weights,
-                
+
                 "deint": deint,
-                
+
                 "field": field,
-                
+
                 "planes": planes,
-                
+
                 "nsize": nsize,
-                
+
                 "nns": nns,
-                
+
                 "qual": qual,
-                
+
                 "etype": etype,
-                
+
                 "pscrn": pscrn,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def noformat(
-    
+
     self,
 
 
@@ -14544,12 +14544,12 @@ References:
 
     *,
     pix_fmts: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Force libavfilter not to use any of the specified pixel formats for the
 input to the next filter.
 
@@ -14567,37 +14567,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#noformat)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='noformat', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "pix_fmts": pix_fmts,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def noise(
-    
+
     self,
 
 
@@ -14605,15 +14605,15 @@ References:
 
     *,
     all_seed: Int = Default('-1'),all_strength: Int = Default('0'),all_flags: Flags| Literal["a","p","t","u"] | Default = Default('0'),c0_seed: Int = Default('-1'),c0_strength: Int = Default('0'),c0_flags: Flags| Literal["a","p","t","u"] | Default = Default('0'),c1_seed: Int = Default('-1'),c1_strength: Int = Default('0'),c1_flags: Flags| Literal["a","p","t","u"] | Default = Default('0'),c2_seed: Int = Default('-1'),c2_strength: Int = Default('0'),c2_flags: Flags| Literal["a","p","t","u"] | Default = Default('0'),c3_seed: Int = Default('-1'),c3_strength: Int = Default('0'),c3_flags: Flags| Literal["a","p","t","u"] | Default = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Add noise on video input frame.
 
 The filter accepts the following options:
@@ -14645,7 +14645,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#noise)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14653,62 +14653,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='noise', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "all_seed": all_seed,
-                
+
                 "all_strength": all_strength,
-                
+
                 "all_flags": all_flags,
-                
+
                 "c0_seed": c0_seed,
-                
+
                 "c0_strength": c0_strength,
-                
+
                 "c0_flags": c0_flags,
-                
+
                 "c1_seed": c1_seed,
-                
+
                 "c1_strength": c1_strength,
-                
+
                 "c1_flags": c1_flags,
-                
+
                 "c2_seed": c2_seed,
-                
+
                 "c2_strength": c2_strength,
-                
+
                 "c2_flags": c2_flags,
-                
+
                 "c3_seed": c3_seed,
-                
+
                 "c3_strength": c3_strength,
-                
+
                 "c3_flags": c3_flags,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def normalize(
-    
+
     self,
 
 
@@ -14716,15 +14716,15 @@ References:
 
     *,
     blackpt: Color = Default('black'),whitept: Color = Default('white'),smoothing: Int = Default('0'),independence: Float = Default('1'),strength: Float = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Normalize RGB video (aka histogram stretching, contrast stretching).
 See: https://en.wikipedia.org/wiki/Normalization_(image_processing)
 
@@ -14763,7 +14763,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#normalize)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14771,55 +14771,55 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='normalize', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "blackpt": blackpt,
-                
+
                 "whitept": whitept,
-                
+
                 "smoothing": smoothing,
-                
+
                 "independence": independence,
-                
+
                 "strength": strength,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def null(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pass the video source unchanged to the output.
 
 
@@ -14833,41 +14833,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#null)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='null', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def oscilloscope(
-    
+
     self,
 
 
@@ -14875,15 +14875,15 @@ References:
 
     *,
     x: Float = Default('0.5'),y: Float = Default('0.5'),s: Float = Default('0.8'),t: Float = Default('0.5'),o: Float = Default('0.8'),tx: Float = Default('0.5'),ty: Float = Default('0.9'),tw: Float = Default('0.8'),th: Float = Default('0.3'),c: Int = Default('7'),g: Boolean = Default('true'),st: Boolean = Default('true'),sc: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 2D Video Oscilloscope.
 
 Useful to measure spatial impulse, step responses, chroma delays, etc.
@@ -14915,7 +14915,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#oscilloscope)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14923,87 +14923,87 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='oscilloscope', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "s": s,
-                
+
                 "t": t,
-                
+
                 "o": o,
-                
+
                 "tx": tx,
-                
+
                 "ty": ty,
-                
+
                 "tw": tw,
-                
+
                 "th": th,
-                
+
                 "c": c,
-                
+
                 "g": g,
-                
+
                 "st": st,
-                
+
                 "sc": sc,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def overlay(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _overlay: VideoStream,
-        
-    
+
+
 
 
     *,
     x: String = Default('0'),y: String = Default('0'),eof_action: Int| Literal["repeat","endall","pass"] | Default = Default('repeat'),eval: Int| Literal["init","frame"] | Default = Default('frame'),shortest: Boolean = Default('false'),format: Int| Literal["yuv420","yuv420p10","yuv422","yuv422p10","yuv444","yuv444p10","rgb","gbrp","auto"] | Default = Default('yuv420'),repeatlast: Boolean = Default('true'),alpha: Int| Literal["straight","premultiplied"] | Default = Default('straight'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
-    
-    
-    
-    
-    
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Overlay one video on top of another.
 
 It takes two inputs and has one output. The first input is the "main"
@@ -15034,7 +15034,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -15042,79 +15042,79 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='overlay', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _overlay,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "eof_action": eof_action,
-                
+
                 "eval": eval,
-                
+
                 "shortest": shortest,
-                
+
                 "format": format,
-                
+
                 "repeatlast": repeatlast,
-                
+
                 "alpha": alpha,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def overlay_opencl(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _overlay: VideoStream,
-        
-    
+
+
 
 
     *,
     x: Int = Default('0'),y: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Overlay one video on top of another.
 
 It takes two inputs and has one output. The first input is the "main" video on which the second input is overlaid.
@@ -15135,73 +15135,73 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='overlay_opencl', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _overlay,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def overlay_vaapi(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _overlay: VideoStream,
-        
-    
+
+
 
 
     *,
     x: String = Default('0'),y: String = Default('0'),w: String = Default('overlay_iw'),h: String = Default('overlay_ih*w/overlay_iw'),alpha: Float = Default('1'),eof_action: Int| Literal["repeat","endall","pass"] | Default = Default('repeat'),shortest: Boolean = Default('false'),repeatlast: Boolean = Default('true'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
-    
-    
-    
-    
-    
+
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Overlay one video on the top of another.
 
 It takes two inputs and has one output. The first input is the "main" video on which the second input is overlaid.
@@ -15228,61 +15228,61 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay_vaapi)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='overlay_vaapi', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _overlay,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "alpha": alpha,
-                
+
                 "eof_action": eof_action,
-                
+
                 "shortest": shortest,
-                
+
                 "repeatlast": repeatlast,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def owdenoise(
-    
+
     self,
 
 
@@ -15290,15 +15290,15 @@ References:
 
     *,
     depth: Int = Default('8'),luma_strength: Double = Default('1'),chroma_strength: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Overcomplete Wavelet denoiser.
 
 The filter accepts the following options:
@@ -15318,7 +15318,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#owdenoise)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -15326,38 +15326,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='owdenoise', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "depth": depth,
-                
+
                 "luma_strength": luma_strength,
-                
+
                 "chroma_strength": chroma_strength,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pad(
-    
+
     self,
 
 
@@ -15365,12 +15365,12 @@ References:
 
     *,
     width: String = Default('iw'),height: String = Default('ih'),x: String = Default('0'),y: String = Default('0'),color: Color = Default('black'),eval: Int| Literal["init","frame"] | Default = Default('init'),aspect: Rational = Default('0/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Add paddings to the input image, and place the original input at the
 provided x, y coordinates.
 
@@ -15394,49 +15394,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pad)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pad', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "color": color,
-                
+
                 "eval": eval,
-                
+
                 "aspect": aspect,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pad_opencl(
-    
+
     self,
 
 
@@ -15444,12 +15444,12 @@ References:
 
     *,
     width: String = Default('iw'),height: String = Default('ih'),x: String = Default('0'),y: String = Default('0'),color: Color = Default('black'),aspect: Rational = Default('0/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Add paddings to the input image, and place the original input at the
 provided x, y coordinates.
 
@@ -15472,51 +15472,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pad_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pad_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "color": color,
-                
+
                 "aspect": aspect,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def palettegen(
-    
+
     self,
 
 
@@ -15524,12 +15524,12 @@ References:
 
     *,
     max_colors: Int = Default('256'),reserve_transparent: Boolean = Default('true'),transparency_color: Color = Default('lime'),stats_mode: Int| Literal["full","diff","single"] | Default = Default('full'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Generate one palette for a whole video stream.
 
 It accepts the following options:
@@ -15549,64 +15549,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#palettegen)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='palettegen', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "max_colors": max_colors,
-                
+
                 "reserve_transparent": reserve_transparent,
-                
+
                 "transparency_color": transparency_color,
-                
+
                 "stats_mode": stats_mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def paletteuse(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _palette: VideoStream,
-        
-    
+
+
 
 
     *,
     dither: Int| Literal["bayer","heckbert","floyd_steinberg","sierra2","sierra2_4a","sierra3","burkes","atkinson"] | Default = Default('sierra2_4a'),bayer_scale: Int = Default('2'),diff_mode: Int| Literal["rectangle"] | Default = Default('0'),new: Boolean = Default('false'),alpha_threshold: Int = Default('128'),debug_kdtree: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Use a palette to downsample an input video stream.
 
 The filter takes two inputs: one video stream and a palette. The palette must
@@ -15631,57 +15631,57 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#paletteuse)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='paletteuse', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _palette,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "dither": dither,
-                
+
                 "bayer_scale": bayer_scale,
-                
+
                 "diff_mode": diff_mode,
-                
+
                 "new": new,
-                
+
                 "alpha_threshold": alpha_threshold,
-                
+
                 "debug_kdtree": debug_kdtree,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def perms(
-    
+
     self,
 
 
@@ -15689,15 +15689,15 @@ References:
 
     *,
     mode: Int| Literal["none","ro","rw","toggle","random"] | Default = Default('none'),seed: Int64 = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Set read/write permissions for the output frames.
 
 These filters are mainly aimed at developers to test direct path in the
@@ -15719,7 +15719,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#perms)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -15727,36 +15727,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='perms', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "seed": seed,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def perspective(
-    
+
     self,
 
 
@@ -15764,15 +15764,15 @@ References:
 
     *,
     x0: String = Default('0'),y0: String = Default('0'),x1: String = Default('W'),y1: String = Default('0'),x2: String = Default('0'),y2: String = Default('H'),x3: String = Default('W'),y3: String = Default('H'),interpolation: Int| Literal["linear","cubic"] | Default = Default('linear'),sense: Int| Literal["source","destination"] | Default = Default('source'),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Correct perspective of video not recorded perpendicular to the screen.
 
 A description of the accepted parameters follows.
@@ -15800,7 +15800,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#perspective)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -15808,54 +15808,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='perspective', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x0": x0,
-                
+
                 "y0": y0,
-                
+
                 "x1": x1,
-                
+
                 "y1": y1,
-                
+
                 "x2": x2,
-                
+
                 "y2": y2,
-                
+
                 "x3": x3,
-                
+
                 "y3": y3,
-                
+
                 "interpolation": interpolation,
-                
+
                 "sense": sense,
-                
+
                 "eval": eval,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def phase(
-    
+
     self,
 
 
@@ -15863,15 +15863,15 @@ References:
 
     *,
     mode: Int| Literal["p","t","b","T","B","u","U","a","A"] | Default = Default('A'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Delay interlaced video by one field time so that the field order changes.
 
 The intended use is to fix PAL movies that have been captured with the
@@ -15892,7 +15892,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#phase)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -15900,34 +15900,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='phase', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def photosensitivity(
-    
+
     self,
 
 
@@ -15935,12 +15935,12 @@ References:
 
     *,
     frames: Int = Default('30'),threshold: Float = Default('1'),skip: Int = Default('1'),bypass: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reduce various flashes in video, so to help users with epilepsy.
 
 It accepts the following options:
@@ -15960,56 +15960,56 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#photosensitivity)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='photosensitivity', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frames": frames,
-                
+
                 "threshold": threshold,
-                
+
                 "skip": skip,
-                
+
                 "bypass": bypass,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pixdesctest(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pixel format descriptor test filter, mainly useful for internal
 testing. The output video should be equal to the input video.
 
@@ -16031,35 +16031,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pixdesctest)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pixdesctest', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pixelize(
-    
+
     self,
 
 
@@ -16067,15 +16067,15 @@ References:
 
     *,
     width: Int = Default('16'),height: Int = Default('16'),mode: Int| Literal["avg","min","max"] | Default = Default('avg'),planes: Flags = Default('F'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply pixelization to video stream.
 
 The filter accepts the following options:
@@ -16096,7 +16096,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pixelize)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -16104,40 +16104,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pixelize', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "mode": mode,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pixscope(
-    
+
     self,
 
 
@@ -16145,15 +16145,15 @@ References:
 
     *,
     x: Float = Default('0.5'),y: Float = Default('0.5'),w: Int = Default('7'),h: Int = Default('7'),o: Float = Default('0.5'),wx: Float = Default('-1'),wy: Float = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Display sample values of color channels. Mainly useful for checking color
 and levels. Minimum supported resolution is 640x480.
 
@@ -16178,7 +16178,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pixscope)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -16186,46 +16186,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pixscope', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "o": o,
-                
+
                 "wx": wx,
-                
+
                 "wy": wy,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pp(
-    
+
     self,
 
 
@@ -16233,15 +16233,15 @@ References:
 
     *,
     subfilters: String = Default('de'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Enable the specified chain of postprocessing subfilters using libpostproc. This
 library should be automatically selected with a GPL build (--enable-gpl).
 Subfilters must be separated by '/' and can be disabled by prepending a '-'.
@@ -16263,7 +16263,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -16271,34 +16271,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pp', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "subfilters": subfilters,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pp7(
-    
+
     self,
 
 
@@ -16306,15 +16306,15 @@ References:
 
     *,
     qp: Int = Default('0'),mode: Int| Literal["hard","soft","medium"] | Default = Default('medium'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Postprocessing filter 7. It is variant of the spp filter,
 similar to spp = 6 with 7 point DCT, where only the center sample is
 used after IDCT.
@@ -16335,7 +16335,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pp7)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -16343,38 +16343,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pp7', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "qp": qp,
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def prewitt(
-    
+
     self,
 
 
@@ -16382,15 +16382,15 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply prewitt operator to input video stream.
 
 The filter accepts the following option:
@@ -16410,7 +16410,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#prewitt)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -16418,38 +16418,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='prewitt', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def prewitt_opencl(
-    
+
     self,
 
 
@@ -16457,12 +16457,12 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply the Prewitt operator (https://en.wikipedia.org/wiki/Prewitt_operator) to input video stream.
 
 The filter accepts the following option:
@@ -16481,41 +16481,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#prewitt_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='prewitt_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def procamp_vaapi(
-    
+
     self,
 
 
@@ -16523,12 +16523,12 @@ References:
 
     *,
     b: Float = Default('0'),s: Float = Default('1'),c: Float = Default('1'),h: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 ProcAmp (color balance) adjustments for hue, saturation, brightness, contrast
 
 
@@ -16546,45 +16546,45 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='procamp_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "b": b,
-                
+
                 "s": s,
-                
+
                 "c": c,
-                
+
                 "h": h,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def pseudocolor(
-    
+
     self,
 
 
@@ -16592,15 +16592,15 @@ References:
 
     *,
     c0: String = Default('val'),c1: String = Default('val'),c2: String = Default('val'),c3: String = Default('val'),index: Int = Default('0'),preset: Int| Literal["none","magma","inferno","plasma","viridis","turbo","cividis","range1","range2","shadows","highlights","solar","nominal","preferred","total","spectral","cool","heat","fiery","blues","green","helix"] | Default = Default('none'),opacity: Float = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Alter frame colors in video with pseudocolors.
 
 This filter accepts the following options:
@@ -16624,7 +16624,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pseudocolor)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -16632,75 +16632,75 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pseudocolor', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "c0": c0,
-                
+
                 "c1": c1,
-                
+
                 "c2": c2,
-                
+
                 "c3": c3,
-                
+
                 "index": index,
-                
+
                 "preset": preset,
-                
+
                 "opacity": opacity,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def psnr(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),stats_version: Int = Default('1'),output_max: Boolean = Default('false'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the average, maximum and minimum PSNR (Peak Signal to Noise
 Ratio) between two input videos.
 
@@ -16744,7 +16744,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#psnr)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -16755,48 +16755,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='psnr', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "stats_file": stats_file,
-                
+
                 "stats_version": stats_version,
-                
+
                 "output_max": output_max,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pullup(
-    
+
     self,
 
 
@@ -16804,12 +16804,12 @@ References:
 
     *,
     jl: Int = Default('1'),jr: Int = Default('1'),jt: Int = Default('4'),jb: Int = Default('4'),sb: Boolean = Default('false'),mp: Int| Literal["y","u","v"] | Default = Default('y'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pulldown reversal (inverse telecine) filter, capable of handling mixed
 hard-telecine, 24000/1001 fps progressive, and 30000/1001 fps progressive
 content.
@@ -16842,47 +16842,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pullup)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pullup', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "jl": jl,
-                
+
                 "jr": jr,
-                
+
                 "jt": jt,
-                
+
                 "jb": jb,
-                
+
                 "sb": sb,
-                
+
                 "mp": mp,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def qp(
-    
+
     self,
 
 
@@ -16890,15 +16890,15 @@ References:
 
     *,
     qp: String = Default(None),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Change video quantization parameters (QP).
 
 The filter accepts the following option:
@@ -16916,7 +16916,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#qp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -16924,34 +16924,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='qp', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "qp": qp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def random(
-    
+
     self,
 
 
@@ -16959,12 +16959,12 @@ References:
 
     *,
     frames: Int = Default('30'),seed: Int64 = Default('-1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Flush video frames from internal cache of frames into a random order.
 No frame is discarded.
 Inspired by frei0r nervous filter.
@@ -16982,39 +16982,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#random)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='random', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frames": frames,
-                
+
                 "seed": seed,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def readeia608(
-    
+
     self,
 
 
@@ -17022,15 +17022,15 @@ References:
 
     *,
     scan_min: Int = Default('0'),scan_max: Int = Default('29'),spw: Float = Default('0.27'),chp: Boolean = Default('false'),lp: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Read closed captioning (EIA-608) information from the top lines of a video frame.
 
 This filter adds frame metadata for lavfi.readeia608.X.cc and
@@ -17054,7 +17054,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#readeia608)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -17062,42 +17062,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='readeia608', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "scan_min": scan_min,
-                
+
                 "scan_max": scan_max,
-                
+
                 "spw": spw,
-                
+
                 "chp": chp,
-                
+
                 "lp": lp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def readvitc(
-    
+
     self,
 
 
@@ -17105,12 +17105,12 @@ References:
 
     *,
     scan_max: Int = Default('45'),thr_b: Double = Default('0.2'),thr_w: Double = Default('0.6'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Read vertical interval timecode (VITC) information from the top lines of a
 video frame.
 
@@ -17135,41 +17135,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#readvitc)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='readvitc', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "scan_max": scan_max,
-                
+
                 "thr_b": thr_b,
-                
+
                 "thr_w": thr_w,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def realtime(
-    
+
     self,
 
 
@@ -17177,12 +17177,12 @@ References:
 
     *,
     limit: Duration = Default('2'),speed: Double = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Slow down filtering to match real time approximately.
 
 These filters will pause the filtering for a variable amount of time to
@@ -17204,64 +17204,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#realtime)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='realtime', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "limit": limit,
-                
+
                 "speed": speed,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def remap(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _xmap: VideoStream,
-        
-    
-        
+
+
+
         _ymap: VideoStream,
-        
-    
+
+
 
 
     *,
     format: Int| Literal["color","gray"] | Default = Default('color'),fill: Color = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remap pixels using 2nd: Xmap and 3rd: Ymap input video stream.
 
 Destination pixel at position (X, Y) will be picked from source (x, y) position
@@ -17285,76 +17285,76 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#remap)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='remap', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _xmap,
-                
-            
-                
+
+
+
                 _ymap,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "format": format,
-                
+
                 "fill": fill,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def remap_opencl(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _xmap: VideoStream,
-        
-    
-        
+
+
+
         _ymap: VideoStream,
-        
-    
+
+
 
 
     *,
     interp: Int| Literal["near","linear"] | Default = Default('linear'),fill: Color = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remap pixels using 2nd: Xmap and 3rd: Ymap input video stream.
 
 Destination pixel at position (X, Y) will be picked from source (x, y) position
@@ -17378,51 +17378,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#remap_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='remap_opencl', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _xmap,
-                
-            
-                
+
+
+
                 _ymap,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "interp": interp,
-                
+
                 "fill": fill,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def removegrain(
-    
+
     self,
 
 
@@ -17430,15 +17430,15 @@ References:
 
     *,
     m0: Int = Default('0'),m1: Int = Default('0'),m2: Int = Default('0'),m3: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The removegrain filter is a spatial denoiser for progressive video.
 
 
@@ -17457,7 +17457,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#removegrain)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -17465,40 +17465,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='removegrain', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "m0": m0,
-                
+
                 "m1": m1,
-                
+
                 "m2": m2,
-                
+
                 "m3": m3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def removelogo(
-    
+
     self,
 
 
@@ -17506,15 +17506,15 @@ References:
 
     *,
     filename: String = Default(None),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Suppress a TV station logo, using an image file to determine which
 pixels comprise the logo. It works by filling in the pixels that
 comprise the logo with neighboring pixels.
@@ -17534,7 +17534,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#removelogo)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -17542,47 +17542,47 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='removelogo', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "filename": filename,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def repeatfields(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 This filter uses the repeat_field flag from the Video ES headers and hard repeats
 fields based on its value.
 
@@ -17597,50 +17597,50 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#repeatfields)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='repeatfields', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def reverse(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reverse a video clip.
 
 Warning: This filter requires memory to buffer the entire clip, so trimming
@@ -17657,35 +17657,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#reverse)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='reverse', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def rgbashift(
-    
+
     self,
 
 
@@ -17693,15 +17693,15 @@ References:
 
     *,
     rh: Int = Default('0'),rv: Int = Default('0'),gh: Int = Default('0'),gv: Int = Default('0'),bh: Int = Default('0'),bv: Int = Default('0'),ah: Int = Default('0'),av: Int = Default('0'),edge: Int| Literal["smear","wrap"] | Default = Default('smear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Shift R/G/B/A pixels horizontally and/or vertically.
 
 The filter accepts the following options:
@@ -17727,7 +17727,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#rgbashift)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -17735,52 +17735,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='rgbashift', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rh": rh,
-                
+
                 "rv": rv,
-                
+
                 "gh": gh,
-                
+
                 "gv": gv,
-                
+
                 "bh": bh,
-                
+
                 "bv": bv,
-                
+
                 "ah": ah,
-                
+
                 "av": av,
-                
+
                 "edge": edge,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def roberts(
-    
+
     self,
 
 
@@ -17788,15 +17788,15 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply roberts cross operator to input video stream.
 
 The filter accepts the following option:
@@ -17816,7 +17816,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#roberts)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -17824,38 +17824,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='roberts', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def roberts_opencl(
-    
+
     self,
 
 
@@ -17863,12 +17863,12 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply the Roberts cross operator (https://en.wikipedia.org/wiki/Roberts_cross) to input video stream.
 
 The filter accepts the following option:
@@ -17887,41 +17887,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#roberts_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='roberts_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def rotate(
-    
+
     self,
 
 
@@ -17929,15 +17929,15 @@ References:
 
     *,
     angle: String = Default('0'),out_w: String = Default('iw'),out_h: String = Default('ih'),fillcolor: String = Default('black'),bilinear: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Rotate video by an arbitrary angle expressed in radians.
 
 The filter accepts the following options:
@@ -17961,7 +17961,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#rotate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -17969,42 +17969,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='rotate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "angle": angle,
-                
+
                 "out_w": out_w,
-                
+
                 "out_h": out_h,
-                
+
                 "fillcolor": fillcolor,
-                
+
                 "bilinear": bilinear,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def sab(
-    
+
     self,
 
 
@@ -18012,15 +18012,15 @@ References:
 
     *,
     luma_radius: Float = Default('1'),luma_pre_filter_radius: Float = Default('1'),luma_strength: Float = Default('1'),chroma_radius: Float = Default('-0.9'),chroma_pre_filter_radius: Float = Default('-0.9'),chroma_strength: Float = Default('-0.9'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Shape Adaptive Blur.
 
 The filter accepts the following options:
@@ -18043,7 +18043,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sab)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -18051,44 +18051,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sab', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_radius": luma_radius,
-                
+
                 "luma_pre_filter_radius": luma_pre_filter_radius,
-                
+
                 "luma_strength": luma_strength,
-                
+
                 "chroma_radius": chroma_radius,
-                
+
                 "chroma_pre_filter_radius": chroma_pre_filter_radius,
-                
+
                 "chroma_strength": chroma_strength,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def scale(
-    
+
     self,
 
 
@@ -18096,12 +18096,12 @@ References:
 
     *,
     w: String = Default(None),h: String = Default(None),flags: String = Default(''),interl: Boolean = Default('false'),in_color_matrix: String| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default('auto'),out_color_matrix: String| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default(None),in_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),out_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),in_v_chr_pos: Int = Default('-513'),in_h_chr_pos: Int = Default('-513'),out_v_chr_pos: Int = Default('-513'),out_h_chr_pos: Int = Default('-513'),force_original_aspect_ratio: Int| Literal["disable","decrease","increase"] | Default = Default('disable'),force_divisible_by: Int = Default('1'),param0: Double = Default('DBL_MAX'),param1: Double = Default('DBL_MAX'),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Scale (resize) the input video, using the libswscale library.
 
 The scale filter forces the output display aspect ratio to be the same
@@ -18139,100 +18139,100 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#scale)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='scale', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "flags": flags,
-                
+
                 "interl": interl,
-                
+
                 "in_color_matrix": in_color_matrix,
-                
+
                 "out_color_matrix": out_color_matrix,
-                
+
                 "in_range": in_range,
-                
+
                 "out_range": out_range,
-                
+
                 "in_v_chr_pos": in_v_chr_pos,
-                
+
                 "in_h_chr_pos": in_h_chr_pos,
-                
+
                 "out_v_chr_pos": out_v_chr_pos,
-                
+
                 "out_h_chr_pos": out_h_chr_pos,
-                
+
                 "force_original_aspect_ratio": force_original_aspect_ratio,
-                
+
                 "force_divisible_by": force_divisible_by,
-                
+
                 "param0": param0,
-                
+
                 "param1": param1,
-                
+
                 "eval": eval,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def scale2ref(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _ref: VideoStream,
-        
-    
+
+
 
 
     *,
     w: String = Default(None),h: String = Default(None),flags: String = Default(''),interl: Boolean = Default('false'),in_color_matrix: String| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default('auto'),out_color_matrix: String| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default(None),in_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),out_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),in_v_chr_pos: Int = Default('-513'),in_h_chr_pos: Int = Default('-513'),out_v_chr_pos: Int = Default('-513'),out_h_chr_pos: Int = Default('-513'),force_original_aspect_ratio: Int| Literal["disable","decrease","increase"] | Default = Default('disable'),force_divisible_by: Int = Default('1'),param0: Double = Default('DBL_MAX'),param1: Double = Default('DBL_MAX'),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> tuple[
-    
-        
+
+
             VideoStream,
-        
-    
-        
+
+
+
             VideoStream,
-        
-    
+
+
 ]:
         """
-        
+
 Scale (resize) the input video, based on a reference video.
 
 See the scale filter for available options, scale2ref supports the same but
@@ -18269,88 +18269,88 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#scale2ref)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='scale2ref', typings_input=('video', 'video'), typings_output=('video', 'video')),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _ref,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "flags": flags,
-                
+
                 "interl": interl,
-                
+
                 "in_color_matrix": in_color_matrix,
-                
+
                 "out_color_matrix": out_color_matrix,
-                
+
                 "in_range": in_range,
-                
+
                 "out_range": out_range,
-                
+
                 "in_v_chr_pos": in_v_chr_pos,
-                
+
                 "in_h_chr_pos": in_h_chr_pos,
-                
+
                 "out_v_chr_pos": out_v_chr_pos,
-                
+
                 "out_h_chr_pos": out_h_chr_pos,
-                
+
                 "force_original_aspect_ratio": force_original_aspect_ratio,
-                
+
                 "force_divisible_by": force_divisible_by,
-                
+
                 "param0": param0,
-                
+
                 "param1": param1,
-                
+
                 "eval": eval,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return (
-            
-                
+
+
                     filter_node.video(0),
-                
-            
-                
+
+
+
                     filter_node.video(1),
-                
-            
+
+
         )
 
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def scale_vaapi(
-    
+
     self,
 
 
@@ -18358,12 +18358,12 @@ References:
 
     *,
     w: String = Default('iw'),h: String = Default('ih'),format: String = Default(None),mode: Int| Literal["default","fast","hq","nl_anamorphic"] | Default = Default('hq'),out_color_matrix: String = Default(None),out_range: Int| Literal["full","limited","jpeg","mpeg","tv","pc"] | Default = Default('0'),out_color_primaries: String = Default(None),out_color_transfer: String = Default(None),out_chroma_location: String = Default(None),force_original_aspect_ratio: Int| Literal["disable","decrease","increase"] | Default = Default('disable'),force_divisible_by: Int = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Scale to/from VAAPI surfaces.
 
 
@@ -18388,57 +18388,57 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='scale_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "format": format,
-                
+
                 "mode": mode,
-                
+
                 "out_color_matrix": out_color_matrix,
-                
+
                 "out_range": out_range,
-                
+
                 "out_color_primaries": out_color_primaries,
-                
+
                 "out_color_transfer": out_color_transfer,
-                
+
                 "out_chroma_location": out_chroma_location,
-                
+
                 "force_original_aspect_ratio": force_original_aspect_ratio,
-                
+
                 "force_divisible_by": force_divisible_by,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def scdet(
-    
+
     self,
 
 
@@ -18446,12 +18446,12 @@ References:
 
     *,
     threshold: Double = Default('10'),sc_pass: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect video scene change.
 
 This filter sets frame metadata with mafd between frame, the scene score, and
@@ -18484,39 +18484,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#scdet)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='scdet', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold": threshold,
-                
+
                 "sc_pass": sc_pass,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def scharr(
-    
+
     self,
 
 
@@ -18524,15 +18524,15 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply scharr operator to input video stream.
 
 The filter accepts the following option:
@@ -18552,7 +18552,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#scharr)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -18560,38 +18560,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='scharr', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def scroll(
-    
+
     self,
 
 
@@ -18599,15 +18599,15 @@ References:
 
     *,
     horizontal: Float = Default('0'),vertical: Float = Default('0'),hpos: Float = Default('0'),vpos: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Scroll input video horizontally and/or vertically by constant speed.
 
 The filter accepts the following options:
@@ -18628,7 +18628,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#scroll)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -18636,40 +18636,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='scroll', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "horizontal": horizontal,
-                
+
                 "vertical": vertical,
-                
+
                 "hpos": hpos,
-                
+
                 "vpos": vpos,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def segment(
-    
+
     self,
 
 
@@ -18677,12 +18677,12 @@ References:
 
     *,
     timestamps: String = Default(None),frames: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Split single input stream into multiple streams.
 
 This filter does opposite of concat filters.
@@ -18705,40 +18705,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#segment)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='segment', typings_input=('video',), typings_output="[StreamType.video] * len((str(timestamps or frames)).split('|'))"),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "timestamps": timestamps,
-                
+
                 "frames": frames,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def select(
-    
+
     self,
 
 
@@ -18746,12 +18746,12 @@ References:
 
     *,
     expr: String = Default('1'),outputs: Int = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Select frames to pass in output.
 
 This filter accepts the following options:
@@ -18770,40 +18770,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#select)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='select', typings_input=('video',), typings_output='[StreamType.video] * int(outputs)'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "expr": expr,
-                
+
                 "outputs": outputs,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def selectivecolor(
-    
+
     self,
 
 
@@ -18811,15 +18811,15 @@ References:
 
     *,
     correction_method: Int| Literal["absolute","relative"] | Default = Default('absolute'),reds: String = Default(None),yellows: String = Default(None),greens: String = Default(None),cyans: String = Default(None),blues: String = Default(None),magentas: String = Default(None),whites: String = Default(None),neutrals: String = Default(None),blacks: String = Default(None),psfile: String = Default(None),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust cyan, magenta, yellow and black (CMYK) to certain ranges of colors (such
 as "reds", "yellows", "greens", "cyans", ...). The adjustment range is defined
 by the "purity" of the color (that is, how saturated it already is).
@@ -18851,7 +18851,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#selectivecolor)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -18859,54 +18859,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='selectivecolor', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "correction_method": correction_method,
-                
+
                 "reds": reds,
-                
+
                 "yellows": yellows,
-                
+
                 "greens": greens,
-                
+
                 "cyans": cyans,
-                
+
                 "blues": blues,
-                
+
                 "magentas": magentas,
-                
+
                 "whites": whites,
-                
+
                 "neutrals": neutrals,
-                
+
                 "blacks": blacks,
-                
+
                 "psfile": psfile,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def sendcmd(
-    
+
     self,
 
 
@@ -18914,12 +18914,12 @@ References:
 
     *,
     commands: String = Default(None),filename: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Send commands to filters in the filtergraph.
 
 These filters read commands to be sent to other filters in the
@@ -18948,52 +18948,52 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sendcmd)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sendcmd', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "commands": commands,
-                
+
                 "filename": filename,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def separatefields(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The separatefields takes a frame-based video input and splits
 each frame into its components fields, producing a new half height clip
 with twice the frame rate and twice the frame count.
@@ -19013,35 +19013,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#separatefields)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='separatefields', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def setdar(
-    
+
     self,
 
 
@@ -19049,12 +19049,12 @@ References:
 
     *,
     dar: String = Default('0'),max: Int = Default('100'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The setdar filter sets the Display Aspect Ratio for the filter
 output video.
 
@@ -19096,39 +19096,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setdar)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='setdar', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dar": dar,
-                
+
                 "max": max,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def setfield(
-    
+
     self,
 
 
@@ -19136,12 +19136,12 @@ References:
 
     *,
     mode: Int| Literal["auto","bff","tff","prog"] | Default = Default('auto'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Force field for the output video frame.
 
 The setfield filter marks the interlace type field for the
@@ -19163,37 +19163,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setfield)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='setfield', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def setparams(
-    
+
     self,
 
 
@@ -19201,12 +19201,12 @@ References:
 
     *,
     field_mode: Int| Literal["auto","bff","tff","prog"] | Default = Default('auto'),range: Int| Literal["auto","unspecified","unknown","limited","tv","mpeg","full","pc","jpeg"] | Default = Default('auto'),color_primaries: Int| Literal["auto","bt709","unknown","bt470m","bt470bg","smpte170m","smpte240m","film","bt2020","smpte428","smpte431","smpte432","jedec-p22","ebu3213"] | Default = Default('auto'),color_trc: Int| Literal["auto","bt709","unknown","bt470m","bt470bg","smpte170m","smpte240m","linear","log100","log316","iec61966-2-4","bt1361e","iec61966-2-1","bt2020-10","bt2020-12","smpte2084","smpte428","arib-std-b67"] | Default = Default('auto'),colorspace: Int| Literal["auto","gbr","bt709","unknown","fcc","bt470bg","smpte170m","smpte240m","ycgco","bt2020nc","bt2020c","smpte2085","chroma-derived-nc","chroma-derived-c","ictcp"] | Default = Default('auto'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Force frame parameter for the output video frame.
 
 The setparams filter marks interlace and color range for the
@@ -19230,45 +19230,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setparams)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='setparams', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "field_mode": field_mode,
-                
+
                 "range": range,
-                
+
                 "color_primaries": color_primaries,
-                
+
                 "color_trc": color_trc,
-                
+
                 "colorspace": colorspace,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def setpts(
-    
+
     self,
 
 
@@ -19276,12 +19276,12 @@ References:
 
     *,
     expr: String = Default('PTS'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Change the PTS (presentation timestamp) of the input frames.
 
 setpts works on video frames, asetpts on audio frames.
@@ -19300,37 +19300,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setpts)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='setpts', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "expr": expr,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def setrange(
-    
+
     self,
 
 
@@ -19338,12 +19338,12 @@ References:
 
     *,
     range: Int| Literal["auto","unspecified","unknown","limited","tv","mpeg","full","pc","jpeg"] | Default = Default('auto'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Force color range for the output video frame.
 
 The setrange filter marks the color range property for the
@@ -19365,37 +19365,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setrange)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='setrange', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "range": range,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def setsar(
-    
+
     self,
 
 
@@ -19403,12 +19403,12 @@ References:
 
     *,
     sar: String = Default('0'),max: Int = Default('100'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The setdar filter sets the Display Aspect Ratio for the filter
 output video.
 
@@ -19450,39 +19450,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setdar)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='setsar', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sar": sar,
-                
+
                 "max": max,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def settb(
-    
+
     self,
 
 
@@ -19490,12 +19490,12 @@ References:
 
     *,
     expr: String = Default('intb'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Set the timebase to use for the output frames timestamps.
 It is mainly useful for testing timebase configuration.
 
@@ -19513,37 +19513,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#settb)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='settb', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "expr": expr,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def sharpness_vaapi(
-    
+
     self,
 
 
@@ -19551,12 +19551,12 @@ References:
 
     *,
     sharpness: Int = Default('44'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 VAAPI VPP for sharpness
 
 
@@ -19571,37 +19571,37 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sharpness_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sharpness": sharpness,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def shear(
-    
+
     self,
 
 
@@ -19609,15 +19609,15 @@ References:
 
     *,
     shx: Float = Default('0'),shy: Float = Default('0'),fillcolor: String = Default('black'),interp: Int| Literal["nearest","bilinear"] | Default = Default('bilinear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply shear transform to input video.
 
 This filter supports the following options:
@@ -19638,7 +19638,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#shear)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -19646,46 +19646,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='shear', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "shx": shx,
-                
+
                 "shy": shy,
-                
+
                 "fillcolor": fillcolor,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def showinfo(
-    
+
     self,
 
 
@@ -19693,12 +19693,12 @@ References:
 
     *,
     checksum: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Show a line containing various information for each input video frame.
 The input video is not modified.
 
@@ -19716,37 +19716,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showinfo)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showinfo', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "checksum": checksum,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showpalette(
-    
+
     self,
 
 
@@ -19754,12 +19754,12 @@ References:
 
     *,
     s: Int = Default('30'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Displays the 256 colors palette of each frame. This filter is only relevant for
 pal8 pixel format frames.
 
@@ -19777,49 +19777,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showpalette)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showpalette', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "s": s,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def shuffleframes(
-    
+
     self,
 
 
@@ -19827,15 +19827,15 @@ References:
 
     *,
     mapping: String = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reorder and/or duplicate and/or drop video frames.
 
 It accepts the following parameters:
@@ -19853,7 +19853,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#shuffleframes)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -19861,34 +19861,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='shuffleframes', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mapping": mapping,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def shufflepixels(
-    
+
     self,
 
 
@@ -19896,15 +19896,15 @@ References:
 
     *,
     direction: Int| Literal["forward","inverse"] | Default = Default('forward'),mode: Int| Literal["horizontal","vertical","block"] | Default = Default('horizontal'),width: Int = Default('10'),height: Int = Default('10'),seed: Int64 = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reorder pixels in video frames.
 
 This filter accepts the following options:
@@ -19926,7 +19926,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#shufflepixels)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -19934,42 +19934,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='shufflepixels', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "direction": direction,
-                
+
                 "mode": mode,
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "seed": seed,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def shuffleplanes(
-    
+
     self,
 
 
@@ -19977,15 +19977,15 @@ References:
 
     *,
     map0: Int = Default('0'),map1: Int = Default('1'),map2: Int = Default('2'),map3: Int = Default('3'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reorder and/or duplicate video planes.
 
 It accepts the following parameters:
@@ -20006,7 +20006,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#shuffleplanes)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -20014,44 +20014,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='shuffleplanes', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "map0": map0,
-                
+
                 "map1": map1,
-                
+
                 "map2": map2,
-                
+
                 "map3": map3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def sidedata(
-    
+
     self,
 
 
@@ -20059,15 +20059,15 @@ References:
 
     *,
     mode: Int| Literal["select","delete"] | Default = Default('select'),type: Int| Literal["PANSCAN","A53_CC","STEREO3D","MATRIXENCODING","DOWNMIX_INFO","REPLAYGAIN","DISPLAYMATRIX","AFD","MOTION_VECTORS","SKIP_SAMPLES","AUDIO_SERVICE_TYPE","MASTERING_DISPLAY_METADATA","GOP_TIMECODE","SPHERICAL","CONTENT_LIGHT_LEVEL","ICC_PROFILE","S12M_TIMECOD","DYNAMIC_HDR_PLUS","REGIONS_OF_INTEREST","DETECTION_BOUNDING_BOXES","SEI_UNREGISTERED"] | Default = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Delete frame side data, or select frames based on it.
 
 This filter accepts the following options:
@@ -20086,7 +20086,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sidedata)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -20094,38 +20094,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sidedata', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def signalstats(
-    
+
     self,
 
 
@@ -20133,12 +20133,12 @@ References:
 
     *,
     stat: Flags| Literal["tout","vrep","brng"] | Default = Default('0'),out: Int| Literal["tout","vrep","brng"] | Default = Default('-1'),c: Color = Default('yellow'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Evaluate various visual metrics that assist in determining issues associated
 with the digitization of analog video media.
 
@@ -20158,51 +20158,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#signalstats)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='signalstats', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "stat": stat,
-                
+
                 "out": out,
-                
+
                 "c": c,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def siti(
-    
+
     self,
 
 
@@ -20210,12 +20210,12 @@ References:
 
     *,
     print_summary: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Calculate Spatial Information (SI) and Temporal Information (TI) scores for a video,
 as defined in ITU-T Rec. P.910 (11/21): Subjective video quality assessment methods
 for multimedia applications. Available PDF at https://www.itu.int/rec/T-REC-P.910-202111-S/en.
@@ -20236,37 +20236,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#siti)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='siti', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "print_summary": print_summary,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def smartblur(
-    
+
     self,
 
 
@@ -20274,15 +20274,15 @@ References:
 
     *,
     luma_radius: Float = Default('1'),luma_strength: Float = Default('1'),luma_threshold: Int = Default('0'),chroma_radius: Float = Default('-0.9'),chroma_strength: Float = Default('-2'),chroma_threshold: Int = Default('-31'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Blur the input video without impacting the outlines.
 
 It accepts the following options:
@@ -20305,7 +20305,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#smartblur)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -20313,48 +20313,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='smartblur', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_radius": luma_radius,
-                
+
                 "luma_strength": luma_strength,
-                
+
                 "luma_threshold": luma_threshold,
-                
+
                 "chroma_radius": chroma_radius,
-                
+
                 "chroma_strength": chroma_strength,
-                
+
                 "chroma_threshold": chroma_threshold,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def sobel(
-    
+
     self,
 
 
@@ -20362,15 +20362,15 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply sobel operator to input video stream.
 
 The filter accepts the following option:
@@ -20390,7 +20390,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sobel)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -20398,38 +20398,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sobel', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def sobel_opencl(
-    
+
     self,
 
 
@@ -20437,12 +20437,12 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply the Sobel operator (https://en.wikipedia.org/wiki/Sobel_operator) to input video stream.
 
 The filter accepts the following option:
@@ -20461,62 +20461,62 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sobel_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sobel_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def spectrumsynth(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _phase: VideoStream,
-        
-    
+
+
 
 
     *,
     sample_rate: Int = Default('44100'),channels: Int = Default('1'),scale: Int| Literal["lin","log"] | Default = Default('log'),slide: Int| Literal["replace","scroll","fullframe","rscroll"] | Default = Default('fullframe'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('rect'),overlap: Float = Default('1'),orientation: Int| Literal["vertical","horizontal"] | Default = Default('vertical'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Synthesize audio from 2 input video spectrums, first input stream represents
 magnitude across time and second represents phase across time.
 The filter will transform from frequency domain as displayed in videos back
@@ -20553,59 +20553,59 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#spectrumsynth)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='spectrumsynth', typings_input=('video', 'video'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _phase,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "sample_rate": sample_rate,
-                
+
                 "channels": channels,
-                
+
                 "scale": scale,
-                
+
                 "slide": slide,
-                
+
                 "win_func": win_func,
-                
+
                 "overlap": overlap,
-                
+
                 "orientation": orientation,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def split(
-    
+
     self,
 
 
@@ -20613,12 +20613,12 @@ References:
 
     *,
     outputs: Int = Default('2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Split input into several identical outputs.
 
 asplit works with audio input, split with video.
@@ -20639,38 +20639,38 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#split)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='split', typings_input=('video',), typings_output='[StreamType.video] * int(outputs)'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "outputs": outputs,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def spp(
-    
+
     self,
 
 
@@ -20678,15 +20678,15 @@ References:
 
     *,
     quality: Int = Default('3'),qp: Int = Default('0'),mode: Int| Literal["hard","soft"] | Default = Default('hard'),use_bframe_qp: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a simple postprocessing filter that compresses and decompresses the image
 at several (or - in the case of quality level 6 - all) shifts
 and average the results.
@@ -20709,7 +20709,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#spp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -20717,40 +20717,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='spp', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "quality": quality,
-                
+
                 "qp": qp,
-                
+
                 "mode": mode,
-                
+
                 "use_bframe_qp": use_bframe_qp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def sr(
-    
+
     self,
 
 
@@ -20758,12 +20758,12 @@ References:
 
     *,
     dnn_backend: Int = Default('1'),scale_factor: Int = Default('2'),model: String = Default(None),input: String = Default('x'),output: String = Default('y'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Scale the input by applying one of the super-resolution methods based on
 convolutional neural networks. Supported models:
 
@@ -20783,74 +20783,74 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sr)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sr', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dnn_backend": dnn_backend,
-                
+
                 "scale_factor": scale_factor,
-                
+
                 "model": model,
-                
+
                 "input": input,
-                
+
                 "output": output,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ssim(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the SSIM (Structural SImilarity Metric) between two input videos.
 
 This filter takes in input two input videos, the first input is
@@ -20880,7 +20880,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ssim)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -20891,70 +20891,70 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ssim', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "stats_file": stats_file,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ssim360(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),compute_chroma: Int = Default('1'),frame_skip_ratio: Int = Default('0'),ref_projection: Int| Literal["e","equirect","c3x2","c2x3","barrel","barrelsplit"] | Default = Default('e'),main_projection: Int| Literal["e","equirect","c3x2","c2x3","barrel","barrelsplit"] | Default = Default('5'),ref_stereo: Int| Literal["mono","tb","lr"] | Default = Default('mono'),main_stereo: Int| Literal["mono","tb","lr"] | Default = Default('3'),ref_pad: Float = Default('0'),main_pad: Float = Default('0'),use_tape: Int = Default('0'),heatmap_str: String = Default(None),default_heatmap_width: Int = Default('32'),default_heatmap_height: Int = Default('16'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Calculate the SSIM between two 360 video streams.
 
 
@@ -20982,7 +20982,7 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -20990,66 +20990,66 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ssim360', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "stats_file": stats_file,
-                
+
                 "compute_chroma": compute_chroma,
-                
+
                 "frame_skip_ratio": frame_skip_ratio,
-                
+
                 "ref_projection": ref_projection,
-                
+
                 "main_projection": main_projection,
-                
+
                 "ref_stereo": ref_stereo,
-                
+
                 "main_stereo": main_stereo,
-                
+
                 "ref_pad": ref_pad,
-                
+
                 "main_pad": main_pad,
-                
+
                 "use_tape": use_tape,
-                
+
                 "heatmap_str": heatmap_str,
-                
+
                 "default_heatmap_width": default_heatmap_width,
-                
+
                 "default_heatmap_height": default_heatmap_height,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def stereo3d(
-    
+
     self,
 
 
@@ -21057,12 +21057,12 @@ References:
 
     *,
     _in: Int| Literal["ab2l","tb2l","ab2r","tb2r","abl","tbl","abr","tbr","al","ar","sbs2l","sbs2r","sbsl","sbsr","irl","irr","icl","icr"] | Default = Default('sbsl'),out: Int| Literal["ab2l","tb2l","ab2r","tb2r","abl","tbl","abr","tbr","agmc","agmd","agmg","agmh","al","ar","arbg","arcc","arcd","arcg","arch","argg","aybc","aybd","aybg","aybh","irl","irr","ml","mr","sbs2l","sbs2r","sbsl","sbsr","chl","chr","icl","icr","hdmi"] | Default = Default('arcd'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert between different stereoscopic image formats.
 
 The filters accept the following options:
@@ -21080,45 +21080,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#stereo3d)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='stereo3d', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "in": _in,
-                
+
                 "out": out,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def subtitles(
-    
+
     self,
 
 
@@ -21126,12 +21126,12 @@ References:
 
     *,
     filename: String = Default(None),original_size: Image_size = Default(None),fontsdir: String = Default(None),alpha: Boolean = Default('false'),charenc: String = Default(None),stream_index: Int = Default('-1'),force_style: String = Default(None),wrap_unicode: Boolean = Default('auto'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw subtitles on top of input video using the libass library.
 
 To enable compilation of this filter you need to configure FFmpeg with
@@ -21160,64 +21160,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#subtitles)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='subtitles', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "filename": filename,
-                
+
                 "original_size": original_size,
-                
+
                 "fontsdir": fontsdir,
-                
+
                 "alpha": alpha,
-                
+
                 "charenc": charenc,
-                
+
                 "stream_index": stream_index,
-                
+
                 "force_style": force_style,
-                
+
                 "wrap_unicode": wrap_unicode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def super2xsai(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Scale the input by 2x and smooth using the Super2xSaI (Scale and
 Interpolate) pixel art scaling algorithm.
 
@@ -21234,39 +21234,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#super2xsai)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='super2xsai', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def swaprect(
-    
+
     self,
 
 
@@ -21274,15 +21274,15 @@ References:
 
     *,
     w: String = Default('w/2'),h: String = Default('h/2'),x1: String = Default('w/2'),y1: String = Default('h/2'),x2: String = Default('0'),y2: String = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Swap two rectangular objects in video.
 
 This filter accepts the following options:
@@ -21305,7 +21305,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#swaprect)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -21313,60 +21313,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='swaprect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "x1": x1,
-                
+
                 "y1": y1,
-                
+
                 "x2": x2,
-                
+
                 "y2": y2,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def swapuv(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Swap U & V plane.
 
 
@@ -21381,7 +21381,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#swapuv)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -21389,32 +21389,32 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='swapuv', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tblend(
-    
+
     self,
 
 
@@ -21422,15 +21422,15 @@ References:
 
     *,
     c0_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c1_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c2_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c3_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),all_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('-1'),c0_expr: String = Default(None),c1_expr: String = Default(None),c2_expr: String = Default(None),c3_expr: String = Default(None),all_expr: String = Default(None),c0_opacity: Double = Default('1'),c1_opacity: Double = Default('1'),c2_opacity: Double = Default('1'),c3_opacity: Double = Default('1'),all_opacity: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Blend successive video frames.
 
 See blend
@@ -21462,7 +21462,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tblend)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -21470,62 +21470,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tblend', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "c0_mode": c0_mode,
-                
+
                 "c1_mode": c1_mode,
-                
+
                 "c2_mode": c2_mode,
-                
+
                 "c3_mode": c3_mode,
-                
+
                 "all_mode": all_mode,
-                
+
                 "c0_expr": c0_expr,
-                
+
                 "c1_expr": c1_expr,
-                
+
                 "c2_expr": c2_expr,
-                
+
                 "c3_expr": c3_expr,
-                
+
                 "all_expr": all_expr,
-                
+
                 "c0_opacity": c0_opacity,
-                
+
                 "c1_opacity": c1_opacity,
-                
+
                 "c2_opacity": c2_opacity,
-                
+
                 "c3_opacity": c3_opacity,
-                
+
                 "all_opacity": all_opacity,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def telecine(
-    
+
     self,
 
 
@@ -21533,12 +21533,12 @@ References:
 
     *,
     first_field: Int| Literal["top","t","bottom","b"] | Default = Default('top'),pattern: String = Default('23'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply telecine process to the video.
 
 This filter accepts the following options:
@@ -21556,43 +21556,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#telecine)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='telecine', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "first_field": first_field,
-                
+
                 "pattern": pattern,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def thistogram(
-    
+
     self,
 
 
@@ -21600,12 +21600,12 @@ References:
 
     *,
     width: Int = Default('0'),display_mode: Int| Literal["overlay","parade","stack"] | Default = Default('stack'),levels_mode: Int| Literal["linear","logarithmic"] | Default = Default('linear'),components: Int = Default('7'),bgopacity: Float = Default('0.9'),envelope: Boolean = Default('false'),ecolor: Color = Default('gold'),slide: Int| Literal["frame","replace","scroll","rscroll","picture"] | Default = Default('replace'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Compute and draw a color distribution histogram for the input video across time.
 
 Unlike histogram video filter which only shows histogram of single input frame
@@ -21636,83 +21636,83 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#thistogram)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='thistogram', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "width": width,
-                
+
                 "display_mode": display_mode,
-                
+
                 "levels_mode": levels_mode,
-                
+
                 "components": components,
-                
+
                 "bgopacity": bgopacity,
-                
+
                 "envelope": envelope,
-                
+
                 "ecolor": ecolor,
-                
+
                 "slide": slide,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def threshold(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _threshold: VideoStream,
-        
-    
-        
+
+
+
         _min: VideoStream,
-        
-    
-        
+
+
+
         _max: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply threshold effect to video stream.
 
 This filter needs four video streams to perform thresholding.
@@ -21735,7 +21735,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#threshold)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -21743,50 +21743,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='threshold', typings_input=('video', 'video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _threshold,
-                
-            
-                
+
+
+
                 _min,
-                
-            
-                
+
+
+
                 _max,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def thumbnail(
-    
+
     self,
 
 
@@ -21794,15 +21794,15 @@ References:
 
     *,
     n: Int = Default('100'),log: Int| Literal["quiet","info","verbose"] | Default = Default('info'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Select the most representative frame in a given sequence of consecutive frames.
 
 The filter accepts the following options:
@@ -21821,7 +21821,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#thumbnail)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -21829,36 +21829,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='thumbnail', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "n": n,
-                
+
                 "log": log,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tile(
-    
+
     self,
 
 
@@ -21866,12 +21866,12 @@ References:
 
     *,
     layout: Image_size = Default('6x5'),nb_frames: Int = Default('0'),margin: Int = Default('0'),padding: Int = Default('0'),color: Color = Default('black'),overlap: Int = Default('0'),init_padding: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Tile several successive frames together.
 
 The untile filter can do the reverse.
@@ -21896,51 +21896,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tile)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tile', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "layout": layout,
-                
+
                 "nb_frames": nb_frames,
-                
+
                 "margin": margin,
-                
+
                 "padding": padding,
-                
+
                 "color": color,
-                
+
                 "overlap": overlap,
-                
+
                 "init_padding": init_padding,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def tinterlace(
-    
+
     self,
 
 
@@ -21948,12 +21948,12 @@ References:
 
     *,
     mode: Int| Literal["merge","drop_even","drop_odd","pad","interleave_top","interleave_bottom","interlacex2","mergex2"] | Default = Default('merge'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Perform various types of temporal field interlacing.
 
 Frames are counted starting from 1, so the first input frame is
@@ -21973,37 +21973,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tinterlace)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tinterlace', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tlut2(
-    
+
     self,
 
 
@@ -22011,15 +22011,15 @@ References:
 
     *,
     c0: String = Default('x'),c1: String = Default('x'),c2: String = Default('x'),c3: String = Default('x'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The lut2 filter takes two input streams and outputs one
 stream.
 
@@ -22044,7 +22044,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut2)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -22052,40 +22052,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tlut2', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "c0": c0,
-                
+
                 "c1": c1,
-                
+
                 "c2": c2,
-                
+
                 "c3": c3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tmedian(
-    
+
     self,
 
 
@@ -22093,15 +22093,15 @@ References:
 
     *,
     radius: Int = Default('1'),planes: Int = Default('15'),percentile: Float = Default('0.5'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pick median pixels from several successive input video frames.
 
 The filter accepts the following options:
@@ -22121,7 +22121,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tmedian)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -22129,38 +22129,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tmedian', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "radius": radius,
-                
+
                 "planes": planes,
-                
+
                 "percentile": percentile,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tmidequalizer(
-    
+
     self,
 
 
@@ -22168,15 +22168,15 @@ References:
 
     *,
     radius: Int = Default('5'),sigma: Float = Default('0.5'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Temporal Midway Video Equalization effect.
 
 Midway Video Equalization adjusts a sequence of video frames to have the same
@@ -22200,7 +22200,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tmidequalizer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -22208,38 +22208,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tmidequalizer', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "radius": radius,
-                
+
                 "sigma": sigma,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tmix(
-    
+
     self,
 
 
@@ -22247,15 +22247,15 @@ References:
 
     *,
     frames: Int = Default('3'),weights: String = Default('1 1 1'),scale: Float = Default('0'),planes: Flags = Default('F'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Mix successive video frames.
 
 A description of the accepted options follows.
@@ -22276,7 +22276,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tmix)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -22284,40 +22284,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tmix', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frames": frames,
-                
+
                 "weights": weights,
-                
+
                 "scale": scale,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tonemap(
-    
+
     self,
 
 
@@ -22325,12 +22325,12 @@ References:
 
     *,
     tonemap: Int| Literal["none","linear","gamma","clip","reinhard","hable","mobius"] | Default = Default('none'),param: Double = Default('nan'),desat: Double = Default('2'),peak: Double = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Tone map colors from different dynamic ranges.
 
 This filter expects data in single precision floating point, as it needs to
@@ -22359,43 +22359,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tonemap)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tonemap', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "tonemap": tonemap,
-                
+
                 "param": param,
-                
+
                 "desat": desat,
-                
+
                 "peak": peak,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tonemap_opencl(
-    
+
     self,
 
 
@@ -22403,12 +22403,12 @@ References:
 
     *,
     tonemap: Int| Literal["none","linear","gamma","clip","reinhard","hable","mobius"] | Default = Default('none'),transfer: Int| Literal["bt709","bt2020"] | Default = Default('bt709'),matrix: Int| Literal["bt709","bt2020"] | Default = Default('-1'),primaries: Int| Literal["bt709","bt2020"] | Default = Default('-1'),range: Int| Literal["tv","pc","limited","full"] | Default = Default('-1'),format: Pix_fmt = Default('none'),peak: Double = Default('0'),param: Double = Default('nan'),desat: Double = Default('0.5'),threshold: Double = Default('0.2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Perform HDR(PQ/HLG) to SDR conversion with tone-mapping.
 
 It accepts the following parameters:
@@ -22434,55 +22434,55 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tonemap_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tonemap_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "tonemap": tonemap,
-                
+
                 "transfer": transfer,
-                
+
                 "matrix": matrix,
-                
+
                 "primaries": primaries,
-                
+
                 "range": range,
-                
+
                 "format": format,
-                
+
                 "peak": peak,
-                
+
                 "param": param,
-                
+
                 "desat": desat,
-                
+
                 "threshold": threshold,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tonemap_vaapi(
-    
+
     self,
 
 
@@ -22490,12 +22490,12 @@ References:
 
     *,
     format: String = Default(None),matrix: String = Default(None),primaries: String = Default(None),transfer: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Perform HDR(High Dynamic Range) to SDR(Standard Dynamic Range) conversion with tone-mapping.
 It maps the dynamic range of HDR10 content to the SDR content.
 It currently only accepts HDR10 as input.
@@ -22517,43 +22517,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tonemap_vaapi)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tonemap_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "format": format,
-                
+
                 "matrix": matrix,
-                
+
                 "primaries": primaries,
-                
+
                 "transfer": transfer,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tpad(
-    
+
     self,
 
 
@@ -22561,12 +22561,12 @@ References:
 
     *,
     start: Int = Default('0'),stop: Int = Default('0'),start_mode: Int| Literal["add","clone"] | Default = Default('add'),stop_mode: Int| Literal["add","clone"] | Default = Default('add'),start_duration: Duration = Default('0'),stop_duration: Duration = Default('0'),color: Color = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Temporarily pad video frames.
 
 The filter accepts the following options:
@@ -22589,49 +22589,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tpad)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tpad', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "start": start,
-                
+
                 "stop": stop,
-                
+
                 "start_mode": start_mode,
-                
+
                 "stop_mode": stop_mode,
-                
+
                 "start_duration": start_duration,
-                
+
                 "stop_duration": stop_duration,
-                
+
                 "color": color,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def transpose(
-    
+
     self,
 
 
@@ -22639,12 +22639,12 @@ References:
 
     *,
     dir: Int| Literal["cclock_flip","clock","cclock","clock_flip"] | Default = Default('cclock_flip'),passthrough: Int| Literal["none","portrait","landscape"] | Default = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Transpose rows with columns in the input video and optionally flip it.
 
 It accepts the following parameters:
@@ -22662,39 +22662,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#transpose)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='transpose', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dir": dir,
-                
+
                 "passthrough": passthrough,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def transpose_opencl(
-    
+
     self,
 
 
@@ -22702,12 +22702,12 @@ References:
 
     *,
     dir: Int| Literal["cclock_flip","clock","cclock","clock_flip"] | Default = Default('cclock_flip'),passthrough: Int| Literal["none","portrait","landscape"] | Default = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Transpose input video
 
 
@@ -22723,39 +22723,39 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='transpose_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dir": dir,
-                
+
                 "passthrough": passthrough,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def transpose_vaapi(
-    
+
     self,
 
 
@@ -22763,12 +22763,12 @@ References:
 
     *,
     dir: Int| Literal["cclock_flip","clock","cclock","clock_flip","reversal","hflip","vflip"] | Default = Default('cclock_flip'),passthrough: Int| Literal["none","portrait","landscape"] | Default = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 VAAPI VPP for transpose
 
 
@@ -22784,43 +22784,43 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='transpose_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dir": dir,
-                
+
                 "passthrough": passthrough,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def trim(
-    
+
     self,
 
 
@@ -22828,12 +22828,12 @@ References:
 
     *,
     start: Duration = Default('INT64_MAX'),end: Duration = Default('INT64_MAX'),start_pts: Int64 = Default('I64_MIN'),end_pts: Int64 = Default('I64_MIN'),duration: Duration = Default('0'),start_frame: Int64 = Default('-1'),end_frame: Int64 = Default('I64_MAX'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Trim the input so that the output contains one continuous subpart of the input.
 
 It accepts the following parameters:
@@ -22856,51 +22856,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#trim)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='trim', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "start": start,
-                
+
                 "end": end,
-                
+
                 "start_pts": start_pts,
-                
+
                 "end_pts": end_pts,
-                
+
                 "duration": duration,
-                
+
                 "start_frame": start_frame,
-                
+
                 "end_frame": end_frame,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def unsharp(
-    
+
     self,
 
 
@@ -22908,15 +22908,15 @@ References:
 
     *,
     luma_msize_x: Int = Default('5'),luma_msize_y: Int = Default('5'),luma_amount: Float = Default('1'),chroma_msize_x: Int = Default('5'),chroma_msize_y: Int = Default('5'),chroma_amount: Float = Default('0'),alpha_msize_x: Int = Default('5'),alpha_msize_y: Int = Default('5'),alpha_amount: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Sharpen or blur the input video.
 
 It accepts the following parameters:
@@ -22942,7 +22942,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#unsharp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -22950,50 +22950,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='unsharp', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_msize_x": luma_msize_x,
-                
+
                 "luma_msize_y": luma_msize_y,
-                
+
                 "luma_amount": luma_amount,
-                
+
                 "chroma_msize_x": chroma_msize_x,
-                
+
                 "chroma_msize_y": chroma_msize_y,
-                
+
                 "chroma_amount": chroma_amount,
-                
+
                 "alpha_msize_x": alpha_msize_x,
-                
+
                 "alpha_msize_y": alpha_msize_y,
-                
+
                 "alpha_amount": alpha_amount,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def unsharp_opencl(
-    
+
     self,
 
 
@@ -23001,12 +23001,12 @@ References:
 
     *,
     luma_msize_x: Float = Default('5'),luma_msize_y: Float = Default('5'),luma_amount: Float = Default('1'),chroma_msize_x: Float = Default('5'),chroma_msize_y: Float = Default('5'),chroma_amount: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Sharpen or blur the input video.
 
 It accepts the following parameters:
@@ -23028,47 +23028,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#unsharp_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='unsharp_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_msize_x": luma_msize_x,
-                
+
                 "luma_msize_y": luma_msize_y,
-                
+
                 "luma_amount": luma_amount,
-                
+
                 "chroma_msize_x": chroma_msize_x,
-                
+
                 "chroma_msize_y": chroma_msize_y,
-                
+
                 "chroma_amount": chroma_amount,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def untile(
-    
+
     self,
 
 
@@ -23076,12 +23076,12 @@ References:
 
     *,
     layout: Image_size = Default('6x5'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Decompose a video made of tiled images into the individual images.
 
 The frame rate of the output video is the frame rate of the input video
@@ -23103,37 +23103,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#untile)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='untile', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "layout": layout,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def uspp(
-    
+
     self,
 
 
@@ -23141,15 +23141,15 @@ References:
 
     *,
     quality: Int = Default('3'),qp: Int = Default('0'),use_bframe_qp: Boolean = Default('false'),codec: String = Default('snow'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply ultra slow/simple postprocessing filter that compresses and decompresses
 the image at several (or - in the case of quality level 8 - all)
 shifts and average the results.
@@ -23178,7 +23178,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#uspp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -23186,40 +23186,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='uspp', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "quality": quality,
-                
+
                 "qp": qp,
-                
+
                 "use_bframe_qp": use_bframe_qp,
-                
+
                 "codec": codec,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def v360(
-    
+
     self,
 
 
@@ -23227,12 +23227,12 @@ References:
 
     *,
     input: Int| Literal["e","equirect","c3x2","c6x1","eac","dfisheye","flat","rectilinear","gnomonic","barrel","fb","c1x6","sg","mercator","ball","hammer","sinusoidal","fisheye","pannini","cylindrical","tetrahedron","barrelsplit","tsp","hequirect","he","equisolid","og","octahedron","cylindricalea"] | Default = Default('e'),output: Int| Literal["e","equirect","c3x2","c6x1","eac","dfisheye","flat","rectilinear","gnomonic","barrel","fb","c1x6","sg","mercator","ball","hammer","sinusoidal","fisheye","pannini","cylindrical","perspective","tetrahedron","barrelsplit","tsp","hequirect","he","equisolid","og","octahedron","cylindricalea"] | Default = Default('c3x2'),interp: Int| Literal["near","nearest","line","linear","lagrange9","cube","cubic","lanc","lanczos","sp16","spline16","gauss","gaussian","mitchell"] | Default = Default('line'),w: Int = Default('0'),h: Int = Default('0'),in_stereo: Int| Literal["2d","sbs","tb"] | Default = Default('2d'),out_stereo: Int| Literal["2d","sbs","tb"] | Default = Default('2d'),in_forder: String = Default('rludfb'),out_forder: String = Default('rludfb'),in_frot: String = Default('000000'),out_frot: String = Default('000000'),in_pad: Float = Default('0'),out_pad: Float = Default('0'),fin_pad: Int = Default('0'),fout_pad: Int = Default('0'),yaw: Float = Default('0'),pitch: Float = Default('0'),roll: Float = Default('0'),rorder: String = Default('ypr'),h_fov: Float = Default('0'),v_fov: Float = Default('0'),d_fov: Float = Default('0'),h_flip: Boolean = Default('false'),v_flip: Boolean = Default('false'),d_flip: Boolean = Default('false'),ih_flip: Boolean = Default('false'),iv_flip: Boolean = Default('false'),in_trans: Boolean = Default('false'),out_trans: Boolean = Default('false'),ih_fov: Float = Default('0'),iv_fov: Float = Default('0'),id_fov: Float = Default('0'),h_offset: Float = Default('0'),v_offset: Float = Default('0'),alpha_mask: Boolean = Default('false'),reset_rot: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert 360 videos between various formats.
 
 The filter accepts the following options:
@@ -23284,107 +23284,107 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#v360)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='v360', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "input": input,
-                
+
                 "output": output,
-                
+
                 "interp": interp,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "in_stereo": in_stereo,
-                
+
                 "out_stereo": out_stereo,
-                
+
                 "in_forder": in_forder,
-                
+
                 "out_forder": out_forder,
-                
+
                 "in_frot": in_frot,
-                
+
                 "out_frot": out_frot,
-                
+
                 "in_pad": in_pad,
-                
+
                 "out_pad": out_pad,
-                
+
                 "fin_pad": fin_pad,
-                
+
                 "fout_pad": fout_pad,
-                
+
                 "yaw": yaw,
-                
+
                 "pitch": pitch,
-                
+
                 "roll": roll,
-                
+
                 "rorder": rorder,
-                
+
                 "h_fov": h_fov,
-                
+
                 "v_fov": v_fov,
-                
+
                 "d_fov": d_fov,
-                
+
                 "h_flip": h_flip,
-                
+
                 "v_flip": v_flip,
-                
+
                 "d_flip": d_flip,
-                
+
                 "ih_flip": ih_flip,
-                
+
                 "iv_flip": iv_flip,
-                
+
                 "in_trans": in_trans,
-                
+
                 "out_trans": out_trans,
-                
+
                 "ih_fov": ih_fov,
-                
+
                 "iv_fov": iv_fov,
-                
+
                 "id_fov": id_fov,
-                
+
                 "h_offset": h_offset,
-                
+
                 "v_offset": v_offset,
-                
+
                 "alpha_mask": alpha_mask,
-                
+
                 "reset_rot": reset_rot,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vaguedenoiser(
-    
+
     self,
 
 
@@ -23392,15 +23392,15 @@ References:
 
     *,
     threshold: Float = Default('2'),method: Int| Literal["hard","soft","garrote"] | Default = Default('garrote'),nsteps: Int = Default('6'),percent: Float = Default('85'),planes: Int = Default('15'),type: Int| Literal["universal","bayes"] | Default = Default('universal'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a wavelet based denoiser.
 
 It transforms each frame from the video input into the wavelet domain,
@@ -23429,7 +23429,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vaguedenoiser)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -23437,73 +23437,73 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vaguedenoiser', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold": threshold,
-                
+
                 "method": method,
-                
+
                 "nsteps": nsteps,
-                
+
                 "percent": percent,
-                
+
                 "planes": planes,
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def varblur(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _radius: VideoStream,
-        
-    
+
+
 
 
     *,
     min_r: Int = Default('0'),max_r: Int = Default('8'),planes: Int = Default('15'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply variable blur filter by using 2nd video stream to set blur radius.
 The 2nd stream must have the same dimensions.
 
@@ -23525,7 +23525,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#varblur)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -23536,48 +23536,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='varblur', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _radius,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "min_r": min_r,
-                
+
                 "max_r": max_r,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vectorscope(
-    
+
     self,
 
 
@@ -23585,12 +23585,12 @@ References:
 
     *,
     mode: Int| Literal["gray","tint","color","color2","color3","color4","color5"] | Default = Default('gray'),x: Int = Default('1'),y: Int = Default('2'),intensity: Float = Default('0.004'),envelope: Int| Literal["none","instant","peak","peak+instant"] | Default = Default('none'),graticule: Int| Literal["none","green","color","invert"] | Default = Default('none'),opacity: Float = Default('0.75'),flags: Flags| Literal["white","black","name"] | Default = Default('name'),bgopacity: Float = Default('0.3'),lthreshold: Float = Default('0'),hthreshold: Float = Default('1'),colorspace: Int| Literal["auto","601","709"] | Default = Default('auto'),tint0: Float = Default('0'),tint1: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Display 2 color component values in the two dimensional graph (which is called
 a vectorscope).
 
@@ -23621,79 +23621,79 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vectorscope)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vectorscope', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "intensity": intensity,
-                
+
                 "envelope": envelope,
-                
+
                 "graticule": graticule,
-                
+
                 "opacity": opacity,
-                
+
                 "flags": flags,
-                
+
                 "bgopacity": bgopacity,
-                
+
                 "lthreshold": lthreshold,
-                
+
                 "hthreshold": hthreshold,
-                
+
                 "colorspace": colorspace,
-                
+
                 "tint0": tint0,
-                
+
                 "tint1": tint1,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vflip(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Flip the input video vertically.
 
 For example, to vertically flip a video with ffmpeg:
@@ -23713,7 +23713,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vflip)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -23721,45 +23721,45 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vflip', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vfrdet(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect variable frame rate video.
 
 This filter tries to detect if the input is variable or constant frame rate.
@@ -23780,35 +23780,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vfrdet)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vfrdet', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vibrance(
-    
+
     self,
 
 
@@ -23816,15 +23816,15 @@ References:
 
     *,
     intensity: Float = Default('0'),rbal: Float = Default('1'),gbal: Float = Default('1'),bbal: Float = Default('1'),rlum: Float = Default('0.072186'),glum: Float = Default('0.715158'),blum: Float = Default('0.212656'),alternate: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Boost or alter saturation.
 
 The filter accepts the following options:
@@ -23849,7 +23849,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vibrance)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -23857,50 +23857,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vibrance', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "intensity": intensity,
-                
+
                 "rbal": rbal,
-                
+
                 "gbal": gbal,
-                
+
                 "bbal": bbal,
-                
+
                 "rlum": rlum,
-                
+
                 "glum": glum,
-                
+
                 "blum": blum,
-                
+
                 "alternate": alternate,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def vidstabdetect(
-    
+
     self,
 
 
@@ -23908,12 +23908,12 @@ References:
 
     *,
     result: String = Default('transforms.trf'),shakiness: Int = Default('5'),accuracy: Int = Default('15'),stepsize: Int = Default('6'),mincontrast: Double = Default('0.25'),show: Int = Default('0'),tripod: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Analyze video stabilization/deshaking. Perform pass 1 of 2, see
 vidstabtransform for pass 2.
 
@@ -23944,49 +23944,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vidstabdetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vidstabdetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "result": result,
-                
+
                 "shakiness": shakiness,
-                
+
                 "accuracy": accuracy,
-                
+
                 "stepsize": stepsize,
-                
+
                 "mincontrast": mincontrast,
-                
+
                 "show": show,
-                
+
                 "tripod": tripod,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vidstabtransform(
-    
+
     self,
 
 
@@ -23994,12 +23994,12 @@ References:
 
     *,
     input: String = Default('transforms.trf'),smoothing: Int = Default('15'),optalgo: Int| Literal["opt","gauss","avg"] | Default = Default('opt'),maxshift: Int = Default('-1'),maxangle: Double = Default('-1'),crop: Int| Literal["keep","black"] | Default = Default('keep'),invert: Int = Default('0'),relative: Int = Default('1'),zoom: Double = Default('0'),optzoom: Int = Default('1'),zoomspeed: Double = Default('0.25'),interpol: Int| Literal["no","linear","bilinear","bicubic"] | Default = Default('bilinear'),tripod: Boolean = Default('false'),debug: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Video stabilization/deshaking: pass 2 of 2,
 see vidstabdetect for pass 1.
 
@@ -24037,92 +24037,92 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vidstabtransform)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vidstabtransform', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "input": input,
-                
+
                 "smoothing": smoothing,
-                
+
                 "optalgo": optalgo,
-                
+
                 "maxshift": maxshift,
-                
+
                 "maxangle": maxangle,
-                
+
                 "crop": crop,
-                
+
                 "invert": invert,
-                
+
                 "relative": relative,
-                
+
                 "zoom": zoom,
-                
+
                 "optzoom": optzoom,
-                
+
                 "zoomspeed": zoomspeed,
-                
+
                 "interpol": interpol,
-                
+
                 "tripod": tripod,
-                
+
                 "debug": debug,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vif(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the average VIF (Visual Information Fidelity) between two input videos.
 
 This filter takes two input videos.
@@ -24159,7 +24159,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vif)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -24170,42 +24170,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vif', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vignette(
-    
+
     self,
 
 
@@ -24213,15 +24213,15 @@ References:
 
     *,
     angle: String = Default('PI/5'),x0: String = Default('w/2'),y0: String = Default('h/2'),mode: Int| Literal["forward","backward"] | Default = Default('forward'),eval: Int| Literal["init","frame"] | Default = Default('init'),dither: Boolean = Default('true'),aspect: Rational = Default('1/1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Make or reverse a natural vignetting effect.
 
 The filter accepts the following options:
@@ -24245,7 +24245,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vignette)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -24253,48 +24253,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vignette', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "angle": angle,
-                
+
                 "x0": x0,
-                
+
                 "y0": y0,
-                
+
                 "mode": mode,
-                
+
                 "eval": eval,
-                
+
                 "dither": dither,
-                
+
                 "aspect": aspect,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def vmafmotion(
-    
+
     self,
 
 
@@ -24302,12 +24302,12 @@ References:
 
     *,
     stats_file: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the average VMAF motion score of a video.
 It is one of the component metrics of VMAF.
 
@@ -24327,45 +24327,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vmafmotion)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vmafmotion', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "stats_file": stats_file,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def w3fdif(
-    
+
     self,
 
 
@@ -24373,15 +24373,15 @@ References:
 
     *,
     filter: Int| Literal["simple","complex"] | Default = Default('complex'),mode: Int| Literal["frame","field"] | Default = Default('field'),parity: Int| Literal["tff","bff","auto"] | Default = Default('auto'),deint: Int| Literal["all","interlaced"] | Default = Default('all'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlace the input video ("w3fdif" stands for "Weston 3 Field
 Deinterlacing Filter").
 
@@ -24414,7 +24414,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#w3fdif)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -24422,40 +24422,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='w3fdif', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "filter": filter,
-                
+
                 "mode": mode,
-                
+
                 "parity": parity,
-                
+
                 "deint": deint,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def waveform(
-    
+
     self,
 
 
@@ -24463,12 +24463,12 @@ References:
 
     *,
     mode: Int| Literal["row","column"] | Default = Default('column'),intensity: Float = Default('0.04'),mirror: Boolean = Default('true'),display: Int| Literal["overlay","stack","parade"] | Default = Default('stack'),components: Int = Default('1'),envelope: Int| Literal["none","instant","peak","peak+instant"] | Default = Default('none'),filter: Int| Literal["lowpass","flat","aflat","chroma","color","acolor","xflat","yflat"] | Default = Default('lowpass'),graticule: Int| Literal["none","green","orange","invert"] | Default = Default('none'),opacity: Float = Default('0.75'),flags: Flags| Literal["numbers","dots"] | Default = Default('numbers'),scale: Int| Literal["digital","millivolts","ire"] | Default = Default('digital'),bgopacity: Float = Default('0.75'),tint0: Float = Default('0'),tint1: Float = Default('0'),fitmode: Int| Literal["none","size"] | Default = Default('none'),input: Int| Literal["all","first"] | Default = Default('first'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Video waveform monitor.
 
 The waveform monitor plots color component intensity. By default luma
@@ -24504,67 +24504,67 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#waveform)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='waveform', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "intensity": intensity,
-                
+
                 "mirror": mirror,
-                
+
                 "display": display,
-                
+
                 "components": components,
-                
+
                 "envelope": envelope,
-                
+
                 "filter": filter,
-                
+
                 "graticule": graticule,
-                
+
                 "opacity": opacity,
-                
+
                 "flags": flags,
-                
+
                 "scale": scale,
-                
+
                 "bgopacity": bgopacity,
-                
+
                 "tint0": tint0,
-                
+
                 "tint1": tint1,
-                
+
                 "fitmode": fitmode,
-                
+
                 "input": input,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def weave(
-    
+
     self,
 
 
@@ -24572,12 +24572,12 @@ References:
 
     *,
     first_field: Int| Literal["top","t","bottom","b"] | Default = Default('top'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The weave takes a field-based video input and join
 each two sequential fields into single frame, producing a new double
 height clip with half the frame rate and half the frame count.
@@ -24599,37 +24599,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#weave)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='weave', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "first_field": first_field,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def xbr(
-    
+
     self,
 
 
@@ -24637,12 +24637,12 @@ References:
 
     *,
     n: Int = Default('3'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply the xBR high-quality magnification filter which is designed for pixel
 art. It follows a set of edge-detection rules, see
 https://forums.libretro.com/t/xbr-algorithm-tutorial/123.
@@ -24661,66 +24661,66 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xbr)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='xbr', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "n": n,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def xcorrelate(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _secondary: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('7'),secondary: Int| Literal["first","all"] | Default = Default('all'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply normalized cross-correlation between first and second input video stream.
 
 Second input video stream dimensions must be lower than first input video stream.
@@ -24742,7 +24742,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xcorrelate)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -24753,67 +24753,67 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='xcorrelate', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _secondary,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "secondary": secondary,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def xfade(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _xfade: VideoStream,
-        
-    
+
+
 
 
     *,
     transition: Int| Literal["custom","fade","wipeleft","wiperight","wipeup","wipedown","slideleft","slideright","slideup","slidedown","circlecrop","rectcrop","distance","fadeblack","fadewhite","radial","smoothleft","smoothright","smoothup","smoothdown","circleopen","circleclose","vertopen","vertclose","horzopen","horzclose","dissolve","pixelize","diagtl","diagtr","diagbl","diagbr","hlslice","hrslice","vuslice","vdslice","hblur","fadegrays","wipetl","wipetr","wipebl","wipebr","squeezeh","squeezev","zoomin","fadefast","fadeslow","hlwind","hrwind","vuwind","vdwind","coverleft","coverright","coverup","coverdown","revealleft","revealright","revealup","revealdown"] | Default = Default('fade'),duration: Duration = Default('1'),offset: Duration = Default('0'),expr: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply cross fade from one input video stream to another input video stream.
 The cross fade is applied for specified duration.
 
@@ -24837,72 +24837,72 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xfade)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='xfade', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _xfade,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "transition": transition,
-                
+
                 "duration": duration,
-                
+
                 "offset": offset,
-                
+
                 "expr": expr,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def xfade_opencl(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _xfade: VideoStream,
-        
-    
+
+
 
 
     *,
     transition: Int| Literal["custom","fade","wipeleft","wiperight","wipeup","wipedown","slideleft","slideright","slideup","slidedown"] | Default = Default('fade'),source: String = Default(None),kernel: String = Default(None),duration: Duration = Default('1'),offset: Duration = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Cross fade two videos with custom transition effect by using OpenCL.
 
 It accepts the following options:
@@ -24923,59 +24923,59 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xfade_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='xfade_opencl', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _xfade,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "transition": transition,
-                
+
                 "source": source,
-                
+
                 "kernel": kernel,
-                
+
                 "duration": duration,
-                
+
                 "offset": offset,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def yadif(
-    
+
     self,
 
 
@@ -24983,15 +24983,15 @@ References:
 
     *,
     mode: Int| Literal["send_frame","send_field","send_frame_nospatial","send_field_nospatial"] | Default = Default('send_frame'),parity: Int| Literal["tff","bff","auto"] | Default = Default('auto'),deint: Int| Literal["all","interlaced"] | Default = Default('all'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlace the input video ("yadif" means "yet another deinterlacing
 filter").
 
@@ -25012,7 +25012,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#yadif)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -25020,38 +25020,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='yadif', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "parity": parity,
-                
+
                 "deint": deint,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def yaepblur(
-    
+
     self,
 
 
@@ -25059,15 +25059,15 @@ References:
 
     *,
     radius: Int = Default('3'),planes: Int = Default('1'),sigma: Int = Default('128'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply blur filter while preserving edges ("yaepblur" means "yet another edge preserving blur filter").
 The algorithm is described in
 "J. S. Lee, Digital image enhancement and noise filtering by use of local statistics, IEEE Trans. Pattern Anal. Mach. Intell. PAMI-2, 1980."
@@ -25089,7 +25089,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#yaepblur)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -25097,40 +25097,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='yaepblur', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "radius": radius,
-                
+
                 "planes": planes,
-                
+
                 "sigma": sigma,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def zmq(
-    
+
     self,
 
 
@@ -25138,12 +25138,12 @@ References:
 
     *,
     bind_address: String = Default('tcp://*:5555'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Receive commands sent through a libzmq client, and forward them to
 filters in the filtergraph.
 
@@ -25202,39 +25202,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#zmq)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='zmq', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "bind_address": bind_address,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def zoompan(
-    
+
     self,
 
 
@@ -25242,12 +25242,12 @@ References:
 
     *,
     zoom: String = Default('1'),x: String = Default('0'),y: String = Default('0'),d: String = Default('90'),s: Image_size = Default('hd720'),fps: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Zoom & Pan effect.
 
 This filter accepts the following options:
@@ -25269,47 +25269,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#zoompan)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='zoompan', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "zoom": zoom,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "d": d,
-                
+
                 "s": s,
-                
+
                 "fps": fps,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def zscale(
-    
+
     self,
 
 
@@ -25317,12 +25317,12 @@ References:
 
     *,
     w: String = Default(None),h: String = Default(None),size: String = Default(None),dither: Int| Literal["none","ordered","random","error_diffusion"] | Default = Default('none'),filter: Int| Literal["point","bilinear","bicubic","spline16","spline36","lanczos"] | Default = Default('bilinear'),out_range: Int| Literal["input","limited","full","unknown","tv","pc"] | Default = Default('input'),primaries: Int| Literal["input","709","unspecified","170m","240m","2020","unknown","bt709","bt470m","bt470bg","smpte170m","smpte240m","film","bt2020","smpte428","smpte431","smpte432","jedec-p22","ebu3213"] | Default = Default('input'),transfer: Int| Literal["input","709","unspecified","601","linear","2020_10","2020_12","unknown","bt470m","bt470bg","smpte170m","smpte240m","bt709","log100","log316","bt2020-10","bt2020-12","smpte2084","iec61966-2-4","iec61966-2-1","arib-std-b67"] | Default = Default('input'),matrix: Int| Literal["input","709","unspecified","470bg","170m","2020_ncl","2020_cl","unknown","gbr","bt709","fcc","bt470bg","smpte170m","smpte240m","ycgco","bt2020nc","bt2020c","chroma-derived-nc","chroma-derived-c","ictcp"] | Default = Default('input'),in_range: Int| Literal["input","limited","full","unknown","tv","pc"] | Default = Default('input'),primariesin: Int| Literal["input","709","unspecified","170m","240m","2020","unknown","bt709","bt470m","bt470bg","smpte170m","smpte240m","film","bt2020","smpte428","smpte431","smpte432","jedec-p22","ebu3213"] | Default = Default('input'),transferin: Int| Literal["input","709","unspecified","601","linear","2020_10","2020_12","unknown","bt470m","bt470bg","smpte170m","smpte240m","bt709","log100","log316","bt2020-10","bt2020-12","smpte2084","iec61966-2-4","iec61966-2-1","arib-std-b67"] | Default = Default('input'),matrixin: Int| Literal["input","709","unspecified","470bg","170m","2020_ncl","2020_cl","unknown","gbr","bt709","fcc","bt470bg","smpte170m","smpte240m","ycgco","bt2020nc","bt2020c","chroma-derived-nc","chroma-derived-c","ictcp"] | Default = Default('input'),chromal: Int| Literal["input","left","center","topleft","top","bottomleft","bottom"] | Default = Default('input'),chromalin: Int| Literal["input","left","center","topleft","top","bottomleft","bottom"] | Default = Default('input'),npl: Double = Default('nan'),agamma: Boolean = Default('true'),param_a: Double = Default('nan'),param_b: Double = Default('nan'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Scale (resize) the input video, using the z.lib library:
 https://github.com/sekrit-twc/zimg. To enable compilation of this
 filter, you need to configure FFmpeg with --enable-libzimg.
@@ -25364,65 +25364,61 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#zscale)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='zscale', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "size": size,
-                
+
                 "dither": dither,
-                
+
                 "filter": filter,
-                
+
                 "out_range": out_range,
-                
+
                 "primaries": primaries,
-                
+
                 "transfer": transfer,
-                
+
                 "matrix": matrix,
-                
+
                 "in_range": in_range,
-                
+
                 "primariesin": primariesin,
-                
+
                 "transferin": transferin,
-                
+
                 "matrixin": matrixin,
-                
+
                 "chromal": chromal,
-                
+
                 "chromalin": chromalin,
-                
+
                 "npl": npl,
-                
+
                 "agamma": agamma,
-                
+
                 "param_a": param_a,
-                
+
                 "param_b": param_b,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
-
-
-        
-    

--- a/packages/v7/pyproject.toml
+++ b/packages/v7/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = ["ffmpeg-core>=1.0.0a1,<2.0"]
 ffmpeg-core = { workspace = true }
 
 [project.optional-dependencies]
-dev = ["pytest>=7.0", "pytest-cov>=4.0", "syrupy>=5.0", "ruff>=0.9.6"]
+dev = ["pytest>=7.0", "pytest-cov>=4.0", "syrupy>=5.0", "ruff==0.12.2"]
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/packages/v7/src/ffmpeg/codecs/decoders.py
+++ b/packages/v7/src/ffmpeg/codecs/decoders.py
@@ -450,295 +450,295 @@ from ..streams.audio import AudioStream
 
 
 def _012v(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed 4:2:2 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def _4xm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     4X Movie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def _8bps(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QuickTime 8BPS video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def aasc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Autodesk RLE
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def agm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Amuse Graphics Movie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def aic(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Apple Intermediate Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def alias_pix(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Alias/Wavefront PIX image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def amv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AMV Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def anm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Deluxe Paint Animation
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ansi(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ASCII/ANSI art
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def apng(
-    
+
 ) -> FFMpegDecoderOption:
     """
     APNG (Animated Portable Network Graphics) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def arbc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Gryphon's Anim Compressor
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def argo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Argonaut Games Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def asv1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ASUS V1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def asv2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ASUS V2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def aura(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Auravision AURA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def aura2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Auravision Aura 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def libdav1d(
-    
+
     tilethreads: int | None = None,
-    
+
     framethreads: int | None = None,
-    
+
     max_frame_delay: int | None = None,
-    
+
     filmgrain: bool | None = None,
-    
+
     oppoint: int | None = None,
-    
+
     alllayers: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     dav1d AV1 decoder by VideoLAN (codec av1)
-    
+
     Args:
         tilethreads: Tile threads (from 0 to 256) (default 0)
         framethreads: Frame threads (from 0 to 256) (default 0)
@@ -751,31 +751,31 @@ def libdav1d(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "tilethreads": tilethreads,
-        
+
         "framethreads": framethreads,
-        
+
         "max_frame_delay": max_frame_delay,
-        
+
         "filmgrain": filmgrain,
-        
+
         "oppoint": oppoint,
-        
+
         "alllayers": alllayers,
-        
+
     }))
 
 
 
 def av1(
-    
+
     operating_point: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Alliance for Open Media AV1
-    
+
     Args:
         operating_point: Select an operating point of the scalable bitstream (from 0 to 31) (default 0)
 
@@ -783,651 +783,651 @@ def av1(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "operating_point": operating_point,
-        
+
     }))
 
 
 
 def avrn(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Avid AVI Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def avrp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Avid 1:1 10-bit RGB Packer
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def avs(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AVS (Audio Video Standard) video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def avui(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Avid Meridien Uncompressed
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bethsoftvid(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bethesda VID video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bfi(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Brute Force & Ignorance
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def binkvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bink video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bintext(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Binary text
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bitpacked(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bitpacked
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bmp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     BMP (Windows and OS/2 bitmap)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bmv_video(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Discworld II BMV video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def brender_pix(
-    
+
 ) -> FFMpegDecoderOption:
     """
     BRender PIX image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def c93(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Interplay C93
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cavs(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Chinese AVS (Audio Video Standard) (AVS1-P2, JiZhun profile)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cdgraphics(
-    
+
 ) -> FFMpegDecoderOption:
     """
     CD Graphics video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cdtoons(
-    
+
 ) -> FFMpegDecoderOption:
     """
     CDToons video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cdxl(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Commodore CDXL video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cfhd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     GoPro CineForm HD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cinepak(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Cinepak
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def clearvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Iterated Systems ClearVideo
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cljr(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Cirrus Logic AccuPak
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cllc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Canopus Lossless Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def eacmv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Electronic Arts CMV video (codec cmv)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cpia(
-    
+
 ) -> FFMpegDecoderOption:
     """
     CPiA video format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cri(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Cintel RAW
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def camstudio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     CamStudio (codec cscd)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cyuv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Creative YUV (CYUV)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dds(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DirectDraw Surface image decoder
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dfa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Chronomaster DFA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dirac(
-    
+
 ) -> FFMpegDecoderOption:
     """
     BBC Dirac VC-2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dnxhd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     VC3/DNxHD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dpx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPX (Digital Picture Exchange) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dsicinvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Delphine Software International CIN video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dvvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DV (Digital Video)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dxa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Feeble Files/ScummVM DXA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dxtory(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Dxtory
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dxv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Resolume DXV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def escape124(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Escape 124
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def escape130(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Escape 130
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def exr(
-    
+
     layer: str | None = None,
-    
+
     part: int | None = None,
-    
+
     gamma: float | None = None,
-    
+
     apply_trc: int | None| Literal["bt709", "gamma", "gamma22", "gamma28", "smpte170m", "smpte240m", "linear", "log", "log_sqrt", "iec61966_2_4", "bt1361", "iec61966_2_1", "bt2020_10bit", "bt2020_12bit", "smpte2084", "smpte428_1"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     OpenEXR image
-    
+
     Args:
         layer: Set the decoding layer (default "")
         part: Set the decoding part (from 0 to INT_MAX) (default 0)
@@ -1438,59 +1438,59 @@ def exr(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "layer": layer,
-        
+
         "part": part,
-        
+
         "gamma": gamma,
-        
+
         "apply_trc": apply_trc,
-        
+
     }))
 
 
 
 def ffv1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     FFmpeg video codec #1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ffvhuff(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Huffyuv FFmpeg variant
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def fic(
-    
+
     skip_cursor: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Mirillis FIC
-    
+
     Args:
         skip_cursor: skip the cursor (default false)
 
@@ -1498,21 +1498,21 @@ def fic(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "skip_cursor": skip_cursor,
-        
+
     }))
 
 
 
 def fits(
-    
+
     blank_value: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Flexible Image Transport System
-    
+
     Args:
         blank_value: value that is used to replace BLANK pixels in data array (from 0 to 65535) (default 0)
 
@@ -1520,117 +1520,117 @@ def fits(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "blank_value": blank_value,
-        
+
     }))
 
 
 
 def flashsv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Flash Screen Video v1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def flashsv2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Flash Screen Video v2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def flic(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Autodesk Animator Flic video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def flv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     FLV / Sorenson Spark / Sorenson H.263 (Flash Video) (codec flv1)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def fmvc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     FM Screen Capture Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def fraps(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Fraps
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def frwu(
-    
+
     change_field_order: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Forward Uncompressed
-    
+
     Args:
         change_field_order: Change field order (default false)
 
@@ -1638,69 +1638,69 @@ def frwu(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "change_field_order": change_field_order,
-        
+
     }))
 
 
 
 def g2m(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Go2Meeting
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def gdv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Gremlin Digital Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def gem(
-    
+
 ) -> FFMpegDecoderOption:
     """
     GEM Raster image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def gif(
-    
+
     trans_color: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     GIF (Graphics Interchange Format)
-    
+
     Args:
         trans_color: color value (ARGB) that is used instead of transparent color (from 0 to UINT32_MAX) (default 16777215)
 
@@ -1708,55 +1708,55 @@ def gif(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "trans_color": trans_color,
-        
+
     }))
 
 
 
 def h261(
-    
+
 ) -> FFMpegDecoderOption:
     """
     H.261
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def h263(
-    
+
 ) -> FFMpegDecoderOption:
     """
     H.263 / H.263-1996, H.263+ / H.263-1998 / H.263 version 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def h263_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem H.263 decoder wrapper (codec h263)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -1765,65 +1765,65 @@ def h263_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def h263i(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Intel H.263
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def h263p(
-    
+
 ) -> FFMpegDecoderOption:
     """
     H.263 / H.263-1996, H.263+ / H.263-1998 / H.263 version 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def h264(
-    
+
     is_avc: bool | None = None,
-    
+
     nal_length_size: int | None = None,
-    
+
     enable_er: bool | None = None,
-    
+
     x264_build: int | None = None,
-    
+
     skip_gray: bool | None = None,
-    
+
     noref_gray: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10
-    
+
     Args:
         is_avc: is avc (default false)
         nal_length_size: nal_length_size (from 0 to 4) (default 0)
@@ -1836,33 +1836,33 @@ def h264(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "is_avc": is_avc,
-        
+
         "nal_length_size": nal_length_size,
-        
+
         "enable_er": enable_er,
-        
+
         "x264_build": x264_build,
-        
+
         "skip_gray": skip_gray,
-        
+
         "noref_gray": noref_gray,
-        
+
     }))
 
 
 
 def h264_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem H.264 decoder wrapper (codec h264)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -1871,63 +1871,63 @@ def h264_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def hap(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Vidvox Hap
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hdr(
-    
+
 ) -> FFMpegDecoderOption:
     """
     HDR (Radiance RGBE format) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hevc(
-    
+
     apply_defdispwin: bool | None = None,
-    
+
     strict_displaywin: bool | None = None,
-    
+
     view_ids: int | None = None,
-    
+
     view_ids_available: int | None = None,
-    
+
     view_pos_available: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     HEVC (High Efficiency Video Coding)
-    
+
     Args:
         apply_defdispwin: Apply default display window from VUI (default false)
         strict_displaywin: stricly apply default display window size (default false)
@@ -1939,31 +1939,31 @@ def hevc(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "apply_defdispwin": apply_defdispwin,
-        
+
         "strict-displaywin": strict_displaywin,
-        
+
         "view_ids": view_ids,
-        
+
         "view_ids_available": view_ids_available,
-        
+
         "view_pos_available": view_pos_available,
-        
+
     }))
 
 
 
 def hevc_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem HEVC decoder wrapper (codec hevc)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -1972,279 +1972,279 @@ def hevc_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def hnm4video(
-    
+
 ) -> FFMpegDecoderOption:
     """
     HNM 4 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hq_hqa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Canopus HQ/HQA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hqx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Canopus HQX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def huffyuv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Huffyuv / HuffYUV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hymt(
-    
+
 ) -> FFMpegDecoderOption:
     """
     HuffYUV MT
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def idcinvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     id Quake II CIN video (codec idcin)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def idf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     iCEDraw text
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def iff(
-    
+
 ) -> FFMpegDecoderOption:
     """
     IFF ACBM/ANIM/DEEP/ILBM/PBM/RGB8/RGBN (codec iff_ilbm)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def imm4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Infinity IMM4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def imm5(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Infinity IMM5
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def indeo2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Intel Indeo 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def indeo3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Intel Indeo 3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def indeo4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Intel Indeo Video Interactive 4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def indeo5(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Intel Indeo Video Interactive 5
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def interplayvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Interplay MVE video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ipu(
-    
+
 ) -> FFMpegDecoderOption:
     """
     IPU Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def jpeg2000(
-    
+
     lowres: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     JPEG 2000
-    
+
     Args:
         lowres: Lower the decoding resolution by a power of two (from 0 to 33) (default 0)
 
@@ -2252,245 +2252,245 @@ def jpeg2000(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "lowres": lowres,
-        
+
     }))
 
 
 
 def jpegls(
-    
+
 ) -> FFMpegDecoderOption:
     """
     JPEG-LS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def jv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bitmap Brothers JV video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def kgv1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Kega Game Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def kmvc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Karl Morton's video codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def lagarith(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Lagarith lossless
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def lead(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LEAD MCMP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def loco(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LOCO
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def lscr(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LEAD Screen Capture
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def m101(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Matrox Uncompressed SD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def eamad(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Electronic Arts Madcow Video (codec mad)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def magicyuv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MagicYUV video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mdec(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sony PlayStation MDEC (Motion DECoder)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def media100(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Media 100
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mimic(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Mimic
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mjpeg(
-    
+
     extern_huff: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     MJPEG (Motion JPEG)
-    
+
     Args:
         extern_huff: Use external huffman table. (default false)
 
@@ -2498,103 +2498,103 @@ def mjpeg(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "extern_huff": extern_huff,
-        
+
     }))
 
 
 
 def mjpegb(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Apple MJPEG-B
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mmvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     American Laser Games MM Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mobiclip(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MobiClip Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def motionpixels(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Motion Pixels video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpeg1video(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-1 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpeg1_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem MPEG1 decoder wrapper (codec mpeg1video)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -2603,23 +2603,23 @@ def mpeg1_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def mpeg2video(
-    
+
     cc_format: int | None| Literal["auto", "a53", "scte20", "dvd"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-2 video
-    
+
     Args:
         cc_format: extract a specific Closed Captions format (from 0 to 3) (default auto)
 
@@ -2627,39 +2627,39 @@ def mpeg2video(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "cc_format": cc_format,
-        
+
     }))
 
 
 
 def mpegvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-1 video (codec mpeg2video)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpeg2_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem MPEG2 decoder wrapper (codec mpeg2video)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -2668,41 +2668,41 @@ def mpeg2_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def mpeg4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-4 part 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpeg4_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem MPEG4 decoder wrapper (codec mpeg4)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -2711,519 +2711,519 @@ def mpeg4_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def msa1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MS ATC Screen
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mscc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Mandsoft Screen Capture Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msmpeg4v1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-4 part 2 Microsoft variant version 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msmpeg4v2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-4 part 2 Microsoft variant version 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msmpeg4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-4 part 2 Microsoft variant version 3 (codec msmpeg4v3)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msp2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Microsoft Paint (MSP) version 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msrle(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Microsoft RLE
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mss1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MS Screen 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mss2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MS Windows Media Video V9 Screen
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msvideo1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Microsoft Video 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mszh(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LCL (LossLess Codec Library) MSZH
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mts2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MS Expression Encoder Screen
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mv30(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MidiVid 3.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mvc1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Silicon Graphics Motion Video Compressor 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mvc2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Silicon Graphics Motion Video Compressor 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mvdv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MidiVid VQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mvha(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MidiVid Archive Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mwsc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MatchWare Screen Capture Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mxpeg(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Mobotix MxPEG video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def notchlc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     NotchLC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def nuv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     NuppelVideo/RTJPEG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def paf_video(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Amazing Studio Packed Animation File Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pam(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PAM (Portable AnyMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pbm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PBM (Portable BitMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PC Paintbrush PCX image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pdv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PDV (PlayDate Video)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pfm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PFM (Portable FloatMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pgm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PGM (Portable GrayMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pgmyuv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PGMYUV (Portable GrayMap YUV) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pgx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PGX (JPEG2000 Test Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def phm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PHM (Portable HalfFloatMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def photocd(
-    
+
     lowres: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Kodak Photo CD
-    
+
     Args:
         lowres: Lower the decoding resolution by a power of two (from 0 to 4) (default 0)
 
@@ -3231,245 +3231,245 @@ def photocd(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "lowres": lowres,
-        
+
     }))
 
 
 
 def pictor(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Pictor/PC Paint
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pixlet(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Apple Pixlet
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def png(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PNG (Portable Network Graphics) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ppm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PPM (Portable PixelMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def prores(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Apple ProRes (iCodec Pro)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def prosumer(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Brooktree ProSumer Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def psd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Photoshop PSD file
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ptx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     V.Flash PTX image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qdraw(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Apple QuickDraw
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qoi(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QOI (Quite OK Image format) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qpeg(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Q-team QPEG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qtrle(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QuickTime Animation (RLE) video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def r10k(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AJA Kona 10-bit RGB Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def r210(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed RGB 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rasc(
-    
+
     skip_cursor: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     RemotelyAnywhere Screen Capture
-    
+
     Args:
         skip_cursor: skip the cursor (default false)
 
@@ -3477,21 +3477,21 @@ def rasc(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "skip_cursor": skip_cursor,
-        
+
     }))
 
 
 
 def rawvideo(
-    
+
     top: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     raw video
-    
+
     Args:
         top: top field first (default auto)
 
@@ -3499,585 +3499,585 @@ def rawvideo(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "top": top,
-        
+
     }))
 
 
 
 def rl2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RL2 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def roqvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     id RoQ video (codec roq)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rpza(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QuickTime video (RPZA)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rscc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     innoHeim/Rsupport Screen Capture Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rtv1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RTV1 (RivaTuner Video)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rv10(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealVideo 1.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rv20(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealVideo 2.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rv30(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealVideo 3.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rv40(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealVideo 4.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sanm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LucasArts SANM/Smush video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def scpr(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ScreenPressor
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def screenpresso(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Screenpresso
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sga(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Digital Pictures SGA Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sgi(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SGI image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sgirle(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Silicon Graphics RLE 8-bit video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sheervideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     BitJazz SheerVideo
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def simbiosis_imx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Simbiosis Interactive IMX Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def smackvid(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Smacker video (codec smackvideo)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def smc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QuickTime Graphics (SMC)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def smvjpeg(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SMV JPEG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def snow(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Snow
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sp5x(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sunplus JPEG (SP5X)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def speedhq(
-    
+
 ) -> FFMpegDecoderOption:
     """
     NewTek SpeedHQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def srgc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Screen Recorder Gold Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sunrast(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sun Rasterfile image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def svq1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sorenson Vector Quantizer 1 / Sorenson Video 1 / SVQ1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def svq3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sorenson Vector Quantizer 3 / Sorenson Video 3 / SVQ3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def targa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Truevision Targa image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def targa_y216(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Pinnacle TARGA CineWave YUV16
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def tdsc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     TDSC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def eatgq(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Electronic Arts TGQ video (codec tgq)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def eatgv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Electronic Arts TGV video (codec tgv)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def theora(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Theora
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def thp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Nintendo Gamecube THP video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def tiertexseqvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Tiertex Limited SEQ video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def tiff(
-    
+
     subimage: bool | None = None,
-    
+
     thumbnail: bool | None = None,
-    
+
     page: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     TIFF image
-    
+
     Args:
         subimage: decode subimage instead if available (default false)
         thumbnail: decode embedded thumbnail subimage instead if available (default false)
@@ -4087,185 +4087,185 @@ def tiff(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "subimage": subimage,
-        
+
         "thumbnail": thumbnail,
-        
+
         "page": page,
-        
+
     }))
 
 
 
 def tmv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     8088flex TMV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def eatqi(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Electronic Arts TQI Video (codec tqi)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def truemotion1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Duck TrueMotion 1.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def truemotion2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Duck TrueMotion 2.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def truemotion2rt(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Duck TrueMotion 2.0 Real Time
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def camtasia(
-    
+
 ) -> FFMpegDecoderOption:
     """
     TechSmith Screen Capture Codec (codec tscc)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def tscc2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     TechSmith Screen Codec 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def txd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Renderware TXD (TeXture Dictionary) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ultimotion(
-    
+
 ) -> FFMpegDecoderOption:
     """
     IBM UltiMotion (codec ulti)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def utvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Ut Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def v210(
-    
+
     custom_stride: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed 4:2:2 10-bit
-    
+
     Args:
         custom_stride: Custom V210 stride (from -1 to INT_MAX) (default 0)
 
@@ -4273,151 +4273,151 @@ def v210(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "custom_stride": custom_stride,
-        
+
     }))
 
 
 
 def v210x(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed 4:2:2 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def v308(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed packed 4:4:4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def v408(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed packed QT 4:4:4:4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def v410(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed 4:4:4 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vb(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Beam Software VB
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vble(
-    
+
 ) -> FFMpegDecoderOption:
     """
     VBLE Lossless Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vbn(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Vizrt Binary Image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vc1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SMPTE VC-1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vc1_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem VC1 decoder wrapper (codec vc1)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -4426,265 +4426,265 @@ def vc1_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def vc1image(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Video 9 Image v2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vcr1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATI VCR1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xl(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Miro VideoXL (codec vixl)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vmdvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sierra VMD video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vmix(
-    
+
 ) -> FFMpegDecoderOption:
     """
     vMix Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vmnc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     VMware Screen Codec / VMware Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vnull(
-    
+
 ) -> FFMpegDecoderOption:
     """
     null video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp5(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP5
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp6(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP6
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp6a(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP6 (Flash version, with alpha channel)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp6f(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP6 (Flash version)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp7(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP7
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp8(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP8
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp8_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem VP8 decoder wrapper (codec vp8)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -4693,57 +4693,57 @@ def vp8_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def libvpx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     libvpx VP8 (codec vp8)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp9(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Google VP9
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp9_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem VP9 decoder wrapper (codec vp9)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -4752,473 +4752,473 @@ def vp9_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def vqc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ViewQuest VQC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vvc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     VVC (Versatile Video Coding)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wbmp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     WBMP (Wireless Application Protocol Bitmap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wcmv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     WinCAM Motion Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def webp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     WebP image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmv1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Video 7
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmv2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Video 8
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmv3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Video 9
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmv3image(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Video 9 Image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wnv1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Winnov WNV1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wrapped_avframe(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AVPacket to AVFrame passthrough
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vqavideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Westwood Studios VQA (Vector Quantized Animation) video (codec ws_vqa)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xan_wc3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Wing Commander III / Xan
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xan_wc4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Wing Commander IV / Xxan
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xbin(
-    
+
 ) -> FFMpegDecoderOption:
     """
     eXtended BINary text
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xbm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     XBM (X BitMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xface(
-    
+
 ) -> FFMpegDecoderOption:
     """
     X-face image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xpm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     XPM (X PixMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xwd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     XWD (X Window Dump) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def y41p(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed YUV 4:1:1 12-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ylc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     YUY2 Lossless Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def yop(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Psygnosis YOP Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def yuv4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed packed 4:2:0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def zerocodec(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ZeroCodec Lossless Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def zlib(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LCL (LossLess Codec Library) ZLIB
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def zmbv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Zip Motion Blocks Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def _8svx_exp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     8SVX exponential
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def _8svx_fib(
-    
+
 ) -> FFMpegDecoderOption:
     """
     8SVX fibonacci
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def aac(
-    
+
     dual_mono_mode: int | None| Literal["auto", "main", "sub", "both"] = None,
-    
+
     channel_order: int | None| Literal["default", "coded"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     AAC (Advanced Audio Coding)
-    
+
     Args:
         dual_mono_mode: Select the channel to decode for dual mono (from -1 to 2) (default auto)
         channel_order: Order in which the channels are to be exported (from 0 to 1) (default default)
@@ -5227,25 +5227,25 @@ def aac(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "dual_mono_mode": dual_mono_mode,
-        
+
         "channel_order": channel_order,
-        
+
     }))
 
 
 
 def aac_fixed(
-    
+
     dual_mono_mode: int | None| Literal["auto", "main", "sub", "both"] = None,
-    
+
     channel_order: int | None| Literal["default", "coded"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     AAC (Advanced Audio Coding) (codec aac)
-    
+
     Args:
         dual_mono_mode: Select the channel to decode for dual mono (from -1 to 2) (default auto)
         channel_order: Order in which the channels are to be exported (from 0 to 1) (default default)
@@ -5254,47 +5254,47 @@ def aac_fixed(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "dual_mono_mode": dual_mono_mode,
-        
+
         "channel_order": channel_order,
-        
+
     }))
 
 
 
 def aac_latm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AAC LATM (Advanced Audio Coding LATM syntax)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ac3(
-    
+
     cons_noisegen: bool | None = None,
-    
+
     drc_scale: float | None = None,
-    
+
     heavy_compr: bool | None = None,
-    
+
     target_level: int | None = None,
-    
+
     downmix: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATSC A/52A (AC-3)
-    
+
     Args:
         cons_noisegen: enable consistent noise generation (default false)
         drc_scale: percentage of dynamic range compression to apply (from 0 to 6) (default 1)
@@ -5306,35 +5306,35 @@ def ac3(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "cons_noisegen": cons_noisegen,
-        
+
         "drc_scale": drc_scale,
-        
+
         "heavy_compr": heavy_compr,
-        
+
         "target_level": target_level,
-        
+
         "downmix": downmix,
-        
+
     }))
 
 
 
 def ac3_fixed(
-    
+
     cons_noisegen: bool | None = None,
-    
+
     drc_scale: float | None = None,
-    
+
     heavy_compr: bool | None = None,
-    
+
     downmix: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATSC A/52A (AC-3) (codec ac3)
-    
+
     Args:
         cons_noisegen: enable consistent noise generation (default false)
         drc_scale: percentage of dynamic range compression to apply (from 0 to 6) (default 1)
@@ -5345,251 +5345,251 @@ def ac3_fixed(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "cons_noisegen": cons_noisegen,
-        
+
         "drc_scale": drc_scale,
-        
+
         "heavy_compr": heavy_compr,
-        
+
         "downmix": downmix,
-        
+
     }))
 
 
 
 def adpcm_4xm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM 4X Movie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_adx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SEGA CRI ADX ADPCM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_afc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Nintendo Gamecube AFC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_agm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM AmuseGraphics Movie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_aica(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Yamaha AICA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_argo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Argonaut Games
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ct(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Creative Technology
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_dtk(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Nintendo Gamecube DTK
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ea(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Electronic Arts
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ea_maxis_xa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Electronic Arts Maxis CDROM XA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ea_r1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Electronic Arts R1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ea_r2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Electronic Arts R2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ea_r3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Electronic Arts R3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ea_xas(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Electronic Arts XAS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def g722(
-    
+
     bits_per_codeword: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     G.722 ADPCM (codec adpcm_g722)
-    
+
     Args:
         bits_per_codeword: Bits per G722 codeword (from 6 to 8) (default 8)
 
@@ -5597,613 +5597,613 @@ def g722(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "bits_per_codeword": bits_per_codeword,
-        
+
     }))
 
 
 
 def g726(
-    
+
 ) -> FFMpegDecoderOption:
     """
     G.726 ADPCM (codec adpcm_g726)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def g726le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     G.726 ADPCM little-endian (codec adpcm_g726le)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_acorn(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Acorn Replay
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_alp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA High Voltage Software ALP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_amv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA AMV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_apc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA CRYO APC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_apm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Ubisoft APM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_cunning(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Cunning Developments
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_dat4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Eurocom DAT4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_dk3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Duck DK3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_dk4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Duck DK4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_ea_eacs(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Electronic Arts EACS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_ea_sead(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Electronic Arts SEAD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_iss(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Funcom ISS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_moflex(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA MobiClip MOFLEX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_mtf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Capcom's MT Framework
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_oki(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Dialogic OKI
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_qt(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA QuickTime
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_rad(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Radical
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_smjpeg(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Loki SDL MJPEG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_ssi(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Simon & Schuster Interactive
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_wav(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA WAV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_ws(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Westwood
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ms(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Microsoft
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_mtaf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM MTAF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_psx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Playstation
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_sbpro_2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Sound Blaster Pro 2-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_sbpro_3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Sound Blaster Pro 2.6-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_sbpro_4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Sound Blaster Pro 4-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_swf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Shockwave Flash
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_thp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Nintendo THP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_thp_le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Nintendo THP (little-endian)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_vima(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LucasArts VIMA audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_xa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM CDROM XA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_xmd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Konami XMD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_yamaha(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Yamaha
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_zork(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Zork
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def alac(
-    
+
     extra_bits_bug: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     ALAC (Apple Lossless Audio Codec)
-    
+
     Args:
         extra_bits_bug: Force non-standard decoding process (default false)
 
@@ -6211,117 +6211,117 @@ def alac(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "extra_bits_bug": extra_bits_bug,
-        
+
     }))
 
 
 
 def amrnb(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AMR-NB (Adaptive Multi-Rate NarrowBand) (codec amr_nb)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def libopencore_amrnb(
-    
+
 ) -> FFMpegDecoderOption:
     """
     OpenCORE AMR-NB (Adaptive Multi-Rate Narrow-Band) (codec amr_nb)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def amrwb(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AMR-WB (Adaptive Multi-Rate WideBand) (codec amr_wb)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def libopencore_amrwb(
-    
+
 ) -> FFMpegDecoderOption:
     """
     OpenCORE AMR-WB (Adaptive Multi-Rate Wide-Band) (codec amr_wb)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def anull(
-    
+
 ) -> FFMpegDecoderOption:
     """
     null audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def apac(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Marian's A-pac audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ape(
-    
+
     max_samples: int | None| Literal["all"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Monkey's Audio
-    
+
     Args:
         max_samples: maximum number of samples decoded per call (from 1 to INT_MAX) (default 4608)
 
@@ -6329,309 +6329,309 @@ def ape(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "max_samples": max_samples,
-        
+
     }))
 
 
 
 def aptx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     aptX (Audio Processing Technology for Bluetooth)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def aptx_hd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     aptX HD (Audio Processing Technology for Bluetooth)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def atrac1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATRAC1 (Adaptive TRansform Acoustic Coding)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def atrac3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATRAC3 (Adaptive TRansform Acoustic Coding 3)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def atrac3al(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATRAC3 AL (Adaptive TRansform Acoustic Coding 3 Advanced Lossless)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def atrac3plus(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATRAC3+ (Adaptive TRansform Acoustic Coding 3+) (codec atrac3p)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def atrac3plusal(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATRAC3+ AL (Adaptive TRansform Acoustic Coding 3+ Advanced Lossless) (codec atrac3pal)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def atrac9(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATRAC9 (Adaptive TRansform Acoustic Coding 9)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def on2avc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 Audio for Video Codec (codec avc)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def binkaudio_dct(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bink Audio (DCT)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def binkaudio_rdft(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bink Audio (RDFT)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bmv_audio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Discworld II BMV audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bonk(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bonk audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cbd2_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Cuberoot-Delta-Exact
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def comfortnoise(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RFC 3389 comfort noise generator
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cook(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Cook / Cooker / Gecko (RealAudio G2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def derf_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Xilam DERF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dfpwm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DFPWM1a audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dolby_e(
-    
+
     channel_order: int | None| Literal["default", "coded"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Dolby E
-    
+
     Args:
         channel_order: Order in which the channels are to be exported (from 0 to 1) (default default)
 
@@ -6639,137 +6639,137 @@ def dolby_e(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "channel_order": channel_order,
-        
+
     }))
 
 
 
 def dsd_lsbf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DSD (Direct Stream Digital), least significant bit first
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dsd_lsbf_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DSD (Direct Stream Digital), least significant bit first, planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dsd_msbf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DSD (Direct Stream Digital), most significant bit first
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dsd_msbf_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DSD (Direct Stream Digital), most significant bit first, planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dsicinaudio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Delphine Software International CIN audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dss_sp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Digital Speech Standard - Standard Play mode (DSS SP)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dst(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DST (Digital Stream Transfer)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dca(
-    
+
     core_only: bool | None = None,
-    
+
     channel_order: int | None| Literal["default", "coded"] = None,
-    
+
     downmix: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     DCA (DTS Coherent Acoustics) (codec dts)
-    
+
     Args:
         core_only: Decode core only without extensions (default false)
         channel_order: Order in which the channels are to be exported (from 0 to 1) (default default)
@@ -6779,49 +6779,49 @@ def dca(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "core_only": core_only,
-        
+
         "channel_order": channel_order,
-        
+
         "downmix": downmix,
-        
+
     }))
 
 
 
 def dvaudio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Ulead DV Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def eac3(
-    
+
     cons_noisegen: bool | None = None,
-    
+
     drc_scale: float | None = None,
-    
+
     heavy_compr: bool | None = None,
-    
+
     target_level: int | None = None,
-    
+
     downmix: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATSC A/52B (AC-3, E-AC-3)
-    
+
     Args:
         cons_noisegen: enable consistent noise generation (default false)
         drc_scale: percentage of dynamic range compression to apply (from 0 to 6) (default 1)
@@ -6833,29 +6833,29 @@ def eac3(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "cons_noisegen": cons_noisegen,
-        
+
         "drc_scale": drc_scale,
-        
+
         "heavy_compr": heavy_compr,
-        
+
         "target_level": target_level,
-        
+
         "downmix": downmix,
-        
+
     }))
 
 
 
 def evrc(
-    
+
     postfilter: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     EVRC (Enhanced Variable Rate Codec)
-    
+
     Args:
         postfilter: enable postfilter (default true)
 
@@ -6863,37 +6863,37 @@ def evrc(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "postfilter": postfilter,
-        
+
     }))
 
 
 
 def fastaudio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MobiClip FastAudio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def flac(
-    
+
     use_buggy_lpc: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     FLAC (Free Lossless Audio Codec)
-    
+
     Args:
         use_buggy_lpc: emulate old buggy lavc behavior (default false)
 
@@ -6901,37 +6901,37 @@ def flac(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "use_buggy_lpc": use_buggy_lpc,
-        
+
     }))
 
 
 
 def ftr(
-    
+
 ) -> FFMpegDecoderOption:
     """
     FTR Voice
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def g723_1(
-    
+
     postfilter: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     G.723.1
-    
+
     Args:
         postfilter: enable postfilter (default true)
 
@@ -6939,261 +6939,261 @@ def g723_1(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "postfilter": postfilter,
-        
+
     }))
 
 
 
 def g729(
-    
+
 ) -> FFMpegDecoderOption:
     """
     G.729
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def gremlin_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Gremlin
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def gsm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     GSM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def gsm_ms(
-    
+
 ) -> FFMpegDecoderOption:
     """
     GSM Microsoft variant
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hca(
-    
+
 ) -> FFMpegDecoderOption:
     """
     CRI HCA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hcom(
-    
+
 ) -> FFMpegDecoderOption:
     """
     HCOM Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def iac(
-    
+
 ) -> FFMpegDecoderOption:
     """
     IAC (Indeo Audio Coder)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ilbc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     iLBC (Internet Low Bitrate Codec)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def imc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     IMC (Intel Music Coder)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def interplay_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Interplay
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def interplayacm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Interplay ACM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mace3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MACE (Macintosh Audio Compression/Expansion) 3:1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mace6(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MACE (Macintosh Audio Compression/Expansion) 6:1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def metasound(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Voxware MetaSound
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def misc4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Micronas SC-4 Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mlp(
-    
+
     downmix: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     MLP (Meridian Lossless Packing)
-    
+
     Args:
         downmix: Request a specific channel layout from the decoder
 
@@ -7201,261 +7201,261 @@ def mlp(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "downmix": downmix,
-        
+
     }))
 
 
 
 def mp1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP1 (MPEG audio layer 1)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp1float(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP1 (MPEG audio layer 1) (codec mp1)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP2 (MPEG audio layer 2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp2float(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP2 (MPEG audio layer 2) (codec mp2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp3float(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP3 (MPEG audio layer 3) (codec mp3)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP3 (MPEG audio layer 3)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp3adufloat(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADU (Application Data Unit) MP3 (MPEG audio layer 3) (codec mp3adu)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp3adu(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADU (Application Data Unit) MP3 (MPEG audio layer 3)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp3on4float(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP3onMP4 (codec mp3on4)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp3on4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP3onMP4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def als(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-4 Audio Lossless Coding (ALS) (codec mp4als)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msnsiren(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MSN Siren
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpc7(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Musepack SV7 (codec musepack7)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpc8(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Musepack SV8 (codec musepack8)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def nellymoser(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Nellymoser Asao
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def opus(
-    
+
     apply_phase_inv: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Opus
-    
+
     Args:
         apply_phase_inv: Apply intensity stereo phase inversion (default true)
 
@@ -7463,21 +7463,21 @@ def opus(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "apply_phase_inv": apply_phase_inv,
-        
+
     }))
 
 
 
 def libopus(
-    
+
     apply_phase_inv: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     libopus Opus (codec opus)
-    
+
     Args:
         apply_phase_inv: Apply intensity stereo phase inversion (default true)
 
@@ -7485,757 +7485,757 @@ def libopus(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "apply_phase_inv": apply_phase_inv,
-        
+
     }))
 
 
 
 def osq(
-    
+
 ) -> FFMpegDecoderOption:
     """
     OSQ (Original Sound Quality)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def paf_audio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Amazing Studio Packed Animation File Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_alaw(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM A-law / G.711 A-law
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_bluray(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 16|20|24-bit big-endian for Blu-ray media
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_dvd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 16|20|24-bit big-endian for DVD media
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f16le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM 16.8 floating point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f24le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM 24.0 floating point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f32be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM 32-bit floating point big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f32le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM 32-bit floating point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f64be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM 64-bit floating point big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f64le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM 64-bit floating point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_lxf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 20-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_mulaw(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM mu-law / G.711 mu-law
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 16-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16be_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 16-bit big-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 16-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16le_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 16-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 24-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24daud(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM D-Cinema audio signed 24-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 24-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24le_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 24-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s32be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 32-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s32le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 32-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s32le_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 32-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s64be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 64-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s64le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 64-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s8(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 8-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s8_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 8-bit planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_sga(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM SGA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u16be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 16-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u16le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 16-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u24be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 24-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u24le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 24-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u32be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 32-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u32le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 32-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u8(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 8-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_vidc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM Archimedes VIDC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qcelp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QCELP / PureVoice
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qdm2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QDesign Music Codec 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qdmc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QDesign Music Codec 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qoa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QOA (Quite OK Audio)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def real_144(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealAudio 1.0 (14.4K) (codec ra_144)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def real_288(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealAudio 2.0 (28.8K) (codec ra_288)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ralf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealAudio Lossless
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rka(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RKA (RK Audio)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def roq_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM id RoQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def s302m(
-    
+
     non_pcm_mode: int | None| Literal["copy", "drop", "decode_copy", "decode_drop"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     SMPTE 302M
-    
+
     Args:
         non_pcm_mode: Chooses what to do with NON-PCM (from 0 to 3) (default decode_drop)
 
@@ -8243,181 +8243,181 @@ def s302m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "non_pcm_mode": non_pcm_mode,
-        
+
     }))
 
 
 
 def sbc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SBC (low-complexity subband codec)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sdx2_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Squareroot-Delta-Exact
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def shorten(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Shorten
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sipr(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealAudio SIPR / ACELP.NET
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def siren(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Siren
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def smackaud(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Smacker audio (codec smackaudio)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sol_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Sol
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sonic(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sonic
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def speex(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Speex
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def tak(
-    
+
 ) -> FFMpegDecoderOption:
     """
     TAK (Tom's lossless Audio Kompressor)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def truehd(
-    
+
     downmix: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     TrueHD
-    
+
     Args:
         downmix: Request a specific channel layout from the decoder
 
@@ -8425,37 +8425,37 @@ def truehd(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "downmix": downmix,
-        
+
     }))
 
 
 
 def truespeech(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DSP Group TrueSpeech
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def tta(
-    
+
     password: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     TTA (True Audio)
-    
+
     Args:
         password: Set decoding password
 
@@ -8463,329 +8463,329 @@ def tta(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "password": password,
-        
+
     }))
 
 
 
 def twinvq(
-    
+
 ) -> FFMpegDecoderOption:
     """
     VQF TwinVQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vmdaudio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sierra VMD audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vorbis(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Vorbis
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def libvorbis(
-    
+
 ) -> FFMpegDecoderOption:
     """
     libvorbis (codec vorbis)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wady_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Marble WADY
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wavarc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Waveform Archiver
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wavesynth(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Wave synthesis pseudo-codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wavpack(
-    
+
 ) -> FFMpegDecoderOption:
     """
     WavPack
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ws_snd1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Westwood Audio (SND1) (codec westwood_snd1)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmalossless(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Audio Lossless
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmapro(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Audio 9 Professional
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmav1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Audio 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmav2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Audio 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmavoice(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Audio Voice
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xan_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Xan
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xma1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Xbox Media Audio 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xma2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Xbox Media Audio 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ssa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ASS (Advanced SubStation Alpha) subtitle (codec ass)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ass(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ASS (Advanced SubStation Alpha) subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dvbsub(
-    
+
     compute_edt: bool | None = None,
-    
+
     compute_clut: bool | None = None,
-    
+
     dvb_substream: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     DVB subtitles (codec dvb_subtitle)
-    
+
     Args:
         compute_edt: compute end of time using pts or timeout (default false)
         compute_clut: compute clut when not available(-1) or only once (-2) or always(1) or never(0) (default auto)
@@ -8795,29 +8795,29 @@ def dvbsub(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "compute_edt": compute_edt,
-        
+
         "compute_clut": compute_clut,
-        
+
         "dvb_substream": dvb_substream,
-        
+
     }))
 
 
 
 def dvdsub(
-    
+
     palette: str | None = None,
-    
+
     ifo_palette: str | None = None,
-    
+
     forced_subs_only: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     DVD subtitles (codec dvd_subtitle)
-    
+
     Args:
         palette: set the global palette
         ifo_palette: obtain the global palette from .IFO file
@@ -8827,29 +8827,29 @@ def dvdsub(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "palette": palette,
-        
+
         "ifo_palette": ifo_palette,
-        
+
         "forced_subs_only": forced_subs_only,
-        
+
     }))
 
 
 
 def cc_dec(
-    
+
     real_time: bool | None = None,
-    
+
     real_time_latency_msec: int | None = None,
-    
+
     data_field: int | None| Literal["auto", "first", "second"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Closed Captions (EIA-608 / CEA-708) (codec eia_608)
-    
+
     Args:
         real_time: emit subtitle events as they are decoded for real-time display (default false)
         real_time_latency_msec: minimum elapsed time between emitting real-time subtitle events (from 0 to 500) (default 200)
@@ -8859,25 +8859,25 @@ def cc_dec(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "real_time": real_time,
-        
+
         "real_time_latency_msec": real_time_latency_msec,
-        
+
         "data_field": data_field,
-        
+
     }))
 
 
 
 def pgssub(
-    
+
     forced_subs_only: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     HDMV Presentation Graphic Stream subtitles (codec hdmv_pgs_subtitle)
-    
+
     Args:
         forced_subs_only: Only show forced subtitles (default false)
 
@@ -8885,55 +8885,55 @@ def pgssub(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "forced_subs_only": forced_subs_only,
-        
+
     }))
 
 
 
 def jacosub(
-    
+
 ) -> FFMpegDecoderOption:
     """
     JACOsub subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def microdvd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MicroDVD subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mov_text(
-    
+
     width: int | None = None,
-    
+
     height: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     3GPP Timed Text subtitle
-    
+
     Args:
         width: Frame width, usually video width (from 0 to INT_MAX) (default 0)
         height: Frame height, usually video height (from 0 to INT_MAX) (default 0)
@@ -8942,39 +8942,39 @@ def mov_text(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "width": width,
-        
+
         "height": height,
-        
+
     }))
 
 
 
 def mpl2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPL2 subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pjs(
-    
+
     keep_ass_markup: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     PJS subtitle
-    
+
     Args:
         keep_ass_markup: Set if ASS tags must be escaped (default false)
 
@@ -8982,53 +8982,53 @@ def pjs(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "keep_ass_markup": keep_ass_markup,
-        
+
     }))
 
 
 
 def realtext(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealText subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sami(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SAMI subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def stl(
-    
+
     keep_ass_markup: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Spruce subtitle format
-    
+
     Args:
         keep_ass_markup: Set if ASS tags must be escaped (default false)
 
@@ -9036,69 +9036,69 @@ def stl(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "keep_ass_markup": keep_ass_markup,
-        
+
     }))
 
 
 
 def srt(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SubRip subtitle (codec subrip)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def subrip(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SubRip subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def subviewer(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SubViewer subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def subviewer1(
-    
+
     keep_ass_markup: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     SubViewer1 subtitle
-    
+
     Args:
         keep_ass_markup: Set if ASS tags must be escaped (default false)
 
@@ -9106,21 +9106,21 @@ def subviewer1(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "keep_ass_markup": keep_ass_markup,
-        
+
     }))
 
 
 
 def text(
-    
+
     keep_ass_markup: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Raw text subtitle
-    
+
     Args:
         keep_ass_markup: Set if ASS tags must be escaped (default false)
 
@@ -9128,21 +9128,21 @@ def text(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "keep_ass_markup": keep_ass_markup,
-        
+
     }))
 
 
 
 def vplayer(
-    
+
     keep_ass_markup: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     VPlayer subtitle
-    
+
     Args:
         keep_ass_markup: Set if ASS tags must be escaped (default false)
 
@@ -9150,40 +9150,39 @@ def vplayer(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "keep_ass_markup": keep_ass_markup,
-        
+
     }))
 
 
 
 def webvtt(
-    
+
 ) -> FFMpegDecoderOption:
     """
     WebVTT subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xsub(
-    
+
 ) -> FFMpegDecoderOption:
     """
     XSUB
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
-    }))
 
+    }))

--- a/packages/v7/src/ffmpeg/codecs/encoders.py
+++ b/packages/v7/src/ffmpeg/codecs/encoders.py
@@ -44,105 +44,105 @@ from ..streams.audio import AudioStream
 
 
 def a64multi(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Multicolor charset for Commodore 64 (codec a64_multi)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def a64multi5(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Multicolor charset for Commodore 64, extended with 5th color (colram) (codec a64_multi5)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def alias_pix(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Alias/Wavefront PIX image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def amv(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     huffman: int | None| Literal["default", "optimal"] = None,
-    
+
     force_duplicated_matrix: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     AMV Video
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -172,69 +172,69 @@ def amv(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "huffman": huffman,
-        
+
         "force_duplicated_matrix": force_duplicated_matrix,
-        
+
     }))
 
 
 
 def apng(
-    
+
     dpi: int | None = None,
-    
+
     dpm: int | None = None,
-    
+
     pred: int | None| Literal["none", "sub", "up", "avg", "paeth", "mixed"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     APNG (Animated Portable Network Graphics) image
-    
+
     Args:
         dpi: Set image resolution (in dots per inch) (from 0 to 65536) (default 0)
         dpm: Set image resolution (in dots per meter) (from 0 to 65536) (default 0)
@@ -244,79 +244,79 @@ def apng(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "dpi": dpi,
-        
+
         "dpm": dpm,
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def asv1(
-    
+
 ) -> FFMpegEncoderOption:
     """
     ASUS V1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def asv2(
-    
+
 ) -> FFMpegEncoderOption:
     """
     ASUS V2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def av1_vaapi(
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     low_power: bool | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     rc_mode: int | None| Literal["auto", "CQP", "CBR", "VBR", "ICQ", "QVBR", "AVBR"] = None,
-    
+
     blbrc: bool | None = None,
-    
+
     profile: int | None| Literal["main", "high", "professional"] = None,
-    
+
     tier: int | None| Literal["main", "high"] = None,
-    
+
     level: int | None| Literal["2.0", "2.1", "3.0", "3.1", "4.0", "4.1", "5.0", "5.1", "5.2", "5.3", "6.0", "6.1", "6.2", "6.3"] = None,
-    
+
     tiles: str | None = None,
-    
+
     tile_groups: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     AV1 (VAAPI) (codec av1)
-    
+
     Args:
         idr_interval: Distance (in I-frames) between key frames (from 0 to INT_MAX) (default 0)
         b_depth: Maximum B-frame reference depth (from 1 to INT_MAX) (default 1)
@@ -335,107 +335,107 @@ def av1_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "low_power": low_power,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "rc_mode": rc_mode,
-        
+
         "blbrc": blbrc,
-        
+
         "profile": profile,
-        
+
         "tier": tier,
-        
+
         "level": level,
-        
+
         "tiles": tiles,
-        
+
         "tile_groups": tile_groups,
-        
+
     }))
 
 
 
 def avrp(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Avid 1:1 10-bit RGB Packer
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def avui(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Avid Meridien Uncompressed
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def bitpacked(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Bitpacked
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def bmp(
-    
+
 ) -> FFMpegEncoderOption:
     """
     BMP (Windows and OS/2 bitmap)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def cfhd(
-    
+
     quality: int | None| Literal["film3+", "film3", "film2+", "film2", "film1.5", "film1+", "film1", "high+", "high", "medium+", "medium", "low+", "low"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     GoPro CineForm HD
-    
+
     Args:
         quality: set quality (from 0 to 12) (default film3+)
 
@@ -443,29 +443,29 @@ def cfhd(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "quality": quality,
-        
+
     }))
 
 
 
 def cinepak(
-    
+
     max_extra_cb_iterations: int | None = None,
-    
+
     skip_empty_cb: bool | None = None,
-    
+
     max_strips: int | None = None,
-    
+
     min_strips: int | None = None,
-    
+
     strip_number_adaptivity: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Cinepak
-    
+
     Args:
         max_extra_cb_iterations: Max extra codebook recalculation passes, more is better and slower (from 0 to INT_MAX) (default 2)
         skip_empty_cb: Avoid wasting bytes, ignore vintage MacOS decoder (default false)
@@ -477,29 +477,29 @@ def cinepak(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "max_extra_cb_iterations": max_extra_cb_iterations,
-        
+
         "skip_empty_cb": skip_empty_cb,
-        
+
         "max_strips": max_strips,
-        
+
         "min_strips": min_strips,
-        
+
         "strip_number_adaptivity": strip_number_adaptivity,
-        
+
     }))
 
 
 
 def cljr(
-    
+
     dither_type: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Cirrus Logic AccuPak
-    
+
     Args:
         dither_type: Dither type (from 0 to 2) (default 1)
 
@@ -507,31 +507,31 @@ def cljr(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "dither_type": dither_type,
-        
+
     }))
 
 
 
 def vc2(
-    
+
     tolerance: float | None = None,
-    
+
     slice_width: int | None = None,
-    
+
     slice_height: int | None = None,
-    
+
     wavelet_depth: int | None = None,
-    
+
     wavelet_type: int | None| Literal["9_7", "5_3", "haar", "haar_noshift"] = None,
-    
+
     qm: int | None| Literal["default", "color", "flat"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     SMPTE VC-2 (codec dirac)
-    
+
     Args:
         tolerance: Max undershoot in percent (from 0 to 45) (default 5)
         slice_width: Slice width (from 32 to 1024) (default 32)
@@ -544,35 +544,35 @@ def vc2(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "tolerance": tolerance,
-        
+
         "slice_width": slice_width,
-        
+
         "slice_height": slice_height,
-        
+
         "wavelet_depth": wavelet_depth,
-        
+
         "wavelet_type": wavelet_type,
-        
+
         "qm": qm,
-        
+
     }))
 
 
 
 def dnxhd(
-    
+
     nitris_compat: bool | None = None,
-    
+
     ibias: int | None = None,
-    
+
     profile: int | None| Literal["dnxhd", "dnxhr_444", "dnxhr_hqx", "dnxhr_hq", "dnxhr_sq", "dnxhr_lb"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     VC3/DNxHD
-    
+
     Args:
         nitris_compat: encode with Avid Nitris compatibility (default false)
         ibias: intra quant bias (from INT_MIN to INT_MAX) (default 0)
@@ -582,41 +582,41 @@ def dnxhd(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "nitris_compat": nitris_compat,
-        
+
         "ibias": ibias,
-        
+
         "profile": profile,
-        
+
     }))
 
 
 
 def dpx(
-    
+
 ) -> FFMpegEncoderOption:
     """
     DPX (Digital Picture Exchange) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def dvvideo(
-    
+
     quant_deadzone: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     DV (Digital Video)
-    
+
     Args:
         quant_deadzone: Quantizer dead zone (from 0 to 1024) (default 7)
 
@@ -624,21 +624,21 @@ def dvvideo(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "quant_deadzone": quant_deadzone,
-        
+
     }))
 
 
 
 def dxv(
-    
+
     format: int | None| Literal["dxt1"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Resolume DXV
-    
+
     Args:
         format: (from 1.14664e+09 to 1.14664e+09) (default dxt1)
 
@@ -646,25 +646,25 @@ def dxv(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "format": format,
-        
+
     }))
 
 
 
 def exr(
-    
+
     compression: int | None| Literal["none", "rle", "zip1", "zip16"] = None,
-    
+
     format: int | None| Literal["half", "float"] = None,
-    
+
     gamma: float | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     OpenEXR image
-    
+
     Args:
         compression: set compression type (from 0 to 3) (default none)
         format: set pixel type (from 1 to 2) (default float)
@@ -674,29 +674,29 @@ def exr(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "compression": compression,
-        
+
         "format": format,
-        
+
         "gamma": gamma,
-        
+
     }))
 
 
 
 def ffv1(
-    
+
     slicecrc: bool | None = None,
-    
+
     coder: int | None| Literal["rice", "range_def", "range_tab", "ac"] = None,
-    
+
     context: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     FFmpeg video codec #1
-    
+
     Args:
         slicecrc: Protect slices with CRCs (default auto)
         coder: Coder type (from -2 to 2) (default rice)
@@ -706,29 +706,29 @@ def ffv1(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "slicecrc": slicecrc,
-        
+
         "coder": coder,
-        
+
         "context": context,
-        
+
     }))
 
 
 
 def ffvhuff(
-    
+
     context: int | None = None,
-    
+
     non_deterministic: bool | None = None,
-    
+
     pred: int | None| Literal["left", "plane", "median"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Huffyuv FFmpeg variant
-    
+
     Args:
         context: Set per-frame huffman tables (from 0 to 1) (default 0)
         non_deterministic: Allow multithreading for e.g. context=1 at the expense of determinism (default false)
@@ -738,121 +738,121 @@ def ffvhuff(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "context": context,
-        
+
         "non_deterministic": non_deterministic,
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def fits(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Flexible Image Transport System
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def flashsv(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Flash Screen Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def flashsv2(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Flash Screen Video Version 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def flv(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     FLV / Sorenson Spark / Sorenson H.263 (Flash Video) (codec flv1)
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -884,73 +884,73 @@ def flv(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def gif(
-    
+
     gifflags: str | None = None,
-    
+
     gifimage: bool | None = None,
-    
+
     global_palette: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     GIF (Graphics Interchange Format)
-    
+
     Args:
         gifflags: set GIF flags (default offsetting+transdiff)
         gifimage: enable encoding only images per frame (default false)
@@ -960,73 +960,73 @@ def gif(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "gifflags": gifflags,
-        
+
         "gifimage": gifimage,
-        
+
         "global_palette": global_palette,
-        
+
     }))
 
 
 
 def h261(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     H.261
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -1058,121 +1058,121 @@ def h261(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def h263(
-    
+
     obmc: bool | None = None,
-    
+
     mb_info: int | None = None,
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     H.263 / H.263-1996
-    
+
     Args:
         obmc: use overlapped block motion compensation. (default false)
         mb_info: emit macroblock info for RFC 2190 packetization, the parameter value is the maximum payload size (from 0 to INT_MAX) (default 0)
@@ -1206,75 +1206,75 @@ def h263(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "obmc": obmc,
-        
+
         "mb_info": mb_info,
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def h263_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     V4L2 mem2mem H.263 encoder wrapper (codec h263)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 4 to INT_MAX) (default 4)
@@ -1283,79 +1283,79 @@ def h263_v4l2m2m(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def h263p(
-    
+
     umv: bool | None = None,
-    
+
     aiv: bool | None = None,
-    
+
     obmc: bool | None = None,
-    
+
     structured_slices: bool | None = None,
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     H.263+ / H.263-1998 / H.263 version 2
-    
+
     Args:
         umv: Use unlimited motion vectors. (default false)
         aiv: Use alternative inter VLC. (default false)
@@ -1391,169 +1391,169 @@ def h263p(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "umv": umv,
-        
+
         "aiv": aiv,
-        
+
         "obmc": obmc,
-        
+
         "structured_slices": structured_slices,
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def libx264(
-    
+
     preset: str | None = None,
-    
+
     tune: str | None = None,
-    
+
     profile: str | None = None,
-    
+
     fastfirstpass: bool | None = None,
-    
+
     level: str | None = None,
-    
+
     passlogfile: str | None = None,
-    
+
     wpredp: str | None = None,
-    
+
     a53cc: bool | None = None,
-    
+
     x264opts: str | None = None,
-    
+
     crf: float | None = None,
-    
+
     crf_max: float | None = None,
-    
+
     qp: int | None = None,
-    
+
     aq_mode: int | None| Literal["none", "variance", "autovariance", "autovariance-biased"] = None,
-    
+
     aq_strength: float | None = None,
-    
+
     psy: bool | None = None,
-    
+
     psy_rd: str | None = None,
-    
+
     rc_lookahead: int | None = None,
-    
+
     weightb: bool | None = None,
-    
+
     weightp: int | None| Literal["none", "simple", "smart"] = None,
-    
+
     ssim: bool | None = None,
-    
+
     intra_refresh: bool | None = None,
-    
+
     bluray_compat: bool | None = None,
-    
+
     b_bias: int | None = None,
-    
+
     b_pyramid: int | None| Literal["none", "strict", "normal"] = None,
-    
+
     mixed_refs: bool | None = None,
-    
+
     _8x8dct: bool | None = None,
-    
+
     fast_pskip: bool | None = None,
-    
+
     aud: bool | None = None,
-    
+
     mbtree: bool | None = None,
-    
+
     deblock: str | None = None,
-    
+
     cplxblur: float | None = None,
-    
+
     partitions: str | None = None,
-    
+
     direct_pred: int | None| Literal["none", "spatial", "temporal", "auto"] = None,
-    
+
     slice_max_size: int | None = None,
-    
+
     stats: str | None = None,
-    
+
     nal_hrd: int | None| Literal["none", "vbr", "cbr"] = None,
-    
+
     avcintra_class: int | None = None,
-    
+
     me_method: int | None| Literal["dia", "hex", "umh", "esa", "tesa"] = None,
-    
+
     forced_idr: bool | None = None,
-    
+
     coder: int | None| Literal["default", "cavlc", "cabac", "vlc", "ac"] = None,
-    
+
     b_strategy: int | None = None,
-    
+
     chromaoffset: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     udu_sei: bool | None = None,
-    
+
     x264_params: str | None = None,
-    
+
     mb_info: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libx264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 (codec h264)
-    
+
     Args:
         preset: Set the encoding preset (cf. x264 --fullhelp) (default "medium")
         tune: Tune the encoding params (cf. x264 --fullhelp)
@@ -1607,205 +1607,205 @@ def libx264(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "preset": preset,
-        
+
         "tune": tune,
-        
+
         "profile": profile,
-        
+
         "fastfirstpass": fastfirstpass,
-        
+
         "level": level,
-        
+
         "passlogfile": passlogfile,
-        
+
         "wpredp": wpredp,
-        
+
         "a53cc": a53cc,
-        
+
         "x264opts": x264opts,
-        
+
         "crf": crf,
-        
+
         "crf_max": crf_max,
-        
+
         "qp": qp,
-        
+
         "aq-mode": aq_mode,
-        
+
         "aq-strength": aq_strength,
-        
+
         "psy": psy,
-        
+
         "psy-rd": psy_rd,
-        
+
         "rc-lookahead": rc_lookahead,
-        
+
         "weightb": weightb,
-        
+
         "weightp": weightp,
-        
+
         "ssim": ssim,
-        
+
         "intra-refresh": intra_refresh,
-        
+
         "bluray-compat": bluray_compat,
-        
+
         "b-bias": b_bias,
-        
+
         "b-pyramid": b_pyramid,
-        
+
         "mixed-refs": mixed_refs,
-        
+
         "8x8dct": _8x8dct,
-        
+
         "fast-pskip": fast_pskip,
-        
+
         "aud": aud,
-        
+
         "mbtree": mbtree,
-        
+
         "deblock": deblock,
-        
+
         "cplxblur": cplxblur,
-        
+
         "partitions": partitions,
-        
+
         "direct-pred": direct_pred,
-        
+
         "slice-max-size": slice_max_size,
-        
+
         "stats": stats,
-        
+
         "nal-hrd": nal_hrd,
-        
+
         "avcintra-class": avcintra_class,
-        
+
         "me_method": me_method,
-        
+
         "forced-idr": forced_idr,
-        
+
         "coder": coder,
-        
+
         "b_strategy": b_strategy,
-        
+
         "chromaoffset": chromaoffset,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "udu_sei": udu_sei,
-        
+
         "x264-params": x264_params,
-        
+
         "mb_info": mb_info,
-        
+
     }))
 
 
 
 def libx264rgb(
-    
+
     preset: str | None = None,
-    
+
     tune: str | None = None,
-    
+
     profile: str | None = None,
-    
+
     fastfirstpass: bool | None = None,
-    
+
     level: str | None = None,
-    
+
     passlogfile: str | None = None,
-    
+
     wpredp: str | None = None,
-    
+
     a53cc: bool | None = None,
-    
+
     x264opts: str | None = None,
-    
+
     crf: float | None = None,
-    
+
     crf_max: float | None = None,
-    
+
     qp: int | None = None,
-    
+
     aq_mode: int | None| Literal["none", "variance", "autovariance", "autovariance-biased"] = None,
-    
+
     aq_strength: float | None = None,
-    
+
     psy: bool | None = None,
-    
+
     psy_rd: str | None = None,
-    
+
     rc_lookahead: int | None = None,
-    
+
     weightb: bool | None = None,
-    
+
     weightp: int | None| Literal["none", "simple", "smart"] = None,
-    
+
     ssim: bool | None = None,
-    
+
     intra_refresh: bool | None = None,
-    
+
     bluray_compat: bool | None = None,
-    
+
     b_bias: int | None = None,
-    
+
     b_pyramid: int | None| Literal["none", "strict", "normal"] = None,
-    
+
     mixed_refs: bool | None = None,
-    
+
     _8x8dct: bool | None = None,
-    
+
     fast_pskip: bool | None = None,
-    
+
     aud: bool | None = None,
-    
+
     mbtree: bool | None = None,
-    
+
     deblock: str | None = None,
-    
+
     cplxblur: float | None = None,
-    
+
     partitions: str | None = None,
-    
+
     direct_pred: int | None| Literal["none", "spatial", "temporal", "auto"] = None,
-    
+
     slice_max_size: int | None = None,
-    
+
     stats: str | None = None,
-    
+
     nal_hrd: int | None| Literal["none", "vbr", "cbr"] = None,
-    
+
     avcintra_class: int | None = None,
-    
+
     me_method: int | None| Literal["dia", "hex", "umh", "esa", "tesa"] = None,
-    
+
     forced_idr: bool | None = None,
-    
+
     coder: int | None| Literal["default", "cavlc", "cabac", "vlc", "ac"] = None,
-    
+
     b_strategy: int | None = None,
-    
+
     chromaoffset: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     udu_sei: bool | None = None,
-    
+
     x264_params: str | None = None,
-    
+
     mb_info: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libx264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 RGB (codec h264)
-    
+
     Args:
         preset: Set the encoding preset (cf. x264 --fullhelp) (default "medium")
         tune: Tune the encoding params (cf. x264 --fullhelp)
@@ -1859,115 +1859,115 @@ def libx264rgb(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "preset": preset,
-        
+
         "tune": tune,
-        
+
         "profile": profile,
-        
+
         "fastfirstpass": fastfirstpass,
-        
+
         "level": level,
-        
+
         "passlogfile": passlogfile,
-        
+
         "wpredp": wpredp,
-        
+
         "a53cc": a53cc,
-        
+
         "x264opts": x264opts,
-        
+
         "crf": crf,
-        
+
         "crf_max": crf_max,
-        
+
         "qp": qp,
-        
+
         "aq-mode": aq_mode,
-        
+
         "aq-strength": aq_strength,
-        
+
         "psy": psy,
-        
+
         "psy-rd": psy_rd,
-        
+
         "rc-lookahead": rc_lookahead,
-        
+
         "weightb": weightb,
-        
+
         "weightp": weightp,
-        
+
         "ssim": ssim,
-        
+
         "intra-refresh": intra_refresh,
-        
+
         "bluray-compat": bluray_compat,
-        
+
         "b-bias": b_bias,
-        
+
         "b-pyramid": b_pyramid,
-        
+
         "mixed-refs": mixed_refs,
-        
+
         "8x8dct": _8x8dct,
-        
+
         "fast-pskip": fast_pskip,
-        
+
         "aud": aud,
-        
+
         "mbtree": mbtree,
-        
+
         "deblock": deblock,
-        
+
         "cplxblur": cplxblur,
-        
+
         "partitions": partitions,
-        
+
         "direct-pred": direct_pred,
-        
+
         "slice-max-size": slice_max_size,
-        
+
         "stats": stats,
-        
+
         "nal-hrd": nal_hrd,
-        
+
         "avcintra-class": avcintra_class,
-        
+
         "me_method": me_method,
-        
+
         "forced-idr": forced_idr,
-        
+
         "coder": coder,
-        
+
         "b_strategy": b_strategy,
-        
+
         "chromaoffset": chromaoffset,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "udu_sei": udu_sei,
-        
+
         "x264-params": x264_params,
-        
+
         "mb_info": mb_info,
-        
+
     }))
 
 
 
 def h264_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     V4L2 mem2mem H.264 encoder wrapper (codec h264)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 4 to INT_MAX) (default 4)
@@ -1976,49 +1976,49 @@ def h264_v4l2m2m(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def h264_vaapi(
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     low_power: bool | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     rc_mode: int | None| Literal["auto", "CQP", "CBR", "VBR", "ICQ", "QVBR", "AVBR"] = None,
-    
+
     blbrc: bool | None = None,
-    
+
     qp: int | None = None,
-    
+
     quality: int | None = None,
-    
+
     coder: int | None| Literal["cavlc", "cabac", "vlc", "ac"] = None,
-    
+
     aud: bool | None = None,
-    
+
     sei: str | None = None,
-    
+
     profile: int | None| Literal["constrained_baseline", "main", "high", "high10"] = None,
-    
+
     level: int | None| Literal["1", "1.1", "1.2", "1.3", "2", "2.1", "2.2", "3", "3.1", "3.2", "4", "4.1", "4.2", "5", "5.1", "5.2", "6", "6.1", "6.2"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     H.264/AVC (VAAPI) (codec h264)
-    
+
     Args:
         idr_interval: Distance (in I-frames) between key frames (from 0 to INT_MAX) (default 0)
         b_depth: Maximum B-frame reference depth (from 1 to INT_MAX) (default 1)
@@ -2039,81 +2039,81 @@ def h264_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "low_power": low_power,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "rc_mode": rc_mode,
-        
+
         "blbrc": blbrc,
-        
+
         "qp": qp,
-        
+
         "quality": quality,
-        
+
         "coder": coder,
-        
+
         "aud": aud,
-        
+
         "sei": sei,
-        
+
         "profile": profile,
-        
+
         "level": level,
-        
+
     }))
 
 
 
 def hdr(
-    
+
 ) -> FFMpegEncoderOption:
     """
     HDR (Radiance RGBE format) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def libx265(
-    
+
     crf: float | None = None,
-    
+
     qp: int | None = None,
-    
+
     forced_idr: bool | None = None,
-    
+
     preset: str | None = None,
-    
+
     tune: str | None = None,
-    
+
     profile: str | None = None,
-    
+
     udu_sei: bool | None = None,
-    
+
     a53cc: bool | None = None,
-    
+
     x265_params: str | None = None,
-    
+
     dolbyvision: bool | None| Literal["auto"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libx265 H.265 / HEVC (codec hevc)
-    
+
     Args:
         crf: set the x265 crf (from -1 to FLT_MAX) (default -1)
         qp: set the x265 qp (from -1 to INT_MAX) (default -1)
@@ -2130,41 +2130,41 @@ def libx265(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "crf": crf,
-        
+
         "qp": qp,
-        
+
         "forced-idr": forced_idr,
-        
+
         "preset": preset,
-        
+
         "tune": tune,
-        
+
         "profile": profile,
-        
+
         "udu_sei": udu_sei,
-        
+
         "a53cc": a53cc,
-        
+
         "x265-params": x265_params,
-        
+
         "dolbyvision": dolbyvision,
-        
+
     }))
 
 
 
 def hevc_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     V4L2 mem2mem HEVC encoder wrapper (codec hevc)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 4 to INT_MAX) (default 4)
@@ -2173,49 +2173,49 @@ def hevc_v4l2m2m(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def hevc_vaapi(
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     low_power: bool | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     rc_mode: int | None| Literal["auto", "CQP", "CBR", "VBR", "ICQ", "QVBR", "AVBR"] = None,
-    
+
     blbrc: bool | None = None,
-    
+
     qp: int | None = None,
-    
+
     aud: bool | None = None,
-    
+
     profile: int | None| Literal["main", "main10", "rext"] = None,
-    
+
     tier: int | None| Literal["main", "high"] = None,
-    
+
     level: int | None| Literal["1", "2", "2.1", "3", "3.1", "4", "4.1", "5", "5.1", "5.2", "6", "6.1", "6.2"] = None,
-    
+
     sei: str | None = None,
-    
+
     tiles: str | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     H.265/HEVC (VAAPI) (codec hevc)
-    
+
     Args:
         idr_interval: Distance (in I-frames) between key frames (from 0 to INT_MAX) (default 0)
         b_depth: Maximum B-frame reference depth (from 1 to INT_MAX) (default 1)
@@ -2236,49 +2236,49 @@ def hevc_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "low_power": low_power,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "rc_mode": rc_mode,
-        
+
         "blbrc": blbrc,
-        
+
         "qp": qp,
-        
+
         "aud": aud,
-        
+
         "profile": profile,
-        
+
         "tier": tier,
-        
+
         "level": level,
-        
+
         "sei": sei,
-        
+
         "tiles": tiles,
-        
+
     }))
 
 
 
 def huffyuv(
-    
+
     non_deterministic: bool | None = None,
-    
+
     pred: int | None| Literal["left", "plane", "median"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Huffyuv / HuffYUV
-    
+
     Args:
         non_deterministic: Allow multithreading for e.g. context=1 at the expense of determinism (default false)
         pred: Prediction method (from 0 to 2) (default left)
@@ -2287,37 +2287,37 @@ def huffyuv(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "non_deterministic": non_deterministic,
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def jpeg2000(
-    
+
     format: int | None| Literal["j2k", "jp2"] = None,
-    
+
     tile_width: int | None = None,
-    
+
     tile_height: int | None = None,
-    
+
     pred: int | None| Literal["dwt97int", "dwt53"] = None,
-    
+
     sop: int | None = None,
-    
+
     eph: int | None = None,
-    
+
     prog: int | None| Literal["lrcp", "rlcp", "rpcl", "pcrl", "cprl"] = None,
-    
+
     layer_rates: str | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     JPEG 2000
-    
+
     Args:
         format: Codec Format (from 0 to 1) (default jp2)
         tile_width: Tile Width (from 1 to 1.07374e+09) (default 256)
@@ -2332,49 +2332,49 @@ def jpeg2000(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "format": format,
-        
+
         "tile_width": tile_width,
-        
+
         "tile_height": tile_height,
-        
+
         "pred": pred,
-        
+
         "sop": sop,
-        
+
         "eph": eph,
-        
+
         "prog": prog,
-        
+
         "layer_rates": layer_rates,
-        
+
     }))
 
 
 
 def libopenjpeg(
-    
+
     format: int | None| Literal["j2k", "jp2"] = None,
-    
+
     profile: int | None| Literal["jpeg2000", "cinema2k", "cinema4k"] = None,
-    
+
     cinema_mode: int | None| Literal["off", "2k_24", "2k_48", "4k_24"] = None,
-    
+
     prog_order: int | None| Literal["lrcp", "rlcp", "rpcl", "pcrl", "cprl"] = None,
-    
+
     numresolution: int | None = None,
-    
+
     irreversible: int | None = None,
-    
+
     disto_alloc: int | None = None,
-    
+
     fixed_quality: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     OpenJPEG JPEG 2000 (codec jpeg2000)
-    
+
     Args:
         format: Codec Format (from 0 to 2) (default jp2)
         profile: (from 0 to 4) (default jpeg2000)
@@ -2389,35 +2389,35 @@ def libopenjpeg(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "format": format,
-        
+
         "profile": profile,
-        
+
         "cinema_mode": cinema_mode,
-        
+
         "prog_order": prog_order,
-        
+
         "numresolution": numresolution,
-        
+
         "irreversible": irreversible,
-        
+
         "disto_alloc": disto_alloc,
-        
+
         "fixed_quality": fixed_quality,
-        
+
     }))
 
 
 
 def jpegls(
-    
+
     pred: int | None| Literal["left", "plane", "median"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     JPEG-LS
-    
+
     Args:
         pred: Prediction method (from 0 to 2) (default left)
 
@@ -2425,21 +2425,21 @@ def jpegls(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def ljpeg(
-    
+
     pred: int | None| Literal["left", "plane", "median"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Lossless JPEG
-    
+
     Args:
         pred: Prediction method (from 1 to 3) (default left)
 
@@ -2447,21 +2447,21 @@ def ljpeg(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def magicyuv(
-    
+
     pred: int | None| Literal["left", "gradient", "median"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MagicYUV video
-    
+
     Args:
         pred: Prediction method (from 1 to 3) (default left)
 
@@ -2469,65 +2469,65 @@ def magicyuv(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def mjpeg(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     huffman: int | None| Literal["default", "optimal"] = None,
-    
+
     force_duplicated_matrix: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MJPEG (Motion JPEG)
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -2557,77 +2557,77 @@ def mjpeg(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "huffman": huffman,
-        
+
         "force_duplicated_matrix": force_duplicated_matrix,
-        
+
     }))
 
 
 
 def mjpeg_vaapi(
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     low_power: bool | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     jfif: bool | None = None,
-    
+
     huffman: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MJPEG (VAAPI) (codec mjpeg)
-    
+
     Args:
         idr_interval: Distance (in I-frames) between key frames (from 0 to INT_MAX) (default 0)
         b_depth: Maximum B-frame reference depth (from 1 to INT_MAX) (default 1)
@@ -2641,95 +2641,95 @@ def mjpeg_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "low_power": low_power,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "jfif": jfif,
-        
+
         "huffman": huffman,
-        
+
     }))
 
 
 
 def mpeg1video(
-    
+
     gop_timecode: str | None = None,
-    
+
     drop_frame_timecode: bool | None = None,
-    
+
     scan_offset: bool | None = None,
-    
+
     timecode_frame_start: int | None = None,
-    
+
     b_strategy: int | None = None,
-    
+
     b_sensitivity: int | None = None,
-    
+
     brd_scale: int | None = None,
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MPEG-1 video
-    
+
     Args:
         gop_timecode: MPEG GOP Timecode in hh:mm:ss[:;.]ff format. Overrides timecode_frame_start.
         drop_frame_timecode: Timecode is in drop frame format. (default false)
@@ -2768,157 +2768,157 @@ def mpeg1video(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "gop_timecode": gop_timecode,
-        
+
         "drop_frame_timecode": drop_frame_timecode,
-        
+
         "scan_offset": scan_offset,
-        
+
         "timecode_frame_start": timecode_frame_start,
-        
+
         "b_strategy": b_strategy,
-        
+
         "b_sensitivity": b_sensitivity,
-        
+
         "brd_scale": brd_scale,
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def mpeg2video(
-    
+
     gop_timecode: str | None = None,
-    
+
     drop_frame_timecode: bool | None = None,
-    
+
     scan_offset: bool | None = None,
-    
+
     timecode_frame_start: int | None = None,
-    
+
     b_strategy: int | None = None,
-    
+
     b_sensitivity: int | None = None,
-    
+
     brd_scale: int | None = None,
-    
+
     intra_vlc: bool | None = None,
-    
+
     non_linear_quant: bool | None = None,
-    
+
     alternate_scan: bool | None = None,
-    
+
     a53cc: bool | None = None,
-    
+
     seq_disp_ext: int | None| Literal["auto", "never", "always"] = None,
-    
+
     video_format: int | None| Literal["component", "pal", "ntsc", "secam", "mac", "unspecified"] = None,
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MPEG-2 video
-    
+
     Args:
         gop_timecode: MPEG GOP Timecode in hh:mm:ss[:;.]ff format. Overrides timecode_frame_start.
         drop_frame_timecode: Timecode is in drop frame format. (default false)
@@ -2963,111 +2963,111 @@ def mpeg2video(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "gop_timecode": gop_timecode,
-        
+
         "drop_frame_timecode": drop_frame_timecode,
-        
+
         "scan_offset": scan_offset,
-        
+
         "timecode_frame_start": timecode_frame_start,
-        
+
         "b_strategy": b_strategy,
-        
+
         "b_sensitivity": b_sensitivity,
-        
+
         "brd_scale": brd_scale,
-        
+
         "intra_vlc": intra_vlc,
-        
+
         "non_linear_quant": non_linear_quant,
-        
+
         "alternate_scan": alternate_scan,
-        
+
         "a53cc": a53cc,
-        
+
         "seq_disp_ext": seq_disp_ext,
-        
+
         "video_format": video_format,
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def mpeg2_vaapi(
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     low_power: bool | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     rc_mode: int | None| Literal["auto", "CQP", "CBR", "VBR", "ICQ", "QVBR", "AVBR"] = None,
-    
+
     blbrc: bool | None = None,
-    
+
     profile: int | None| Literal["simple", "main"] = None,
-    
+
     level: int | None| Literal["low", "main", "high_1440", "high"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MPEG-2 (VAAPI) (codec mpeg2video)
-    
+
     Args:
         idr_interval: Distance (in I-frames) between key frames (from 0 to INT_MAX) (default 0)
         b_depth: Maximum B-frame reference depth (from 1 to INT_MAX) (default 1)
@@ -3083,97 +3083,97 @@ def mpeg2_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "low_power": low_power,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "rc_mode": rc_mode,
-        
+
         "blbrc": blbrc,
-        
+
         "profile": profile,
-        
+
         "level": level,
-        
+
     }))
 
 
 
 def mpeg4(
-    
+
     data_partitioning: bool | None = None,
-    
+
     alternate_scan: bool | None = None,
-    
+
     mpeg_quant: int | None = None,
-    
+
     b_strategy: int | None = None,
-    
+
     b_sensitivity: int | None = None,
-    
+
     brd_scale: int | None = None,
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MPEG-4 part 2
-    
+
     Args:
         data_partitioning: Use data partitioning. (default false)
         alternate_scan: Enable alternate scantable. (default false)
@@ -3211,93 +3211,93 @@ def mpeg4(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "data_partitioning": data_partitioning,
-        
+
         "alternate_scan": alternate_scan,
-        
+
         "mpeg_quant": mpeg_quant,
-        
+
         "b_strategy": b_strategy,
-        
+
         "b_sensitivity": b_sensitivity,
-        
+
         "brd_scale": brd_scale,
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def libxvid(
-    
+
     lumi_aq: int | None = None,
-    
+
     variance_aq: int | None = None,
-    
+
     ssim: int | None| Literal["off", "avg", "frame"] = None,
-    
+
     ssim_acc: int | None = None,
-    
+
     gmc: int | None = None,
-    
+
     me_quality: int | None = None,
-    
+
     mpeg_quant: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libxvidcore MPEG-4 part 2 (codec mpeg4)
-    
+
     Args:
         lumi_aq: Luminance masking AQ (from 0 to 1) (default 0)
         variance_aq: Variance AQ (from 0 to 1) (default 0)
@@ -3311,35 +3311,35 @@ def libxvid(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "lumi_aq": lumi_aq,
-        
+
         "variance_aq": variance_aq,
-        
+
         "ssim": ssim,
-        
+
         "ssim_acc": ssim_acc,
-        
+
         "gmc": gmc,
-        
+
         "me_quality": me_quality,
-        
+
         "mpeg_quant": mpeg_quant,
-        
+
     }))
 
 
 
 def mpeg4_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     V4L2 mem2mem MPEG4 encoder wrapper (codec mpeg4)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 4 to INT_MAX) (default 4)
@@ -3348,71 +3348,71 @@ def mpeg4_v4l2m2m(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def msmpeg4v2(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MPEG-4 part 2 Microsoft variant version 2
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -3444,117 +3444,117 @@ def msmpeg4v2(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def msmpeg4(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MPEG-4 part 2 Microsoft variant version 3 (codec msmpeg4v3)
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -3586,217 +3586,217 @@ def msmpeg4(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def msrle(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Microsoft RLE
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def msvideo1(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Microsoft Video-1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pam(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PAM (Portable AnyMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pbm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PBM (Portable BitMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcx(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PC Paintbrush PCX image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pfm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PFM (Portable FloatMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pgm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PGM (Portable GrayMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pgmyuv(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PGMYUV (Portable GrayMap YUV) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def phm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PHM (Portable HalfFloatMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def png(
-    
+
     dpi: int | None = None,
-    
+
     dpm: int | None = None,
-    
+
     pred: int | None| Literal["none", "sub", "up", "avg", "paeth", "mixed"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     PNG (Portable Network Graphics) image
-    
+
     Args:
         dpi: Set image resolution (in dots per inch) (from 0 to 65536) (default 0)
         dpm: Set image resolution (in dots per meter) (from 0 to 65536) (default 0)
@@ -3806,41 +3806,41 @@ def png(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "dpi": dpi,
-        
+
         "dpm": dpm,
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def ppm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PPM (Portable PixelMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def prores(
-    
+
     vendor: str | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Apple ProRes
-    
+
     Args:
         vendor: vendor ID (default "fmpg")
 
@@ -3848,21 +3848,21 @@ def prores(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "vendor": vendor,
-        
+
     }))
 
 
 
 def prores_aw(
-    
+
     vendor: str | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Apple ProRes (codec prores)
-    
+
     Args:
         vendor: vendor ID (default "fmpg")
 
@@ -3870,31 +3870,31 @@ def prores_aw(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "vendor": vendor,
-        
+
     }))
 
 
 
 def prores_ks(
-    
+
     mbs_per_slice: int | None = None,
-    
+
     profile: int | None| Literal["auto", "proxy", "lt", "standard", "hq", "4444", "4444xq"] = None,
-    
+
     vendor: str | None = None,
-    
+
     bits_per_mb: int | None = None,
-    
+
     quant_mat: int | None| Literal["auto", "proxy", "lt", "standard", "hq", "default"] = None,
-    
+
     alpha_bits: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Apple ProRes (iCodec Pro) (codec prores)
-    
+
     Args:
         mbs_per_slice: macroblocks per slice (from 1 to 8) (default 8)
         profile: (from -1 to 5) (default auto)
@@ -3907,111 +3907,111 @@ def prores_ks(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mbs_per_slice": mbs_per_slice,
-        
+
         "profile": profile,
-        
+
         "vendor": vendor,
-        
+
         "bits_per_mb": bits_per_mb,
-        
+
         "quant_mat": quant_mat,
-        
+
         "alpha_bits": alpha_bits,
-        
+
     }))
 
 
 
 def qoi(
-    
+
 ) -> FFMpegEncoderOption:
     """
     QOI (Quite OK Image format) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def qtrle(
-    
+
 ) -> FFMpegEncoderOption:
     """
     QuickTime Animation (RLE) video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def r10k(
-    
+
 ) -> FFMpegEncoderOption:
     """
     AJA Kona 10-bit RGB Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def r210(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed RGB 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def rawvideo(
-    
+
 ) -> FFMpegEncoderOption:
     """
     raw video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def roqvideo(
-    
+
     quake3_compat: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     id RoQ video (codec roq)
-    
+
     Args:
         quake3_compat: Whether to respect known limitations in Quake 3 decoder (default true)
 
@@ -4019,25 +4019,25 @@ def roqvideo(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "quake3_compat": quake3_compat,
-        
+
     }))
 
 
 
 def rpza(
-    
+
     skip_frame_thresh: int | None = None,
-    
+
     continue_one_color_thresh: int | None = None,
-    
+
     sixteen_color_thresh: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     QuickTime video (RPZA)
-    
+
     Args:
         skip_frame_thresh: (from 0 to 24) (default 1)
         continue_one_color_thresh: (from 0 to 24) (default 0)
@@ -4047,73 +4047,73 @@ def rpza(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "skip_frame_thresh": skip_frame_thresh,
-        
+
         "continue_one_color_thresh": continue_one_color_thresh,
-        
+
         "sixteen_color_thresh": sixteen_color_thresh,
-        
+
     }))
 
 
 
 def rv10(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     RealVideo 1.0
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -4145,117 +4145,117 @@ def rv10(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def rv20(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     RealVideo 2.0
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -4287,69 +4287,69 @@ def rv20(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def sgi(
-    
+
     rle: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     SGI image
-    
+
     Args:
         rle: Use run-length compression (from 0 to 1) (default 1)
 
@@ -4357,51 +4357,51 @@ def sgi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "rle": rle,
-        
+
     }))
 
 
 
 def smc(
-    
+
 ) -> FFMpegEncoderOption:
     """
     QuickTime Graphics (SMC)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def snow(
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone", "iter"] = None,
-    
+
     memc_only: bool | None = None,
-    
+
     no_bitstream: bool | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
     iterative_dia_size: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     pred: int | None| Literal["dwt97", "dwt53"] = None,
-    
+
     rc_eq: str | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Snow
-    
+
     Args:
         motion_est: motion estimation algorithm (from 0 to 3) (default epzs)
         memc_only: Only do ME/MC (I frames -> ref, P frame -> ME+MC). (default false)
@@ -4416,83 +4416,83 @@ def snow(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "motion_est": motion_est,
-        
+
         "memc_only": memc_only,
-        
+
         "no_bitstream": no_bitstream,
-        
+
         "intra_penalty": intra_penalty,
-        
+
         "iterative_dia_size": iterative_dia_size,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "pred": pred,
-        
+
         "rc_eq": rc_eq,
-        
+
     }))
 
 
 
 def speedhq(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     NewTek SpeedHQ
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -4524,69 +4524,69 @@ def speedhq(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def sunrast(
-    
+
     rle: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Sun Rasterfile image
-    
+
     Args:
         rle: Use run-length compression (from 0 to 1) (default 1)
 
@@ -4594,21 +4594,21 @@ def sunrast(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "rle": rle,
-        
+
     }))
 
 
 
 def svq1(
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Sorenson Vector Quantizer 1 / Sorenson Video 1 / SVQ1
-    
+
     Args:
         motion_est: Motion estimation algorithm (from 0 to 2) (default epzs)
 
@@ -4616,21 +4616,21 @@ def svq1(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "motion-est": motion_est,
-        
+
     }))
 
 
 
 def targa(
-    
+
     rle: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Truevision Targa image
-    
+
     Args:
         rle: Use run-length compression (from 0 to 1) (default 1)
 
@@ -4638,39 +4638,39 @@ def targa(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "rle": rle,
-        
+
     }))
 
 
 
 def libtheora(
-    
+
 ) -> FFMpegEncoderOption:
     """
     libtheora Theora (codec theora)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def tiff(
-    
+
     dpi: int | None = None,
-    
+
     compression_algo: int | None| Literal["packbits", "raw", "lzw", "deflate"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     TIFF image
-    
+
     Args:
         dpi: set the image resolution (in dpi) (from 1 to 65536) (default 72)
         compression_algo: (from 1 to 32946) (default packbits)
@@ -4679,23 +4679,23 @@ def tiff(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "dpi": dpi,
-        
+
         "compression_algo": compression_algo,
-        
+
     }))
 
 
 
 def utvideo(
-    
+
     pred: int | None| Literal["none", "left", "gradient", "median"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Ut Video
-    
+
     Args:
         pred: Prediction method (from 0 to 3) (default left)
 
@@ -4703,85 +4703,85 @@ def utvideo(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def v210(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed 4:2:2 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def v308(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed packed 4:4:4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def v408(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed packed QT 4:4:4:4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def v410(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed 4:4:4 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def vbn(
-    
+
     format: int | None| Literal["raw", "dxt1", "dxt5"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Vizrt Binary Image
-    
+
     Args:
         format: Texture format (from 0 to 3) (default dxt5)
 
@@ -4789,83 +4789,83 @@ def vbn(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "format": format,
-        
+
     }))
 
 
 
 def vnull(
-    
+
 ) -> FFMpegEncoderOption:
     """
     null video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def libvpx(
-    
+
     lag_in_frames: int | None = None,
-    
+
     arnr_maxframes: int | None = None,
-    
+
     arnr_strength: int | None = None,
-    
+
     arnr_type: int | None| Literal["backward", "forward", "centered"] = None,
-    
+
     tune: int | None| Literal["psnr", "ssim"] = None,
-    
+
     deadline: int | None| Literal["best", "good", "realtime"] = None,
-    
+
     error_resilient: str | None = None,
-    
+
     max_intra_rate: int | None = None,
-    
+
     crf: int | None = None,
-    
+
     static_thresh: int | None = None,
-    
+
     drop_threshold: int | None = None,
-    
+
     noise_sensitivity: int | None = None,
-    
+
     undershoot_pct: int | None = None,
-    
+
     overshoot_pct: int | None = None,
-    
+
     ts_parameters: str | None = None,
-    
+
     auto_alt_ref: int | None = None,
-    
+
     cpu_used: int | None = None,
-    
+
     screen_content_mode: int | None = None,
-    
+
     speed: int | None = None,
-    
+
     quality: int | None| Literal["best", "good", "realtime"] = None,
-    
+
     vp8flags: str | None = None,
-    
+
     arnr_max_frames: int | None = None,
-    
+
     rc_lookahead: int | None = None,
-    
+
     sharpness: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libvpx VP8 (codec vp8)
-    
+
     Args:
         lag_in_frames: Number of frames to look ahead for alternate reference frame selection (from -1 to INT_MAX) (default -1)
         arnr_maxframes: altref noise reduction max frame count (from -1 to INT_MAX) (default -1)
@@ -4896,69 +4896,69 @@ def libvpx(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "lag-in-frames": lag_in_frames,
-        
+
         "arnr-maxframes": arnr_maxframes,
-        
+
         "arnr-strength": arnr_strength,
-        
+
         "arnr-type": arnr_type,
-        
+
         "tune": tune,
-        
+
         "deadline": deadline,
-        
+
         "error-resilient": error_resilient,
-        
+
         "max-intra-rate": max_intra_rate,
-        
+
         "crf": crf,
-        
+
         "static-thresh": static_thresh,
-        
+
         "drop-threshold": drop_threshold,
-        
+
         "noise-sensitivity": noise_sensitivity,
-        
+
         "undershoot-pct": undershoot_pct,
-        
+
         "overshoot-pct": overshoot_pct,
-        
+
         "ts-parameters": ts_parameters,
-        
+
         "auto-alt-ref": auto_alt_ref,
-        
+
         "cpu-used": cpu_used,
-        
+
         "screen-content-mode": screen_content_mode,
-        
+
         "speed": speed,
-        
+
         "quality": quality,
-        
+
         "vp8flags": vp8flags,
-        
+
         "arnr_max_frames": arnr_max_frames,
-        
+
         "rc_lookahead": rc_lookahead,
-        
+
         "sharpness": sharpness,
-        
+
     }))
 
 
 
 def vp8_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     V4L2 mem2mem VP8 encoder wrapper (codec vp8)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 4 to INT_MAX) (default 4)
@@ -4967,39 +4967,39 @@ def vp8_v4l2m2m(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def vp8_vaapi(
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     low_power: bool | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     rc_mode: int | None| Literal["auto", "CQP", "CBR", "VBR", "ICQ", "QVBR", "AVBR"] = None,
-    
+
     blbrc: bool | None = None,
-    
+
     loop_filter_level: int | None = None,
-    
+
     loop_filter_sharpness: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     VP8 (VAAPI) (codec vp8)
-    
+
     Args:
         idr_interval: Distance (in I-frames) between key frames (from 0 to INT_MAX) (default 0)
         b_depth: Maximum B-frame reference depth (from 1 to INT_MAX) (default 1)
@@ -5015,53 +5015,53 @@ def vp8_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "low_power": low_power,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "rc_mode": rc_mode,
-        
+
         "blbrc": blbrc,
-        
+
         "loop_filter_level": loop_filter_level,
-        
+
         "loop_filter_sharpness": loop_filter_sharpness,
-        
+
     }))
 
 
 
 def vp9_vaapi(
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     low_power: bool | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     rc_mode: int | None| Literal["auto", "CQP", "CBR", "VBR", "ICQ", "QVBR", "AVBR"] = None,
-    
+
     blbrc: bool | None = None,
-    
+
     loop_filter_level: int | None = None,
-    
+
     loop_filter_sharpness: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     VP9 (VAAPI) (codec vp9)
-    
+
     Args:
         idr_interval: Distance (in I-frames) between key frames (from 0 to INT_MAX) (default 0)
         b_depth: Maximum B-frame reference depth (from 1 to INT_MAX) (default 1)
@@ -5077,61 +5077,61 @@ def vp9_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "low_power": low_power,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "rc_mode": rc_mode,
-        
+
         "blbrc": blbrc,
-        
+
         "loop_filter_level": loop_filter_level,
-        
+
         "loop_filter_sharpness": loop_filter_sharpness,
-        
+
     }))
 
 
 
 def wbmp(
-    
+
 ) -> FFMpegEncoderOption:
     """
     WBMP (Wireless Application Protocol Bitmap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def libwebp_anim(
-    
+
     lossless: int | None = None,
-    
+
     preset: int | None| Literal["none", "default", "picture", "photo", "drawing", "icon", "text"] = None,
-    
+
     cr_threshold: int | None = None,
-    
+
     cr_size: int | None = None,
-    
+
     quality: float | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libwebp WebP image (codec webp)
-    
+
     Args:
         lossless: Use lossless mode (from 0 to 1) (default 0)
         preset: Configuration preset (from -1 to 5) (default none)
@@ -5143,37 +5143,37 @@ def libwebp_anim(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "lossless": lossless,
-        
+
         "preset": preset,
-        
+
         "cr_threshold": cr_threshold,
-        
+
         "cr_size": cr_size,
-        
+
         "quality": quality,
-        
+
     }))
 
 
 
 def libwebp(
-    
+
     lossless: int | None = None,
-    
+
     preset: int | None| Literal["none", "default", "picture", "photo", "drawing", "icon", "text"] = None,
-    
+
     cr_threshold: int | None = None,
-    
+
     cr_size: int | None = None,
-    
+
     quality: float | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libwebp WebP image (codec webp)
-    
+
     Args:
         lossless: Use lossless mode (from 0 to 1) (default 0)
         preset: Configuration preset (from -1 to 5) (default none)
@@ -5185,77 +5185,77 @@ def libwebp(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "lossless": lossless,
-        
+
         "preset": preset,
-        
+
         "cr_threshold": cr_threshold,
-        
+
         "cr_size": cr_size,
-        
+
         "quality": quality,
-        
+
     }))
 
 
 
 def wmv1(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Windows Media Video 7
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -5287,117 +5287,117 @@ def wmv1(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def wmv2(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Windows Media Video 8
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -5429,211 +5429,211 @@ def wmv2(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
     }))
 
 
 
 def wrapped_avframe(
-    
+
 ) -> FFMpegEncoderOption:
     """
     AVFrame to AVPacket passthrough
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def xbm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     XBM (X BitMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def xface(
-    
+
 ) -> FFMpegEncoderOption:
     """
     X-face image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def xwd(
-    
+
 ) -> FFMpegEncoderOption:
     """
     XWD (X Window Dump) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def y41p(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed YUV 4:1:1 12-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def yuv4(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed packed 4:2:0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def zlib(
-    
+
 ) -> FFMpegEncoderOption:
     """
     LCL (LossLess Codec Library) ZLIB
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def zmbv(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Zip Motion Blocks Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def aac(
-    
+
     aac_coder: int | None| Literal["anmr", "twoloop", "fast"] = None,
-    
+
     aac_ms: bool | None = None,
-    
+
     aac_is: bool | None = None,
-    
+
     aac_pns: bool | None = None,
-    
+
     aac_tns: bool | None = None,
-    
+
     aac_ltp: bool | None = None,
-    
+
     aac_pred: bool | None = None,
-    
+
     aac_pce: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     AAC (Advanced Audio Coding)
-    
+
     Args:
         aac_coder: Coding algorithm (from 0 to 2) (default twoloop)
         aac_ms: Force M/S stereo coding (default auto)
@@ -5648,73 +5648,73 @@ def aac(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "aac_coder": aac_coder,
-        
+
         "aac_ms": aac_ms,
-        
+
         "aac_is": aac_is,
-        
+
         "aac_pns": aac_pns,
-        
+
         "aac_tns": aac_tns,
-        
+
         "aac_ltp": aac_ltp,
-        
+
         "aac_pred": aac_pred,
-        
+
         "aac_pce": aac_pce,
-        
+
     }))
 
 
 
 def ac3(
-    
+
     center_mixlev: float | None = None,
-    
+
     surround_mixlev: float | None = None,
-    
+
     mixing_level: int | None = None,
-    
+
     room_type: int | None| Literal["notindicated", "large", "small"] = None,
-    
+
     per_frame_metadata: bool | None = None,
-    
+
     copyright: int | None = None,
-    
+
     dialnorm: int | None = None,
-    
+
     dsur_mode: int | None| Literal["notindicated", "on", "off"] = None,
-    
+
     original: int | None = None,
-    
+
     dmix_mode: int | None| Literal["notindicated", "ltrt", "loro", "dplii"] = None,
-    
+
     ltrt_cmixlev: float | None = None,
-    
+
     ltrt_surmixlev: float | None = None,
-    
+
     loro_cmixlev: float | None = None,
-    
+
     loro_surmixlev: float | None = None,
-    
+
     dsurex_mode: int | None| Literal["notindicated", "on", "off", "dpliiz"] = None,
-    
+
     dheadphone_mode: int | None| Literal["notindicated", "on", "off"] = None,
-    
+
     ad_conv_type: int | None| Literal["standard", "hdcd"] = None,
-    
+
     stereo_rematrixing: bool | None = None,
-    
+
     channel_coupling: int | None| Literal["auto"] = None,
-    
+
     cpl_start_band: int | None| Literal["auto"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ATSC A/52A (AC-3)
-    
+
     Args:
         center_mixlev: Center Mix Level (from 0 to 1) (default 0.594604)
         surround_mixlev: Surround Mix Level (from 0 to 1) (default 0.5)
@@ -5741,97 +5741,97 @@ def ac3(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "center_mixlev": center_mixlev,
-        
+
         "surround_mixlev": surround_mixlev,
-        
+
         "mixing_level": mixing_level,
-        
+
         "room_type": room_type,
-        
+
         "per_frame_metadata": per_frame_metadata,
-        
+
         "copyright": copyright,
-        
+
         "dialnorm": dialnorm,
-        
+
         "dsur_mode": dsur_mode,
-        
+
         "original": original,
-        
+
         "dmix_mode": dmix_mode,
-        
+
         "ltrt_cmixlev": ltrt_cmixlev,
-        
+
         "ltrt_surmixlev": ltrt_surmixlev,
-        
+
         "loro_cmixlev": loro_cmixlev,
-        
+
         "loro_surmixlev": loro_surmixlev,
-        
+
         "dsurex_mode": dsurex_mode,
-        
+
         "dheadphone_mode": dheadphone_mode,
-        
+
         "ad_conv_type": ad_conv_type,
-        
+
         "stereo_rematrixing": stereo_rematrixing,
-        
+
         "channel_coupling": channel_coupling,
-        
+
         "cpl_start_band": cpl_start_band,
-        
+
     }))
 
 
 
 def ac3_fixed(
-    
+
     center_mixlev: float | None = None,
-    
+
     surround_mixlev: float | None = None,
-    
+
     mixing_level: int | None = None,
-    
+
     room_type: int | None| Literal["notindicated", "large", "small"] = None,
-    
+
     per_frame_metadata: bool | None = None,
-    
+
     copyright: int | None = None,
-    
+
     dialnorm: int | None = None,
-    
+
     dsur_mode: int | None| Literal["notindicated", "on", "off"] = None,
-    
+
     original: int | None = None,
-    
+
     dmix_mode: int | None| Literal["notindicated", "ltrt", "loro", "dplii"] = None,
-    
+
     ltrt_cmixlev: float | None = None,
-    
+
     ltrt_surmixlev: float | None = None,
-    
+
     loro_cmixlev: float | None = None,
-    
+
     loro_surmixlev: float | None = None,
-    
+
     dsurex_mode: int | None| Literal["notindicated", "on", "off", "dpliiz"] = None,
-    
+
     dheadphone_mode: int | None| Literal["notindicated", "on", "off"] = None,
-    
+
     ad_conv_type: int | None| Literal["standard", "hdcd"] = None,
-    
+
     stereo_rematrixing: bool | None = None,
-    
+
     channel_coupling: int | None| Literal["auto"] = None,
-    
+
     cpl_start_band: int | None| Literal["auto"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ATSC A/52A (AC-3) (codec ac3)
-    
+
     Args:
         center_mixlev: Center Mix Level (from 0 to 1) (default 0.594604)
         surround_mixlev: Surround Mix Level (from 0 to 1) (default 0.5)
@@ -5858,75 +5858,75 @@ def ac3_fixed(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "center_mixlev": center_mixlev,
-        
+
         "surround_mixlev": surround_mixlev,
-        
+
         "mixing_level": mixing_level,
-        
+
         "room_type": room_type,
-        
+
         "per_frame_metadata": per_frame_metadata,
-        
+
         "copyright": copyright,
-        
+
         "dialnorm": dialnorm,
-        
+
         "dsur_mode": dsur_mode,
-        
+
         "original": original,
-        
+
         "dmix_mode": dmix_mode,
-        
+
         "ltrt_cmixlev": ltrt_cmixlev,
-        
+
         "ltrt_surmixlev": ltrt_surmixlev,
-        
+
         "loro_cmixlev": loro_cmixlev,
-        
+
         "loro_surmixlev": loro_surmixlev,
-        
+
         "dsurex_mode": dsurex_mode,
-        
+
         "dheadphone_mode": dheadphone_mode,
-        
+
         "ad_conv_type": ad_conv_type,
-        
+
         "stereo_rematrixing": stereo_rematrixing,
-        
+
         "channel_coupling": channel_coupling,
-        
+
         "cpl_start_band": cpl_start_band,
-        
+
     }))
 
 
 
 def adpcm_adx(
-    
+
 ) -> FFMpegEncoderOption:
     """
     SEGA CRI ADX ADPCM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_argo(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM Argonaut Games
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -5934,37 +5934,37 @@ def adpcm_argo(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def g722(
-    
+
 ) -> FFMpegEncoderOption:
     """
     G.722 ADPCM (codec adpcm_g722)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def g726(
-    
+
     code_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     G.726 ADPCM (codec adpcm_g726)
-    
+
     Args:
         code_size: Bits per code (from 2 to 5) (default 4)
 
@@ -5972,21 +5972,21 @@ def g726(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "code_size": code_size,
-        
+
     }))
 
 
 
 def g726le(
-    
+
     code_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     G.726 little endian ADPCM ("right-justified") (codec adpcm_g726le)
-    
+
     Args:
         code_size: Bits per code (from 2 to 5) (default 4)
 
@@ -5994,21 +5994,21 @@ def g726le(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "code_size": code_size,
-        
+
     }))
 
 
 
 def adpcm_ima_alp(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA High Voltage Software ALP
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6016,21 +6016,21 @@ def adpcm_ima_alp(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ima_amv(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA AMV
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6038,21 +6038,21 @@ def adpcm_ima_amv(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ima_apm(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA Ubisoft APM
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6060,21 +6060,21 @@ def adpcm_ima_apm(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ima_qt(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA QuickTime
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6082,21 +6082,21 @@ def adpcm_ima_qt(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ima_ssi(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA Simon & Schuster Interactive
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6104,21 +6104,21 @@ def adpcm_ima_ssi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ima_wav(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA WAV
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6126,21 +6126,21 @@ def adpcm_ima_wav(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ima_ws(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA Westwood
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6148,21 +6148,21 @@ def adpcm_ima_ws(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ms(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM Microsoft
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6170,21 +6170,21 @@ def adpcm_ms(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_swf(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM Shockwave Flash
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6192,21 +6192,21 @@ def adpcm_swf(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_yamaha(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM Yamaha
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6214,23 +6214,23 @@ def adpcm_yamaha(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def alac(
-    
+
     min_prediction_order: int | None = None,
-    
+
     max_prediction_order: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ALAC (Apple Lossless Audio Codec)
-    
+
     Args:
         min_prediction_order: (from 1 to 30) (default 4)
         max_prediction_order: (from 1 to 30) (default 6)
@@ -6239,23 +6239,23 @@ def alac(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "min_prediction_order": min_prediction_order,
-        
+
         "max_prediction_order": max_prediction_order,
-        
+
     }))
 
 
 
 def libopencore_amrnb(
-    
+
     dtx: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     OpenCORE AMR-NB (Adaptive Multi-Rate Narrow-Band) (codec amr_nb)
-    
+
     Args:
         dtx: Allow DTX (generate comfort noise) (from 0 to 1) (default 0)
 
@@ -6263,101 +6263,101 @@ def libopencore_amrnb(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "dtx": dtx,
-        
+
     }))
 
 
 
 def anull(
-    
+
 ) -> FFMpegEncoderOption:
     """
     null audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def aptx(
-    
+
 ) -> FFMpegEncoderOption:
     """
     aptX (Audio Processing Technology for Bluetooth)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def aptx_hd(
-    
+
 ) -> FFMpegEncoderOption:
     """
     aptX HD (Audio Processing Technology for Bluetooth)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def comfortnoise(
-    
+
 ) -> FFMpegEncoderOption:
     """
     RFC 3389 comfort noise generator
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def dfpwm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     DFPWM1a audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def dca(
-    
+
     dca_adpcm: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     DCA (DTS Coherent Acoustics) (codec dts)
-    
+
     Args:
         dca_adpcm: Use ADPCM encoding (default false)
 
@@ -6365,55 +6365,55 @@ def dca(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "dca_adpcm": dca_adpcm,
-        
+
     }))
 
 
 
 def eac3(
-    
+
     mixing_level: int | None = None,
-    
+
     room_type: int | None| Literal["notindicated", "large", "small"] = None,
-    
+
     per_frame_metadata: bool | None = None,
-    
+
     copyright: int | None = None,
-    
+
     dialnorm: int | None = None,
-    
+
     dsur_mode: int | None| Literal["notindicated", "on", "off"] = None,
-    
+
     original: int | None = None,
-    
+
     dmix_mode: int | None| Literal["notindicated", "ltrt", "loro", "dplii"] = None,
-    
+
     ltrt_cmixlev: float | None = None,
-    
+
     ltrt_surmixlev: float | None = None,
-    
+
     loro_cmixlev: float | None = None,
-    
+
     loro_surmixlev: float | None = None,
-    
+
     dsurex_mode: int | None| Literal["notindicated", "on", "off", "dpliiz"] = None,
-    
+
     dheadphone_mode: int | None| Literal["notindicated", "on", "off"] = None,
-    
+
     ad_conv_type: int | None| Literal["standard", "hdcd"] = None,
-    
+
     stereo_rematrixing: bool | None = None,
-    
+
     channel_coupling: int | None| Literal["auto"] = None,
-    
+
     cpl_start_band: int | None| Literal["auto"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ATSC A/52 E-AC-3
-    
+
     Args:
         mixing_level: Mixing Level (from -1 to 111) (default -1)
         room_type: Room Type (from -1 to 2) (default -1)
@@ -6438,71 +6438,71 @@ def eac3(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mixing_level": mixing_level,
-        
+
         "room_type": room_type,
-        
+
         "per_frame_metadata": per_frame_metadata,
-        
+
         "copyright": copyright,
-        
+
         "dialnorm": dialnorm,
-        
+
         "dsur_mode": dsur_mode,
-        
+
         "original": original,
-        
+
         "dmix_mode": dmix_mode,
-        
+
         "ltrt_cmixlev": ltrt_cmixlev,
-        
+
         "ltrt_surmixlev": ltrt_surmixlev,
-        
+
         "loro_cmixlev": loro_cmixlev,
-        
+
         "loro_surmixlev": loro_surmixlev,
-        
+
         "dsurex_mode": dsurex_mode,
-        
+
         "dheadphone_mode": dheadphone_mode,
-        
+
         "ad_conv_type": ad_conv_type,
-        
+
         "stereo_rematrixing": stereo_rematrixing,
-        
+
         "channel_coupling": channel_coupling,
-        
+
         "cpl_start_band": cpl_start_band,
-        
+
     }))
 
 
 
 def flac(
-    
+
     lpc_coeff_precision: int | None = None,
-    
+
     lpc_type: int | None| Literal["none", "fixed", "levinson", "cholesky"] = None,
-    
+
     lpc_passes: int | None = None,
-    
+
     min_partition_order: int | None = None,
-    
+
     prediction_order_method: int | None| Literal["estimation", "2level", "4level", "8level", "search", "log"] = None,
-    
+
     ch_mode: int | None| Literal["auto", "indep", "left_side", "right_side", "mid_side"] = None,
-    
+
     exact_rice_parameters: bool | None = None,
-    
+
     multi_dim_quant: bool | None = None,
-    
+
     min_prediction_order: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     FLAC (Free Lossless Audio Codec)
-    
+
     Args:
         lpc_coeff_precision: LPC coefficient precision (from 0 to 15) (default 15)
         lpc_type: LPC algorithm (from -1 to 3) (default -1)
@@ -6518,65 +6518,65 @@ def flac(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "lpc_coeff_precision": lpc_coeff_precision,
-        
+
         "lpc_type": lpc_type,
-        
+
         "lpc_passes": lpc_passes,
-        
+
         "min_partition_order": min_partition_order,
-        
+
         "prediction_order_method": prediction_order_method,
-        
+
         "ch_mode": ch_mode,
-        
+
         "exact_rice_parameters": exact_rice_parameters,
-        
+
         "multi_dim_quant": multi_dim_quant,
-        
+
         "min_prediction_order": min_prediction_order,
-        
+
     }))
 
 
 
 def g723_1(
-    
+
 ) -> FFMpegEncoderOption:
     """
     G.723.1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def mlp(
-    
+
     max_interval: int | None = None,
-    
+
     lpc_coeff_precision: int | None = None,
-    
+
     lpc_type: int | None| Literal["levinson", "cholesky"] = None,
-    
+
     lpc_passes: int | None = None,
-    
+
     codebook_search: int | None = None,
-    
+
     prediction_order: int | None| Literal["estimation", "search"] = None,
-    
+
     rematrix_precision: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MLP (Meridian Lossless Packing)
-    
+
     Args:
         max_interval: Max number of frames between each new header (from 8 to 128) (default 16)
         lpc_coeff_precision: LPC coefficient precision (from 0 to 15) (default 15)
@@ -6590,73 +6590,73 @@ def mlp(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "max_interval": max_interval,
-        
+
         "lpc_coeff_precision": lpc_coeff_precision,
-        
+
         "lpc_type": lpc_type,
-        
+
         "lpc_passes": lpc_passes,
-        
+
         "codebook_search": codebook_search,
-        
+
         "prediction_order": prediction_order,
-        
+
         "rematrix_precision": rematrix_precision,
-        
+
     }))
 
 
 
 def mp2(
-    
+
 ) -> FFMpegEncoderOption:
     """
     MP2 (MPEG audio layer 2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def mp2fixed(
-    
+
 ) -> FFMpegEncoderOption:
     """
     MP2 fixed point (MPEG audio layer 2) (codec mp2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def libmp3lame(
-    
+
     reservoir: bool | None = None,
-    
+
     joint_stereo: bool | None = None,
-    
+
     abr: bool | None = None,
-    
+
     copyright: bool | None = None,
-    
+
     original: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libmp3lame MP3 (MPEG audio layer 3) (codec mp3)
-    
+
     Args:
         reservoir: use bit reservoir (default true)
         joint_stereo: use joint stereo (default true)
@@ -6668,47 +6668,47 @@ def libmp3lame(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "reservoir": reservoir,
-        
+
         "joint_stereo": joint_stereo,
-        
+
         "abr": abr,
-        
+
         "copyright": copyright,
-        
+
         "original": original,
-        
+
     }))
 
 
 
 def nellymoser(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Nellymoser Asao
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def opus(
-    
+
     opus_delay: float | None = None,
-    
+
     apply_phase_inv: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Opus
-    
+
     Args:
         opus_delay: Maximum delay in milliseconds (from 2.5 to 360) (default 360)
         apply_phase_inv: Apply intensity stereo phase inversion (default true)
@@ -6717,35 +6717,35 @@ def opus(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "opus_delay": opus_delay,
-        
+
         "apply_phase_inv": apply_phase_inv,
-        
+
     }))
 
 
 
 def libopus(
-    
+
     application: int | None| Literal["voip", "audio", "lowdelay"] = None,
-    
+
     frame_duration: float | None = None,
-    
+
     packet_loss: int | None = None,
-    
+
     fec: bool | None = None,
-    
+
     vbr: int | None| Literal["off", "on", "constrained"] = None,
-    
+
     mapping_family: int | None = None,
-    
+
     apply_phase_inv: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libopus Opus (codec opus)
-    
+
     Args:
         application: Intended application type (from 2048 to 2051) (default audio)
         frame_duration: Duration of a frame in milliseconds (from 2.5 to 120) (default 20)
@@ -6759,579 +6759,579 @@ def libopus(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "application": application,
-        
+
         "frame_duration": frame_duration,
-        
+
         "packet_loss": packet_loss,
-        
+
         "fec": fec,
-        
+
         "vbr": vbr,
-        
+
         "mapping_family": mapping_family,
-        
+
         "apply_phase_inv": apply_phase_inv,
-        
+
     }))
 
 
 
 def pcm_alaw(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM A-law / G.711 A-law
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_bluray(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 16|20|24-bit big-endian for Blu-ray media
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_dvd(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 16|20|24-bit big-endian for DVD media
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f32be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM 32-bit floating point big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f32le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM 32-bit floating point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f64be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM 64-bit floating point big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f64le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM 64-bit floating point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_mulaw(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM mu-law / G.711 mu-law
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 16-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16be_planar(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 16-bit big-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 16-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16le_planar(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 16-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 24-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24daud(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM D-Cinema audio signed 24-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 24-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24le_planar(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 24-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s32be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 32-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s32le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 32-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s32le_planar(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 32-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s64be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 64-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s64le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 64-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s8(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 8-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s8_planar(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 8-bit planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u16be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 16-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u16le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 16-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u24be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 24-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u24le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 24-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u32be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 32-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u32le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 32-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u8(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 8-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_vidc(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM Archimedes VIDC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def real_144(
-    
+
 ) -> FFMpegEncoderOption:
     """
     RealAudio 1.0 (14.4K) (codec ra_144)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def roq_dpcm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     id RoQ DPCM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def s302m(
-    
+
 ) -> FFMpegEncoderOption:
     """
     SMPTE 302M
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def sbc(
-    
+
     sbc_delay: str | None = None,
-    
+
     msbc: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     SBC (low-complexity subband codec)
-    
+
     Args:
         sbc_delay: set maximum algorithmic latency (default 0.013)
         msbc: use mSBC mode (wideband speech mono SBC) (default false)
@@ -7340,67 +7340,67 @@ def sbc(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "sbc_delay": sbc_delay,
-        
+
         "msbc": msbc,
-        
+
     }))
 
 
 
 def sonic(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Sonic
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def sonicls(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Sonic lossless
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def truehd(
-    
+
     max_interval: int | None = None,
-    
+
     lpc_coeff_precision: int | None = None,
-    
+
     lpc_type: int | None| Literal["levinson", "cholesky"] = None,
-    
+
     lpc_passes: int | None = None,
-    
+
     codebook_search: int | None = None,
-    
+
     prediction_order: int | None| Literal["estimation", "search"] = None,
-    
+
     rematrix_precision: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     TrueHD
-    
+
     Args:
         max_interval: Max number of frames between each new header (from 8 to 128) (default 16)
         lpc_coeff_precision: LPC coefficient precision (from 0 to 15) (default 15)
@@ -7414,65 +7414,65 @@ def truehd(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "max_interval": max_interval,
-        
+
         "lpc_coeff_precision": lpc_coeff_precision,
-        
+
         "lpc_type": lpc_type,
-        
+
         "lpc_passes": lpc_passes,
-        
+
         "codebook_search": codebook_search,
-        
+
         "prediction_order": prediction_order,
-        
+
         "rematrix_precision": rematrix_precision,
-        
+
     }))
 
 
 
 def tta(
-    
+
 ) -> FFMpegEncoderOption:
     """
     TTA (True Audio)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def vorbis(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Vorbis
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def libvorbis(
-    
+
     iblock: float | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libvorbis (codec vorbis)
-    
+
     Args:
         iblock: Sets the impulse block bias (from -15 to 0) (default 0)
 
@@ -7480,23 +7480,23 @@ def libvorbis(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "iblock": iblock,
-        
+
     }))
 
 
 
 def wavpack(
-    
+
     joint_stereo: bool | None = None,
-    
+
     optimize_mono: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     WavPack
-    
+
     Args:
         joint_stereo: (default auto)
         optimize_mono: (default false)
@@ -7505,105 +7505,105 @@ def wavpack(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "joint_stereo": joint_stereo,
-        
+
         "optimize_mono": optimize_mono,
-        
+
     }))
 
 
 
 def wmav1(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Windows Media Audio 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def wmav2(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Windows Media Audio 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def ssa(
-    
+
 ) -> FFMpegEncoderOption:
     """
     ASS (Advanced SubStation Alpha) subtitle (codec ass)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def ass(
-    
+
 ) -> FFMpegEncoderOption:
     """
     ASS (Advanced SubStation Alpha) subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def dvbsub(
-    
+
 ) -> FFMpegEncoderOption:
     """
     DVB subtitles (codec dvb_subtitle)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def dvdsub(
-    
+
     palette: str | None = None,
-    
+
     even_rows_fix: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     DVD subtitles (codec dvd_subtitle)
-    
+
     Args:
         palette: set the global palette
         even_rows_fix: Make number of rows even (workaround for some players) (default false)
@@ -7612,23 +7612,23 @@ def dvdsub(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "palette": palette,
-        
+
         "even_rows_fix": even_rows_fix,
-        
+
     }))
 
 
 
 def mov_text(
-    
+
     height: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     3GPP Timed Text subtitle
-    
+
     Args:
         height: Frame height, usually video height (from 0 to INT_MAX) (default 0)
 
@@ -7636,1124 +7636,103 @@ def mov_text(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "height": height,
-        
+
     }))
 
 
 
 def srt(
-    
+
 ) -> FFMpegEncoderOption:
     """
     SubRip subtitle (codec subrip)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def subrip(
-    
+
 ) -> FFMpegEncoderOption:
     """
     SubRip subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def text(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Raw text subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def ttml(
-    
+
 ) -> FFMpegEncoderOption:
     """
     TTML subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def webvtt(
-    
+
 ) -> FFMpegEncoderOption:
     """
     WebVTT subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def xsub(
-    
+
 ) -> FFMpegEncoderOption:
     """
     DivX subtitles (XSUB)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/packages/v7/src/ffmpeg/dag/global_runnable/global_args.py
+++ b/packages/v7/src/ffmpeg/dag/global_runnable/global_args.py
@@ -93,242 +93,242 @@ class GlobalArgs(ABC):
 
         return self._global_node(**merge(
             {
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "loglevel": loglevel,
-                
+
                 "v": v,
-                
+
                 "report": report,
-                
+
                 "max_alloc": max_alloc,
-                
+
                 "cpuflags": cpuflags,
-                
+
                 "cpucount": cpucount,
-                
+
                 "hide_banner": hide_banner,
-                
-                
-                
-                
+
+
+
+
                 "y": y,
-                
+
                 "n": n,
-                
+
                 "ignore_unknown": ignore_unknown,
-                
+
                 "copy_unknown": copy_unknown,
-                
+
                 "recast_media": recast_media,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "benchmark": benchmark,
-                
+
                 "benchmark_all": benchmark_all,
-                
+
                 "progress": progress,
-                
+
                 "stdin": stdin,
-                
+
                 "timelimit": timelimit,
-                
+
                 "dump": dump,
-                
+
                 "hex": hex,
-                
-                
-                
-                
-                
+
+
+
+
+
                 "frame_drop_threshold": frame_drop_threshold,
-                
+
                 "copyts": copyts,
-                
+
                 "start_at_zero": start_at_zero,
-                
+
                 "copytb": copytb,
-                
-                
-                
-                
+
+
+
+
                 "dts_delta_threshold": dts_delta_threshold,
-                
+
                 "dts_error_threshold": dts_error_threshold,
-                
+
                 "xerror": xerror,
-                
+
                 "abort_on": abort_on,
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
                 "filter_threads": filter_threads,
-                
-                
-                
+
+
+
                 "filter_complex": filter_complex,
-                
+
                 "filter_complex_threads": filter_complex_threads,
-                
+
                 "lavfi": lavfi,
-                
+
                 "filter_complex_script": filter_complex_script,
-                
+
                 "auto_conversion_filters": auto_conversion_filters,
-                
+
                 "stats": stats,
-                
+
                 "stats_period": stats_period,
-                
-                
-                
-                
+
+
+
+
                 "debug_ts": debug_ts,
-                
+
                 "max_error_rate": max_error_rate,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "vstats": vstats,
-                
+
                 "vstats_file": vstats_file,
-                
+
                 "vstats_version": vstats_version,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "vaapi_device": vaapi_device,
-                
+
                 "init_hw_device": init_hw_device,
-                
+
                 "filter_hw_device": filter_hw_device,
-                
+
                 "adrift_threshold": adrift_threshold,
-                
-                
+
+
                 "qphist": qphist,
-                
+
                 "vsync": vsync,
-                
-                
+
+
             }, extra_options)
         ).stream()

--- a/packages/v7/src/ffmpeg/dag/io/_input.py
+++ b/packages/v7/src/ffmpeg/dag/io/_input.py
@@ -126,249 +126,249 @@ def input(
     return InputNode(
         filename=str(filename),
         kwargs=merge({
-            
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "f": f,
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 "c": c,
-                
+
                 "codec": codec,
-                
-                
-                
-                
-                
+
+
+
+
+
                 "t": t,
-                
+
                 "to": to,
-                
-                
+
+
                 "ss": ss,
-                
+
                 "sseof": sseof,
-                
+
                 "seek_timestamp": seek_timestamp,
-                
+
                 "accurate_seek": accurate_seek,
-                
+
                 "isync": isync,
-                
+
                 "itsoffset": itsoffset,
-                
+
                 "itsscale": itsscale,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "re": re,
-                
+
                 "readrate": readrate,
-                
+
                 "readrate_initial_burst": readrate_initial_burst,
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
                 "bitexact": bitexact,
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
                 "tag": tag,
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
                 "reinit_filter": reinit_filter,
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
                 "dump_attachment": dump_attachment,
-                
+
                 "stream_loop": stream_loop,
-                
-                
-                
+
+
+
                 "discard": discard,
-                
-                
+
+
                 "thread_queue_size": thread_queue_size,
-                
+
                 "find_stream_info": find_stream_info,
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
                 "r": r,
-                
-                
+
+
                 "s": s,
-                
-                
+
+
                 "pix_fmt": pix_fmt,
-                
+
                 "display_rotation": display_rotation,
-                
+
                 "display_hflip": display_hflip,
-                
+
                 "display_vflip": display_vflip,
-                
+
                 "vn": vn,
-                
-                
+
+
                 "vcodec": vcodec,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
                 "vtag": vtag,
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 "hwaccel": hwaccel,
-                
+
                 "hwaccel_device": hwaccel_device,
-                
+
                 "hwaccel_output_format": hwaccel_output_format,
-                
-                
+
+
                 "autorotate": autorotate,
-                
-                
+
+
                 "apply_cropping": apply_cropping,
-                
-                
-                
-                
+
+
+
+
                 "ar": ar,
-                
+
                 "ac": ac,
-                
+
                 "an": an,
-                
+
                 "acodec": acodec,
-                
-                
-                
-                
+
+
+
+
                 "sample_fmt": sample_fmt,
-                
+
                 "channel_layout": channel_layout,
-                
+
                 "ch_layout": ch_layout,
-                
-                
+
+
                 "guess_layout_max": guess_layout_max,
-                
+
                 "sn": sn,
-                
+
                 "scodec": scodec,
-                
-                
+
+
                 "fix_sub_duration": fix_sub_duration,
-                
+
                 "canvas_size": canvas_size,
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 "bsf": bsf,
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
                 "dcodec": dcodec,
-                
+
                 "dn": dn,
-                
-                
-                
-                
-                
+
+
+
+
+
                 "top": top,
-                
-                
-                
-                
+
+
+
+
         }, decoder_options, demuxer_options, format_options, codec_options, extra_options )
     ).stream()

--- a/packages/v7/src/ffmpeg/dag/io/_output.py
+++ b/packages/v7/src/ffmpeg/dag/io/_output.py
@@ -163,290 +163,290 @@ def output(
         inputs=streams,
         filename=str(filename),
         kwargs=merge({
-            
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "f": f,
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 "c": c,
-                
+
                 "codec": codec,
-                
+
                 "pre": pre,
-                
+
                 "map": map,
-                
+
                 "map_metadata": map_metadata,
-                
+
                 "map_chapters": map_chapters,
-                
+
                 "t": t,
-                
+
                 "to": to,
-                
+
                 "fs": fs,
-                
+
                 "ss": ss,
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
                 "timestamp": timestamp,
-                
+
                 "metadata": metadata,
-                
+
                 "program": program,
-                
+
                 "stream_group": stream_group,
-                
+
                 "dframes": dframes,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
                 "target": target,
-                
-                
-                
-                
-                
+
+
+
+
+
                 "shortest": shortest,
-                
+
                 "shortest_buf_duration": shortest_buf_duration,
-                
+
                 "bitexact": bitexact,
-                
-                
-                
-                
-                
+
+
+
+
+
                 "copyinkf": copyinkf,
-                
+
                 "copypriorss": copypriorss,
-                
+
                 "frames": frames,
-                
+
                 "tag": tag,
-                
+
                 "q": q,
-                
+
                 "qscale": qscale,
-                
+
                 "profile": profile,
-                
+
                 "filter": filter,
-                
-                
+
+
                 "filter_script": filter_script,
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
                 "attach": attach,
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 "disposition": disposition,
-                
+
                 "thread_queue_size": thread_queue_size,
-                
-                
+
+
                 "bits_per_raw_sample": bits_per_raw_sample,
-                
+
                 "stats_enc_pre": stats_enc_pre,
-                
+
                 "stats_enc_post": stats_enc_post,
-                
+
                 "stats_mux_pre": stats_mux_pre,
-                
+
                 "stats_enc_pre_fmt": stats_enc_pre_fmt,
-                
+
                 "stats_enc_post_fmt": stats_enc_post_fmt,
-                
+
                 "stats_mux_pre_fmt": stats_mux_pre_fmt,
-                
+
                 "vframes": vframes,
-                
+
                 "r": r,
-                
+
                 "fpsmax": fpsmax,
-                
+
                 "s": s,
-                
+
                 "aspect": aspect,
-                
+
                 "pix_fmt": pix_fmt,
-                
-                
-                
-                
+
+
+
+
                 "vn": vn,
-                
+
                 "rc_override": rc_override,
-                
+
                 "vcodec": vcodec,
-                
+
                 "timecode": timecode,
-                
+
                 "pass": _pass,
-                
+
                 "passlogfile": passlogfile,
-                
-                
-                
-                
+
+
+
+
                 "vf": vf,
-                
+
                 "intra_matrix": intra_matrix,
-                
+
                 "inter_matrix": inter_matrix,
-                
+
                 "chroma_intra_matrix": chroma_intra_matrix,
-                
+
                 "vtag": vtag,
-                
+
                 "fps_mode": fps_mode,
-                
+
                 "force_fps": force_fps,
-                
+
                 "streamid": streamid,
-                
+
                 "force_key_frames": force_key_frames,
-                
+
                 "b": b,
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 "autoscale": autoscale,
-                
-                
+
+
                 "fix_sub_duration_heartbeat": fix_sub_duration_heartbeat,
-                
+
                 "aframes": aframes,
-                
+
                 "aq": aq,
-                
+
                 "ar": ar,
-                
+
                 "ac": ac,
-                
+
                 "an": an,
-                
+
                 "acodec": acodec,
-                
+
                 "ab": ab,
-                
+
                 "apad": apad,
-                
+
                 "atag": atag,
-                
+
                 "sample_fmt": sample_fmt,
-                
+
                 "channel_layout": channel_layout,
-                
+
                 "ch_layout": ch_layout,
-                
+
                 "af": af,
-                
-                
+
+
                 "sn": sn,
-                
+
                 "scodec": scodec,
-                
+
                 "stag": stag,
-                
-                
-                
+
+
+
                 "muxdelay": muxdelay,
-                
+
                 "muxpreload": muxpreload,
-                
+
                 "sdp_file": sdp_file,
-                
+
                 "time_base": time_base,
-                
+
                 "enc_time_base": enc_time_base,
-                
+
                 "bsf": bsf,
-                
+
                 "apre": apre,
-                
+
                 "vpre": vpre,
-                
+
                 "spre": spre,
-                
+
                 "fpre": fpre,
-                
+
                 "max_muxing_queue_size": max_muxing_queue_size,
-                
+
                 "muxing_queue_data_threshold": muxing_queue_data_threshold,
-                
+
                 "dcodec": dcodec,
-                
+
                 "dn": dn,
-                
-                
-                
-                
-                
+
+
+
+
+
                 "top": top,
-                
-                
-                
-                
+
+
+
+
         }, encoder_options, muxer_options, format_options, codec_options, extra_options )
     ).stream()

--- a/packages/v7/src/ffmpeg/dag/io/output_args.py
+++ b/packages/v7/src/ffmpeg/dag/io/output_args.py
@@ -173,289 +173,289 @@ class OutputArgs(ABC):
         """
 
         return self._output_node(*streams, filename=filename, **merge({
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
             "f": f,
-                
-            
-            
-            
-            
-            
+
+
+
+
+
+
             "c": c,
-                
+
             "codec": codec,
-                
+
             "pre": pre,
-                
+
             "map": map,
-                
+
             "map_metadata": map_metadata,
-                
+
             "map_chapters": map_chapters,
-                
+
             "t": t,
-                
+
             "to": to,
-                
+
             "fs": fs,
-                
+
             "ss": ss,
-                
-            
-            
-            
-            
-            
-            
+
+
+
+
+
+
+
             "timestamp": timestamp,
-                
+
             "metadata": metadata,
-                
+
             "program": program,
-                
+
             "stream_group": stream_group,
-                
+
             "dframes": dframes,
-                
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
+
+
+
+
+
+
+
+
+
+
+
             "target": target,
-                
-            
-            
-            
-            
+
+
+
+
+
             "shortest": shortest,
-                
+
             "shortest_buf_duration": shortest_buf_duration,
-                
+
             "bitexact": bitexact,
-                
-            
-            
-            
-            
+
+
+
+
+
             "copyinkf": copyinkf,
-                
+
             "copypriorss": copypriorss,
-                
+
             "frames": frames,
-                
+
             "tag": tag,
-                
+
             "q": q,
-                
+
             "qscale": qscale,
-                
+
             "profile": profile,
-                
+
             "filter": filter,
-                
-            
+
+
             "filter_script": filter_script,
-                
-            
-            
-            
-            
-            
-            
-            
-            
+
+
+
+
+
+
+
+
+
             "attach": attach,
-                
-            
-            
-            
-            
-            
+
+
+
+
+
+
             "disposition": disposition,
-                
+
             "thread_queue_size": thread_queue_size,
-                
-            
+
+
             "bits_per_raw_sample": bits_per_raw_sample,
-                
+
             "stats_enc_pre": stats_enc_pre,
-                
+
             "stats_enc_post": stats_enc_post,
-                
+
             "stats_mux_pre": stats_mux_pre,
-                
+
             "stats_enc_pre_fmt": stats_enc_pre_fmt,
-                
+
             "stats_enc_post_fmt": stats_enc_post_fmt,
-                
+
             "stats_mux_pre_fmt": stats_mux_pre_fmt,
-                
+
             "vframes": vframes,
-                
+
             "r": r,
-                
+
             "fpsmax": fpsmax,
-                
+
             "s": s,
-                
+
             "aspect": aspect,
-                
+
             "pix_fmt": pix_fmt,
-                
-            
-            
-            
+
+
+
+
             "vn": vn,
-                
+
             "rc_override": rc_override,
-                
+
             "vcodec": vcodec,
-                
+
             "timecode": timecode,
-                
+
             "pass": _pass,
-                
+
             "passlogfile": passlogfile,
-                
-            
-            
-            
+
+
+
+
             "vf": vf,
-                
+
             "intra_matrix": intra_matrix,
-                
+
             "inter_matrix": inter_matrix,
-                
+
             "chroma_intra_matrix": chroma_intra_matrix,
-                
+
             "vtag": vtag,
-                
+
             "fps_mode": fps_mode,
-                
+
             "force_fps": force_fps,
-                
+
             "streamid": streamid,
-                
+
             "force_key_frames": force_key_frames,
-                
+
             "b": b,
-                
-            
-            
-            
-            
-            
+
+
+
+
+
+
             "autoscale": autoscale,
-                
-            
+
+
             "fix_sub_duration_heartbeat": fix_sub_duration_heartbeat,
-                
+
             "aframes": aframes,
-                
+
             "aq": aq,
-                
+
             "ar": ar,
-                
+
             "ac": ac,
-                
+
             "an": an,
-                
+
             "acodec": acodec,
-                
+
             "ab": ab,
-                
+
             "apad": apad,
-                
+
             "atag": atag,
-                
+
             "sample_fmt": sample_fmt,
-                
+
             "channel_layout": channel_layout,
-                
+
             "ch_layout": ch_layout,
-                
+
             "af": af,
-                
-            
+
+
             "sn": sn,
-                
+
             "scodec": scodec,
-                
+
             "stag": stag,
-                
-            
-            
+
+
+
             "muxdelay": muxdelay,
-                
+
             "muxpreload": muxpreload,
-                
+
             "sdp_file": sdp_file,
-                
+
             "time_base": time_base,
-                
+
             "enc_time_base": enc_time_base,
-                
+
             "bsf": bsf,
-                
+
             "apre": apre,
-                
+
             "vpre": vpre,
-                
+
             "spre": spre,
-                
+
             "fpre": fpre,
-                
+
             "max_muxing_queue_size": max_muxing_queue_size,
-                
+
             "muxing_queue_data_threshold": muxing_queue_data_threshold,
-                
+
             "dcodec": dcodec,
-                
+
             "dn": dn,
-                
-            
-            
-            
-            
+
+
+
+
+
             "top": top,
-                
-            
-            
-            
+
+
+
+
         }, encoder_options, muxer_options, format_options, codec_options, extra_options)).stream()

--- a/packages/v7/src/ffmpeg/filters.py
+++ b/packages/v7/src/ffmpeg/filters.py
@@ -45,36 +45,36 @@ import re
 
 
 
-    
 
-    
 
-    
+
+
+
 def aap(
-    
 
-    
-        
+
+
+
         _input: AudioStream,
-        
-    
-        
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('16'),projection: Int = Default('2'),mu: Float = Default('0.0001'),delta: Float = Default('0.001'),out_mode: Int| Literal["i","d","o","n","e"] | Default = Default('o'),precision: Int| Literal["auto","float","double"] | Default = Default('auto'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Apply Affine Projection algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to estimate unknown audio based on multiple input audio samples.
@@ -100,7 +100,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aap)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -108,85 +108,85 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='aap', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _input,
-            
-        
-            
+
+
+
             _desired,
-            
-        
+
+
 
 
         **merge({
-            
+
             "order": order,
-            
+
             "projection": projection,
-            
+
             "mu": mu,
-            
+
             "delta": delta,
-            
+
             "out_mode": out_mode,
-            
+
             "precision": precision,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
 def acrossfade(
-    
 
-    
-        
+
+
+
         _crossfade0: AudioStream,
-        
-    
-        
+
+
+
         _crossfade1: AudioStream,
-        
-    
+
+
 
 
     *,
     nb_samples: Int64 = Default('44100'),duration: Duration = Default('0'),overlap: Boolean = Default('true'),curve1: Int| Literal["nofade","tri","qsin","esin","hsin","log","ipar","qua","cub","squ","cbr","par","exp","iqsin","ihsin","dese","desi","losi","sinc","isinc","quat","quatr","qsin2","hsin2"] | Default = Default('tri'),curve2: Int| Literal["nofade","tri","qsin","esin","hsin","log","ipar","qua","cub","squ","cbr","par","exp","iqsin","ihsin","dese","desi","losi","sinc","isinc","quat","quatr","qsin2","hsin2"] | Default = Default('tri'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Apply cross fade from one input audio stream to another input audio stream.
 The cross fade is applied for specified duration near the end of first stream.
 
@@ -208,132 +208,132 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acrossfade)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='acrossfade', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _crossfade0,
-            
-        
-            
+
+
+
             _crossfade1,
-            
-        
+
+
 
 
         **merge({
-            
+
             "nb_samples": nb_samples,
-            
+
             "duration": duration,
-            
+
             "overlap": overlap,
-            
+
             "curve1": curve1,
-            
+
             "curve2": curve2,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def ainterleave(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     nb_inputs: Int = Auto('len(streams)'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Temporally interleave frames from several inputs.
 
 interleave works with video inputs, ainterleave with audio.
@@ -372,82 +372,82 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#interleave)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='ainterleave', typings_input='[StreamType.audio] * int(nb_inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "nb_inputs": nb_inputs,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
 def alphamerge(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _alpha: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Add or replace the alpha component of the primary input with the
 grayscale value of a second input. This is intended for use with
 alphaextract to allow the transmission or storage of frame
@@ -473,7 +473,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#alphamerge)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -484,55 +484,55 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='alphamerge', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _alpha,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def amerge(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Merge two or more audio streams into a single multi-channel stream.
 
 The filter accepts the following options:
@@ -549,54 +549,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amerge)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='amerge', typings_input='[StreamType.audio] * int(inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def amix(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),dropout_transition: Float = Default('2'),weights: String = Default('1 1'),normalize: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Mixes multiple audio inputs into a single output.
 
 Note that this filter only supports float samples (the amerge
@@ -622,70 +622,70 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amix)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='amix', typings_input='[StreamType.audio] * int(inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "duration": duration,
-            
+
             "dropout_transition": dropout_transition,
-            
+
             "weights": weights,
-            
+
             "normalize": normalize,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def amultiply(
-    
 
-    
-        
+
+
+
         _multiply0: AudioStream,
-        
-    
-        
+
+
+
         _multiply1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Multiply first audio stream with second audio stream and store result
 in output audio stream. Multiplication is done by multiplying each
 sample from first stream with sample at same position from second stream.
@@ -704,69 +704,69 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amultiply)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='amultiply', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _multiply0,
-            
-        
-            
+
+
+
             _multiply1,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def anlmf(
-    
 
-    
-        
+
+
+
         _input: AudioStream,
-        
-    
-        
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('256'),mu: Float = Default('0.75'),eps: Float = Default('1'),leakage: Float = Default('0'),out_mode: Int| Literal["i","d","o","n","e"] | Default = Default('o'),precision: Int| Literal["auto","float","double"] | Default = Default('auto'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Apply Normalized Least-Mean-(Squares|Fourth) algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to mimic a desired filter by finding the filter coefficients that
@@ -793,7 +793,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anlmf)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -801,74 +801,74 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='anlmf', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _input,
-            
-        
-            
+
+
+
             _desired,
-            
-        
+
+
 
 
         **merge({
-            
+
             "order": order,
-            
+
             "mu": mu,
-            
+
             "eps": eps,
-            
+
             "leakage": leakage,
-            
+
             "out_mode": out_mode,
-            
+
             "precision": precision,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
+
+
+
 def anlms(
-    
 
-    
-        
+
+
+
         _input: AudioStream,
-        
-    
-        
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('256'),mu: Float = Default('0.75'),eps: Float = Default('1'),leakage: Float = Default('0'),out_mode: Int| Literal["i","d","o","n","e"] | Default = Default('o'),precision: Int| Literal["auto","float","double"] | Default = Default('auto'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Apply Normalized Least-Mean-(Squares|Fourth) algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to mimic a desired filter by finding the filter coefficients that
@@ -895,7 +895,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anlmf)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -903,92 +903,92 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='anlms', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _input,
-            
-        
-            
+
+
+
             _desired,
-            
-        
+
+
 
 
         **merge({
-            
+
             "order": order,
-            
+
             "mu": mu,
-            
+
             "eps": eps,
-            
+
             "leakage": leakage,
-            
+
             "out_mode": out_mode,
-            
+
             "precision": precision,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
 def apsnr(
-    
 
-    
-        
+
+
+
         _input0: AudioStream,
-        
-    
-        
+
+
+
         _input1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Measure Audio Peak Signal-to-Noise Ratio.
 
 This filter takes two audio streams for input, and outputs first
@@ -1007,7 +1007,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#apsnr)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -1015,72 +1015,72 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='apsnr', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _input0,
-            
-        
-            
+
+
+
             _input1,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
 def arls(
-    
 
-    
-        
+
+
+
         _input: AudioStream,
-        
-    
-        
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('16'),_lambda: Float = Default('1'),delta: Float = Default('2'),out_mode: Int| Literal["i","d","o","n","e"] | Default = Default('o'),precision: Int| Literal["auto","float","double"] | Default = Default('auto'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Apply Recursive Least Squares algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to mimic a desired filter by recursively finding the filter coefficients that
@@ -1106,7 +1106,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#arls)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -1114,74 +1114,74 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='arls', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _input,
-            
-        
-            
+
+
+
             _desired,
-            
-        
+
+
 
 
         **merge({
-            
+
             "order": order,
-            
+
             "lambda": _lambda,
-            
+
             "delta": delta,
-            
+
             "out_mode": out_mode,
-            
+
             "precision": precision,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def asdr(
-    
 
-    
-        
+
+
+
         _input0: AudioStream,
-        
-    
-        
+
+
+
         _input1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Measure Audio Signal-to-Distortion Ratio.
 
 This filter takes two audio streams for input, and outputs first
@@ -1200,7 +1200,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asdr)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -1208,80 +1208,80 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='asdr', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _input0,
-            
-        
-            
+
+
+
             _input1,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
 def asisdr(
-    
 
-    
-        
+
+
+
         _input0: AudioStream,
-        
-    
-        
+
+
+
         _input1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Measure Audio Scaled-Invariant Signal-to-Distortion Ratio.
 
 This filter takes two audio streams for input, and outputs first
@@ -1300,7 +1300,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asisdr)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -1308,63 +1308,63 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='asisdr', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _input0,
-            
-        
-            
+
+
+
             _input1,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
 def astreamselect(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),map: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Select video or audio streams.
 
 The filter accepts the following options:
@@ -1383,87 +1383,87 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#streamselect)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='astreamselect', typings_input='[StreamType.audio] * int(inputs)', typings_output="[StreamType.audio] * len(re.findall(r'\\d+', str(map)))"),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "map": map,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def axcorrelate(
-    
 
-    
-        
+
+
+
         _axcorrelate0: AudioStream,
-        
-    
-        
+
+
+
         _axcorrelate1: AudioStream,
-        
-    
+
+
 
 
     *,
     size: Int = Default('256'),algo: Int| Literal["slow","fast","best"] | Default = Default('best'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Calculate normalized windowed cross-correlation between two input audio streams.
 
 Resulted samples are always between -1 and 1 inclusive.
@@ -1487,98 +1487,98 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#axcorrelate)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='axcorrelate', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _axcorrelate0,
-            
-        
-            
+
+
+
             _axcorrelate1,
-            
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "algo": algo,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def blend(
-    
 
-    
-        
+
+
+
         _top: VideoStream,
-        
-    
-        
+
+
+
         _bottom: VideoStream,
-        
-    
+
+
 
 
     *,
     c0_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c1_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c2_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c3_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),all_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('-1'),c0_expr: String = Default(None),c1_expr: String = Default(None),c2_expr: String = Default(None),c3_expr: String = Default(None),all_expr: String = Default(None),c0_opacity: Double = Default('1'),c1_opacity: Double = Default('1'),c2_opacity: Double = Default('1'),c3_opacity: Double = Default('1'),all_opacity: Double = Default('1'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Blend two video frames into each other.
 
 The blend filter takes two input streams and outputs one
@@ -1619,7 +1619,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blend)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -1630,92 +1630,92 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='blend', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _top,
-            
-        
-            
+
+
+
             _bottom,
-            
-        
+
+
 
 
         **merge({
-            
+
             "c0_mode": c0_mode,
-            
+
             "c1_mode": c1_mode,
-            
+
             "c2_mode": c2_mode,
-            
+
             "c3_mode": c3_mode,
-            
+
             "all_mode": all_mode,
-            
+
             "c0_expr": c0_expr,
-            
+
             "c1_expr": c1_expr,
-            
+
             "c2_expr": c2_expr,
-            
+
             "c3_expr": c3_expr,
-            
+
             "all_expr": all_expr,
-            
+
             "c0_opacity": c0_opacity,
-            
+
             "c1_opacity": c1_opacity,
-            
+
             "c2_opacity": c2_opacity,
-            
+
             "c3_opacity": c3_opacity,
-            
+
             "all_opacity": all_opacity,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def bm3d(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     sigma: Float = Default('1'),block: Int = Default('16'),bstep: Int = Default('4'),group: Int = Default('1'),range: Int = Default('9'),mstep: Int = Default('1'),thmse: Float = Default('0'),hdthr: Float = Default('2.7'),estim: Int| Literal["basic","final"] | Default = Default('basic'),ref: Boolean = Default('false'),planes: Int = Default('7'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Denoise frames using Block-Matching 3D algorithm.
 
 The filter accepts the following options.
@@ -1743,7 +1743,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bm3d)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -1751,138 +1751,138 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='bm3d', typings_input='[StreamType.video] + [StreamType.video] if ref else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "sigma": sigma,
-            
+
             "block": block,
-            
+
             "bstep": bstep,
-            
+
             "group": group,
-            
+
             "range": range,
-            
+
             "mstep": mstep,
-            
+
             "thmse": thmse,
-            
+
             "hdthr": hdthr,
-            
+
             "estim": estim,
-            
+
             "ref": ref,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def colormap(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _target: VideoStream,
-        
-    
+
+
 
 
     *,
     patch_size: Image_size = Default('64x64'),nb_patches: Int = Default('0'),type: Int| Literal["relative","absolute"] | Default = Default('absolute'),kernel: Int| Literal["euclidean","weuclidean"] | Default = Default('euclidean'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply custom color maps to video stream.
 
 This filter needs three input video streams.
@@ -1908,7 +1908,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colormap)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -1916,77 +1916,77 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='colormap', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _target,
-            
-        
+
+
 
 
         **merge({
-            
+
             "patch_size": patch_size,
-            
+
             "nb_patches": nb_patches,
-            
+
             "type": type,
-            
+
             "kernel": kernel,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
 def concat(
-    
 
-    
+
+
     *streams: FilterableStream,
-    
 
 
-    
+
+
     n: Int = Auto('len(streams) // (int(v) + int(a))'),v: Int = Default('1'),a: Int = Default('0'),unsafe: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Concatenate audio and video streams, joining them together one after the
 other.
 
@@ -2012,77 +2012,77 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#concat)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='concat', typings_input='([StreamType.video]*int(v) + [StreamType.audio]*int(a))*int(n)', typings_output='[StreamType.video]*int(v) + [StreamType.audio]*int(a)'),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "n": n,
-            
+
             "v": v,
-            
+
             "a": a,
-            
+
             "unsafe": unsafe,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def convolve(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _impulse: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('7'),impulse: Int| Literal["first","all"] | Default = Default('all'),noise: Float = Default('1e-07'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply 2D convolution of video stream in frequency domain using second stream
 as impulse.
 
@@ -2104,7 +2104,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#convolve)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -2115,77 +2115,77 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='convolve', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _impulse,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "impulse": impulse,
-            
+
             "noise": noise,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def corr(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Obtain the correlation between two input videos.
 
 This filter takes two input videos.
@@ -2221,7 +2221,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#corr)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -2232,81 +2232,81 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='corr', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def decimate(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     cycle: Int = Default('5'),dupthresh: Double = Default('1.1'),scthresh: Double = Default('15'),blockx: Int = Default('32'),blocky: Int = Default('32'),ppsrc: Boolean = Default('false'),chroma: Boolean = Default('true'),mixed: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Drop duplicated frames at regular intervals.
 
 The filter accepts the following options:
@@ -2330,80 +2330,80 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#decimate)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='decimate', typings_input='[StreamType.video] + ([StreamType.video] if ppsrc else [])', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "cycle": cycle,
-            
+
             "dupthresh": dupthresh,
-            
+
             "scthresh": scthresh,
-            
+
             "blockx": blockx,
-            
+
             "blocky": blocky,
-            
+
             "ppsrc": ppsrc,
-            
+
             "chroma": chroma,
-            
+
             "mixed": mixed,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def deconvolve(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _impulse: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('7'),impulse: Int| Literal["first","all"] | Default = Default('all'),noise: Float = Default('1e-07'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply 2D deconvolution of video stream in frequency domain using second stream
 as impulse.
 
@@ -2425,7 +2425,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deconvolve)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -2436,104 +2436,104 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='deconvolve', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _impulse,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "impulse": impulse,
-            
+
             "noise": noise,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def displace(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _xmap: VideoStream,
-        
-    
-        
+
+
+
         _ymap: VideoStream,
-        
-    
+
+
 
 
     *,
     edge: Int| Literal["blank","smear","wrap","mirror"] | Default = Default('smear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Displace pixels as indicated by second and third input stream.
 
 It takes three input streams and outputs one stream, the first input is the
@@ -2562,7 +2562,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#displace)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -2570,124 +2570,124 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='displace', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _xmap,
-            
-        
-            
+
+
+
             _ymap,
-            
-        
+
+
 
 
         **merge({
-            
+
             "edge": edge,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def feedback(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _feedin: VideoStream,
-        
-    
+
+
 
 
     *,
     x: Int = Default('0'),w: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> tuple[
-    
-        
+
+
             VideoStream,
-        
-    
-        
+
+
+
             VideoStream,
-        
-    
+
+
 ]:
     """
-    
+
 Apply feedback video filter.
 
 This filter pass cropped input frames to 2nd output.
@@ -2715,7 +2715,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#feedback)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -2723,76 +2723,76 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='feedback', typings_input=('video', 'video'), typings_output=('video', 'video')),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _feedin,
-            
-        
+
+
 
 
         **merge({
-            
+
             "x": x,
-            
+
             "w": w,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return (
-        
-            
+
+
                 filter_node.video(0),
-            
-        
-            
+
+
+
                 filter_node.video(1),
-            
-        
+
+
     )
 
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def fieldmatch(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     order: Int| Literal["auto","bff","tff"] | Default = Default('auto'),mode: Int| Literal["pc","pc_n","pc_u","pc_n_ub","pcn","pcn_ub"] | Default = Default('pc_n'),ppsrc: Boolean = Default('false'),field: Int| Literal["auto","bottom","top"] | Default = Default('auto'),mchroma: Boolean = Default('true'),y0: Int = Default('0'),scthresh: Double = Default('12'),combmatch: Int| Literal["none","sc","full"] | Default = Default('sc'),combdbg: Int| Literal["none","pcn","pcnub"] | Default = Default('none'),cthresh: Int = Default('9'),chroma: Boolean = Default('false'),blockx: Int = Default('16'),blocky: Int = Default('16'),combpel: Int = Default('80'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Field matching filter for inverse telecine. It is meant to reconstruct the
 progressive frames from a telecined stream. The filter does not drop duplicated
 frames, so to achieve a complete inverse telecine fieldmatch needs to be
@@ -2850,100 +2850,100 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fieldmatch)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='fieldmatch', typings_input='[StreamType.video] + [StreamType.video] if ppsrc else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "order": order,
-            
+
             "mode": mode,
-            
+
             "ppsrc": ppsrc,
-            
+
             "field": field,
-            
+
             "mchroma": mchroma,
-            
+
             "y0": y0,
-            
+
             "scthresh": scthresh,
-            
+
             "combmatch": combmatch,
-            
+
             "combdbg": combdbg,
-            
+
             "cthresh": cthresh,
-            
+
             "chroma": chroma,
-            
+
             "blockx": blockx,
-            
+
             "blocky": blocky,
-            
+
             "combpel": combpel,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
 def framepack(
-    
 
-    
-        
+
+
+
         _left: VideoStream,
-        
-    
-        
+
+
+
         _right: VideoStream,
-        
-    
+
+
 
 
     *,
     format: Int| Literal["sbs","tab","frameseq","lines","columns"] | Default = Default('sbs'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Pack two different video streams into a stereoscopic video, setting proper
 metadata on supported codecs. The two views should have the same size and
 framerate and processing will stop when the shorter video ends. Please note
@@ -2964,70 +2964,70 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#framepack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='framepack', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _left,
-            
-        
-            
+
+
+
             _right,
-            
-        
+
+
 
 
         **merge({
-            
+
             "format": format,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def freezeframes(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _replace: VideoStream,
-        
-    
+
+
 
 
     *,
     first: Int64 = Default('0'),last: Int64 = Default('0'),replace: Int64 = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Freeze video frames.
 
 This filter freezes video frames using frame from 2nd input.
@@ -3048,83 +3048,83 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#freezeframes)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='freezeframes', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _replace,
-            
-        
+
+
 
 
         **merge({
-            
+
             "first": first,
-            
+
             "last": last,
-            
+
             "replace": replace,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
 def guided(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     radius: Int = Default('3'),eps: Float = Default('0.01'),mode: Int| Literal["basic","fast"] | Default = Default('basic'),sub: Int = Default('4'),guidance: Int| Literal["off","on"] | Default = Default('off'),planes: Int = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply guided filter for edge-preserving smoothing, dehazing and so on.
 
 The filter accepts the following options:
@@ -3147,7 +3147,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#guided)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -3155,75 +3155,75 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='guided', typings_input='[StreamType.video] + [StreamType.video] if guidance else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "radius": radius,
-            
+
             "eps": eps,
-            
+
             "mode": mode,
-            
+
             "sub": sub,
-            
+
             "guidance": guidance,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def haldclut(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _clut: VideoStream,
-        
-    
+
+
 
 
     *,
     clut: Int| Literal["first","all"] | Default = Default('all'),interp: Int| Literal["nearest","trilinear","tetrahedral","pyramid","prism"] | Default = Default('tetrahedral'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply a Hald CLUT to a video stream.
 
 First input is the video stream to process, and second one is the Hald CLUT.
@@ -3246,7 +3246,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#haldclut)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -3257,63 +3257,63 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='haldclut', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _clut,
-            
-        
+
+
 
 
         **merge({
-            
+
             "clut": clut,
-            
+
             "interp": interp,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def headphone(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     map: String = Default(None),gain: Float = Default('0'),lfe: Float = Default('0'),type: Int| Literal["time","freq"] | Default = Default('freq'),size: Int = Default('1024'),hrir: Int| Literal["stereo","multich"] | Default = Default('stereo'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Apply head-related transfer functions (HRTFs) to create virtual
 loudspeakers around the user for binaural listening via headphones.
 The HRIRs are provided via additional streams, for each channel
@@ -3338,78 +3338,78 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#headphone)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='headphone', typings_input="[StreamType.audio] + [StreamType.audio] * (len(str(map).split('|')) - 1) if int(hrir) == 1 else []", typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "map": map,
-            
+
             "gain": gain,
-            
+
             "lfe": lfe,
-            
+
             "type": type,
-            
+
             "size": size,
-            
+
             "hrir": hrir,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
 def hstack(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),shortest: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos horizontally.
 
 All streams must be of same pixel format and of same height.
@@ -3432,54 +3432,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hstack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='hstack', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def hstack_vaapi(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Default('2'),shortest: Boolean = Default('false'),height: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos horizontally.
 
 This is the VA-API variant of the hstack filter, each input stream may
@@ -3502,84 +3502,84 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hstack_vaapi)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='hstack_vaapi', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
             "height": height,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
 def hysteresis(
-    
 
-    
-        
+
+
+
         _base: VideoStream,
-        
-    
-        
+
+
+
         _alt: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),threshold: Int = Default('0'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Grow first stream into second stream by connecting components.
 This makes it possible to build more robust edge masks.
 
@@ -3600,7 +3600,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hysteresis)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -3611,73 +3611,73 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='hysteresis', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _base,
-            
-        
-            
+
+
+
             _alt,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "threshold": threshold,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def identity(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Obtain the identity score between two input videos.
 
 This filter takes two input videos.
@@ -3713,7 +3713,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#identity)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -3724,63 +3724,63 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='identity', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def interleave(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     nb_inputs: Int = Auto('len(streams)'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Temporally interleave frames from several inputs.
 
 interleave works with video inputs, ainterleave with audio.
@@ -3819,54 +3819,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#interleave)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='interleave', typings_input='[StreamType.video] * int(nb_inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "nb_inputs": nb_inputs,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def join(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),channel_layout: String = Default('stereo'),map: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Join multiple input streams into one multi-channel stream.
 
 It accepts the following parameters:
@@ -3885,71 +3885,71 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#join)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='join', typings_input='[StreamType.audio] * int(inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "channel_layout": channel_layout,
-            
+
             "map": map,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
 def limitdiff(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     threshold: Float = Default('0.00392157'),elasticity: Float = Default('2'),reference: Boolean = Default('false'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply limited difference filter using second and optionally third video stream.
 
 The filter accepts the following options:
@@ -3970,7 +3970,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#limitdiff)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -3978,85 +3978,85 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='limitdiff', typings_input='[StreamType.video, StreamType.video] + ([StreamType.video] if reference else [])', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "threshold": threshold,
-            
+
             "elasticity": elasticity,
-            
+
             "reference": reference,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
 def lut2(
-    
 
-    
-        
+
+
+
         _srcx: VideoStream,
-        
-    
-        
+
+
+
         _srcy: VideoStream,
-        
-    
+
+
 
 
     *,
     c0: String = Default('x'),c1: String = Default('x'),c2: String = Default('x'),c3: String = Default('x'),d: Int = Default('0'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The lut2 filter takes two input streams and outputs one
 stream.
 
@@ -4083,7 +4083,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut2)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -4094,86 +4094,86 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='lut2', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _srcx,
-            
-        
-            
+
+
+
             _srcy,
-            
-        
+
+
 
 
         **merge({
-            
+
             "c0": c0,
-            
+
             "c1": c1,
-            
+
             "c2": c2,
-            
+
             "c3": c3,
-            
+
             "d": d,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def maskedclamp(
-    
 
-    
-        
+
+
+
         _base: VideoStream,
-        
-    
-        
+
+
+
         _dark: VideoStream,
-        
-    
-        
+
+
+
         _bright: VideoStream,
-        
-    
+
+
 
 
     *,
     undershoot: Int = Default('0'),overshoot: Int = Default('0'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Clamp the first input stream with the second input and third input stream.
 
 Returns the value of first stream to be between second input
@@ -4196,7 +4196,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedclamp)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4204,76 +4204,76 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='maskedclamp', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _base,
-            
-        
-            
+
+
+
             _dark,
-            
-        
-            
+
+
+
             _bright,
-            
-        
+
+
 
 
         **merge({
-            
+
             "undershoot": undershoot,
-            
+
             "overshoot": overshoot,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def maskedmax(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _filter1: VideoStream,
-        
-    
-        
+
+
+
         _filter2: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Merge the second and third input stream into output stream using absolute differences
 between second input stream and first input stream and absolute difference between
 third input stream and first input stream. The picked value will be from second input
@@ -4295,7 +4295,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedmax)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4303,72 +4303,72 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='maskedmax', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _filter1,
-            
-        
-            
+
+
+
             _filter2,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def maskedmerge(
-    
 
-    
-        
+
+
+
         _base: VideoStream,
-        
-    
-        
+
+
+
         _overlay: VideoStream,
-        
-    
-        
+
+
+
         _mask: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Merge the first input stream with the second input stream using per pixel
 weights in the third input stream.
 
@@ -4393,7 +4393,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedmerge)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4401,72 +4401,72 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='maskedmerge', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _base,
-            
-        
-            
+
+
+
             _overlay,
-            
-        
-            
+
+
+
             _mask,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def maskedmin(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _filter1: VideoStream,
-        
-    
-        
+
+
+
         _filter2: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Merge the second and third input stream into output stream using absolute differences
 between second input stream and first input stream and absolute difference between
 third input stream and first input stream. The picked value will be from second input
@@ -4488,7 +4488,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedmin)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4496,68 +4496,68 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='maskedmin', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _filter1,
-            
-        
-            
+
+
+
             _filter2,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def maskedthreshold(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     threshold: Int = Default('1'),planes: Int = Default('15'),mode: Int| Literal["abs","diff"] | Default = Default('abs'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Pick pixels comparing absolute difference of two video streams with fixed
 threshold.
 
@@ -4583,7 +4583,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedthreshold)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4591,67 +4591,67 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='maskedthreshold', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
             "threshold": threshold,
-            
+
             "planes": planes,
-            
+
             "mode": mode,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def mergeplanes(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     mapping: Int = Default('-1'),format: Pix_fmt = Default('yuva444p'),map0s: Int = Default('0'),map0p: Int = Default('0'),map1s: Int = Default('0'),map1p: Int = Default('0'),map2s: Int = Default('0'),map2p: Int = Default('0'),map3s: Int = Default('0'),map3p: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Merge color channel components from several video streams.
 
 The filter accepts up to 4 input streams, and merge selected input
@@ -4680,83 +4680,83 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mergeplanes)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='mergeplanes', typings_input='[StreamType.video] * int(max(hex(int(mapping))[2::2]))', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "mapping": mapping,
-            
+
             "format": format,
-            
+
             "map0s": map0s,
-            
+
             "map0p": map0p,
-            
+
             "map1s": map1s,
-            
+
             "map1p": map1p,
-            
+
             "map2s": map2s,
-            
+
             "map2p": map2p,
-            
+
             "map3s": map3s,
-            
+
             "map3p": map3p,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def midequalizer(
-    
 
-    
-        
+
+
+
         _in0: VideoStream,
-        
-    
-        
+
+
+
         _in1: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply Midway Image Equalization effect using two video streams.
 
 Midway Image Equalization adjusts a pair of images to have the same
@@ -4782,7 +4782,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#midequalizer)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4790,60 +4790,60 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='midequalizer', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _in0,
-            
-        
-            
+
+
+
             _in1,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def mix(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),weights: String = Default('1 1'),scale: Float = Default('0'),planes: Flags = Default('F'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Mix several video input streams into one video stream.
 
 A description of the accepted options follows.
@@ -4865,7 +4865,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mix)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4873,73 +4873,73 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='mix', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "weights": weights,
-            
+
             "scale": scale,
-            
+
             "planes": planes,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def morpho(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _structure: VideoStream,
-        
-    
+
+
 
 
     *,
     mode: Int| Literal["erode","dilate","open","close","gradient","tophat","blackhat"] | Default = Default('erode'),planes: Int = Default('7'),structure: Int| Literal["first","all"] | Default = Default('all'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 This filter allows to apply main morphological grayscale transforms,
 erode and dilate with arbitrary structures set in second input stream.
 
@@ -4965,7 +4965,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#morpho)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -4976,81 +4976,81 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='morpho', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _structure,
-            
-        
+
+
 
 
         **merge({
-            
+
             "mode": mode,
-            
+
             "planes": planes,
-            
+
             "structure": structure,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def msad(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Obtain the MSAD (Mean Sum of Absolute Differences) between two input videos.
 
 This filter takes two input videos.
@@ -5086,7 +5086,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#msad)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -5097,64 +5097,64 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='msad', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def multiply(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _factor: VideoStream,
-        
-    
+
+
 
 
     *,
     scale: Float = Default('1'),offset: Float = Default('0.5'),planes: Flags = Default('F'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Multiply first video stream pixels values with second video stream pixels values.
 
 The filter accepts the following options:
@@ -5174,7 +5174,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#multiply)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -5182,97 +5182,97 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='multiply', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _factor,
-            
-        
+
+
 
 
         **merge({
-            
+
             "scale": scale,
-            
+
             "offset": offset,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def overlay(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _overlay: VideoStream,
-        
-    
+
+
 
 
     *,
     x: String = Default('0'),y: String = Default('0'),eof_action: Int| Literal["repeat","endall","pass"] | Default = Default('repeat'),eval: Int| Literal["init","frame"] | Default = Default('frame'),shortest: Boolean = Default('false'),format: Int| Literal["yuv420","yuv420p10","yuv422","yuv422p10","yuv444","yuv444p10","rgb","gbrp","auto"] | Default = Default('yuv420'),repeatlast: Boolean = Default('true'),alpha: Int| Literal["straight","premultiplied"] | Default = Default('straight'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
-    
-    
-    
-    
-    
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Overlay one video on top of another.
 
 It takes two inputs and has one output. The first input is the "main"
@@ -5303,7 +5303,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -5311,77 +5311,77 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='overlay', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _overlay,
-            
-        
+
+
 
 
         **merge({
-            
+
             "x": x,
-            
+
             "y": y,
-            
+
             "eof_action": eof_action,
-            
+
             "eval": eval,
-            
+
             "shortest": shortest,
-            
+
             "format": format,
-            
+
             "repeatlast": repeatlast,
-            
+
             "alpha": alpha,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def overlay_opencl(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _overlay: VideoStream,
-        
-    
+
+
 
 
     *,
     x: Int = Default('0'),y: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Overlay one video on top of another.
 
 It takes two inputs and has one output. The first input is the "main" video on which the second input is overlaid.
@@ -5402,71 +5402,71 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay_opencl)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='overlay_opencl', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _overlay,
-            
-        
+
+
 
 
         **merge({
-            
+
             "x": x,
-            
+
             "y": y,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def overlay_vaapi(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _overlay: VideoStream,
-        
-    
+
+
 
 
     *,
     x: String = Default('0'),y: String = Default('0'),w: String = Default('overlay_iw'),h: String = Default('overlay_ih*w/overlay_iw'),alpha: Float = Default('1'),eof_action: Int| Literal["repeat","endall","pass"] | Default = Default('repeat'),shortest: Boolean = Default('false'),repeatlast: Boolean = Default('true'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
-    
-    
-    
-    
-    
+
+
+
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Overlay one video on the top of another.
 
 It takes two inputs and has one output. The first input is the "main" video on which the second input is overlaid.
@@ -5493,94 +5493,94 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay_vaapi)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='overlay_vaapi', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _overlay,
-            
-        
+
+
 
 
         **merge({
-            
+
             "x": x,
-            
+
             "y": y,
-            
+
             "w": w,
-            
+
             "h": h,
-            
+
             "alpha": alpha,
-            
+
             "eof_action": eof_action,
-            
+
             "shortest": shortest,
-            
+
             "repeatlast": repeatlast,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
 def paletteuse(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _palette: VideoStream,
-        
-    
+
+
 
 
     *,
     dither: Int| Literal["bayer","heckbert","floyd_steinberg","sierra2","sierra2_4a","sierra3","burkes","atkinson"] | Default = Default('sierra2_4a'),bayer_scale: Int = Default('2'),diff_mode: Int| Literal["rectangle"] | Default = Default('0'),new: Boolean = Default('false'),alpha_threshold: Int = Default('128'),debug_kdtree: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Use a palette to downsample an input video stream.
 
 The filter takes two inputs: one video stream and a palette. The palette must
@@ -5605,93 +5605,93 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#paletteuse)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='paletteuse', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _palette,
-            
-        
+
+
 
 
         **merge({
-            
+
             "dither": dither,
-            
+
             "bayer_scale": bayer_scale,
-            
+
             "diff_mode": diff_mode,
-            
+
             "new": new,
-            
+
             "alpha_threshold": alpha_threshold,
-            
+
             "debug_kdtree": debug_kdtree,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def premultiply(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     planes: Int = Default('15'),inplace: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply alpha premultiply effect to input video stream using first plane
 of second stream as alpha.
 
@@ -5713,7 +5713,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#premultiply)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -5721,62 +5721,62 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='premultiply', typings_input='[StreamType.video] + [StreamType.video] if inplace else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "inplace": inplace,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def program_opencl(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     source: String = Default(None),kernel: String = Default(None),inputs: Int = Default('1'),size: Image_size = Default(None),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Filter video using an OpenCL program.
 
 
@@ -5795,7 +5795,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#program_opencl)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -5803,71 +5803,71 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='program_opencl', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "source": source,
-            
+
             "kernel": kernel,
-            
+
             "inputs": inputs,
-            
+
             "size": size,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def psnr(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),stats_version: Int = Default('1'),output_max: Boolean = Default('false'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Obtain the average, maximum and minimum PSNR (Peak Signal to Noise
 Ratio) between two input videos.
 
@@ -5911,7 +5911,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#psnr)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -5922,83 +5922,83 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='psnr', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
             "stats_file": stats_file,
-            
+
             "stats_version": stats_version,
-            
+
             "output_max": output_max,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
 def remap(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _xmap: VideoStream,
-        
-    
-        
+
+
+
         _ymap: VideoStream,
-        
-    
+
+
 
 
     *,
     format: Int| Literal["color","gray"] | Default = Default('color'),fill: Color = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Remap pixels using 2nd: Xmap and 3rd: Ymap input video stream.
 
 Destination pixel at position (X, Y) will be picked from source (x, y) position
@@ -6022,74 +6022,74 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#remap)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='remap', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _xmap,
-            
-        
-            
+
+
+
             _ymap,
-            
-        
+
+
 
 
         **merge({
-            
+
             "format": format,
-            
+
             "fill": fill,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def remap_opencl(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _xmap: VideoStream,
-        
-    
-        
+
+
+
         _ymap: VideoStream,
-        
-    
+
+
 
 
     *,
     interp: Int| Literal["near","linear"] | Default = Default('linear'),fill: Color = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Remap pixels using 2nd: Xmap and 3rd: Ymap input video stream.
 
 Destination pixel at position (X, Y) will be picked from source (x, y) position
@@ -6113,104 +6113,104 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#remap_opencl)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='remap_opencl', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _xmap,
-            
-        
-            
+
+
+
             _ymap,
-            
-        
+
+
 
 
         **merge({
-            
+
             "interp": interp,
-            
+
             "fill": fill,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def scale2ref(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _ref: VideoStream,
-        
-    
+
+
 
 
     *,
     w: String = Default(None),h: String = Default(None),flags: String = Default(''),interl: Boolean = Default('false'),size: String = Default(None),in_color_matrix: Int| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default('auto'),out_color_matrix: Int| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default('2'),in_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),out_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),in_chroma_loc: Int| Literal["auto","unknown","left","center","topleft","top","bottomleft","bottom"] | Default = Default('auto'),out_chroma_loc: Int| Literal["auto","unknown","left","center","topleft","top","bottomleft","bottom"] | Default = Default('auto'),in_v_chr_pos: Int = Default('-513'),in_h_chr_pos: Int = Default('-513'),out_v_chr_pos: Int = Default('-513'),out_h_chr_pos: Int = Default('-513'),force_original_aspect_ratio: Int| Literal["disable","decrease","increase"] | Default = Default('disable'),force_divisible_by: Int = Default('1'),param0: Double = Default('DBL_MAX'),param1: Double = Default('DBL_MAX'),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> tuple[
-    
-        
+
+
             VideoStream,
-        
-    
-        
+
+
+
             VideoStream,
-        
-    
+
+
 ]:
     """
-    
+
 Scale the input video size and/or convert the image format to the given reference.
 
 
@@ -6245,177 +6245,177 @@ References:
     [FFmpeg Documentation](None)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='scale2ref', typings_input=('video', 'video'), typings_output=('video', 'video')),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _ref,
-            
-        
+
+
 
 
         **merge({
-            
+
             "w": w,
-            
+
             "h": h,
-            
+
             "flags": flags,
-            
+
             "interl": interl,
-            
+
             "size": size,
-            
+
             "in_color_matrix": in_color_matrix,
-            
+
             "out_color_matrix": out_color_matrix,
-            
+
             "in_range": in_range,
-            
+
             "out_range": out_range,
-            
+
             "in_chroma_loc": in_chroma_loc,
-            
+
             "out_chroma_loc": out_chroma_loc,
-            
+
             "in_v_chr_pos": in_v_chr_pos,
-            
+
             "in_h_chr_pos": in_h_chr_pos,
-            
+
             "out_v_chr_pos": out_v_chr_pos,
-            
+
             "out_h_chr_pos": out_h_chr_pos,
-            
+
             "force_original_aspect_ratio": force_original_aspect_ratio,
-            
+
             "force_divisible_by": force_divisible_by,
-            
+
             "param0": param0,
-            
+
             "param1": param1,
-            
+
             "eval": eval,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return (
-        
-            
+
+
                 filter_node.video(0),
-            
-        
-            
+
+
+
                 filter_node.video(1),
-            
-        
+
+
     )
 
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def sidechaincompress(
-    
 
-    
-        
+
+
+
         _main: AudioStream,
-        
-    
-        
+
+
+
         _sidechain: AudioStream,
-        
-    
+
+
 
 
     *,
     level_in: Double = Default('1'),mode: Int| Literal["downward","upward"] | Default = Default('downward'),threshold: Double = Default('0.125'),ratio: Double = Default('2'),attack: Double = Default('20'),release: Double = Default('250'),makeup: Double = Default('1'),knee: Double = Default('2.82843'),link: Int| Literal["average","maximum"] | Default = Default('average'),detection: Int| Literal["peak","rms"] | Default = Default('rms'),level_sc: Double = Default('1'),mix: Double = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 This filter acts like normal compressor but has the ability to compress
 detected signal using second input signal.
 It needs two input streams and returns one output stream.
@@ -6448,89 +6448,89 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sidechaincompress)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='sidechaincompress', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _sidechain,
-            
-        
+
+
 
 
         **merge({
-            
+
             "level_in": level_in,
-            
+
             "mode": mode,
-            
+
             "threshold": threshold,
-            
+
             "ratio": ratio,
-            
+
             "attack": attack,
-            
+
             "release": release,
-            
+
             "makeup": makeup,
-            
+
             "knee": knee,
-            
+
             "link": link,
-            
+
             "detection": detection,
-            
+
             "level_sc": level_sc,
-            
+
             "mix": mix,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
+
+
+
 def sidechaingate(
-    
 
-    
-        
+
+
+
         _main: AudioStream,
-        
-    
-        
+
+
+
         _sidechain: AudioStream,
-        
-    
+
+
 
 
     *,
     level_in: Double = Default('1'),mode: Int| Literal["downward","upward"] | Default = Default('downward'),range: Double = Default('0.06125'),threshold: Double = Default('0.125'),ratio: Double = Default('2'),attack: Double = Default('20'),release: Double = Default('250'),makeup: Double = Default('1'),knee: Double = Default('2.82843'),detection: Int| Literal["peak","rms"] | Default = Default('rms'),link: Int| Literal["average","maximum"] | Default = Default('average'),level_sc: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 A sidechain gate acts like a normal (wideband) gate but has the ability to
 filter the detected signal before sending it to the gain reduction stage.
 Normally a gate uses the full range signal to detect a level above the
@@ -6569,7 +6569,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sidechaingate)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -6577,83 +6577,83 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='sidechaingate', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _sidechain,
-            
-        
+
+
 
 
         **merge({
-            
+
             "level_in": level_in,
-            
+
             "mode": mode,
-            
+
             "range": range,
-            
+
             "threshold": threshold,
-            
+
             "ratio": ratio,
-            
+
             "attack": attack,
-            
+
             "release": release,
-            
+
             "makeup": makeup,
-            
+
             "knee": knee,
-            
+
             "detection": detection,
-            
+
             "link": link,
-            
+
             "level_sc": level_sc,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def signature(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     detectmode: Int| Literal["off","full","fast"] | Default = Default('off'),nb_inputs: Int = Auto('len(streams)'),filename: String = Default(''),format: Int| Literal["binary","xml"] | Default = Default('binary'),th_d: Int = Default('9000'),th_dc: Int = Default('60000'),th_xh: Int = Default('116'),th_di: Int = Default('0'),th_it: Double = Default('0.5'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Calculates the MPEG-7 Video Signature. The filter can handle more than one
 input. In this case the matching between the inputs can be calculated additionally.
 The filter always passes through the first input. The signature of each stream can
@@ -6681,94 +6681,94 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#signature)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='signature', typings_input='[StreamType.video] * int(nb_inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "detectmode": detectmode,
-            
+
             "nb_inputs": nb_inputs,
-            
+
             "filename": filename,
-            
+
             "format": format,
-            
+
             "th_d": th_d,
-            
+
             "th_dc": th_dc,
-            
+
             "th_xh": th_xh,
-            
+
             "th_di": th_di,
-            
+
             "th_it": th_it,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
 def spectrumsynth(
-    
 
-    
-        
+
+
+
         _magnitude: VideoStream,
-        
-    
-        
+
+
+
         _phase: VideoStream,
-        
-    
+
+
 
 
     *,
     sample_rate: Int = Default('44100'),channels: Int = Default('1'),scale: Int| Literal["lin","log"] | Default = Default('log'),slide: Int| Literal["replace","scroll","fullframe","rscroll"] | Default = Default('fullframe'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('rect'),overlap: Float = Default('1'),orientation: Int| Literal["vertical","horizontal"] | Default = Default('vertical'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Synthesize audio from 2 input video spectrums, first input stream represents
 magnitude across time and second represents phase across time.
 The filter will transform from frequency domain as displayed in videos back
@@ -6805,90 +6805,90 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#spectrumsynth)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='spectrumsynth', typings_input=('video', 'video'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _magnitude,
-            
-        
-            
+
+
+
             _phase,
-            
-        
+
+
 
 
         **merge({
-            
+
             "sample_rate": sample_rate,
-            
+
             "channels": channels,
-            
+
             "scale": scale,
-            
+
             "slide": slide,
-            
+
             "win_func": win_func,
-            
+
             "overlap": overlap,
-            
+
             "orientation": orientation,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def ssim(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Obtain the SSIM (Structural SImilarity Metric) between two input videos.
 
 This filter takes in input two input videos, the first input is
@@ -6918,7 +6918,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ssim)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -6929,68 +6929,68 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='ssim', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
             "stats_file": stats_file,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def ssim360(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),compute_chroma: Int = Default('1'),frame_skip_ratio: Int = Default('0'),ref_projection: Int| Literal["e","equirect","c3x2","c2x3","barrel","barrelsplit"] | Default = Default('e'),main_projection: Int| Literal["e","equirect","c3x2","c2x3","barrel","barrelsplit"] | Default = Default('5'),ref_stereo: Int| Literal["mono","tb","lr"] | Default = Default('mono'),main_stereo: Int| Literal["mono","tb","lr"] | Default = Default('3'),ref_pad: Float = Default('0'),main_pad: Float = Default('0'),use_tape: Int = Default('0'),heatmap_str: String = Default(None),default_heatmap_width: Int = Default('32'),default_heatmap_height: Int = Default('16'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Calculate the SSIM between two 360 video streams.
 
 
@@ -7018,7 +7018,7 @@ References:
     [FFmpeg Documentation](None)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -7026,85 +7026,85 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='ssim360', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
             "stats_file": stats_file,
-            
+
             "compute_chroma": compute_chroma,
-            
+
             "frame_skip_ratio": frame_skip_ratio,
-            
+
             "ref_projection": ref_projection,
-            
+
             "main_projection": main_projection,
-            
+
             "ref_stereo": ref_stereo,
-            
+
             "main_stereo": main_stereo,
-            
+
             "ref_pad": ref_pad,
-            
+
             "main_pad": main_pad,
-            
+
             "use_tape": use_tape,
-            
+
             "heatmap_str": heatmap_str,
-            
+
             "default_heatmap_width": default_heatmap_width,
-            
+
             "default_heatmap_height": default_heatmap_height,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def streamselect(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),map: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Select video or audio streams.
 
 The filter accepts the following options:
@@ -7123,94 +7123,94 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#streamselect)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='streamselect', typings_input='[StreamType.video] * int(inputs)', typings_output="[StreamType.video] * len(re.findall(r'\\d+', str(map)))"),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "map": map,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def threshold(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _threshold: VideoStream,
-        
-    
-        
+
+
+
         _min: VideoStream,
-        
-    
-        
+
+
+
         _max: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply threshold effect to video stream.
 
 This filter needs four video streams to perform thresholding.
@@ -7233,7 +7233,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#threshold)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -7241,104 +7241,104 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='threshold', typings_input=('video', 'video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _threshold,
-            
-        
-            
+
+
+
             _min,
-            
-        
-            
+
+
+
             _max,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def unpremultiply(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     planes: Int = Default('15'),inplace: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply alpha unpremultiply effect to input video stream using first plane
 of second stream as alpha.
 
@@ -7360,7 +7360,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#unpremultiply)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -7368,77 +7368,77 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='unpremultiply', typings_input='[StreamType.video] + ([StreamType.video] if inplace else [])', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "inplace": inplace,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
 def varblur(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _radius: VideoStream,
-        
-    
+
+
 
 
     *,
     min_r: Int = Default('0'),max_r: Int = Default('8'),planes: Int = Default('15'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply variable blur filter by using 2nd video stream to set blur radius.
 The 2nd stream must have the same dimensions.
 
@@ -7460,7 +7460,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#varblur)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -7471,89 +7471,89 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='varblur', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _radius,
-            
-        
+
+
 
 
         **merge({
-            
+
             "min_r": min_r,
-            
+
             "max_r": max_r,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
 def vif(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Obtain the average VIF (Visual Information Fidelity) between two input videos.
 
 This filter takes two input videos.
@@ -7590,7 +7590,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vif)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -7601,65 +7601,65 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='vif', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
 def vstack(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),shortest: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos vertically.
 
 All streams must be of same pixel format and of same width.
@@ -7682,54 +7682,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vstack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='vstack', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def vstack_vaapi(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Default('2'),shortest: Boolean = Default('false'),width: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos vertically.
 
 This is the VA-API variant of the vstack filter, each input stream may
@@ -7752,78 +7752,78 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vstack_vaapi)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='vstack_vaapi', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
             "width": width,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def xcorrelate(
-    
 
-    
-        
+
+
+
         _primary: VideoStream,
-        
-    
-        
+
+
+
         _secondary: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('7'),secondary: Int| Literal["first","all"] | Default = Default('all'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply normalized cross-correlation between first and second input video stream.
 
 Second input video stream dimensions must be lower than first input video stream.
@@ -7845,7 +7845,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xcorrelate)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -7856,65 +7856,65 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xcorrelate', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _primary,
-            
-        
-            
+
+
+
             _secondary,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "secondary": secondary,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xfade(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _xfade: VideoStream,
-        
-    
+
+
 
 
     *,
     transition: Int| Literal["custom","fade","wipeleft","wiperight","wipeup","wipedown","slideleft","slideright","slideup","slidedown","circlecrop","rectcrop","distance","fadeblack","fadewhite","radial","smoothleft","smoothright","smoothup","smoothdown","circleopen","circleclose","vertopen","vertclose","horzopen","horzclose","dissolve","pixelize","diagtl","diagtr","diagbl","diagbr","hlslice","hrslice","vuslice","vdslice","hblur","fadegrays","wipetl","wipetr","wipebl","wipebr","squeezeh","squeezev","zoomin","fadefast","fadeslow","hlwind","hrwind","vuwind","vdwind","coverleft","coverright","coverup","coverdown","revealleft","revealright","revealup","revealdown"] | Default = Default('fade'),duration: Duration = Default('1'),offset: Duration = Default('0'),expr: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply cross fade from one input video stream to another input video stream.
 The cross fade is applied for specified duration.
 
@@ -7938,70 +7938,70 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xfade)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xfade', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _xfade,
-            
-        
+
+
 
 
         **merge({
-            
+
             "transition": transition,
-            
+
             "duration": duration,
-            
+
             "offset": offset,
-            
+
             "expr": expr,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xfade_opencl(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _xfade: VideoStream,
-        
-    
+
+
 
 
     *,
     transition: Int| Literal["custom","fade","wipeleft","wiperight","wipeup","wipedown","slideleft","slideright","slideup","slidedown"] | Default = Default('fade'),source: String = Default(None),kernel: String = Default(None),duration: Duration = Default('1'),offset: Duration = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Cross fade two videos with custom transition effect by using OpenCL.
 
 It accepts the following options:
@@ -8022,74 +8022,74 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xfade_opencl)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xfade_opencl', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _xfade,
-            
-        
+
+
 
 
         **merge({
-            
+
             "transition": transition,
-            
+
             "source": source,
-            
+
             "kernel": kernel,
-            
+
             "duration": duration,
-            
+
             "offset": offset,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xmedian(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),planes: Int = Default('15'),percentile: Float = Default('0.5'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Pick median pixels from several input videos.
 
 The filter accepts the following options:
@@ -8110,7 +8110,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xmedian)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -8121,69 +8121,69 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xmedian', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "planes": planes,
-            
+
             "percentile": percentile,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xpsnr(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Obtain the average (across all input frames) and minimum (across all color plane averages)
 eXtended Perceptually weighted peak Signal-to-Noise Ratio (XPSNR) between two input videos.
 
@@ -8209,7 +8209,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xpsnr)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -8220,57 +8220,57 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xpsnr', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
             "stats_file": stats_file,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xstack(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),layout: String = Default(None),grid: Image_size = Default(None),shortest: Boolean = Default('false'),fill: String = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack video inputs into custom layout.
 
 All streams must be of same pixel format.
@@ -8293,60 +8293,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xstack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xstack', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "layout": layout,
-            
+
             "grid": grid,
-            
+
             "shortest": shortest,
-            
+
             "fill": fill,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xstack_vaapi(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Default('2'),shortest: Boolean = Default('false'),layout: String = Default(None),grid: Image_size = Default(None),grid_tile_size: Image_size = Default(None),fill: String = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack video inputs into custom layout.
 
 This is the VA-API variant of the xstack filter,  each input stream may
@@ -8372,53 +8372,36 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xstack_vaapi)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xstack_vaapi', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
             "layout": layout,
-            
+
             "grid": grid,
-            
+
             "grid_tile_size": grid_tile_size,
-            
+
             "fill": fill,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
-
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    

--- a/packages/v7/src/ffmpeg/formats/demuxers.py
+++ b/packages/v7/src/ffmpeg/formats/demuxers.py
@@ -406,45 +406,45 @@ from ..streams.audio import AudioStream
 
 
 def _3dostr(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     3DO STR
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def _4xm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     4X Technologies
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def aa(
-    
+
     aa_fixed_key: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Audible AA format files
-    
+
     Args:
         aa_fixed_key: Fixed key used for handling Audible AA files
 
@@ -452,53 +452,53 @@ def aa(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "aa_fixed_key": aa_fixed_key,
-        
+
     }))
 
 
 
 def aac(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw ADTS AAC (Advanced Audio Coding)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def aax(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CRI AAX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ac3(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw AC-3
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -506,53 +506,53 @@ def ac3(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def ac4(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw AC-4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ace(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     tri-Ace Audio Container
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def acm(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Interplay ACM
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -560,41 +560,41 @@ def acm(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def act(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     ACT Voice file format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def adf(
-    
+
     linespeed: int | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Artworx Data Format
-    
+
     Args:
         linespeed: set simulated line speed (bytes per second) (from 1 to INT_MAX) (default 6000)
         video_size: set video size, such as 640x480 or hd720.
@@ -604,139 +604,139 @@ def adf(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "linespeed": linespeed,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def adp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     ADP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ads(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony PS2 ADS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def adx(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CRI ADX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def aea(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MD STUDIO audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def afc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AFC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def aiff(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Audio IFF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def aix(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CRI AIX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def alaw(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM A-law
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -745,39 +745,39 @@ def alaw(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def alias_pix(
-    
+
     pattern_type: int | None| Literal["glob_sequence", "glob", "sequence", "none"] = None,
-    
+
     start_number: int | None = None,
-    
+
     start_number_range: int | None = None,
-    
+
     ts_from_file: int | None| Literal["none", "sec", "ns"] = None,
-    
+
     export_path_metadata: bool | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Alias/Wavefront PIX image
-    
+
     Args:
         pattern_type: set pattern type (from 0 to INT_MAX) (default 4)
         start_number: set first number in the sequence (from INT_MIN to INT_MAX) (default 0)
@@ -793,53 +793,53 @@ def alias_pix(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "pattern_type": pattern_type,
-        
+
         "start_number": start_number,
-        
+
         "start_number_range": start_number_range,
-        
+
         "ts_from_file": ts_from_file,
-        
+
         "export_path_metadata": export_path_metadata,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def alp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     LEGO Racers ALP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def amr(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     3GPP AMR
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -847,21 +847,21 @@ def amr(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def amrnb(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw AMR-NB
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -869,21 +869,21 @@ def amrnb(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def amrwb(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw AMR-WB
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -891,37 +891,37 @@ def amrwb(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def anm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Deluxe Paint Animation
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def apac(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw APAC
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -929,73 +929,73 @@ def apac(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def apc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CRYO APC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ape(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Monkey's Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def apm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Ubisoft Rayman 2 APM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def apng(
-    
+
     ignore_loop: bool | None = None,
-    
+
     max_fps: int | None = None,
-    
+
     default_fps: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Animated Portable Network Graphics
-    
+
     Args:
         ignore_loop: ignore loop setting (default true)
         max_fps: maximum framerate (0 is no limit) (from 0 to INT_MAX) (default 0)
@@ -1005,25 +1005,25 @@ def apng(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "ignore_loop": ignore_loop,
-        
+
         "max_fps": max_fps,
-        
+
         "default_fps": default_fps,
-        
+
     }))
 
 
 
 def aptx(
-    
+
     sample_rate: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw aptX
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 48000)
 
@@ -1031,21 +1031,21 @@ def aptx(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
     }))
 
 
 
 def aptx_hd(
-    
+
     sample_rate: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw aptX HD
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 48000)
 
@@ -1053,21 +1053,21 @@ def aptx_hd(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
     }))
 
 
 
 def aqtitle(
-    
+
     subfps: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AQTitle subtitles
-    
+
     Args:
         subfps: set the movie frame rate (from 0 to INT_MAX) (default 25/1)
 
@@ -1075,71 +1075,71 @@ def aqtitle(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "subfps": subfps,
-        
+
     }))
 
 
 
 def argo_asf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Argonaut Games ASF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def argo_brp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Argonaut Games BRP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def argo_cvg(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Argonaut Games CVG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def asf(
-    
+
     no_resync_search: bool | None = None,
-    
+
     export_xmp: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     ASF (Advanced / Active Streaming Format)
-    
+
     Args:
         no_resync_search: Don't try to resynchronize by looking for a certain optional start code (default false)
         export_xmp: Export full XMP metadata (default false)
@@ -1148,87 +1148,87 @@ def asf(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "no_resync_search": no_resync_search,
-        
+
         "export_xmp": export_xmp,
-        
+
     }))
 
 
 
 def asf_o(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     ASF (Advanced / Active Streaming Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ass(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SSA (SubStation Alpha) subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ast(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AST (Audio Stream)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def au(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sun AU
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def av1(
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AV1 Annex B
-    
+
     Args:
         framerate: (default "25")
 
@@ -1236,21 +1236,21 @@ def av1(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def avi(
-    
+
     use_odml: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AVI (Audio Video Interleaved)
-    
+
     Args:
         use_odml: use odml index (default true)
 
@@ -1258,55 +1258,55 @@ def avi(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "use_odml": use_odml,
-        
+
     }))
 
 
 
 def avr(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AVR (Audio Visual Research)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def avs(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Argonaut Games Creature Shock
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def avs2(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw AVS2-P2/IEEE1857.4
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -1315,25 +1315,25 @@ def avs2(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def avs3(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw AVS3-P2/IEEE1857.10
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -1342,75 +1342,75 @@ def avs3(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def bethsoftvid(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Bethesda Softworks VID
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def bfi(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Brute Force & Ignorance
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def bfstm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     BFSTM (Binary Cafe Stream)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def bin(
-    
+
     linespeed: int | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Binary text
-    
+
     Args:
         linespeed: set simulated line speed (bytes per second) (from 1 to INT_MAX) (default 6000)
         video_size: set video size, such as 640x480 or hd720.
@@ -1420,77 +1420,77 @@ def bin(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "linespeed": linespeed,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def bink(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Bink
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def binka(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Bink Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def bit(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     G.729 BIT file format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def bitpacked(
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Bitpacked
-    
+
     Args:
         pixel_format: set pixel format (default "yuv420p")
         video_size: set frame size
@@ -1500,33 +1500,33 @@ def bitpacked(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def bmp_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped bmp sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -1538,61 +1538,61 @@ def bmp_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def bmv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Discworld II BMV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def boa(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Black Ops Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def bonk(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw Bonk
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -1600,37 +1600,37 @@ def bonk(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def brender_pix(
-    
+
     pattern_type: int | None| Literal["glob_sequence", "glob", "sequence", "none"] = None,
-    
+
     start_number: int | None = None,
-    
+
     start_number_range: int | None = None,
-    
+
     ts_from_file: int | None| Literal["none", "sec", "ns"] = None,
-    
+
     export_path_metadata: bool | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     BRender PIX image
-    
+
     Args:
         pattern_type: set pattern type (from 0 to INT_MAX) (default 4)
         start_number: set first number in the sequence (from INT_MIN to INT_MAX) (default 0)
@@ -1646,87 +1646,87 @@ def brender_pix(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "pattern_type": pattern_type,
-        
+
         "start_number": start_number,
-        
+
         "start_number_range": start_number_range,
-        
+
         "ts_from_file": ts_from_file,
-        
+
         "export_path_metadata": export_path_metadata,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def brstm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     BRSTM (Binary Revolution Stream)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def c93(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Interplay C93
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def caf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Apple CAF (Core Audio Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def cavsvideo(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw Chinese AVS (Audio Video Standard)
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -1735,41 +1735,41 @@ def cavsvideo(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def cdg(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CD Graphics
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def cdxl(
-    
+
     sample_rate: int | None = None,
-    
+
     frame_rate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Commodore CDXL video
-    
+
     Args:
         sample_rate: (from 8000 to INT_MAX) (default 11025)
         frame_rate: (default "15")
@@ -1778,39 +1778,39 @@ def cdxl(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "frame_rate": frame_rate,
-        
+
     }))
 
 
 
 def cine(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Phantom Cine
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def codec2(
-    
+
     frames_per_packet: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     codec2 .c2 demuxer
-    
+
     Args:
         frames_per_packet: Number of frames to read at a time. Higher = faster decoding, lower granularity (from 1 to INT_MAX) (default 1)
 
@@ -1818,23 +1818,23 @@ def codec2(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frames_per_packet": frames_per_packet,
-        
+
     }))
 
 
 
 def codec2raw(
-    
+
     mode: int | None| Literal["3200", "2400", "1600", "1400", "1300", "1200", "700", "700B", "700C"] = None,
-    
+
     frames_per_packet: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw codec2 demuxer
-    
+
     Args:
         mode: codec2 mode [mandatory] (from -1 to 8) (default -1)
         frames_per_packet: Number of frames to read at a time. Higher = faster decoding, lower granularity (from 1 to INT_MAX) (default 1)
@@ -1843,27 +1843,27 @@ def codec2raw(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "mode": mode,
-        
+
         "frames_per_packet": frames_per_packet,
-        
+
     }))
 
 
 
 def concat(
-    
+
     safe: bool | None = None,
-    
+
     auto_convert: bool | None = None,
-    
+
     segment_time_metadata: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Virtual concatenation script
-    
+
     Args:
         safe: enable safe mode (default true)
         auto_convert: automatically convert bitstream format (default true)
@@ -1873,33 +1873,33 @@ def concat(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "safe": safe,
-        
+
         "auto_convert": auto_convert,
-        
+
         "segment_time_metadata": segment_time_metadata,
-        
+
     }))
 
 
 
 def cri_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped cri sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -1911,29 +1911,29 @@ def cri_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def data(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw data
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -1941,61 +1941,61 @@ def data(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def daud(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     D-Cinema audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dcstr(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sega DC STR
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dds_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped dds sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -2007,63 +2007,63 @@ def dds_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def derf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Xilam DERF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dfa(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Chronomaster DFA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dfpwm(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw DFPWM1a
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 48000)
         ch_layout: (default "mono")
@@ -2072,41 +2072,41 @@ def dfpwm(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def dhav(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Video DAV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dirac(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw Dirac
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -2115,25 +2115,25 @@ def dirac(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def dnxhd(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw DNxHD (SMPTE VC-3)
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -2142,31 +2142,31 @@ def dnxhd(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def dpx_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped dpx sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -2178,77 +2178,77 @@ def dpx_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def dsf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     DSD Stream File (DSF)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dsicin(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Delphine Software International CIN
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dss(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Digital Speech Standard (DSS)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dts(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw DTS
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -2256,53 +2256,53 @@ def dts(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def dtshd(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw DTS-HD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     DV (Digital Video)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dvbsub(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw dvbsub
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -2310,21 +2310,21 @@ def dvbsub(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def dvbtxt(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     dvbtxt
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -2332,37 +2332,37 @@ def dvbtxt(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def dxa(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     DXA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ea(
-    
+
     merge_alpha: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Electronic Arts Multimedia
-    
+
     Args:
         merge_alpha: return VP6 alpha in the main video stream (default false)
 
@@ -2370,37 +2370,37 @@ def ea(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "merge_alpha": merge_alpha,
-        
+
     }))
 
 
 
 def ea_cdata(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Electronic Arts cdata
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def eac3(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw E-AC-3
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -2408,37 +2408,37 @@ def eac3(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def epaf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Ensoniq Paris Audio File
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def evc(
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     EVC Annex B
-    
+
     Args:
         framerate: (default "25")
 
@@ -2446,29 +2446,29 @@ def evc(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def exr_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped exr sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -2480,31 +2480,31 @@ def exr_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def f32be(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM 32-bit floating-point big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -2513,25 +2513,25 @@ def f32be(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def f32le(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM 32-bit floating-point little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -2540,25 +2540,25 @@ def f32le(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def f64be(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM 64-bit floating-point big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -2567,25 +2567,25 @@ def f64be(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def f64le(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM 64-bit floating-point little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -2594,87 +2594,87 @@ def f64le(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def d(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     fbdev           Linux framebuffer
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ffmetadata(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     FFmpeg metadata in text
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def film_cpk(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sega FILM / CPK
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def filmstrip(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Adobe Filmstrip
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def fits(
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Flexible Image Transport System
-    
+
     Args:
         framerate: set the framerate (default "1")
 
@@ -2682,21 +2682,21 @@ def fits(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def flac(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw FLAC
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -2704,43 +2704,43 @@ def flac(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def flic(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     FLI/FLC/FLX animation
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def flv(
-    
+
     flv_metadata: bool | None = None,
-    
+
     flv_full_metadata: bool | None = None,
-    
+
     flv_ignore_prevtag: bool | None = None,
-    
+
     missing_streams: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     FLV (Flash Video)
-    
+
     Args:
         flv_metadata: Allocate streams according to the onMetaData array (default false)
         flv_full_metadata: Dump full metadata of the onMetadata (default false)
@@ -2751,75 +2751,75 @@ def flv(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "flv_metadata": flv_metadata,
-        
+
         "flv_full_metadata": flv_full_metadata,
-        
+
         "flv_ignore_prevtag": flv_ignore_prevtag,
-        
+
         "missing_streams": missing_streams,
-        
+
     }))
 
 
 
 def frm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Megalux Frame
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def fsb(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     FMOD Sample Bank
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def fwse(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Capcom's MT Framework sound
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def g722(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw G.722
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -2827,39 +2827,39 @@ def g722(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def g723_1(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     G.723.1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def g726(
-    
+
     code_size: int | None = None,
-    
+
     sample_rate: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw big-endian G.726 ("left aligned")
-    
+
     Args:
         code_size: Bits per G.726 code (from 2 to 5) (default 4)
         sample_rate: (from 0 to INT_MAX) (default 8000)
@@ -2868,25 +2868,25 @@ def g726(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "code_size": code_size,
-        
+
         "sample_rate": sample_rate,
-        
+
     }))
 
 
 
 def g726le(
-    
+
     code_size: int | None = None,
-    
+
     sample_rate: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw little-endian G.726 ("right aligned")
-    
+
     Args:
         code_size: Bits per G.726 code (from 2 to 5) (default 4)
         sample_rate: (from 0 to INT_MAX) (default 8000)
@@ -2895,23 +2895,23 @@ def g726le(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "code_size": code_size,
-        
+
         "sample_rate": sample_rate,
-        
+
     }))
 
 
 
 def g729(
-    
+
     bit_rate: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     G.729 raw format demuxer
-    
+
     Args:
         bit_rate: (from 0 to INT_MAX) (default 8000)
 
@@ -2919,45 +2919,45 @@ def g729(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "bit_rate": bit_rate,
-        
+
     }))
 
 
 
 def gdv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Gremlin Digital Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def gem_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped gem sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -2969,51 +2969,51 @@ def gem_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def genh(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     GENeric Header
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def gif(
-    
+
     min_delay: int | None = None,
-    
+
     max_gif_delay: int | None = None,
-    
+
     default_delay: int | None = None,
-    
+
     ignore_loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CompuServe Graphics Interchange Format (GIF)
-    
+
     Args:
         min_delay: minimum valid delay between frames (in hundredths of second) (from 0 to 6000) (default 2)
         max_gif_delay: maximum valid delay between frames (in hundredths of seconds) (from 0 to 65535) (default 65535)
@@ -3024,35 +3024,35 @@ def gif(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "min_delay": min_delay,
-        
+
         "max_gif_delay": max_gif_delay,
-        
+
         "default_delay": default_delay,
-        
+
         "ignore_loop": ignore_loop,
-        
+
     }))
 
 
 
 def gif_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped gif sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3064,29 +3064,29 @@ def gif_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def gsm(
-    
+
     sample_rate: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw GSM
-    
+
     Args:
         sample_rate: (from 1 to 6.50753e+07) (default 8000)
 
@@ -3094,39 +3094,39 @@ def gsm(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
     }))
 
 
 
 def gxf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     GXF (General eXchange Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def h261(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw H.261
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -3135,25 +3135,25 @@ def h261(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def h263(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw H.263
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -3162,25 +3162,25 @@ def h263(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def h264(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw H.264 video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -3189,27 +3189,27 @@ def h264(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def hca(
-    
+
     hca_lowkey: int | None = None,
-    
+
     hca_highkey: int | None = None,
-    
+
     hca_subkey: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CRI HCA
-    
+
     Args:
         hca_lowkey: Low key used for handling CRI HCA files (from 0 to UINT32_MAX) (default 0)
         hca_highkey: High key used for handling CRI HCA files (from 0 to UINT32_MAX) (default 0)
@@ -3219,49 +3219,49 @@ def hca(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "hca_lowkey": hca_lowkey,
-        
+
         "hca_highkey": hca_highkey,
-        
+
         "hca_subkey": hca_subkey,
-        
+
     }))
 
 
 
 def hcom(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Macintosh HCOM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def hdr_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped hdr sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3273,31 +3273,31 @@ def hdr_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def hevc(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw HEVC video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -3306,43 +3306,43 @@ def hevc(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def hls(
-    
+
     live_start_index: int | None = None,
-    
+
     prefer_x_start: bool | None = None,
-    
+
     allowed_extensions: str | None = None,
-    
+
     extension_picky: bool | None = None,
-    
+
     max_reload: int | None = None,
-    
+
     m3u8_hold_counters: int | None = None,
-    
+
     http_persistent: bool | None = None,
-    
+
     http_multiple: bool | None = None,
-    
+
     http_seekable: bool | None = None,
-    
+
     seg_format_options: str | None = None,
-    
+
     seg_max_retry: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Apple HTTP Live Streaming
-    
+
     Args:
         live_start_index: segment index to start live streams at (negative values are from the end) (from INT_MIN to INT_MAX) (default -3)
         prefer_x_start: prefer to use #EXT-X-START if it's in playlist instead of live_start_index (default false)
@@ -3360,109 +3360,109 @@ def hls(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "live_start_index": live_start_index,
-        
+
         "prefer_x_start": prefer_x_start,
-        
+
         "allowed_extensions": allowed_extensions,
-        
+
         "extension_picky": extension_picky,
-        
+
         "max_reload": max_reload,
-        
+
         "m3u8_hold_counters": m3u8_hold_counters,
-        
+
         "http_persistent": http_persistent,
-        
+
         "http_multiple": http_multiple,
-        
+
         "http_seekable": http_seekable,
-        
+
         "seg_format_options": seg_format_options,
-        
+
         "seg_max_retry": seg_max_retry,
-        
+
     }))
 
 
 
 def hnm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Cryo HNM v4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def iamf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Raw Immersive Audio Model and Formats
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ico(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Microsoft Windows ICO
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def idcin(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     id Cinematic
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def idf(
-    
+
     linespeed: int | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     iCE Draw File
-    
+
     Args:
         linespeed: set simulated line speed (bytes per second) (from 1 to INT_MAX) (default 6000)
         video_size: set video size, such as 640x480 or hd720.
@@ -3472,89 +3472,89 @@ def idf(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "linespeed": linespeed,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def iff(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     IFF (Interchange File Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ifv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     IFV CCTV DVR
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ilbc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     iLBC storage
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def image2(
-    
+
     pattern_type: int | None| Literal["glob_sequence", "glob", "sequence", "none"] = None,
-    
+
     start_number: int | None = None,
-    
+
     start_number_range: int | None = None,
-    
+
     ts_from_file: int | None| Literal["none", "sec", "ns"] = None,
-    
+
     export_path_metadata: bool | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     image2 sequence
-    
+
     Args:
         pattern_type: set pattern type (from 0 to INT_MAX) (default 4)
         start_number: set first number in the sequence (from INT_MIN to INT_MAX) (default 0)
@@ -3570,45 +3570,45 @@ def image2(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "pattern_type": pattern_type,
-        
+
         "start_number": start_number,
-        
+
         "start_number_range": start_number_range,
-        
+
         "ts_from_file": ts_from_file,
-        
+
         "export_path_metadata": export_path_metadata,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def image2pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped image2 sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3620,31 +3620,31 @@ def image2pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def ingenient(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw Ingenient MJPEG
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -3653,39 +3653,39 @@ def ingenient(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def ipmovie(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Interplay MVE
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ipu(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw IPU Video
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -3693,109 +3693,109 @@ def ipu(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def ircam(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Berkeley/IRCAM/CARL Sound Format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def iss(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Funcom ISS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def iv8(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     IndigoVision 8000 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ivf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     On2 IVF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ivr(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     IVR (Internet Video Recording)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def j2k_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped j2k sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3807,53 +3807,53 @@ def j2k_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def jacosub(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     JACOsub subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def jpeg_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped jpeg sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3865,37 +3865,37 @@ def jpeg_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def jpegls_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped jpegls sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3907,53 +3907,53 @@ def jpegls_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def jpegxl_anim(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Animated JPEG XL
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def jpegxl_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped jpegxl sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3965,67 +3965,67 @@ def jpegxl_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def jv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Bitmap Brothers JV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def d(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     kmsgrab         KMS screen capture
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def kux(
-    
+
     flv_metadata: bool | None = None,
-    
+
     flv_full_metadata: bool | None = None,
-    
+
     flv_ignore_prevtag: bool | None = None,
-    
+
     missing_streams: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     KUX (YouKu)
-    
+
     Args:
         flv_metadata: Allocate streams according to the onMetaData array (default false)
         flv_full_metadata: Dump full metadata of the onMetadata (default false)
@@ -4036,97 +4036,97 @@ def kux(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "flv_metadata": flv_metadata,
-        
+
         "flv_full_metadata": flv_full_metadata,
-        
+
         "flv_ignore_prevtag": flv_ignore_prevtag,
-        
+
         "missing_streams": missing_streams,
-        
+
     }))
 
 
 
 def kvag(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Simon & Schuster Interactive VAG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def laf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     LAF (Limitless Audio Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def d(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     lavfi           Libavfilter virtual input device
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def lc3(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     LC3 (Low Complexity Communication Codec)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def live_flv(
-    
+
     flv_metadata: bool | None = None,
-    
+
     flv_full_metadata: bool | None = None,
-    
+
     flv_ignore_prevtag: bool | None = None,
-    
+
     missing_streams: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     live RTMP FLV (Flash Video)
-    
+
     Args:
         flv_metadata: Allocate streams according to the onMetaData array (default false)
         flv_full_metadata: Dump full metadata of the onMetadata (default false)
@@ -4137,43 +4137,43 @@ def live_flv(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "flv_metadata": flv_metadata,
-        
+
         "flv_full_metadata": flv_full_metadata,
-        
+
         "flv_ignore_prevtag": flv_ignore_prevtag,
-        
+
         "missing_streams": missing_streams,
-        
+
     }))
 
 
 
 def lmlm4(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw lmlm4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def loas(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     LOAS AudioSyncStream
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -4181,87 +4181,87 @@ def loas(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def lrc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     LRC lyrics
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def luodat(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Video CCTV DAT
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def lvf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     LVF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def lxf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     VR native stream (LXF)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def m4v(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw MPEG-4 video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -4270,71 +4270,71 @@ def m4v(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def mca(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MCA Audio Format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mcc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MacCaption
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mgsts(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Metal Gear Solid: The Twin Snakes
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def microdvd(
-    
+
     subfps: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MicroDVD subtitle format
-    
+
     Args:
         subfps: set the movie frame rate fallback (from 0 to INT_MAX) (default 0/1)
 
@@ -4342,23 +4342,23 @@ def microdvd(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "subfps": subfps,
-        
+
     }))
 
 
 
 def mjpeg(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw MJPEG video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -4367,25 +4367,25 @@ def mjpeg(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def mjpeg_2000(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw MJPEG 2000 video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -4394,23 +4394,23 @@ def mjpeg_2000(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def mlp(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw MLP
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -4418,101 +4418,101 @@ def mlp(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def mlv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Magic Lantern Video (MLV)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     American Laser Games MM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mmf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Yamaha SMAF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mods(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MobiClip MODS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def moflex(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MobiClip MOFLEX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mp3(
-    
+
     usetoc: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MP2/3 (MPEG audio layer 2/3)
-    
+
     Args:
         usetoc: use table of contents (default false)
 
@@ -4520,79 +4520,79 @@ def mp3(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "usetoc": usetoc,
-        
+
     }))
 
 
 
 def mpc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Musepack
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mpc8(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Musepack SV8
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mpeg(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MPEG-PS (MPEG-2 Program Stream)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mpegts(
-    
+
     resync_size: int | None = None,
-    
+
     fix_teletext_pts: bool | None = None,
-    
+
     scan_all_pmts: bool | None = None,
-    
+
     skip_unknown_pmt: bool | None = None,
-    
+
     merge_pmt_versions: bool | None = None,
-    
+
     max_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MPEG-TS (MPEG-2 Transport Stream)
-    
+
     Args:
         resync_size: set size limit for looking up a new synchronization (from 0 to INT_MAX) (default 65536)
         fix_teletext_pts: try to fix pts values of dvb teletext streams (default true)
@@ -4605,33 +4605,33 @@ def mpegts(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "resync_size": resync_size,
-        
+
         "fix_teletext_pts": fix_teletext_pts,
-        
+
         "scan_all_pmts": scan_all_pmts,
-        
+
         "skip_unknown_pmt": skip_unknown_pmt,
-        
+
         "merge_pmt_versions": merge_pmt_versions,
-        
+
         "max_packet_size": max_packet_size,
-        
+
     }))
 
 
 
 def mpegtsraw(
-    
+
     resync_size: int | None = None,
-    
+
     compute_pcr: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw MPEG-TS (MPEG-2 Transport Stream)
-    
+
     Args:
         resync_size: set size limit for looking up a new synchronization (from 0 to INT_MAX) (default 65536)
         compute_pcr: compute exact PCR for each transport stream packet (default false)
@@ -4640,25 +4640,25 @@ def mpegtsraw(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "resync_size": resync_size,
-        
+
         "compute_pcr": compute_pcr,
-        
+
     }))
 
 
 
 def mpegvideo(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw MPEG video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -4667,23 +4667,23 @@ def mpegvideo(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def mpjpeg(
-    
+
     strict_mime_boundary: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MIME multipart JPEG
-    
+
     Args:
         strict_mime_boundary: require MIME boundaries match (default false)
 
@@ -4691,135 +4691,135 @@ def mpjpeg(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "strict_mime_boundary": strict_mime_boundary,
-        
+
     }))
 
 
 
 def mpl2(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MPL2 subtitles
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mpsub(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MPlayer subtitles
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def msf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony PS3 MSF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def msnwctcp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MSN TCP Webcam stream
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def msp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Microsoft Paint (MSP))
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mtaf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Konami PS2 MTAF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mtv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MTV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mulaw(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM mu-law
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -4828,71 +4828,71 @@ def mulaw(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def musx(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Eurocom MUSX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Silicon Graphics Movie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mvi(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Motion Pixels MVI
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mxf(
-    
+
     eia608_extract: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MXF (Material eXchange Format)
-    
+
     Args:
         eia608_extract: extract eia 608 captions from s436m track (default false)
 
@@ -4900,133 +4900,133 @@ def mxf(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "eia608_extract": eia608_extract,
-        
+
     }))
 
 
 
 def mxg(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MxPEG clip
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def nc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     NC camera feed
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def nistsphere(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     NIST SPeech HEader REsources
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def nsp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Computerized Speech Lab NSP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def nsv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Nullsoft Streaming Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def nut(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     NUT
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def nuv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     NuppelVideo
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def obu(
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AV1 low overhead OBU
-    
+
     Args:
         framerate: (default "25")
 
@@ -5034,53 +5034,53 @@ def obu(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def ogg(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Ogg
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def oma(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony OpenMG audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def osq(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw OSQ
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -5088,61 +5088,61 @@ def osq(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def d(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     oss             OSS (Open Sound System) capture
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def paf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Amazing Studio Packed Animation File
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def pam_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pam sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5154,37 +5154,37 @@ def pam_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pbm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pbm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5196,37 +5196,37 @@ def pbm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pcx_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pcx sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5238,53 +5238,53 @@ def pcx_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pdv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PlayDate Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def pfm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pfm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5296,37 +5296,37 @@ def pfm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pgm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pgm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5338,37 +5338,37 @@ def pgm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pgmyuv_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pgmyuv sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5380,37 +5380,37 @@ def pgmyuv_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pgx_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pgx sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5422,37 +5422,37 @@ def pgx_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def phm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped phm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5464,37 +5464,37 @@ def phm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def photocd_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped photocd sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5506,37 +5506,37 @@ def photocd_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pictor_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pictor sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5548,69 +5548,69 @@ def pictor_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pjs(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PJS (Phoenix Japanimation Society) subtitles
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def pmp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Playstation Portable PMP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def png_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped png sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5622,53 +5622,53 @@ def png_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pp_bnk(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Pro Pinball Series Soundbank
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ppm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped ppm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5680,37 +5680,37 @@ def ppm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def psd_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped psd sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5722,101 +5722,101 @@ def psd_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def psxstr(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony Playstation STR
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def pva(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     TechnoTrend PVA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def pvf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PVF (Portable Voice Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def qcp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     QCP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def qdraw_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped qdraw sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5828,53 +5828,53 @@ def qdraw_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def qoa(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     QOA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def qoi_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped qoi sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5886,49 +5886,49 @@ def qoi_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def r3d(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     REDCODE R3D
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rawvideo(
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw video
-    
+
     Args:
         pixel_format: set pixel format (default "yuv420p")
         video_size: set frame size
@@ -5938,195 +5938,195 @@ def rawvideo(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def rcwt(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RCWT (Raw Captions With Time)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def realtext(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RealText subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def redspark(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RedSpark
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rka(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RKA (RK Audio)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rl2(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RL2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RealMedia
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def roq(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     id RoQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rpl(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RPL / ARMovie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rsd(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     GameCube RSD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rso(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Lego Mindstorms RSO
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rtp(
-    
+
     rtp_flags: str | None = None,
-    
+
     listen_timeout: str | None = None,
-    
+
     localaddr: str | None = None,
-    
+
     allowed_media_types: str | None = None,
-    
+
     reorder_queue_size: int | None = None,
-    
+
     buffer_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RTP input
-    
+
     Args:
         rtp_flags: set RTP flags (default 0)
         listen_timeout: set maximum timeout (in seconds) to wait for incoming connections (default 10)
@@ -6139,51 +6139,51 @@ def rtp(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "rtp_flags": rtp_flags,
-        
+
         "listen_timeout": listen_timeout,
-        
+
         "localaddr": localaddr,
-        
+
         "allowed_media_types": allowed_media_types,
-        
+
         "reorder_queue_size": reorder_queue_size,
-        
+
         "buffer_size": buffer_size,
-        
+
     }))
 
 
 
 def rtsp(
-    
+
     initial_pause: bool | None = None,
-    
+
     rtsp_transport: str | None = None,
-    
+
     rtsp_flags: str | None = None,
-    
+
     allowed_media_types: str | None = None,
-    
+
     min_port: int | None = None,
-    
+
     max_port: int | None = None,
-    
+
     listen_timeout: int | None = None,
-    
+
     timeout: int | None = None,
-    
+
     reorder_queue_size: int | None = None,
-    
+
     buffer_size: int | None = None,
-    
+
     user_agent: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RTSP input
-    
+
     Args:
         initial_pause: do not start playing the stream immediately (default false)
         rtsp_transport: set RTSP transport protocols (default 0)
@@ -6201,43 +6201,43 @@ def rtsp(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "initial_pause": initial_pause,
-        
+
         "rtsp_transport": rtsp_transport,
-        
+
         "rtsp_flags": rtsp_flags,
-        
+
         "allowed_media_types": allowed_media_types,
-        
+
         "min_port": min_port,
-        
+
         "max_port": max_port,
-        
+
         "listen_timeout": listen_timeout,
-        
+
         "timeout": timeout,
-        
+
         "reorder_queue_size": reorder_queue_size,
-        
+
         "buffer_size": buffer_size,
-        
+
         "user_agent": user_agent,
-        
+
     }))
 
 
 
 def s16be(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 16-bit big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -6246,25 +6246,25 @@ def s16be(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def s16le(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 16-bit little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -6273,25 +6273,25 @@ def s16le(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def s24be(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 24-bit big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -6300,25 +6300,25 @@ def s24be(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def s24le(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 24-bit little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -6327,25 +6327,25 @@ def s24le(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def s32be(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 32-bit big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -6354,25 +6354,25 @@ def s32be(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def s32le(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 32-bit little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -6381,41 +6381,41 @@ def s32le(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def s337m(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SMPTE 337M
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def s8(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 8-bit
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -6424,55 +6424,55 @@ def s8(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def sami(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SAMI subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sap(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SAP input
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sbc(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw SBC (low-complexity subband codec)
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -6480,23 +6480,23 @@ def sbc(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def sbg(
-    
+
     sample_rate: int | None = None,
-    
+
     max_file_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SBaGen binaural beats script
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 0)
         max_file_size: (from 0 to INT_MAX) (default 5000000)
@@ -6505,81 +6505,81 @@ def sbg(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "max_file_size": max_file_size,
-        
+
     }))
 
 
 
 def scc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Scenarist Closed Captions
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def scd(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Square Enix SCD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sdns(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Xbox SDNS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sdp(
-    
+
     sdp_flags: str | None = None,
-    
+
     listen_timeout: str | None = None,
-    
+
     localaddr: str | None = None,
-    
+
     allowed_media_types: str | None = None,
-    
+
     reorder_queue_size: int | None = None,
-    
+
     buffer_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SDP
-    
+
     Args:
         sdp_flags: SDP flags (default 0)
         listen_timeout: set maximum timeout (in seconds) to wait for incoming connections (default 10)
@@ -6592,79 +6592,79 @@ def sdp(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sdp_flags": sdp_flags,
-        
+
         "listen_timeout": listen_timeout,
-        
+
         "localaddr": localaddr,
-        
+
         "allowed_media_types": allowed_media_types,
-        
+
         "reorder_queue_size": reorder_queue_size,
-        
+
         "buffer_size": buffer_size,
-        
+
     }))
 
 
 
 def sdr2(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SDR2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sds(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MIDI Sample Dump Standard
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sdx(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sample Dump eXchange
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ser(
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SER (Simple uncompressed video format for astronomical capturing)
-    
+
     Args:
         framerate: set frame rate (default "25")
 
@@ -6672,45 +6672,45 @@ def ser(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def sga(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Digital Pictures SGA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sgi_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped sgi sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -6722,29 +6722,29 @@ def sgi_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def shn(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw Shorten
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -6752,55 +6752,55 @@ def shn(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def siff(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Beam Software SIFF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def simbiosis_imx(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Simbiosis Interactive IMX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sln(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Asterisk raw pcm
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 8000)
         ch_layout: (default "mono")
@@ -6809,191 +6809,191 @@ def sln(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def smjpeg(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Loki SDL MJPEG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def smk(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Smacker
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def smush(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     LucasArts Smush
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sol(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sierra SOL
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sox(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SoX (Sound eXchange) native
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def spdif(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     IEC 61937 (compressed data in S/PDIF)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def srt(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SubRip subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def stl(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Spruce subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def subviewer(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SubViewer subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def subviewer1(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SubViewer v1 subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sunrast_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped sunrast sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -7005,69 +7005,69 @@ def sunrast_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def sup(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw HDMV Presentation Graphic Stream subtitles
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def svag(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Konami PS2 SVAG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def svg_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped svg sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -7079,61 +7079,61 @@ def svg_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def svs(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Square SVS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def swf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SWF (ShockWave Flash)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def tak(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw TAK
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -7141,21 +7141,21 @@ def tak(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def tedcaptions(
-    
+
     start_time: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     TED Talks captions
-    
+
     Args:
         start_time: set the start time (offset) of the subtitles, in ms (from I64_MIN to I64_MAX) (default 15000)
 
@@ -7163,61 +7163,61 @@ def tedcaptions(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "start_time": start_time,
-        
+
     }))
 
 
 
 def thp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     THP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def tiertexseq(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Tiertex Limited SEQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def tiff_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped tiff sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -7229,45 +7229,45 @@ def tiff_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def tmv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     8088flex TMV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def truehd(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw TrueHD
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -7275,41 +7275,41 @@ def truehd(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def tta(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     TTA (True Audio)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def tty(
-    
+
     chars_per_frame: int | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Tele-typewriter
-    
+
     Args:
         chars_per_frame: (from 1 to INT_MAX) (default 6000)
         video_size: A string describing frame size, such as 640x480 or hd720.
@@ -7319,59 +7319,59 @@ def tty(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "chars_per_frame": chars_per_frame,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def txd(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Renderware TeXture Dictionary
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ty(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     TiVo TY Stream
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def u16be(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 16-bit big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -7380,25 +7380,25 @@ def u16be(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def u16le(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 16-bit little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -7407,25 +7407,25 @@ def u16le(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def u24be(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 24-bit big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -7434,25 +7434,25 @@ def u24be(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def u24le(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 24-bit little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -7461,25 +7461,25 @@ def u24le(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def u32be(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 32-bit big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -7488,25 +7488,25 @@ def u32be(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def u32le(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 32-bit little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -7515,25 +7515,25 @@ def u32le(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def u8(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 8-bit
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -7542,41 +7542,41 @@ def u8(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def usm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CRI USM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def v210(
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Uncompressed 4:2:2 10-bit
-    
+
     Args:
         video_size: set frame size
         framerate: set frame rate (default "25")
@@ -7585,25 +7585,25 @@ def v210(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def v210x(
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Uncompressed 4:2:2 10-bit
-    
+
     Args:
         video_size: set frame size
         framerate: set frame rate (default "25")
@@ -7612,47 +7612,47 @@ def v210x(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def vag(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony PS2 VAG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vbn_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped vbn sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -7664,31 +7664,31 @@ def vbn_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def vc1(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw VC-1
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -7697,41 +7697,41 @@ def vc1(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def vc1test(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     VC-1 test bitstream
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vidc(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM Archimedes VIDC
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -7740,87 +7740,87 @@ def vidc(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def d(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     video4linux2,v4l2 Video4Linux2 device grab
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vividas(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Vividas VIV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vivo(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Vivo
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vmd(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sierra VMD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vobsub(
-    
+
     sub_name: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     VobSub subtitle format
-    
+
     Args:
         sub_name: URI for .sub file
 
@@ -7828,87 +7828,87 @@ def vobsub(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sub_name": sub_name,
-        
+
     }))
 
 
 
 def voc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Creative Voice
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vpk(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony PS2 VPK
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vplayer(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     VPlayer subtitles
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vqf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Nippon Telegraph and Telephone Corporation (NTT) TwinVQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vvc(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw H.266/VVC video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -7917,23 +7917,23 @@ def vvc(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def w64(
-    
+
     max_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony Wave64
-    
+
     Args:
         max_size: max size of single packet (from 0 to 4.1943e+06) (default 0)
 
@@ -7941,39 +7941,39 @@ def w64(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "max_size": max_size,
-        
+
     }))
 
 
 
 def wady(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Marble WADY
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def wav(
-    
+
     ignore_length: bool | None = None,
-    
+
     max_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     WAV / WAVE (Waveform Audio)
-    
+
     Args:
         ignore_length: Ignore length (default false)
         max_size: max size of single packet (from 0 to 4.1943e+06) (default 0)
@@ -7982,57 +7982,57 @@ def wav(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "ignore_length": ignore_length,
-        
+
         "max_size": max_size,
-        
+
     }))
 
 
 
 def wavarc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Waveform Archiver
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def wc3movie(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Wing Commander III movie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def webm_dash_manifest(
-    
+
     live: bool | None = None,
-    
+
     bandwidth: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     WebM DASH Manifest
-    
+
     Args:
         live: flag indicating that the input is a live file that only has the headers. (default false)
         bandwidth: bandwidth of this stream to be specified in the DASH manifest. (from 0 to INT_MAX) (default 0)
@@ -8041,31 +8041,31 @@ def webm_dash_manifest(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "live": live,
-        
+
         "bandwidth": bandwidth,
-        
+
     }))
 
 
 
 def webp_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped webp sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -8077,29 +8077,29 @@ def webp_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def webvtt(
-    
+
     kind: int | None| Literal["subtitles", "captions", "descriptions", "metadata"] = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     WebVTT subtitle
-    
+
     Args:
         kind: Set kind of WebVTT track (from 0 to INT_MAX) (default subtitles)
 
@@ -8107,37 +8107,37 @@ def webvtt(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "kind": kind,
-        
+
     }))
 
 
 
 def wsaud(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Westwood Studios audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def wsd(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Wideband Single-bit Data (WSD)
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -8145,121 +8145,121 @@ def wsd(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def wsvqa(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Westwood Studios VQA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def wtv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Windows Television (WTV)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def wv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     WavPack
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def wve(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Psion 3 audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def d(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     x11grab         X11 screen capture, using XCB
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def xa(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Maxis XA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def xbin(
-    
+
     linespeed: int | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     eXtended BINary text (XBIN)
-    
+
     Args:
         linespeed: set simulated line speed (bytes per second) (from 1 to INT_MAX) (default 6000)
         video_size: set video size, such as 640x480 or hd720.
@@ -8269,33 +8269,33 @@ def xbin(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "linespeed": linespeed,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def xbm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped xbm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -8307,69 +8307,69 @@ def xbm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def xmd(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Konami XMD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def xmv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Microsoft XMV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def xpm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped xpm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -8381,53 +8381,53 @@ def xpm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def xvag(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony PS3 XVAG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def xwd_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped xwd sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -8439,64 +8439,63 @@ def xwd_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def xwma(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Microsoft xWMA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def yop(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Psygnosis YOP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def yuv4mpegpipe(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     YUV4MPEG pipe
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
-    }))
 
+    }))

--- a/packages/v7/src/ffmpeg/formats/muxers.py
+++ b/packages/v7/src/ffmpeg/formats/muxers.py
@@ -44,61 +44,61 @@ from ..streams.audio import AudioStream
 
 
 def _3g2(
-    
+
     brand: str | None = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_prft: int | None| Literal["pts", "wallclock"] = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     3GP2 (3GPP2 file format)
-    
+
     Args:
         brand: Override major brand
         empty_hdlr_name: write zero-length name string in hdlr atoms within mdia and minf atoms (default false)
@@ -130,117 +130,117 @@ def _3g2(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "brand": brand,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "frag_duration": frag_duration,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "frag_size": frag_size,
-        
+
         "fragment_index": fragment_index,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "movie_timescale": movie_timescale,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "use_editlist": use_editlist,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_prft": write_prft,
-        
+
         "write_tmcd": write_tmcd,
-        
+
     }))
 
 
 
 def _3gp(
-    
+
     brand: str | None = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_prft: int | None| Literal["pts", "wallclock"] = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     3GP (3GPP file format)
-    
+
     Args:
         brand: Override major brand
         empty_hdlr_name: write zero-length name string in hdlr atoms within mdia and minf atoms (default false)
@@ -272,101 +272,101 @@ def _3gp(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "brand": brand,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "frag_duration": frag_duration,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "frag_size": frag_size,
-        
+
         "fragment_index": fragment_index,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "movie_timescale": movie_timescale,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "use_editlist": use_editlist,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_prft": write_prft,
-        
+
         "write_tmcd": write_tmcd,
-        
+
     }))
 
 
 
 def a64(
-    
+
 ) -> FFMpegMuxerOption:
     """
     a64 - video for Commodore 64
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ac3(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw AC-3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ac4(
-    
+
     write_crc: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw AC-4
-    
+
     Args:
         write_crc: enable checksum (default false)
 
@@ -374,25 +374,25 @@ def ac4(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "write_crc": write_crc,
-        
+
     }))
 
 
 
 def adts(
-    
+
     write_id3v2: bool | None = None,
-    
+
     write_apetag: bool | None = None,
-    
+
     write_mpeg2: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     ADTS AAC (Advanced Audio Coding)
-    
+
     Args:
         write_id3v2: Enable ID3v2 tag writing (default false)
         write_apetag: Enable APE tag writing (default false)
@@ -402,59 +402,59 @@ def adts(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "write_id3v2": write_id3v2,
-        
+
         "write_apetag": write_apetag,
-        
+
         "write_mpeg2": write_mpeg2,
-        
+
     }))
 
 
 
 def adx(
-    
+
 ) -> FFMpegMuxerOption:
     """
     CRI ADX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def aea(
-    
+
 ) -> FFMpegMuxerOption:
     """
     MD STUDIO audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def aiff(
-    
+
     write_id3v2: bool | None = None,
-    
+
     id3v2_version: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Audio IFF
-    
+
     Args:
         write_id3v2: Enable ID3 tags writing. (default false)
         id3v2_version: Select ID3v2 version to write. Currently 3 and 4 are supported. (from 3 to 4) (default 4)
@@ -463,39 +463,39 @@ def aiff(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "write_id3v2": write_id3v2,
-        
+
         "id3v2_version": id3v2_version,
-        
+
     }))
 
 
 
 def alaw(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM A-law
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def alp(
-    
+
     type: int | None| Literal["auto", "tun", "pcm"] = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     LEGO Racers ALP
-    
+
     Args:
         type: set file type (from 0 to 2) (default auto)
 
@@ -503,71 +503,71 @@ def alp(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "type": type,
-        
+
     }))
 
 
 
 def amr(
-    
+
 ) -> FFMpegMuxerOption:
     """
     3GPP AMR
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def amv(
-    
+
 ) -> FFMpegMuxerOption:
     """
     AMV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def apm(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Ubisoft Rayman 2 APM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def apng(
-    
+
     plays: int | None = None,
-    
+
     final_delay: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Animated Portable Network Graphics
-    
+
     Args:
         plays: Number of times to play the output: 0 - infinite loop, 1 - no loop (from 0 to 65535) (default 1)
         final_delay: Force delay after the last frame (from 0 to 65535) (default 0/1)
@@ -576,59 +576,59 @@ def apng(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "plays": plays,
-        
+
         "final_delay": final_delay,
-        
+
     }))
 
 
 
 def aptx(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw aptX (Audio Processing Technology for Bluetooth)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def aptx_hd(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw aptX HD (Audio Processing Technology for Bluetooth)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def argo_asf(
-    
+
     version_major: int | None = None,
-    
+
     version_minor: int | None = None,
-    
+
     name: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Argonaut Games ASF
-    
+
     Args:
         version_major: override file major version (from 0 to 65535) (default 2)
         version_minor: override file minor version (from 0 to 65535) (default 1)
@@ -638,29 +638,29 @@ def argo_asf(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "version_major": version_major,
-        
+
         "version_minor": version_minor,
-        
+
         "name": name,
-        
+
     }))
 
 
 
 def argo_cvg(
-    
+
     skip_rate_check: bool | None = None,
-    
+
     loop: bool | None = None,
-    
+
     reverb: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Argonaut Games CVG
-    
+
     Args:
         skip_rate_check: skip sample rate check (default false)
         loop: set loop flag (default false)
@@ -670,25 +670,25 @@ def argo_cvg(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "skip_rate_check": skip_rate_check,
-        
+
         "loop": loop,
-        
+
         "reverb": reverb,
-        
+
     }))
 
 
 
 def asf(
-    
+
     packet_size: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     ASF (Advanced / Active Streaming Format)
-    
+
     Args:
         packet_size: Packet size (from 100 to 65536) (default 3200)
 
@@ -696,21 +696,21 @@ def asf(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "packet_size": packet_size,
-        
+
     }))
 
 
 
 def asf_stream(
-    
+
     packet_size: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     ASF (Advanced / Active Streaming Format)
-    
+
     Args:
         packet_size: Packet size (from 100 to 65536) (default 3200)
 
@@ -718,21 +718,21 @@ def asf_stream(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "packet_size": packet_size,
-        
+
     }))
 
 
 
 def ass(
-    
+
     ignore_readorder: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     SSA (SubStation Alpha) subtitle
-    
+
     Args:
         ignore_readorder: write events immediately, even if they're out-of-order (default false)
 
@@ -740,23 +740,23 @@ def ass(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "ignore_readorder": ignore_readorder,
-        
+
     }))
 
 
 
 def ast(
-    
+
     loopstart: int | None = None,
-    
+
     loopend: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     AST (Audio Stream)
-    
+
     Args:
         loopstart: Loopstart position in milliseconds. (from -1 to INT_MAX) (default -1)
         loopend: Loopend position in milliseconds. (from 0 to INT_MAX) (default 0)
@@ -765,43 +765,43 @@ def ast(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "loopstart": loopstart,
-        
+
         "loopend": loopend,
-        
+
     }))
 
 
 
 def au(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Sun AU
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def avi(
-    
+
     reserve_index_space: int | None = None,
-    
+
     write_channel_mask: bool | None = None,
-    
+
     flipped_raw_rgb: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     AVI (Audio Video Interleaved)
-    
+
     Args:
         reserve_index_space: reserve space (in bytes) at the beginning of the file for each stream index (from 0 to INT_MAX) (default 0)
         write_channel_mask: write channel mask into wave format header (default true)
@@ -811,27 +811,27 @@ def avi(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "reserve_index_space": reserve_index_space,
-        
+
         "write_channel_mask": write_channel_mask,
-        
+
         "flipped_raw_rgb": flipped_raw_rgb,
-        
+
     }))
 
 
 
 def avif(
-    
+
     movie_timescale: int | None = None,
-    
+
     loop: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     AVIF
-    
+
     Args:
         movie_timescale: set movie timescale (from 1 to INT_MAX) (default 1000)
         loop: Number of times to loop animated AVIF: 0 - infinite loop (from 0 to INT_MAX) (default 0)
@@ -840,237 +840,237 @@ def avif(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "movie_timescale": movie_timescale,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def avm2(
-    
+
 ) -> FFMpegMuxerOption:
     """
     SWF (ShockWave Flash) (AVM2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def avs2(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw AVS2-P2/IEEE1857.4 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def avs3(
-    
+
 ) -> FFMpegMuxerOption:
     """
     AVS3-P2/IEEE1857.10
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def bit(
-    
+
 ) -> FFMpegMuxerOption:
     """
     G.729 BIT file format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def caf(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Apple CAF (Core Audio Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def cavsvideo(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw Chinese AVS (Audio Video Standard) video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def codec2(
-    
+
 ) -> FFMpegMuxerOption:
     """
     codec2 .c2 muxer
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def codec2raw(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw codec2 muxer
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def crc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     CRC testing
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dash(
-    
+
     adaptation_sets: str | None = None,
-    
+
     dash_segment_type: int | None| Literal["auto", "mp4", "webm"] = None,
-    
+
     extra_window_size: int | None = None,
-    
+
     format_options: str | None = None,
-    
+
     frag_duration: str | None = None,
-    
+
     frag_type: int | None| Literal["none", "every_frame", "duration", "pframes"] = None,
-    
+
     global_sidx: bool | None = None,
-    
+
     hls_master_name: str | None = None,
-    
+
     hls_playlist: bool | None = None,
-    
+
     http_opts: str | None = None,
-    
+
     http_persistent: bool | None = None,
-    
+
     http_user_agent: str | None = None,
-    
+
     ignore_io_errors: bool | None = None,
-    
+
     index_correction: bool | None = None,
-    
+
     init_seg_name: str | None = None,
-    
+
     ldash: bool | None = None,
-    
+
     lhls: bool | None = None,
-    
+
     master_m3u8_publish_rate: int | None = None,
-    
+
     max_playback_rate: str | None = None,
-    
+
     media_seg_name: str | None = None,
-    
+
     method: str | None = None,
-    
+
     min_playback_rate: str | None = None,
-    
+
     mpd_profile: str | None = None,
-    
+
     remove_at_exit: bool | None = None,
-    
+
     seg_duration: str | None = None,
-    
+
     single_file: bool | None = None,
-    
+
     single_file_name: str | None = None,
-    
+
     streaming: bool | None = None,
-    
+
     target_latency: str | None = None,
-    
+
     timeout: str | None = None,
-    
+
     update_period: int | None = None,
-    
+
     use_template: bool | None = None,
-    
+
     use_timeline: bool | None = None,
-    
+
     utc_timing_url: str | None = None,
-    
+
     window_size: int | None = None,
-    
+
     write_prft: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     DASH Muxer
-    
+
     Args:
         adaptation_sets: Adaptation sets. Syntax: id=0,streams=0,1,2 id=1,streams=3,4 and so on
         dash_segment_type: set dash segment files type (from 0 to 2) (default auto)
@@ -1113,205 +1113,205 @@ def dash(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "adaptation_sets": adaptation_sets,
-        
+
         "dash_segment_type": dash_segment_type,
-        
+
         "extra_window_size": extra_window_size,
-        
+
         "format_options": format_options,
-        
+
         "frag_duration": frag_duration,
-        
+
         "frag_type": frag_type,
-        
+
         "global_sidx": global_sidx,
-        
+
         "hls_master_name": hls_master_name,
-        
+
         "hls_playlist": hls_playlist,
-        
+
         "http_opts": http_opts,
-        
+
         "http_persistent": http_persistent,
-        
+
         "http_user_agent": http_user_agent,
-        
+
         "ignore_io_errors": ignore_io_errors,
-        
+
         "index_correction": index_correction,
-        
+
         "init_seg_name": init_seg_name,
-        
+
         "ldash": ldash,
-        
+
         "lhls": lhls,
-        
+
         "master_m3u8_publish_rate": master_m3u8_publish_rate,
-        
+
         "max_playback_rate": max_playback_rate,
-        
+
         "media_seg_name": media_seg_name,
-        
+
         "method": method,
-        
+
         "min_playback_rate": min_playback_rate,
-        
+
         "mpd_profile": mpd_profile,
-        
+
         "remove_at_exit": remove_at_exit,
-        
+
         "seg_duration": seg_duration,
-        
+
         "single_file": single_file,
-        
+
         "single_file_name": single_file_name,
-        
+
         "streaming": streaming,
-        
+
         "target_latency": target_latency,
-        
+
         "timeout": timeout,
-        
+
         "update_period": update_period,
-        
+
         "use_template": use_template,
-        
+
         "use_timeline": use_timeline,
-        
+
         "utc_timing_url": utc_timing_url,
-        
+
         "window_size": window_size,
-        
+
         "write_prft": write_prft,
-        
+
     }))
 
 
 
 def data(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw data
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def daud(
-    
+
 ) -> FFMpegMuxerOption:
     """
     D-Cinema audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dfpwm(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw DFPWM1a
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dirac(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw Dirac
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dnxhd(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw DNxHD (SMPTE VC-3)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dts(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw DTS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dv(
-    
+
 ) -> FFMpegMuxerOption:
     """
     DV (Digital Video)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dvd(
-    
+
     muxrate: int | None = None,
-    
+
     preload: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MPEG-2 PS (DVD VOB)
-    
+
     Args:
         muxrate: mux rate as bits/s (from 0 to 1.67772e+09) (default 0)
         preload: initial demux-decode delay in microseconds (from 0 to INT_MAX) (default 500000)
@@ -1320,135 +1320,135 @@ def dvd(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "muxrate": muxrate,
-        
+
         "preload": preload,
-        
+
     }))
 
 
 
 def eac3(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw E-AC-3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def evc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw EVC video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def f32be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM 32-bit floating-point big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def f32le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM 32-bit floating-point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def f4v(
-    
+
     brand: str | None = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_prft: int | None| Literal["pts", "wallclock"] = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     F4V Adobe Flash Video
-    
+
     Args:
         brand: Override major brand
         empty_hdlr_name: write zero-length name string in hdlr atoms within mdia and minf atoms (default false)
@@ -1480,153 +1480,153 @@ def f4v(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "brand": brand,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "frag_duration": frag_duration,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "frag_size": frag_size,
-        
+
         "fragment_index": fragment_index,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "movie_timescale": movie_timescale,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "use_editlist": use_editlist,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_prft": write_prft,
-        
+
         "write_tmcd": write_tmcd,
-        
+
     }))
 
 
 
 def f64be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM 64-bit floating-point big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def f64le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM 64-bit floating-point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def d(
-    
+
 ) -> FFMpegMuxerOption:
     """
     fbdev           Linux framebuffer
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ffmetadata(
-    
+
 ) -> FFMpegMuxerOption:
     """
     FFmpeg metadata in text
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def fifo(
-    
+
     attempt_recovery: bool | None = None,
-    
+
     drop_pkts_on_overflow: bool | None = None,
-    
+
     fifo_format: str | None = None,
-    
+
     format_opts: str | None = None,
-    
+
     max_recovery_attempts: int | None = None,
-    
+
     queue_size: int | None = None,
-    
+
     recovery_wait_streamtime: bool | None = None,
-    
+
     recovery_wait_time: str | None = None,
-    
+
     recover_any_error: bool | None = None,
-    
+
     restart_with_keyframe: bool | None = None,
-    
+
     timeshift: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     FIFO queue pseudo-muxer
-    
+
     Args:
         attempt_recovery: Attempt recovery in case of failure (default false)
         drop_pkts_on_overflow: Drop packets on fifo queue overflow not to block encoder (default false)
@@ -1644,89 +1644,89 @@ def fifo(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "attempt_recovery": attempt_recovery,
-        
+
         "drop_pkts_on_overflow": drop_pkts_on_overflow,
-        
+
         "fifo_format": fifo_format,
-        
+
         "format_opts": format_opts,
-        
+
         "max_recovery_attempts": max_recovery_attempts,
-        
+
         "queue_size": queue_size,
-        
+
         "recovery_wait_streamtime": recovery_wait_streamtime,
-        
+
         "recovery_wait_time": recovery_wait_time,
-        
+
         "recover_any_error": recover_any_error,
-        
+
         "restart_with_keyframe": restart_with_keyframe,
-        
+
         "timeshift": timeshift,
-        
+
     }))
 
 
 
 def film_cpk(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Sega FILM / CPK
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def filmstrip(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Adobe Filmstrip
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def fits(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Flexible Image Transport System
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def flac(
-    
+
     write_header: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw FLAC
-    
+
     Args:
         write_header: Write the file header (default true)
 
@@ -1734,21 +1734,21 @@ def flac(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "write_header": write_header,
-        
+
     }))
 
 
 
 def flv(
-    
+
     flvflags: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     FLV (Flash Video)
-    
+
     Args:
         flvflags: FLV muxer flags (default 0)
 
@@ -1756,39 +1756,39 @@ def flv(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "flvflags": flvflags,
-        
+
     }))
 
 
 
 def framecrc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     framecrc testing
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def framehash(
-    
+
     hash: str | None = None,
-    
+
     format_version: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Per-frame hash testing
-    
+
     Args:
         hash: set hash to use (default "sha256")
         format_version: file format version (from 1 to 2) (default 2)
@@ -1797,25 +1797,25 @@ def framehash(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "hash": hash,
-        
+
         "format_version": format_version,
-        
+
     }))
 
 
 
 def framemd5(
-    
+
     hash: str | None = None,
-    
+
     format_version: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Per-frame MD5 testing
-    
+
     Args:
         hash: set hash to use (default "md5")
         format_version: file format version (from 1 to 2) (default 2)
@@ -1824,89 +1824,89 @@ def framemd5(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "hash": hash,
-        
+
         "format_version": format_version,
-        
+
     }))
 
 
 
 def g722(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw G.722
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def g723_1(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw G.723.1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def g726(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw big-endian G.726 ("left-justified")
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def g726le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw little-endian G.726 ("right-justified")
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def gif(
-    
+
     loop: int | None = None,
-    
+
     final_delay: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     CompuServe Graphics Interchange Format (GIF)
-    
+
     Args:
         loop: Number of times to loop the output: -1 - no loop, 0 - infinite loop (from -1 to 65535) (default 0)
         final_delay: Force delay (in centiseconds) after the last frame (from -1 to 65535) (default -1)
@@ -1915,103 +1915,103 @@ def gif(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "loop": loop,
-        
+
         "final_delay": final_delay,
-        
+
     }))
 
 
 
 def gsm(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw GSM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def gxf(
-    
+
 ) -> FFMpegMuxerOption:
     """
     GXF (General eXchange Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def h261(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw H.261
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def h263(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw H.263
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def h264(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw H.264 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def hash(
-    
+
     hash: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Hash testing
-    
+
     Args:
         hash: set hash to use (default "sha256")
 
@@ -2019,27 +2019,27 @@ def hash(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "hash": hash,
-        
+
     }))
 
 
 
 def hds(
-    
+
     window_size: int | None = None,
-    
+
     extra_window_size: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     remove_at_exit: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     HDS Muxer
-    
+
     Args:
         window_size: number of fragments kept in the manifest (from 0 to INT_MAX) (default 0)
         extra_window_size: number of fragments kept outside of the manifest before removing from disk (from 0 to INT_MAX) (default 5)
@@ -2050,111 +2050,111 @@ def hds(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "window_size": window_size,
-        
+
         "extra_window_size": extra_window_size,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "remove_at_exit": remove_at_exit,
-        
+
     }))
 
 
 
 def hevc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw HEVC video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def hls(
-    
+
     start_number: int | None = None,
-    
+
     hls_time: str | None = None,
-    
+
     hls_init_time: str | None = None,
-    
+
     hls_list_size: int | None = None,
-    
+
     hls_delete_threshold: int | None = None,
-    
+
     hls_vtt_options: str | None = None,
-    
+
     hls_allow_cache: int | None = None,
-    
+
     hls_base_url: str | None = None,
-    
+
     hls_segment_filename: str | None = None,
-    
+
     hls_segment_options: str | None = None,
-    
+
     hls_segment_size: int | None = None,
-    
+
     hls_key_info_file: str | None = None,
-    
+
     hls_enc: bool | None = None,
-    
+
     hls_enc_key: str | None = None,
-    
+
     hls_enc_key_url: str | None = None,
-    
+
     hls_enc_iv: str | None = None,
-    
+
     hls_subtitle_path: str | None = None,
-    
+
     hls_segment_type: int | None| Literal["mpegts", "fmp4"] = None,
-    
+
     hls_fmp4_init_filename: str | None = None,
-    
+
     hls_fmp4_init_resend: bool | None = None,
-    
+
     hls_flags: str | None = None,
-    
+
     strftime: bool | None = None,
-    
+
     strftime_mkdir: bool | None = None,
-    
+
     hls_playlist_type: int | None| Literal["event", "vod"] = None,
-    
+
     method: str | None = None,
-    
+
     hls_start_number_source: int | None| Literal["generic", "epoch", "epoch_us", "datetime"] = None,
-    
+
     http_user_agent: str | None = None,
-    
+
     var_stream_map: str | None = None,
-    
+
     cc_stream_map: str | None = None,
-    
+
     master_pl_name: str | None = None,
-    
+
     master_pl_publish_rate: int | None = None,
-    
+
     http_persistent: bool | None = None,
-    
+
     timeout: str | None = None,
-    
+
     ignore_io_errors: bool | None = None,
-    
+
     headers: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Apple HTTP Live Streaming
-    
+
     Args:
         start_number: set first number in the sequence (from 0 to I64_MAX) (default 0)
         hls_time: set segment length (default 2)
@@ -2196,147 +2196,147 @@ def hls(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "start_number": start_number,
-        
+
         "hls_time": hls_time,
-        
+
         "hls_init_time": hls_init_time,
-        
+
         "hls_list_size": hls_list_size,
-        
+
         "hls_delete_threshold": hls_delete_threshold,
-        
+
         "hls_vtt_options": hls_vtt_options,
-        
+
         "hls_allow_cache": hls_allow_cache,
-        
+
         "hls_base_url": hls_base_url,
-        
+
         "hls_segment_filename": hls_segment_filename,
-        
+
         "hls_segment_options": hls_segment_options,
-        
+
         "hls_segment_size": hls_segment_size,
-        
+
         "hls_key_info_file": hls_key_info_file,
-        
+
         "hls_enc": hls_enc,
-        
+
         "hls_enc_key": hls_enc_key,
-        
+
         "hls_enc_key_url": hls_enc_key_url,
-        
+
         "hls_enc_iv": hls_enc_iv,
-        
+
         "hls_subtitle_path": hls_subtitle_path,
-        
+
         "hls_segment_type": hls_segment_type,
-        
+
         "hls_fmp4_init_filename": hls_fmp4_init_filename,
-        
+
         "hls_fmp4_init_resend": hls_fmp4_init_resend,
-        
+
         "hls_flags": hls_flags,
-        
+
         "strftime": strftime,
-        
+
         "strftime_mkdir": strftime_mkdir,
-        
+
         "hls_playlist_type": hls_playlist_type,
-        
+
         "method": method,
-        
+
         "hls_start_number_source": hls_start_number_source,
-        
+
         "http_user_agent": http_user_agent,
-        
+
         "var_stream_map": var_stream_map,
-        
+
         "cc_stream_map": cc_stream_map,
-        
+
         "master_pl_name": master_pl_name,
-        
+
         "master_pl_publish_rate": master_pl_publish_rate,
-        
+
         "http_persistent": http_persistent,
-        
+
         "timeout": timeout,
-        
+
         "ignore_io_errors": ignore_io_errors,
-        
+
         "headers": headers,
-        
+
     }))
 
 
 
 def iamf(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Raw Immersive Audio Model and Formats
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ico(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Microsoft Windows ICO
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ilbc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     iLBC storage
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def image2(
-    
+
     update: bool | None = None,
-    
+
     start_number: int | None = None,
-    
+
     strftime: bool | None = None,
-    
+
     frame_pts: bool | None = None,
-    
+
     atomic_writing: bool | None = None,
-    
+
     protocol_opts: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     image2 sequence
-    
+
     Args:
         update: continuously overwrite one file (default false)
         start_number: set first number in the sequence (from 0 to INT_MAX) (default 1)
@@ -2349,95 +2349,95 @@ def image2(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "update": update,
-        
+
         "start_number": start_number,
-        
+
         "strftime": strftime,
-        
+
         "frame_pts": frame_pts,
-        
+
         "atomic_writing": atomic_writing,
-        
+
         "protocol_opts": protocol_opts,
-        
+
     }))
 
 
 
 def image2pipe(
-    
+
 ) -> FFMpegMuxerOption:
     """
     piped image2 sequence
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ipod(
-    
+
     brand: str | None = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_prft: int | None| Literal["pts", "wallclock"] = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     iPod H.264 MP4 (MPEG-4 Part 14)
-    
+
     Args:
         brand: Override major brand
         empty_hdlr_name: write zero-length name string in hdlr atoms within mdia and minf atoms (default false)
@@ -2469,133 +2469,133 @@ def ipod(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "brand": brand,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "frag_duration": frag_duration,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "frag_size": frag_size,
-        
+
         "fragment_index": fragment_index,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "movie_timescale": movie_timescale,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "use_editlist": use_editlist,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_prft": write_prft,
-        
+
         "write_tmcd": write_tmcd,
-        
+
     }))
 
 
 
 def ircam(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Berkeley/IRCAM/CARL Sound Format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ismv(
-    
+
     brand: str | None = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_prft: int | None| Literal["pts", "wallclock"] = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     ISMV/ISMA (Smooth Streaming)
-    
+
     Args:
         brand: Override major brand
         empty_hdlr_name: write zero-length name string in hdlr atoms within mdia and minf atoms (default false)
@@ -2627,117 +2627,117 @@ def ismv(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "brand": brand,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "frag_duration": frag_duration,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "frag_size": frag_size,
-        
+
         "fragment_index": fragment_index,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "movie_timescale": movie_timescale,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "use_editlist": use_editlist,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_prft": write_prft,
-        
+
         "write_tmcd": write_tmcd,
-        
+
     }))
 
 
 
 def ivf(
-    
+
 ) -> FFMpegMuxerOption:
     """
     On2 IVF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def jacosub(
-    
+
 ) -> FFMpegMuxerOption:
     """
     JACOsub subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def kvag(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Simon & Schuster Interactive VAG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def latm(
-    
+
     smc_interval: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     LOAS/LATM
-    
+
     Args:
         smc_interval: StreamMuxConfig interval. (from 1 to 65535) (default 20)
 
@@ -2745,89 +2745,89 @@ def latm(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "smc-interval": smc_interval,
-        
+
     }))
 
 
 
 def lc3(
-    
+
 ) -> FFMpegMuxerOption:
     """
     LC3 (Low Complexity Communication Codec)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def lrc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     LRC lyrics
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def m4v(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw MPEG-4 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def matroska(
-    
+
     reserve_index_space: int | None = None,
-    
+
     cues_to_front: bool | None = None,
-    
+
     cluster_size_limit: int | None = None,
-    
+
     cluster_time_limit: int | None = None,
-    
+
     dash: bool | None = None,
-    
+
     dash_track_number: int | None = None,
-    
+
     live: bool | None = None,
-    
+
     allow_raw_vfw: bool | None = None,
-    
+
     flipped_raw_rgb: bool | None = None,
-    
+
     write_crc32: bool | None = None,
-    
+
     default_mode: int | None| Literal["infer", "infer_no_subs", "passthrough"] = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Matroska
-    
+
     Args:
         reserve_index_space: reserve a given amount of space (in bytes) at the beginning of the file for the index (cues) (from 0 to INT_MAX) (default 0)
         cues_to_front: move Cues (the index) to the front by shifting data if necessary (default false)
@@ -2845,41 +2845,41 @@ def matroska(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "reserve_index_space": reserve_index_space,
-        
+
         "cues_to_front": cues_to_front,
-        
+
         "cluster_size_limit": cluster_size_limit,
-        
+
         "cluster_time_limit": cluster_time_limit,
-        
+
         "dash": dash,
-        
+
         "dash_track_number": dash_track_number,
-        
+
         "live": live,
-        
+
         "allow_raw_vfw": allow_raw_vfw,
-        
+
         "flipped_raw_rgb": flipped_raw_rgb,
-        
+
         "write_crc32": write_crc32,
-        
+
         "default_mode": default_mode,
-        
+
     }))
 
 
 
 def md5(
-    
+
     hash: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MD5 testing
-    
+
     Args:
         hash: set hash to use (default "md5")
 
@@ -2887,149 +2887,149 @@ def md5(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "hash": hash,
-        
+
     }))
 
 
 
 def microdvd(
-    
+
 ) -> FFMpegMuxerOption:
     """
     MicroDVD subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mjpeg(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw MJPEG video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mkvtimestamp_v2(
-    
+
 ) -> FFMpegMuxerOption:
     """
     extract pts as timecode v2 format, as defined by mkvtoolnix
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mlp(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw MLP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mmf(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Yamaha SMAF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mov(
-    
+
     brand: str | None = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_prft: int | None| Literal["pts", "wallclock"] = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     QuickTime / MOV
-    
+
     Args:
         brand: Override major brand
         empty_hdlr_name: write zero-length name string in hdlr atoms within mdia and minf atoms (default false)
@@ -3061,89 +3061,89 @@ def mov(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "brand": brand,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "frag_duration": frag_duration,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "frag_size": frag_size,
-        
+
         "fragment_index": fragment_index,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "movie_timescale": movie_timescale,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "use_editlist": use_editlist,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_prft": write_prft,
-        
+
         "write_tmcd": write_tmcd,
-        
+
     }))
 
 
 
 def mp2(
-    
+
 ) -> FFMpegMuxerOption:
     """
     MP2 (MPEG audio layer 2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mp3(
-    
+
     id3v2_version: int | None = None,
-    
+
     write_id3v1: bool | None = None,
-    
+
     write_xing: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MP3 (MPEG audio layer 3)
-    
+
     Args:
         id3v2_version: Select ID3v2 version to write. Currently 3 and 4 are supported. (from 0 to 4) (default 4)
         write_id3v1: Enable ID3v1 writing. ID3v1 tags are written in UTF-8 which may not be supported by most software. (default false)
@@ -3153,73 +3153,73 @@ def mp3(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "id3v2_version": id3v2_version,
-        
+
         "write_id3v1": write_id3v1,
-        
+
         "write_xing": write_xing,
-        
+
     }))
 
 
 
 def mp4(
-    
+
     brand: str | None = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_prft: int | None| Literal["pts", "wallclock"] = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MP4 (MPEG-4 Part 14)
-    
+
     Args:
         brand: Override major brand
         empty_hdlr_name: write zero-length name string in hdlr atoms within mdia and minf atoms (default false)
@@ -3251,71 +3251,71 @@ def mp4(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "brand": brand,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "frag_duration": frag_duration,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "frag_size": frag_size,
-        
+
         "fragment_index": fragment_index,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "movie_timescale": movie_timescale,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "use_editlist": use_editlist,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_prft": write_prft,
-        
+
         "write_tmcd": write_tmcd,
-        
+
     }))
 
 
 
 def mpeg(
-    
+
     muxrate: int | None = None,
-    
+
     preload: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MPEG-1 Systems / MPEG program stream
-    
+
     Args:
         muxrate: mux rate as bits/s (from 0 to 1.67772e+09) (default 0)
         preload: initial demux-decode delay in microseconds (from 0 to INT_MAX) (default 500000)
@@ -3324,87 +3324,87 @@ def mpeg(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "muxrate": muxrate,
-        
+
         "preload": preload,
-        
+
     }))
 
 
 
 def mpeg1video(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw MPEG-1 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mpeg2video(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw MPEG-2 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mpegts(
-    
+
     mpegts_transport_stream_id: int | None = None,
-    
+
     mpegts_original_network_id: int | None = None,
-    
+
     mpegts_service_id: int | None = None,
-    
+
     mpegts_service_type: int | None| Literal["digital_tv", "digital_radio", "teletext", "advanced_codec_digital_radio", "mpeg2_digital_hdtv", "advanced_codec_digital_sdtv", "advanced_codec_digital_hdtv", "hevc_digital_hdtv"] = None,
-    
+
     mpegts_pmt_start_pid: int | None = None,
-    
+
     mpegts_start_pid: int | None = None,
-    
+
     mpegts_m2ts_mode: bool | None = None,
-    
+
     muxrate: int | None = None,
-    
+
     pes_payload_size: int | None = None,
-    
+
     mpegts_flags: str | None = None,
-    
+
     mpegts_copyts: bool | None = None,
-    
+
     tables_version: int | None = None,
-    
+
     omit_video_pes_length: bool | None = None,
-    
+
     pcr_period: int | None = None,
-    
+
     pat_period: str | None = None,
-    
+
     sdt_period: str | None = None,
-    
+
     nit_period: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MPEG-TS (MPEG-2 Transport Stream)
-    
+
     Args:
         mpegts_transport_stream_id: Set transport_stream_id field. (from 1 to 65535) (default 1)
         mpegts_original_network_id: Set original_network_id field. (from 1 to 65535) (default 65281)
@@ -3428,53 +3428,53 @@ def mpegts(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "mpegts_transport_stream_id": mpegts_transport_stream_id,
-        
+
         "mpegts_original_network_id": mpegts_original_network_id,
-        
+
         "mpegts_service_id": mpegts_service_id,
-        
+
         "mpegts_service_type": mpegts_service_type,
-        
+
         "mpegts_pmt_start_pid": mpegts_pmt_start_pid,
-        
+
         "mpegts_start_pid": mpegts_start_pid,
-        
+
         "mpegts_m2ts_mode": mpegts_m2ts_mode,
-        
+
         "muxrate": muxrate,
-        
+
         "pes_payload_size": pes_payload_size,
-        
+
         "mpegts_flags": mpegts_flags,
-        
+
         "mpegts_copyts": mpegts_copyts,
-        
+
         "tables_version": tables_version,
-        
+
         "omit_video_pes_length": omit_video_pes_length,
-        
+
         "pcr_period": pcr_period,
-        
+
         "pat_period": pat_period,
-        
+
         "sdt_period": sdt_period,
-        
+
         "nit_period": nit_period,
-        
+
     }))
 
 
 
 def mpjpeg(
-    
+
     boundary_tag: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MIME multipart JPEG
-    
+
     Args:
         boundary_tag: Boundary tag (default "ffmpeg")
 
@@ -3482,39 +3482,39 @@ def mpjpeg(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "boundary_tag": boundary_tag,
-        
+
     }))
 
 
 
 def mulaw(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM mu-law
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mxf(
-    
+
     signal_standard: int | None| Literal["bt601", "bt1358", "smpte347m", "smpte274m", "smpte296m", "smpte349m", "smpte428"] = None,
-    
+
     store_user_comments: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MXF (Material eXchange Format)
-    
+
     Args:
         signal_standard: Force/set Signal Standard (from -1 to 7) (default -1)
         store_user_comments: (default true)
@@ -3523,27 +3523,27 @@ def mxf(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "signal_standard": signal_standard,
-        
+
         "store_user_comments": store_user_comments,
-        
+
     }))
 
 
 
 def mxf_d10(
-    
+
     d10_channelcount: int | None = None,
-    
+
     signal_standard: int | None| Literal["bt601", "bt1358", "smpte347m", "smpte274m", "smpte296m", "smpte349m", "smpte428"] = None,
-    
+
     store_user_comments: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MXF (Material eXchange Format) D-10 Mapping
-    
+
     Args:
         d10_channelcount: Force/set channelcount in generic sound essence descriptor (from -1 to 8) (default -1)
         signal_standard: Force/set Signal Standard (from -1 to 7) (default -1)
@@ -3553,29 +3553,29 @@ def mxf_d10(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "d10_channelcount": d10_channelcount,
-        
+
         "signal_standard": signal_standard,
-        
+
         "store_user_comments": store_user_comments,
-        
+
     }))
 
 
 
 def mxf_opatom(
-    
+
     mxf_audio_edit_rate: str | None = None,
-    
+
     signal_standard: int | None| Literal["bt601", "bt1358", "smpte347m", "smpte274m", "smpte296m", "smpte349m", "smpte428"] = None,
-    
+
     store_user_comments: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MXF (Material eXchange Format) Operational Pattern Atom
-    
+
     Args:
         mxf_audio_edit_rate: Audio edit rate for timecode (from 0 to INT_MAX) (default 25/1)
         signal_standard: Force/set Signal Standard (from -1 to 7) (default -1)
@@ -3585,43 +3585,43 @@ def mxf_opatom(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "mxf_audio_edit_rate": mxf_audio_edit_rate,
-        
+
         "signal_standard": signal_standard,
-        
+
         "store_user_comments": store_user_comments,
-        
+
     }))
 
 
 
 def null(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw null video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def nut(
-    
+
     syncpoints: str | None = None,
-    
+
     write_index: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     NUT
-    
+
     Args:
         syncpoints: NUT syncpoint behaviour (default 0)
         write_index: Write index (default true)
@@ -3630,45 +3630,45 @@ def nut(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "syncpoints": syncpoints,
-        
+
         "write_index": write_index,
-        
+
     }))
 
 
 
 def obu(
-    
+
 ) -> FFMpegMuxerOption:
     """
     AV1 low overhead OBU
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def oga(
-    
+
     serial_offset: int | None = None,
-    
+
     oggpagesize: int | None = None,
-    
+
     pagesize: int | None = None,
-    
+
     page_duration: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Ogg Audio
-    
+
     Args:
         serial_offset: serial number offset (from 0 to INT_MAX) (default 0)
         oggpagesize: Set preferred Ogg page size. (from 0 to 65025) (default 0)
@@ -3679,33 +3679,33 @@ def oga(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "serial_offset": serial_offset,
-        
+
         "oggpagesize": oggpagesize,
-        
+
         "pagesize": pagesize,
-        
+
         "page_duration": page_duration,
-        
+
     }))
 
 
 
 def ogg(
-    
+
     serial_offset: int | None = None,
-    
+
     oggpagesize: int | None = None,
-    
+
     pagesize: int | None = None,
-    
+
     page_duration: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Ogg
-    
+
     Args:
         serial_offset: serial number offset (from 0 to INT_MAX) (default 0)
         oggpagesize: Set preferred Ogg page size. (from 0 to 65025) (default 0)
@@ -3716,33 +3716,33 @@ def ogg(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "serial_offset": serial_offset,
-        
+
         "oggpagesize": oggpagesize,
-        
+
         "pagesize": pagesize,
-        
+
         "page_duration": page_duration,
-        
+
     }))
 
 
 
 def ogv(
-    
+
     serial_offset: int | None = None,
-    
+
     oggpagesize: int | None = None,
-    
+
     pagesize: int | None = None,
-    
+
     page_duration: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Ogg Video
-    
+
     Args:
         serial_offset: serial number offset (from 0 to INT_MAX) (default 0)
         oggpagesize: Set preferred Ogg page size. (from 0 to 65025) (default 0)
@@ -3753,49 +3753,49 @@ def ogv(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "serial_offset": serial_offset,
-        
+
         "oggpagesize": oggpagesize,
-        
+
         "pagesize": pagesize,
-        
+
         "page_duration": page_duration,
-        
+
     }))
 
 
 
 def oma(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Sony OpenMG audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def opus(
-    
+
     serial_offset: int | None = None,
-    
+
     oggpagesize: int | None = None,
-    
+
     pagesize: int | None = None,
-    
+
     page_duration: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Ogg Opus
-    
+
     Args:
         serial_offset: serial number offset (from 0 to INT_MAX) (default 0)
         oggpagesize: Set preferred Ogg page size. (from 0 to 65025) (default 0)
@@ -3806,91 +3806,91 @@ def opus(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "serial_offset": serial_offset,
-        
+
         "oggpagesize": oggpagesize,
-        
+
         "pagesize": pagesize,
-        
+
         "page_duration": page_duration,
-        
+
     }))
 
 
 
 def d(
-    
+
 ) -> FFMpegMuxerOption:
     """
     oss             OSS (Open Sound System) playback
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def psp(
-    
+
     brand: str | None = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_prft: int | None| Literal["pts", "wallclock"] = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     PSP MP4 (MPEG-4 Part 14)
-    
+
     Args:
         brand: Override major brand
         empty_hdlr_name: write zero-length name string in hdlr atoms within mdia and minf atoms (default false)
@@ -3922,157 +3922,157 @@ def psp(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "brand": brand,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "frag_duration": frag_duration,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "frag_size": frag_size,
-        
+
         "fragment_index": fragment_index,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "movie_timescale": movie_timescale,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "use_editlist": use_editlist,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_prft": write_prft,
-        
+
         "write_tmcd": write_tmcd,
-        
+
     }))
 
 
 
 def rawvideo(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def rcwt(
-    
+
 ) -> FFMpegMuxerOption:
     """
     RCWT (Raw Captions With Time)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def rm(
-    
+
 ) -> FFMpegMuxerOption:
     """
     RealMedia
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def roq(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw id RoQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def rso(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Lego Mindstorms RSO
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def rtp(
-    
+
     rtpflags: str | None = None,
-    
+
     payload_type: int | None = None,
-    
+
     ssrc: int | None = None,
-    
+
     cname: str | None = None,
-    
+
     seq: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     RTP output
-    
+
     Args:
         rtpflags: RTP muxer flags (default 0)
         payload_type: Specify RTP payload type (from -1 to 127) (default -1)
@@ -4084,31 +4084,31 @@ def rtp(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "rtpflags": rtpflags,
-        
+
         "payload_type": payload_type,
-        
+
         "ssrc": ssrc,
-        
+
         "cname": cname,
-        
+
         "seq": seq,
-        
+
     }))
 
 
 
 def rtp_mpegts(
-    
+
     mpegts_muxer_options: str | None = None,
-    
+
     rtp_muxer_options: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     RTP/mpegts output format
-    
+
     Args:
         mpegts_muxer_options: set list of options for the MPEG-TS muxer
         rtp_muxer_options: set list of options for the RTP muxer
@@ -4117,33 +4117,33 @@ def rtp_mpegts(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "mpegts_muxer_options": mpegts_muxer_options,
-        
+
         "rtp_muxer_options": rtp_muxer_options,
-        
+
     }))
 
 
 
 def rtsp(
-    
+
     rtpflags: str | None = None,
-    
+
     rtsp_transport: str | None = None,
-    
+
     min_port: int | None = None,
-    
+
     max_port: int | None = None,
-    
+
     buffer_size: int | None = None,
-    
+
     pkt_size: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     RTSP output
-    
+
     Args:
         rtpflags: RTP muxer flags (default 0)
         rtsp_transport: set RTSP transport protocols (default 0)
@@ -4156,245 +4156,245 @@ def rtsp(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "rtpflags": rtpflags,
-        
+
         "rtsp_transport": rtsp_transport,
-        
+
         "min_port": min_port,
-        
+
         "max_port": max_port,
-        
+
         "buffer_size": buffer_size,
-        
+
         "pkt_size": pkt_size,
-        
+
     }))
 
 
 
 def s16be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 16-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def s16le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 16-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def s24be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 24-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def s24le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 24-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def s32be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 32-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def s32le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 32-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def s8(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 8-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def sap(
-    
+
 ) -> FFMpegMuxerOption:
     """
     SAP output
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def sbc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw SBC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def scc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Scenarist Closed Captions
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def segment(
-    
+
     reference_stream: str | None = None,
-    
+
     segment_format: str | None = None,
-    
+
     segment_format_options: str | None = None,
-    
+
     segment_list: str | None = None,
-    
+
     segment_header_filename: str | None = None,
-    
+
     segment_list_flags: str | None = None,
-    
+
     segment_list_size: int | None = None,
-    
+
     segment_list_type: int | None| Literal["flat", "csv", "ext", "ffconcat", "m3u8", "hls"] = None,
-    
+
     segment_atclocktime: bool | None = None,
-    
+
     segment_clocktime_offset: str | None = None,
-    
+
     segment_clocktime_wrap_duration: str | None = None,
-    
+
     segment_time: str | None = None,
-    
+
     segment_time_delta: str | None = None,
-    
+
     min_seg_duration: str | None = None,
-    
+
     segment_times: str | None = None,
-    
+
     segment_frames: str | None = None,
-    
+
     segment_wrap: int | None = None,
-    
+
     segment_list_entry_prefix: str | None = None,
-    
+
     segment_start_number: int | None = None,
-    
+
     segment_wrap_number: int | None = None,
-    
+
     strftime: bool | None = None,
-    
+
     increment_tc: bool | None = None,
-    
+
     break_non_keyframes: bool | None = None,
-    
+
     individual_header_trailer: bool | None = None,
-    
+
     write_header_trailer: bool | None = None,
-    
+
     reset_timestamps: bool | None = None,
-    
+
     initial_offset: str | None = None,
-    
+
     write_empty_segments: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     segment
-    
+
     Args:
         reference_stream: set reference stream (default "auto")
         segment_format: set container format used for the segments
@@ -4429,99 +4429,99 @@ def segment(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "reference_stream": reference_stream,
-        
+
         "segment_format": segment_format,
-        
+
         "segment_format_options": segment_format_options,
-        
+
         "segment_list": segment_list,
-        
+
         "segment_header_filename": segment_header_filename,
-        
+
         "segment_list_flags": segment_list_flags,
-        
+
         "segment_list_size": segment_list_size,
-        
+
         "segment_list_type": segment_list_type,
-        
+
         "segment_atclocktime": segment_atclocktime,
-        
+
         "segment_clocktime_offset": segment_clocktime_offset,
-        
+
         "segment_clocktime_wrap_duration": segment_clocktime_wrap_duration,
-        
+
         "segment_time": segment_time,
-        
+
         "segment_time_delta": segment_time_delta,
-        
+
         "min_seg_duration": min_seg_duration,
-        
+
         "segment_times": segment_times,
-        
+
         "segment_frames": segment_frames,
-        
+
         "segment_wrap": segment_wrap,
-        
+
         "segment_list_entry_prefix": segment_list_entry_prefix,
-        
+
         "segment_start_number": segment_start_number,
-        
+
         "segment_wrap_number": segment_wrap_number,
-        
+
         "strftime": strftime,
-        
+
         "increment_tc": increment_tc,
-        
+
         "break_non_keyframes": break_non_keyframes,
-        
+
         "individual_header_trailer": individual_header_trailer,
-        
+
         "write_header_trailer": write_header_trailer,
-        
+
         "reset_timestamps": reset_timestamps,
-        
+
         "initial_offset": initial_offset,
-        
+
         "write_empty_segments": write_empty_segments,
-        
+
     }))
 
 
 
 def smjpeg(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Loki SDL MJPEG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def smoothstreaming(
-    
+
     window_size: int | None = None,
-    
+
     extra_window_size: int | None = None,
-    
+
     lookahead_count: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     remove_at_exit: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Smooth Streaming Muxer
-    
+
     Args:
         window_size: number of fragments kept in the manifest (from 0 to INT_MAX) (default 0)
         extra_window_size: number of fragments kept outside of the manifest before removing from disk (from 0 to INT_MAX) (default 5)
@@ -4533,49 +4533,49 @@ def smoothstreaming(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "window_size": window_size,
-        
+
         "extra_window_size": extra_window_size,
-        
+
         "lookahead_count": lookahead_count,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "remove_at_exit": remove_at_exit,
-        
+
     }))
 
 
 
 def sox(
-    
+
 ) -> FFMpegMuxerOption:
     """
     SoX (Sound eXchange) native
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def spdif(
-    
+
     spdif_flags: str | None = None,
-    
+
     dtshd_rate: int | None = None,
-    
+
     dtshd_fallback_time: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     IEC 61937 (used on S/PDIF - IEC958)
-    
+
     Args:
         spdif_flags: IEC 61937 encapsulation flags (default 0)
         dtshd_rate: mux complete DTS frames in HD mode at the specified IEC958 rate (in Hz, default 0=disabled) (from 0 to 768000) (default 0)
@@ -4585,31 +4585,31 @@ def spdif(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "spdif_flags": spdif_flags,
-        
+
         "dtshd_rate": dtshd_rate,
-        
+
         "dtshd_fallback_time": dtshd_fallback_time,
-        
+
     }))
 
 
 
 def spx(
-    
+
     serial_offset: int | None = None,
-    
+
     oggpagesize: int | None = None,
-    
+
     pagesize: int | None = None,
-    
+
     page_duration: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Ogg Speex
-    
+
     Args:
         serial_offset: serial number offset (from 0 to INT_MAX) (default 0)
         oggpagesize: Set preferred Ogg page size. (from 0 to 65025) (default 0)
@@ -4620,43 +4620,43 @@ def spx(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "serial_offset": serial_offset,
-        
+
         "oggpagesize": oggpagesize,
-        
+
         "pagesize": pagesize,
-        
+
         "page_duration": page_duration,
-        
+
     }))
 
 
 
 def srt(
-    
+
 ) -> FFMpegMuxerOption:
     """
     SubRip subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def streamhash(
-    
+
     hash: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Per-stream hash testing
-    
+
     Args:
         hash: set hash to use (default "sha256")
 
@@ -4664,39 +4664,39 @@ def streamhash(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "hash": hash,
-        
+
     }))
 
 
 
 def sup(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw HDMV Presentation Graphic Stream subtitles
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def svcd(
-    
+
     muxrate: int | None = None,
-    
+
     preload: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MPEG-2 PS (SVCD)
-    
+
     Args:
         muxrate: mux rate as bits/s (from 0 to 1.67772e+09) (default 0)
         preload: initial demux-decode delay in microseconds (from 0 to INT_MAX) (default 500000)
@@ -4705,41 +4705,41 @@ def svcd(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "muxrate": muxrate,
-        
+
         "preload": preload,
-        
+
     }))
 
 
 
 def swf(
-    
+
 ) -> FFMpegMuxerOption:
     """
     SWF (ShockWave Flash)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def tee(
-    
+
     use_fifo: bool | None = None,
-    
+
     fifo_options: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Multiple muxer tee
-    
+
     Args:
         use_fifo: Use fifo pseudo-muxer to separate actual muxers from encoder (default false)
         fifo_options: fifo pseudo-muxer options
@@ -4748,233 +4748,233 @@ def tee(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "use_fifo": use_fifo,
-        
+
         "fifo_options": fifo_options,
-        
+
     }))
 
 
 
 def truehd(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw TrueHD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def tta(
-    
+
 ) -> FFMpegMuxerOption:
     """
     TTA (True Audio)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ttml(
-    
+
 ) -> FFMpegMuxerOption:
     """
     TTML subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u16be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 16-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u16le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 16-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u24be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 24-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u24le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 24-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u32be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 32-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u32le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 32-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u8(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 8-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def uncodedframecrc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     uncoded framecrc testing
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def vc1(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw VC-1 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def vc1test(
-    
+
 ) -> FFMpegMuxerOption:
     """
     VC-1 test bitstream
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def vcd(
-    
+
     muxrate: int | None = None,
-    
+
     preload: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MPEG-1 Systems / MPEG program stream (VCD)
-    
+
     Args:
         muxrate: mux rate as bits/s (from 0 to 1.67772e+09) (default 0)
         preload: initial demux-decode delay in microseconds (from 0 to INT_MAX) (default 500000)
@@ -4983,57 +4983,57 @@ def vcd(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "muxrate": muxrate,
-        
+
         "preload": preload,
-        
+
     }))
 
 
 
 def vidc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM Archimedes VIDC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def d(
-    
+
 ) -> FFMpegMuxerOption:
     """
     video4linux2,v4l2 Video4Linux2 output device
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def vob(
-    
+
     muxrate: int | None = None,
-    
+
     preload: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MPEG-2 PS (VOB)
-    
+
     Args:
         muxrate: mux rate as bits/s (from 0 to 1.67772e+09) (default 0)
         preload: initial demux-decode delay in microseconds (from 0 to INT_MAX) (default 500000)
@@ -5042,81 +5042,81 @@ def vob(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "muxrate": muxrate,
-        
+
         "preload": preload,
-        
+
     }))
 
 
 
 def voc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Creative Voice
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def vvc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw H.266/VVC video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def w64(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Sony Wave64
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def wav(
-    
+
     write_bext: bool | None = None,
-    
+
     write_peak: int | None| Literal["off", "on", "only"] = None,
-    
+
     rf64: int | None| Literal["auto", "always", "never"] = None,
-    
+
     peak_block_size: int | None = None,
-    
+
     peak_format: int | None = None,
-    
+
     peak_ppv: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     WAV / WAVE (Waveform Audio)
-    
+
     Args:
         write_bext: Write BEXT chunk. (default false)
         write_peak: Write Peak Envelope chunk. (from 0 to 2) (default off)
@@ -5129,51 +5129,51 @@ def wav(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "write_bext": write_bext,
-        
+
         "write_peak": write_peak,
-        
+
         "rf64": rf64,
-        
+
         "peak_block_size": peak_block_size,
-        
+
         "peak_format": peak_format,
-        
+
         "peak_ppv": peak_ppv,
-        
+
     }))
 
 
 
 def webm(
-    
+
     reserve_index_space: int | None = None,
-    
+
     cues_to_front: bool | None = None,
-    
+
     cluster_size_limit: int | None = None,
-    
+
     cluster_time_limit: int | None = None,
-    
+
     dash: bool | None = None,
-    
+
     dash_track_number: int | None = None,
-    
+
     live: bool | None = None,
-    
+
     allow_raw_vfw: bool | None = None,
-    
+
     flipped_raw_rgb: bool | None = None,
-    
+
     write_crc32: bool | None = None,
-    
+
     default_mode: int | None| Literal["infer", "infer_no_subs", "passthrough"] = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     WebM
-    
+
     Args:
         reserve_index_space: reserve a given amount of space (in bytes) at the beginning of the file for the index (cues) (from 0 to INT_MAX) (default 0)
         cues_to_front: move Cues (the index) to the front by shifting data if necessary (default false)
@@ -5191,47 +5191,47 @@ def webm(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "reserve_index_space": reserve_index_space,
-        
+
         "cues_to_front": cues_to_front,
-        
+
         "cluster_size_limit": cluster_size_limit,
-        
+
         "cluster_time_limit": cluster_time_limit,
-        
+
         "dash": dash,
-        
+
         "dash_track_number": dash_track_number,
-        
+
         "live": live,
-        
+
         "allow_raw_vfw": allow_raw_vfw,
-        
+
         "flipped_raw_rgb": flipped_raw_rgb,
-        
+
         "write_crc32": write_crc32,
-        
+
         "default_mode": default_mode,
-        
+
     }))
 
 
 
 def webm_chunk(
-    
+
     chunk_start_index: int | None = None,
-    
+
     header: str | None = None,
-    
+
     audio_chunk_duration: int | None = None,
-    
+
     method: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     WebM Chunk Muxer
-    
+
     Args:
         chunk_start_index: start index of the chunk (from 0 to INT_MAX) (default 0)
         header: filename of the header where the initialization data will be written
@@ -5242,39 +5242,39 @@ def webm_chunk(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "chunk_start_index": chunk_start_index,
-        
+
         "header": header,
-        
+
         "audio_chunk_duration": audio_chunk_duration,
-        
+
         "method": method,
-        
+
     }))
 
 
 
 def webm_dash_manifest(
-    
+
     adaptation_sets: str | None = None,
-    
+
     live: bool | None = None,
-    
+
     chunk_start_index: int | None = None,
-    
+
     chunk_duration_ms: int | None = None,
-    
+
     utc_timing_url: str | None = None,
-    
+
     time_shift_buffer_depth: float | None = None,
-    
+
     minimum_update_period: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     WebM DASH Manifest
-    
+
     Args:
         adaptation_sets: Adaptation sets. Syntax: id=0,streams=0,1,2 id=1,streams=3,4 and so on
         live: create a live stream manifest (default false)
@@ -5288,33 +5288,33 @@ def webm_dash_manifest(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "adaptation_sets": adaptation_sets,
-        
+
         "live": live,
-        
+
         "chunk_start_index": chunk_start_index,
-        
+
         "chunk_duration_ms": chunk_duration_ms,
-        
+
         "utc_timing_url": utc_timing_url,
-        
+
         "time_shift_buffer_depth": time_shift_buffer_depth,
-        
+
         "minimum_update_period": minimum_update_period,
-        
+
     }))
 
 
 
 def webp(
-    
+
     loop: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     WebP
-    
+
     Args:
         loop: Number of times to loop the output: 0 - infinite loop (from 0 to 65535) (default 1)
 
@@ -5322,804 +5322,87 @@ def webp(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def webvtt(
-    
+
 ) -> FFMpegMuxerOption:
     """
     WebVTT subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def wsaud(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Westwood Studios audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def wtv(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Windows Television (WTV)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def wv(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw WavPack
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def yuv4mpegpipe(
-    
+
 ) -> FFMpegMuxerOption:
     """
     YUV4MPEG pipe
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/packages/v7/src/ffmpeg/sources.py
+++ b/packages/v7/src/ffmpeg/sources.py
@@ -43,31 +43,31 @@ from .streams.audio import AudioStream
 import re
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def abuffer(
-    
 
-    
+
+
 
 
     *,
     time_base: Rational = Default('0/1'),sample_rate: Int = Default('0'),sample_fmt: Sample_fmt = Default('none'),channel_layout: String = Default(None),channels: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Buffer audio frames, and make them available to the filter chain.
 
 This source is mainly intended for a programmatic use, in particular
@@ -91,100 +91,100 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#abuffer)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='abuffer', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "time_base": time_base,
-            
+
             "sample_rate": sample_rate,
-            
+
             "sample_fmt": sample_fmt,
-            
+
             "channel_layout": channel_layout,
-            
+
             "channels": channels,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def aevalsrc(
-    
 
-    
+
+
 
 
     *,
     exprs: String = Default(None),nb_samples: Int = Default('1024'),sample_rate: String = Default('44100'),duration: Duration = Default('-0.000001'),channel_layout: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate an audio signal specified by an expression.
 
 This source accepts in input one or more expressions (one for each
@@ -209,60 +209,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aevalsrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='aevalsrc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "exprs": exprs,
-            
+
             "nb_samples": nb_samples,
-            
+
             "sample_rate": sample_rate,
-            
+
             "duration": duration,
-            
+
             "channel_layout": channel_layout,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def afdelaysrc(
-    
 
-    
+
+
 
 
     *,
     delay: Double = Default('0'),sample_rate: Int = Default('44100'),nb_samples: Int = Default('1024'),taps: Int = Default('0'),channel_layout: String = Default('stereo'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate a fractional delay FIR coefficients.
 
 The resulting stream can be used with afir filter for filtering the audio signal.
@@ -285,60 +285,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afdelaysrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='afdelaysrc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "delay": delay,
-            
+
             "sample_rate": sample_rate,
-            
+
             "nb_samples": nb_samples,
-            
+
             "taps": taps,
-            
+
             "channel_layout": channel_layout,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def afireqsrc(
-    
 
-    
+
+
 
 
     *,
     preset: Int| Literal["custom","flat","acoustic","bass","beats","classic","clear","deep bass","dubstep","electronic","hardstyle","hip-hop","jazz","metal","movie","pop","r&b","rock","vocal booster"] | Default = Default('flat'),gains: String = Default('0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'),bands: String = Default('25 40 63 100 160 250 400 630 1000 1600 2500 4000 6300 10000 16000 24000'),taps: Int = Default('4096'),sample_rate: Int = Default('44100'),nb_samples: Int = Default('1024'),interp: Int| Literal["linear","cubic"] | Default = Default('linear'),phase: Int| Literal["linear","min"] | Default = Default('min'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate a FIR equalizer coefficients.
 
 The resulting stream can be used with afir filter for filtering the audio signal.
@@ -364,62 +364,62 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afireqsrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='afireqsrc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "preset": preset,
-            
+
             "gains": gains,
-            
+
             "bands": bands,
-            
+
             "taps": taps,
-            
+
             "sample_rate": sample_rate,
-            
+
             "nb_samples": nb_samples,
-            
+
             "interp": interp,
-            
+
             "phase": phase,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
+
+
+
 def afirsrc(
-    
 
-    
+
+
 
 
     *,
     taps: Int = Default('1025'),frequency: String = Default('0 1'),magnitude: String = Default('1 1'),phase: String = Default('0 0'),sample_rate: Int = Default('44100'),nb_samples: Int = Default('1024'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('blackman'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate a FIR coefficients using frequency sampling method.
 
 The resulting stream can be used with afir filter for filtering the audio signal.
@@ -444,78 +444,78 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afirsrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='afirsrc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "taps": taps,
-            
+
             "frequency": frequency,
-            
+
             "magnitude": magnitude,
-            
+
             "phase": phase,
-            
+
             "sample_rate": sample_rate,
-            
+
             "nb_samples": nb_samples,
-            
+
             "win_func": win_func,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
 def ainterleave(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     nb_inputs: Int = Auto('len(streams)'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Temporally interleave frames from several inputs.
 
 interleave works with video inputs, ainterleave with audio.
@@ -554,58 +554,58 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#interleave)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='ainterleave', typings_input='[StreamType.audio] * int(nb_inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "nb_inputs": nb_inputs,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def allrgb(
-    
 
-    
+
+
 
 
     *,
     rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -666,52 +666,52 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='allrgb', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def allyuv(
-    
 
-    
+
+
 
 
     *,
     rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -772,60 +772,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='allyuv', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def amerge(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Merge two or more audio streams into a single multi-channel stream.
 
 The filter accepts the following options:
@@ -842,54 +842,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amerge)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='amerge', typings_input='[StreamType.audio] * int(inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def amix(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),dropout_transition: Float = Default('2'),weights: String = Default('1 1'),normalize: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Mixes multiple audio inputs into a single output.
 
 Note that this filter only supports float samples (the amerge
@@ -915,64 +915,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amix)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='amix', typings_input='[StreamType.audio] * int(inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "duration": duration,
-            
+
             "dropout_transition": dropout_transition,
-            
+
             "weights": weights,
-            
+
             "normalize": normalize,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
+
+
+
 def amovie(
-    
 
-    
+
+
 
 
     *,
     filename: String = Default(None),format_name: String = Default(None),stream_index: Int = Default('-1'),seek_point: Double = Default('0'),streams: String = Default(None),loop: Int = Default('1'),discontinuity: Duration = Default('0'),dec_threads: Int = Default('0'),format_opts: Dictionary = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 This is the same as movie source, except it selects an audio
 stream by default.
 
 
 Args:
-    filename: 
+    filename:
     format_name: set format name
     stream_index: set stream index (from -1 to INT_MAX) (default -1)
     seek_point: set seekpoint (seconds) (from 0 to 9.22337e+12) (default 0)
@@ -991,77 +991,77 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amovie)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='amovie', typings_input="[StreamType.audio] * len(streams.split('+'))", typings_output="[StreamType.audio] * len(streams.split('+'))"),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "filename": filename,
-            
+
             "format_name": format_name,
-            
+
             "stream_index": stream_index,
-            
+
             "seek_point": seek_point,
-            
+
             "streams": streams,
-            
+
             "loop": loop,
-            
+
             "discontinuity": discontinuity,
-            
+
             "dec_threads": dec_threads,
-            
+
             "format_opts": format_opts,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
 def anoisesrc(
-    
 
-    
+
+
 
 
     *,
     sample_rate: Int = Default('48000'),amplitude: Double = Default('1'),duration: Duration = Default('0'),color: Int| Literal["white","pink","brown","blue","violet","velvet"] | Default = Default('white'),seed: Int64 = Default('-1'),nb_samples: Int = Default('1024'),density: Double = Default('0.05'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate a noise audio signal.
 
 The filter accepts the following options:
@@ -1084,64 +1084,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anoisesrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='anoisesrc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "sample_rate": sample_rate,
-            
+
             "amplitude": amplitude,
-            
+
             "duration": duration,
-            
+
             "color": color,
-            
+
             "seed": seed,
-            
+
             "nb_samples": nb_samples,
-            
+
             "density": density,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def anullsrc(
-    
 
-    
+
+
 
 
     *,
     channel_layout: String = Default('stereo'),sample_rate: Int = Default('44100'),nb_samples: Int = Default('1024'),duration: Duration = Default('-0.000001'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 The null audio source, return unprocessed audio frames. It is mainly useful
 as a template and to be employed in analysis / debugging tools, or as
 the source for filters which ignore the input data (for example the sox
@@ -1164,114 +1164,114 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anullsrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='anullsrc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "channel_layout": channel_layout,
-            
+
             "sample_rate": sample_rate,
-            
+
             "nb_samples": nb_samples,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def astreamselect(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),map: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Select video or audio streams.
 
 The filter accepts the following options:
@@ -1290,87 +1290,87 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#streamselect)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='astreamselect', typings_input='[StreamType.audio] * int(inputs)', typings_output="[StreamType.audio] * len(re.findall(r'\\d+', str(map)))"),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "map": map,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def avsynctest(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('hd720'),framerate: Video_rate = Default('30'),samplerate: Int = Default('44100'),amplitude: Float = Default('0.7'),period: Int = Default('3'),delay: Int = Default('0'),cycle: Boolean = Default('false'),duration: Duration = Default('0'),fg: Color = Default('white'),bg: Color = Default('black'),ag: Color = Default('gray'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> tuple[
-    
-        
+
+
             AudioStream,
-        
-    
-        
+
+
+
             VideoStream,
-        
-    
+
+
 ]:
     """
-    
+
 Generate an Audio/Video Sync Test.
 
 Generated stream periodically shows flash video frame and emits beep in audio.
@@ -1401,116 +1401,116 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#avsynctest)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='avsynctest', typings_input=(), typings_output=('audio', 'video')),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "framerate": framerate,
-            
+
             "samplerate": samplerate,
-            
+
             "amplitude": amplitude,
-            
+
             "period": period,
-            
+
             "delay": delay,
-            
+
             "cycle": cycle,
-            
+
             "duration": duration,
-            
+
             "fg": fg,
-            
+
             "bg": bg,
-            
+
             "ag": ag,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return (
-        
-            
+
+
                 filter_node.audio(0),
-            
-        
-            
+
+
+
                 filter_node.video(0),
-            
-        
+
+
     )
 
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def bm3d(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     sigma: Float = Default('1'),block: Int = Default('16'),bstep: Int = Default('4'),group: Int = Default('1'),range: Int = Default('9'),mstep: Int = Default('1'),thmse: Float = Default('0'),hdthr: Float = Default('2.7'),estim: Int| Literal["basic","final"] | Default = Default('basic'),ref: Boolean = Default('false'),planes: Int = Default('7'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Denoise frames using Block-Matching 3D algorithm.
 
 The filter accepts the following options.
@@ -1538,7 +1538,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bm3d)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -1546,71 +1546,71 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='bm3d', typings_input='[StreamType.video] + [StreamType.video] if ref else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "sigma": sigma,
-            
+
             "block": block,
-            
+
             "bstep": bstep,
-            
+
             "group": group,
-            
+
             "range": range,
-            
+
             "mstep": mstep,
-            
+
             "thmse": thmse,
-            
+
             "hdthr": hdthr,
-            
+
             "estim": estim,
-            
+
             "ref": ref,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def buffer(
-    
 
-    
+
+
 
 
     *,
     width: Int = Default('0'),video_size: Image_size = Default(None),height: Int = Default('0'),pix_fmt: Pix_fmt = Default('none'),sar: Rational = Default('0/1'),time_base: Rational = Default('0/1'),colorspace: Int| Literal["gbr","bt709","unknown","fcc","bt470bg","smpte170m","smpte240m","ycgco","ycgco-re","ycgco-ro","bt2020nc","bt2020c","smpte2085","chroma-derived-nc","chroma-derived-c","ictcp","ipt-c2"] | Default = Default('unknown'),range: Int| Literal["unspecified","unknown","limited","tv","mpeg","full","pc","jpeg"] | Default = Default('unspecified'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Buffer video frames, and make them available to the filter chain.
 
 This source is mainly intended for a programmatic use, in particular
@@ -1637,70 +1637,70 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#buffer)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='buffer', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "width": width,
-            
+
             "video_size": video_size,
-            
+
             "height": height,
-            
+
             "pix_fmt": pix_fmt,
-            
+
             "sar": sar,
-            
+
             "time_base": time_base,
-            
+
             "colorspace": colorspace,
-            
+
             "range": range,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def cellauto(
-    
 
-    
+
+
 
 
     *,
     filename: String = Default(None),pattern: String = Default(None),rate: Video_rate = Default('25'),size: Image_size = Default(None),rule: Int = Default('110'),random_fill_ratio: Double = Default('0.618034'),random_seed: Int64 = Default('-1'),scroll: Boolean = Default('true'),start_full: Boolean = Default('false'),full: Boolean = Default('true'),stitch: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Create a pattern generated by an elementary cellular automaton.
 
 The initial state of the cellular automaton can be defined through the
@@ -1735,86 +1735,86 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#cellauto)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='cellauto', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "filename": filename,
-            
+
             "pattern": pattern,
-            
+
             "rate": rate,
-            
+
             "size": size,
-            
+
             "rule": rule,
-            
+
             "random_fill_ratio": random_fill_ratio,
-            
+
             "random_seed": random_seed,
-            
+
             "scroll": scroll,
-            
+
             "start_full": start_full,
-            
+
             "full": full,
-            
+
             "stitch": stitch,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
 def color(
-    
 
-    
+
+
 
 
     *,
     color: Color = Default('black'),size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -1877,60 +1877,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='color', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "color": color,
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def colorchart(
-    
 
-    
+
+
 
 
     *,
     rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),patch_size: Image_size = Default('64x64'),preset: Int| Literal["reference","skintones"] | Default = Default('reference'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -1993,76 +1993,76 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='colorchart', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
             "patch_size": patch_size,
-            
+
             "preset": preset,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
 def colorspectrum(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),type: Int| Literal["black","white","all"] | Default = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -2125,64 +2125,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='colorspectrum', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
             "type": type,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def concat(
-    
 
-    
+
+
     *streams: FilterableStream,
-    
 
 
-    
+
+
     n: Int = Auto('len(streams) // (int(v) + int(a))'),v: Int = Default('1'),a: Int = Default('0'),unsafe: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Concatenate audio and video streams, joining them together one after the
 other.
 
@@ -2208,95 +2208,95 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#concat)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='concat', typings_input='([StreamType.video]*int(v) + [StreamType.audio]*int(a))*int(n)', typings_output='[StreamType.video]*int(v) + [StreamType.audio]*int(a)'),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "n": n,
-            
+
             "v": v,
-            
+
             "a": a,
-            
+
             "unsafe": unsafe,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def decimate(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     cycle: Int = Default('5'),dupthresh: Double = Default('1.1'),scthresh: Double = Default('15'),blockx: Int = Default('32'),blocky: Int = Default('32'),ppsrc: Boolean = Default('false'),chroma: Boolean = Default('true'),mixed: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Drop duplicated frames at regular intervals.
 
 The filter accepts the following options:
@@ -2320,156 +2320,156 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#decimate)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='decimate', typings_input='[StreamType.video] + ([StreamType.video] if ppsrc else [])', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "cycle": cycle,
-            
+
             "dupthresh": dupthresh,
-            
+
             "scthresh": scthresh,
-            
+
             "blockx": blockx,
-            
+
             "blocky": blocky,
-            
+
             "ppsrc": ppsrc,
-            
+
             "chroma": chroma,
-            
+
             "mixed": mixed,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def fieldmatch(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     order: Int| Literal["auto","bff","tff"] | Default = Default('auto'),mode: Int| Literal["pc","pc_n","pc_u","pc_n_ub","pcn","pcn_ub"] | Default = Default('pc_n'),ppsrc: Boolean = Default('false'),field: Int| Literal["auto","bottom","top"] | Default = Default('auto'),mchroma: Boolean = Default('true'),y0: Int = Default('0'),scthresh: Double = Default('12'),combmatch: Int| Literal["none","sc","full"] | Default = Default('sc'),combdbg: Int| Literal["none","pcn","pcnub"] | Default = Default('none'),cthresh: Int = Default('9'),chroma: Boolean = Default('false'),blockx: Int = Default('16'),blocky: Int = Default('16'),combpel: Int = Default('80'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Field matching filter for inverse telecine. It is meant to reconstruct the
 progressive frames from a telecined stream. The filter does not drop duplicated
 frames, so to achieve a complete inverse telecine fieldmatch needs to be
@@ -2527,112 +2527,112 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fieldmatch)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='fieldmatch', typings_input='[StreamType.video] + [StreamType.video] if ppsrc else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "order": order,
-            
+
             "mode": mode,
-            
+
             "ppsrc": ppsrc,
-            
+
             "field": field,
-            
+
             "mchroma": mchroma,
-            
+
             "y0": y0,
-            
+
             "scthresh": scthresh,
-            
+
             "combmatch": combmatch,
-            
+
             "combdbg": combdbg,
-            
+
             "cthresh": cthresh,
-            
+
             "chroma": chroma,
-            
+
             "blockx": blockx,
-            
+
             "blocky": blocky,
-            
+
             "combpel": combpel,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def gradients(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('640x480'),rate: Video_rate = Default('25'),c0: Color = Default('random'),c1: Color = Default('random'),c2: Color = Default('random'),c3: Color = Default('random'),c4: Color = Default('random'),c5: Color = Default('random'),c6: Color = Default('random'),c7: Color = Default('random'),x0: Int = Default('-1'),y0: Int = Default('-1'),x1: Int = Default('-1'),y1: Int = Default('-1'),nb_colors: Int = Default('2'),seed: Int64 = Default('-1'),duration: Duration = Default('-0.000001'),speed: Float = Default('0.01'),type: Int| Literal["linear","radial","circular","spiral","square"] | Default = Default('linear'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate several gradients.
 
 
@@ -2665,95 +2665,95 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#gradients)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='gradients', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "c0": c0,
-            
+
             "c1": c1,
-            
+
             "c2": c2,
-            
+
             "c3": c3,
-            
+
             "c4": c4,
-            
+
             "c5": c5,
-            
+
             "c6": c6,
-            
+
             "c7": c7,
-            
+
             "x0": x0,
-            
+
             "y0": y0,
-            
+
             "x1": x1,
-            
+
             "y1": y1,
-            
+
             "nb_colors": nb_colors,
-            
+
             "seed": seed,
-            
+
             "duration": duration,
-            
+
             "speed": speed,
-            
+
             "type": type,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def guided(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     radius: Int = Default('3'),eps: Float = Default('0.01'),mode: Int| Literal["basic","fast"] | Default = Default('basic'),sub: Int = Default('4'),guidance: Int| Literal["off","on"] | Default = Default('off'),planes: Int = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply guided filter for edge-preserving smoothing, dehazing and so on.
 
 The filter accepts the following options:
@@ -2776,7 +2776,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#guided)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -2784,61 +2784,61 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='guided', typings_input='[StreamType.video] + [StreamType.video] if guidance else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "radius": radius,
-            
+
             "eps": eps,
-            
+
             "mode": mode,
-            
+
             "sub": sub,
-            
+
             "guidance": guidance,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def haldclutsrc(
-    
 
-    
+
+
 
 
     *,
     level: Int = Default('6'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -2900,58 +2900,58 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='haldclutsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "level": level,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def headphone(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     map: String = Default(None),gain: Float = Default('0'),lfe: Float = Default('0'),type: Int| Literal["time","freq"] | Default = Default('freq'),size: Int = Default('1024'),hrir: Int| Literal["stereo","multich"] | Default = Default('stereo'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Apply head-related transfer functions (HRTFs) to create virtual
 loudspeakers around the user for binaural listening via headphones.
 The HRIRs are provided via additional streams, for each channel
@@ -2976,66 +2976,66 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#headphone)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='headphone', typings_input="[StreamType.audio] + [StreamType.audio] * (len(str(map).split('|')) - 1) if int(hrir) == 1 else []", typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "map": map,
-            
+
             "gain": gain,
-            
+
             "lfe": lfe,
-            
+
             "type": type,
-            
+
             "size": size,
-            
+
             "hrir": hrir,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def hilbert(
-    
 
-    
+
+
 
 
     *,
     sample_rate: Int = Default('44100'),taps: Int = Default('22051'),nb_samples: Int = Default('1024'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('blackman'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate odd-tap Hilbert transform FIR coefficients.
 
 The resulting stream can be used with afir filter for phase-shifting
@@ -3061,64 +3061,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hilbert)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='hilbert', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "sample_rate": sample_rate,
-            
+
             "taps": taps,
-            
+
             "nb_samples": nb_samples,
-            
+
             "win_func": win_func,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def hstack(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),shortest: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos horizontally.
 
 All streams must be of same pixel format and of same height.
@@ -3141,54 +3141,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hstack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='hstack', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def hstack_vaapi(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Default('2'),shortest: Boolean = Default('false'),height: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos horizontally.
 
 This is the VA-API variant of the hstack filter, each input stream may
@@ -3211,82 +3211,82 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hstack_vaapi)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='hstack_vaapi', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
             "height": height,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def interleave(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     nb_inputs: Int = Auto('len(streams)'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Temporally interleave frames from several inputs.
 
 interleave works with video inputs, ainterleave with audio.
@@ -3325,54 +3325,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#interleave)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='interleave', typings_input='[StreamType.video] * int(nb_inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "nb_inputs": nb_inputs,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def join(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),channel_layout: String = Default('stereo'),map: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Join multiple input streams into one multi-channel stream.
 
 It accepts the following parameters:
@@ -3391,64 +3391,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#join)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='join', typings_input='[StreamType.audio] * int(inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "channel_layout": channel_layout,
-            
+
             "map": map,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
 def life(
-    
 
-    
+
+
 
 
     *,
     filename: String = Default(None),size: Image_size = Default(None),rate: Video_rate = Default('25'),rule: String = Default('B3/S23'),random_fill_ratio: Double = Default('0.618034'),random_seed: Int64 = Default('-1'),stitch: Boolean = Default('true'),mold: Int = Default('0'),life_color: Color = Default('white'),death_color: Color = Default('black'),mold_color: Color = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate a life pattern.
 
 This source is based on a generalization of John Conway's life game.
@@ -3487,73 +3487,73 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#life)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='life', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "filename": filename,
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "rule": rule,
-            
+
             "random_fill_ratio": random_fill_ratio,
-            
+
             "random_seed": random_seed,
-            
+
             "stitch": stitch,
-            
+
             "mold": mold,
-            
+
             "life_color": life_color,
-            
+
             "death_color": death_color,
-            
+
             "mold_color": mold_color,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def limitdiff(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     threshold: Float = Default('0.00392157'),elasticity: Float = Default('2'),reference: Boolean = Default('false'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply limited difference filter using second and optionally third video stream.
 
 The filter accepts the following options:
@@ -3574,7 +3574,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#limitdiff)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -3582,77 +3582,77 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='limitdiff', typings_input='[StreamType.video, StreamType.video] + ([StreamType.video] if reference else [])', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "threshold": threshold,
-            
+
             "elasticity": elasticity,
-            
+
             "reference": reference,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def mandelbrot(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('640x480'),rate: Video_rate = Default('25'),maxiter: Int = Default('7189'),start_x: Double = Default('-0.743644'),start_y: Double = Default('-0.131826'),start_scale: Double = Default('3'),end_scale: Double = Default('0.3'),end_pts: Double = Default('400'),bailout: Double = Default('10'),morphxf: Double = Default('0.01'),morphyf: Double = Default('0.0123'),morphamp: Double = Default('0'),outer: Int| Literal["iteration_count","normalized_iteration_count","white","outz"] | Default = Default('normalized_iteration_count'),inner: Int| Literal["black","period","convergence","mincol"] | Default = Default('mincol'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate a Mandelbrot set fractal, and progressively zoom towards the
 point specified with start_x and start_y.
 
@@ -3683,94 +3683,94 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mandelbrot)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='mandelbrot', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "maxiter": maxiter,
-            
+
             "start_x": start_x,
-            
+
             "start_y": start_y,
-            
+
             "start_scale": start_scale,
-            
+
             "end_scale": end_scale,
-            
+
             "end_pts": end_pts,
-            
+
             "bailout": bailout,
-            
+
             "morphxf": morphxf,
-            
+
             "morphyf": morphyf,
-            
+
             "morphamp": morphamp,
-            
+
             "outer": outer,
-            
+
             "inner": inner,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
 def mergeplanes(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     mapping: Int = Default('-1'),format: Pix_fmt = Default('yuva444p'),map0s: Int = Default('0'),map0p: Int = Default('0'),map1s: Int = Default('0'),map1p: Int = Default('0'),map2s: Int = Default('0'),map2p: Int = Default('0'),map3s: Int = Default('0'),map3p: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Merge color channel components from several video streams.
 
 The filter accepts up to 4 input streams, and merge selected input
@@ -3799,81 +3799,81 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mergeplanes)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='mergeplanes', typings_input='[StreamType.video] * int(max(hex(int(mapping))[2::2]))', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "mapping": mapping,
-            
+
             "format": format,
-            
+
             "map0s": map0s,
-            
+
             "map0p": map0p,
-            
+
             "map1s": map1s,
-            
+
             "map1p": map1p,
-            
+
             "map2s": map2s,
-            
+
             "map2p": map2p,
-            
+
             "map3s": map3s,
-            
+
             "map3p": map3p,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def mix(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),weights: String = Default('1 1'),scale: Float = Default('0'),planes: Flags = Default('F'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Mix several video input streams into one video stream.
 
 A description of the accepted options follows.
@@ -3895,7 +3895,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mix)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -3903,59 +3903,59 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='mix', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "weights": weights,
-            
+
             "scale": scale,
-            
+
             "planes": planes,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def movie(
-    
 
-    
+
+
 
 
     *,
     filename: String = Default(None),format_name: String = Default(None),stream_index: Int = Default('-1'),seek_point: Double = Default('0'),streams: String = Default(None),loop: Int = Default('1'),discontinuity: Duration = Default('0'),dec_threads: Int = Default('0'),format_opts: Dictionary = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Read audio and/or video stream(s) from a movie container.
 
 It accepts the following parameters:
@@ -3981,67 +3981,67 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#movie)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='movie', typings_input="[StreamType.video] * len(streams.split('+'))", typings_output="[StreamType.video] * len(streams.split('+'))"),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "filename": filename,
-            
+
             "format_name": format_name,
-            
+
             "stream_index": stream_index,
-            
+
             "seek_point": seek_point,
-            
+
             "streams": streams,
-            
+
             "loop": loop,
-            
+
             "discontinuity": discontinuity,
-            
+
             "dec_threads": dec_threads,
-            
+
             "format_opts": format_opts,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def mptestsrc(
-    
 
-    
+
+
 
 
     *,
     rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),test: Int| Literal["dc_luma","dc_chroma","freq_luma","freq_chroma","amp_luma","amp_chroma","cbp","mv","ring1","ring2","all"] | Default = Default('all'),max_frames: Int64 = Default('30'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate various test patterns, as generated by the MPlayer test filter.
 
 The size of the generated video is fixed, and is 256x256.
@@ -4064,76 +4064,76 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mptestsrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='mptestsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "test": test,
-            
+
             "max_frames": max_frames,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def nullsrc(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -4195,54 +4195,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='nullsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def openclsrc(
-    
 
-    
+
+
 
 
     *,
     source: String = Default(None),kernel: String = Default(None),size: Image_size = Default(None),format: Pix_fmt = Default('none'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate video using an OpenCL program.
 
 
@@ -4261,72 +4261,72 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#openclsrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='openclsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "source": source,
-            
+
             "kernel": kernel,
-            
+
             "size": size,
-            
+
             "format": format,
-            
+
             "rate": rate,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
 def pal100bars(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -4388,54 +4388,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='pal100bars', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def pal75bars(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -4497,60 +4497,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='pal75bars', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def perlin(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),octaves: Int = Default('1'),persistence: Double = Default('1'),xscale: Double = Default('1'),yscale: Double = Default('1'),tscale: Double = Default('1'),random_mode: Int| Literal["random","ken","seed"] | Default = Default('random'),random_seed: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate Perlin noise.
 
 Perlin noise is a kind of noise with local continuity in space. This
@@ -4585,87 +4585,87 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#perlin)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='perlin', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "octaves": octaves,
-            
+
             "persistence": persistence,
-            
+
             "xscale": xscale,
-            
+
             "yscale": yscale,
-            
+
             "tscale": tscale,
-            
+
             "random_mode": random_mode,
-            
+
             "random_seed": random_seed,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
 def premultiply(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     planes: Int = Default('15'),inplace: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply alpha premultiply effect to input video stream using first plane
 of second stream as alpha.
 
@@ -4687,7 +4687,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#premultiply)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4695,62 +4695,62 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='premultiply', typings_input='[StreamType.video] + [StreamType.video] if inplace else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "inplace": inplace,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def program_opencl(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     source: String = Default(None),kernel: String = Default(None),inputs: Int = Default('1'),size: Image_size = Default(None),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Filter video using an OpenCL program.
 
 
@@ -4769,7 +4769,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#program_opencl)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -4777,85 +4777,85 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='program_opencl', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "source": source,
-            
+
             "kernel": kernel,
-            
+
             "inputs": inputs,
-            
+
             "size": size,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def rgbtestsrc(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),complement: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -4918,69 +4918,69 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='rgbtestsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
             "complement": complement,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def scale(
-    
 
-    
+
+
 
 
     *,
     w: String = Default(None),h: String = Default(None),flags: String = Default(''),interl: Boolean = Default('false'),size: String = Default(None),in_color_matrix: Int| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default('auto'),out_color_matrix: Int| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default('2'),in_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),out_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),in_chroma_loc: Int| Literal["auto","unknown","left","center","topleft","top","bottomleft","bottom"] | Default = Default('auto'),out_chroma_loc: Int| Literal["auto","unknown","left","center","topleft","top","bottomleft","bottom"] | Default = Default('auto'),in_v_chr_pos: Int = Default('-513'),in_h_chr_pos: Int = Default('-513'),out_v_chr_pos: Int = Default('-513'),out_h_chr_pos: Int = Default('-513'),force_original_aspect_ratio: Int| Literal["disable","decrease","increase"] | Default = Default('disable'),force_divisible_by: Int = Default('1'),param0: Double = Default('DBL_MAX'),param1: Double = Default('DBL_MAX'),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Scale (resize) the input video, using the libswscale library.
 
 The scale filter forces the output display aspect ratio to be the same
@@ -5022,7 +5022,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#scale)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -5030,155 +5030,155 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='scale', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "w": w,
-            
+
             "h": h,
-            
+
             "flags": flags,
-            
+
             "interl": interl,
-            
+
             "size": size,
-            
+
             "in_color_matrix": in_color_matrix,
-            
+
             "out_color_matrix": out_color_matrix,
-            
+
             "in_range": in_range,
-            
+
             "out_range": out_range,
-            
+
             "in_chroma_loc": in_chroma_loc,
-            
+
             "out_chroma_loc": out_chroma_loc,
-            
+
             "in_v_chr_pos": in_v_chr_pos,
-            
+
             "in_h_chr_pos": in_h_chr_pos,
-            
+
             "out_v_chr_pos": out_v_chr_pos,
-            
+
             "out_h_chr_pos": out_h_chr_pos,
-            
+
             "force_original_aspect_ratio": force_original_aspect_ratio,
-            
+
             "force_divisible_by": force_divisible_by,
-            
+
             "param0": param0,
-            
+
             "param1": param1,
-            
+
             "eval": eval,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def sierpinski(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('640x480'),rate: Video_rate = Default('25'),seed: Int64 = Default('-1'),jump: Int = Default('100'),type: Int| Literal["carpet","triangle"] | Default = Default('carpet'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate a Sierpinski carpet/triangle fractal, and randomly pan around.
 
 This source accepts the following options:
@@ -5199,60 +5199,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sierpinski)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='sierpinski', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "seed": seed,
-            
+
             "jump": jump,
-            
+
             "type": type,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def signature(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     detectmode: Int| Literal["off","full","fast"] | Default = Default('off'),nb_inputs: Int = Auto('len(streams)'),filename: String = Default(''),format: Int| Literal["binary","xml"] | Default = Default('binary'),th_d: Int = Default('9000'),th_dc: Int = Default('60000'),th_xh: Int = Default('116'),th_di: Int = Default('0'),th_it: Double = Default('0.5'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Calculates the MPEG-7 Video Signature. The filter can handle more than one
 input. In this case the matching between the inputs can be calculated additionally.
 The filter always passes through the first input. The signature of each stream can
@@ -5280,70 +5280,70 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#signature)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='signature', typings_input='[StreamType.video] * int(nb_inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "detectmode": detectmode,
-            
+
             "nb_inputs": nb_inputs,
-            
+
             "filename": filename,
-            
+
             "format": format,
-            
+
             "th_d": th_d,
-            
+
             "th_dc": th_dc,
-            
+
             "th_xh": th_xh,
-            
+
             "th_di": th_di,
-            
+
             "th_it": th_it,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def sinc(
-    
 
-    
+
+
 
 
     *,
     sample_rate: Int = Default('44100'),nb_samples: Int = Default('1024'),hp: Float = Default('0'),lp: Float = Default('0'),phase: Float = Default('50'),beta: Float = Default('-1'),att: Float = Default('120'),round: Boolean = Default('false'),hptaps: Int = Default('0'),lptaps: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate a sinc kaiser-windowed low-pass, high-pass, band-pass, or band-reject FIR coefficients.
 
 The resulting stream can be used with afir filter for filtering the audio signal.
@@ -5371,66 +5371,66 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sinc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='sinc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "sample_rate": sample_rate,
-            
+
             "nb_samples": nb_samples,
-            
+
             "hp": hp,
-            
+
             "lp": lp,
-            
+
             "phase": phase,
-            
+
             "beta": beta,
-            
+
             "att": att,
-            
+
             "round": round,
-            
+
             "hptaps": hptaps,
-            
+
             "lptaps": lptaps,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
+
+
+
 def sine(
-    
 
-    
+
+
 
 
     *,
     frequency: Double = Default('440'),beep_factor: Double = Default('0'),sample_rate: Int = Default('44100'),duration: Duration = Default('0'),samples_per_frame: String = Default('1024'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate an audio signal made of a sine wave with amplitude 1/8.
 
 The audio signal is bit-exact.
@@ -5453,60 +5453,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sine)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='sine', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "frequency": frequency,
-            
+
             "beep_factor": beep_factor,
-            
+
             "sample_rate": sample_rate,
-            
+
             "duration": duration,
-            
+
             "samples_per_frame": samples_per_frame,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def smptebars(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -5568,54 +5568,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='smptebars', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def smptehdbars(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -5677,78 +5677,78 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='smptehdbars', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def streamselect(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),map: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Select video or audio streams.
 
 The filter accepts the following options:
@@ -5767,69 +5767,69 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#streamselect)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='streamselect', typings_input='[StreamType.video] * int(inputs)', typings_output="[StreamType.video] * len(re.findall(r'\\d+', str(map)))"),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "map": map,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
 def testsrc(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),decimals: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -5892,56 +5892,56 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='testsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
             "decimals": decimals,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def testsrc2(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),alpha: Int = Default('255'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -6004,103 +6004,103 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='testsrc2', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
             "alpha": alpha,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def unpremultiply(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     planes: Int = Default('15'),inplace: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply alpha unpremultiply effect to input video stream using first plane
 of second stream as alpha.
 
@@ -6122,7 +6122,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#unpremultiply)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -6130,91 +6130,91 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='unpremultiply', typings_input='[StreamType.video] + ([StreamType.video] if inplace else [])', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "inplace": inplace,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def vstack(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),shortest: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos vertically.
 
 All streams must be of same pixel format and of same width.
@@ -6237,54 +6237,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vstack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='vstack', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def vstack_vaapi(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Default('2'),shortest: Boolean = Default('false'),width: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos vertically.
 
 This is the VA-API variant of the vstack filter, each input stream may
@@ -6307,78 +6307,78 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vstack_vaapi)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='vstack_vaapi', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
             "width": width,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
 def xmedian(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),planes: Int = Default('15'),percentile: Float = Default('0.5'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Pick median pixels from several input videos.
 
 The filter accepts the following options:
@@ -6399,7 +6399,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xmedian)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -6410,57 +6410,57 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xmedian', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "planes": planes,
-            
+
             "percentile": percentile,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def xstack(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),layout: String = Default(None),grid: Image_size = Default(None),shortest: Boolean = Default('false'),fill: String = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack video inputs into custom layout.
 
 All streams must be of same pixel format.
@@ -6483,60 +6483,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xstack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xstack', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "layout": layout,
-            
+
             "grid": grid,
-            
+
             "shortest": shortest,
-            
+
             "fill": fill,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xstack_vaapi(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Default('2'),shortest: Boolean = Default('false'),layout: String = Default(None),grid: Image_size = Default(None),grid_tile_size: Image_size = Default(None),fill: String = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack video inputs into custom layout.
 
 This is the VA-API variant of the xstack filter,  each input stream may
@@ -6562,64 +6562,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xstack_vaapi)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xstack_vaapi', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
             "layout": layout,
-            
+
             "grid": grid,
-            
+
             "grid_tile_size": grid_tile_size,
-            
+
             "fill": fill,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def yuvtestsrc(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -6681,56 +6681,56 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='yuvtestsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def zoneplate(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),precision: Int = Default('10'),xo: Int = Default('0'),yo: Int = Default('0'),to: Int = Default('0'),k0: Int = Default('0'),kx: Int = Default('0'),ky: Int = Default('0'),kt: Int = Default('0'),kxt: Int = Default('0'),kyt: Int = Default('0'),kxy: Int = Default('0'),kx2: Int = Default('0'),ky2: Int = Default('0'),kt2: Int = Default('0'),ku: Int = Default('0'),kv: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate a zoneplate test video pattern.
 
 This source accepts the following options:
@@ -6766,69 +6766,62 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#zoneplate)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='zoneplate', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
             "precision": precision,
-            
+
             "xo": xo,
-            
+
             "yo": yo,
-            
+
             "to": to,
-            
+
             "k0": k0,
-            
+
             "kx": kx,
-            
+
             "ky": ky,
-            
+
             "kt": kt,
-            
+
             "kxt": kxt,
-            
+
             "kyt": kyt,
-            
+
             "kxy": kxy,
-            
+
             "kx2": kx2,
-            
+
             "ky2": ky2,
-            
+
             "kt2": kt2,
-            
+
             "ku": ku,
-            
+
             "kv": kv,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
-
-
-    
-
-    
-
-    

--- a/packages/v7/src/ffmpeg/streams/audio.py
+++ b/packages/v7/src/ffmpeg/streams/audio.py
@@ -48,12 +48,12 @@ class AudioStream(FilterableStream):
     Audio stream.
     """
 
-    
-        
-    
-    
+
+
+
+
     def a3dscope(
-    
+
     self,
 
 
@@ -61,12 +61,12 @@ class AudioStream(FilterableStream):
 
     *,
     rate: Video_rate = Default('25'),size: Image_size = Default('hd720'),fov: Float = Default('90'),roll: Float = Default('0'),pitch: Float = Default('0'),yaw: Float = Default('0'),xzoom: Float = Default('1'),xpos: Float = Default('0'),length: Int = Default('15'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to 3d scope video output.
 
 The filter accepts the following options:
@@ -91,77 +91,77 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#a3dscope)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='a3dscope', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rate": rate,
-                
+
                 "size": size,
-                
+
                 "fov": fov,
-                
+
                 "roll": roll,
-                
+
                 "pitch": pitch,
-                
+
                 "yaw": yaw,
-                
+
                 "xzoom": xzoom,
-                
+
                 "xpos": xpos,
-                
+
                 "length": length,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aap(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('16'),projection: Int = Default('2'),mu: Float = Default('0.0001'),delta: Float = Default('0.001'),out_mode: Int| Literal["i","d","o","n","e"] | Default = Default('o'),precision: Int| Literal["auto","float","double"] | Default = Default('auto'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply Affine Projection algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to estimate unknown audio based on multiple input audio samples.
@@ -187,7 +187,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aap)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -195,52 +195,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aap', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _desired,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "order": order,
-                
+
                 "projection": projection,
-                
+
                 "mu": mu,
-                
+
                 "delta": delta,
-                
+
                 "out_mode": out_mode,
-                
+
                 "precision": precision,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def abench(
-    
+
     self,
 
 
@@ -248,12 +248,12 @@ References:
 
     *,
     action: Int| Literal["start","stop"] | Default = Default('start'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Benchmark part of a filtergraph.
 
 The filter accepts the following options:
@@ -270,37 +270,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bench)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='abench', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "action": action,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def abitscope(
-    
+
     self,
 
 
@@ -308,12 +308,12 @@ References:
 
     *,
     rate: Video_rate = Default('25'),size: Image_size = Default('1024x256'),colors: String = Default('red|green|blue|yellow|orange|lime|pink|magenta|brown'),mode: Int| Literal["bars","trace"] | Default = Default('bars'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a video output, displaying the audio bit scope.
 
 The filter accepts the following options:
@@ -333,47 +333,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#abitscope)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='abitscope', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rate": rate,
-                
+
                 "size": size,
-                
+
                 "colors": colors,
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def acompressor(
-    
+
     self,
 
 
@@ -381,12 +381,12 @@ References:
 
     *,
     level_in: Double = Default('1'),mode: Int| Literal["downward","upward"] | Default = Default('downward'),threshold: Double = Default('0.125'),ratio: Double = Default('2'),attack: Double = Default('20'),release: Double = Default('250'),makeup: Double = Default('1'),knee: Double = Default('2.82843'),link: Int| Literal["average","maximum"] | Default = Default('average'),detection: Int| Literal["peak","rms"] | Default = Default('rms'),level_sc: Double = Default('1'),mix: Double = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 A compressor is mainly used to reduce the dynamic range of a signal.
 Especially modern music is mostly compressed at a high ratio to
 improve the overall loudness. It's done to get the highest attention
@@ -439,59 +439,59 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acompressor)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acompressor', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "mode": mode,
-                
+
                 "threshold": threshold,
-                
+
                 "ratio": ratio,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "makeup": makeup,
-                
+
                 "knee": knee,
-                
+
                 "link": link,
-                
+
                 "detection": detection,
-                
+
                 "level_sc": level_sc,
-                
+
                 "mix": mix,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def acontrast(
-    
+
     self,
 
 
@@ -499,12 +499,12 @@ References:
 
     *,
     contrast: Float = Default('33'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Simple audio dynamic range compression/expansion filter.
 
 The filter accepts the following options:
@@ -521,50 +521,50 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acontrast)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acontrast', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "contrast": contrast,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def acopy(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Copy the input audio source unchanged to the output. This is mainly useful for
 testing purposes.
 
@@ -579,56 +579,56 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acopy)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acopy', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def acrossfade(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _crossfade1: AudioStream,
-        
-    
+
+
 
 
     *,
     nb_samples: Int64 = Default('44100'),duration: Duration = Default('0'),overlap: Boolean = Default('true'),curve1: Int| Literal["nofade","tri","qsin","esin","hsin","log","ipar","qua","cub","squ","cbr","par","exp","iqsin","ihsin","dese","desi","losi","sinc","isinc","quat","quatr","qsin2","hsin2"] | Default = Default('tri'),curve2: Int| Literal["nofade","tri","qsin","esin","hsin","log","ipar","qua","cub","squ","cbr","par","exp","iqsin","ihsin","dese","desi","losi","sinc","isinc","quat","quatr","qsin2","hsin2"] | Default = Default('tri'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply cross fade from one input audio stream to another input audio stream.
 The cross fade is applied for specified duration near the end of first stream.
 
@@ -650,53 +650,53 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acrossfade)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acrossfade', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _crossfade1,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "nb_samples": nb_samples,
-                
+
                 "duration": duration,
-                
+
                 "overlap": overlap,
-                
+
                 "curve1": curve1,
-                
+
                 "curve2": curve2,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def acrossover(
-    
+
     self,
 
 
@@ -704,12 +704,12 @@ References:
 
     *,
     split: String = Default('500'),order: Int| Literal["2nd","4th","6th","8th","10th","12th","14th","16th","18th","20th"] | Default = Default('4th'),level: Float = Default('1'),gain: String = Default('1.f'),precision: Int| Literal["auto","float","double"] | Default = Default('auto'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Split audio stream into several bands.
 
 This filter splits audio stream into two or more frequency ranges.
@@ -734,46 +734,46 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acrossover)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acrossover', typings_input=('audio',), typings_output="[StreamType.audio] * len(re.split(r'[ |]+', str(split)))"),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "split": split,
-                
+
                 "order": order,
-                
+
                 "level": level,
-                
+
                 "gain": gain,
-                
+
                 "precision": precision,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def acrusher(
-    
+
     self,
 
 
@@ -781,15 +781,15 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),bits: Double = Default('8'),mix: Double = Default('0.5'),mode: Int| Literal["lin","log"] | Default = Default('lin'),dc: Double = Default('1'),aa: Double = Default('0.5'),samples: Double = Default('1'),lfo: Boolean = Default('false'),lforange: Double = Default('20'),lforate: Double = Default('0.3'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Reduce audio bit resolution.
 
 This filter is bit crusher with enhanced functionality. A bit crusher
@@ -834,7 +834,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acrusher)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -842,54 +842,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acrusher', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "bits": bits,
-                
+
                 "mix": mix,
-                
+
                 "mode": mode,
-                
+
                 "dc": dc,
-                
+
                 "aa": aa,
-                
+
                 "samples": samples,
-                
+
                 "lfo": lfo,
-                
+
                 "lforange": lforange,
-                
+
                 "lforate": lforate,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def acue(
-    
+
     self,
 
 
@@ -897,12 +897,12 @@ References:
 
     *,
     cue: Int64 = Default('0'),preroll: Duration = Default('0'),buffer: Duration = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Delay audio filtering until a given wallclock timestamp. See the cue
 filter.
 
@@ -920,43 +920,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acue)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acue', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cue": cue,
-                
+
                 "preroll": preroll,
-                
+
                 "buffer": buffer,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def adeclick(
-    
+
     self,
 
 
@@ -964,15 +964,15 @@ References:
 
     *,
     window: Double = Default('55'),overlap: Double = Default('75'),arorder: Double = Default('2'),threshold: Double = Default('2'),burst: Double = Default('2'),method: Int| Literal["add","a","save","s"] | Default = Default('add'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Remove impulsive noise from input audio.
 
 Samples detected as impulsive noise are replaced by interpolated samples using
@@ -996,7 +996,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adeclick)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1004,44 +1004,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adeclick', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "window": window,
-                
+
                 "overlap": overlap,
-                
+
                 "arorder": arorder,
-                
+
                 "threshold": threshold,
-                
+
                 "burst": burst,
-                
+
                 "method": method,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adeclip(
-    
+
     self,
 
 
@@ -1049,15 +1049,15 @@ References:
 
     *,
     window: Double = Default('55'),overlap: Double = Default('75'),arorder: Double = Default('8'),threshold: Double = Default('10'),hsize: Int = Default('1000'),method: Int| Literal["add","a","save","s"] | Default = Default('add'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Remove clipped samples from input audio.
 
 Samples detected as clipped are replaced by interpolated samples using
@@ -1081,7 +1081,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adeclip)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1089,44 +1089,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adeclip', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "window": window,
-                
+
                 "overlap": overlap,
-                
+
                 "arorder": arorder,
-                
+
                 "threshold": threshold,
-                
+
                 "hsize": hsize,
-                
+
                 "method": method,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adecorrelate(
-    
+
     self,
 
 
@@ -1134,15 +1134,15 @@ References:
 
     *,
     stages: Int = Default('6'),seed: Int64 = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply decorrelation to input audio stream.
 
 The filter accepts the following options:
@@ -1161,7 +1161,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adecorrelate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1169,36 +1169,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adecorrelate', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "stages": stages,
-                
+
                 "seed": seed,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adelay(
-    
+
     self,
 
 
@@ -1206,15 +1206,15 @@ References:
 
     *,
     delays: String = Default(None),all: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Delay one or more audio channels.
 
 Samples in delayed channel are filled with silence.
@@ -1235,7 +1235,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adelay)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1243,36 +1243,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adelay', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "delays": delays,
-                
+
                 "all": all,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adenorm(
-    
+
     self,
 
 
@@ -1280,15 +1280,15 @@ References:
 
     *,
     level: Double = Default('-351'),type: Int| Literal["dc","ac","square","pulse"] | Default = Default('dc'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Remedy denormals in audio by adding extremely low-level noise.
 
 This filter shall be placed before any filter that can produce denormals.
@@ -1309,7 +1309,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adenorm)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1317,52 +1317,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adenorm', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level": level,
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aderivative(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Compute derivative/integral of audio stream.
 
 Applying both filters one after another produces original audio.
@@ -1379,7 +1379,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aderivative)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1387,32 +1387,32 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aderivative', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adrawgraph(
-    
+
     self,
 
 
@@ -1420,12 +1420,12 @@ References:
 
     *,
     m1: String = Default(''),fg1: String = Default('0xffff0000'),m2: String = Default(''),fg2: String = Default('0xff00ff00'),m3: String = Default(''),fg3: String = Default('0xffff00ff'),m4: String = Default(''),fg4: String = Default('0xffffff00'),bg: Color = Default('white'),min: Float = Default('-1'),max: Float = Default('1'),mode: Int| Literal["bar","dot","line"] | Default = Default('line'),slide: Int| Literal["frame","replace","scroll","rscroll","picture"] | Default = Default('frame'),size: Image_size = Default('900x256'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw a graph using input audio metadata.
 
 See drawgraph
@@ -1456,65 +1456,65 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adrawgraph)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adrawgraph', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "m1": m1,
-                
+
                 "fg1": fg1,
-                
+
                 "m2": m2,
-                
+
                 "fg2": fg2,
-                
+
                 "m3": m3,
-                
+
                 "fg3": fg3,
-                
+
                 "m4": m4,
-                
+
                 "fg4": fg4,
-                
+
                 "bg": bg,
-                
+
                 "min": min,
-                
+
                 "max": max,
-                
+
                 "mode": mode,
-                
+
                 "slide": slide,
-                
+
                 "size": size,
-                
+
                 "rate": rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adrc(
-    
+
     self,
 
 
@@ -1522,15 +1522,15 @@ References:
 
     *,
     transfer: String = Default('p'),attack: Double = Default('50'),release: Double = Default('100'),channels: String = Default('all'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply spectral dynamic range controller filter to input audio stream.
 
 A description of the accepted options follows.
@@ -1551,7 +1551,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adrc)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1559,40 +1559,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adrc', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "transfer": transfer,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "channels": channels,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adynamicequalizer(
-    
+
     self,
 
 
@@ -1600,15 +1600,15 @@ References:
 
     *,
     threshold: Double = Default('0'),dfrequency: Double = Default('1000'),dqfactor: Double = Default('1'),tfrequency: Double = Default('1000'),tqfactor: Double = Default('1'),attack: Double = Default('20'),release: Double = Default('200'),ratio: Double = Default('1'),makeup: Double = Default('0'),range: Double = Default('50'),mode: Int| Literal["listen","cutbelow","cutabove","boostbelow","boostabove"] | Default = Default('cutbelow'),dftype: Int| Literal["bandpass","lowpass","highpass","peak"] | Default = Default('bandpass'),tftype: Int| Literal["bell","lowshelf","highshelf"] | Default = Default('bell'),auto: Int| Literal["disabled","off","on","adaptive"] | Default = Default('off'),precision: Int| Literal["auto","float","double"] | Default = Default('auto'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply dynamic equalization to input audio stream.
 
 A description of the accepted options follows.
@@ -1640,7 +1640,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adynamicequalizer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1648,62 +1648,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adynamicequalizer', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold": threshold,
-                
+
                 "dfrequency": dfrequency,
-                
+
                 "dqfactor": dqfactor,
-                
+
                 "tfrequency": tfrequency,
-                
+
                 "tqfactor": tqfactor,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "ratio": ratio,
-                
+
                 "makeup": makeup,
-                
+
                 "range": range,
-                
+
                 "mode": mode,
-                
+
                 "dftype": dftype,
-                
+
                 "tftype": tftype,
-                
+
                 "auto": auto,
-                
+
                 "precision": precision,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adynamicsmooth(
-    
+
     self,
 
 
@@ -1711,15 +1711,15 @@ References:
 
     *,
     sensitivity: Double = Default('2'),basefreq: Double = Default('22050'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply dynamic smoothing to input audio stream.
 
 A description of the accepted options follows.
@@ -1738,7 +1738,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adynamicsmooth)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1746,36 +1746,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adynamicsmooth', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sensitivity": sensitivity,
-                
+
                 "basefreq": basefreq,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aecho(
-    
+
     self,
 
 
@@ -1783,12 +1783,12 @@ References:
 
     *,
     in_gain: Float = Default('0.6'),out_gain: Float = Default('0.3'),delays: String = Default('1000'),decays: String = Default('0.5'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply echoing to the input audio.
 
 Echoes are reflected sound and can occur naturally amongst mountains
@@ -1816,43 +1816,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aecho)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aecho', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "in_gain": in_gain,
-                
+
                 "out_gain": out_gain,
-                
+
                 "delays": delays,
-                
+
                 "decays": decays,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aemphasis(
-    
+
     self,
 
 
@@ -1860,15 +1860,15 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),mode: Int| Literal["reproduction","production"] | Default = Default('reproduction'),type: Int| Literal["col","emi","bsi","riaa","cd","50fm","75fm","50kf","75kf"] | Default = Default('cd'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Audio emphasis filter creates or restores material directly taken from LPs or
 emphased CDs with different filter curves. E.g. to store music on vinyl the
 signal has to be altered by a filter first to even out the disadvantages of
@@ -1894,7 +1894,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aemphasis)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1902,40 +1902,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aemphasis', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "mode": mode,
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aeval(
-    
+
     self,
 
 
@@ -1943,15 +1943,15 @@ References:
 
     *,
     exprs: String = Default(None),channel_layout: String = Default(None),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Modify an audio signal according to the specified expressions.
 
 This filter accepts one or more expressions (one for each channel),
@@ -1973,7 +1973,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aeval)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1981,38 +1981,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aeval', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "exprs": exprs,
-                
+
                 "channel_layout": channel_layout,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def aexciter(
-    
+
     self,
 
 
@@ -2020,15 +2020,15 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),amount: Double = Default('1'),drive: Double = Default('8.5'),blend: Double = Default('0'),freq: Double = Default('7500'),ceil: Double = Default('9999'),listen: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 An exciter is used to produce high sound that is not present in the
 original signal. This is done by creating harmonic distortions of the
 signal which are restricted in range and added to the original signal.
@@ -2058,7 +2058,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aexciter)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2066,48 +2066,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aexciter', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "amount": amount,
-                
+
                 "drive": drive,
-                
+
                 "blend": blend,
-                
+
                 "freq": freq,
-                
+
                 "ceil": ceil,
-                
+
                 "listen": listen,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def afade(
-    
+
     self,
 
 
@@ -2115,15 +2115,15 @@ References:
 
     *,
     type: Int| Literal["in","out"] | Default = Default('in'),start_sample: Int64 = Default('0'),nb_samples: Int64 = Default('44100'),start_time: Duration = Default('0'),duration: Duration = Default('0'),curve: Int| Literal["nofade","tri","qsin","esin","hsin","log","ipar","qua","cub","squ","cbr","par","exp","iqsin","ihsin","dese","desi","losi","sinc","isinc","quat","quatr","qsin2","hsin2"] | Default = Default('tri'),silence: Double = Default('0'),unity: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply fade-in/out effect to input audio.
 
 A description of the accepted parameters follows.
@@ -2148,7 +2148,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afade)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2156,50 +2156,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='afade', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "type": type,
-                
+
                 "start_sample": start_sample,
-                
+
                 "nb_samples": nb_samples,
-                
+
                 "start_time": start_time,
-                
+
                 "duration": duration,
-                
+
                 "curve": curve,
-                
+
                 "silence": silence,
-                
+
                 "unity": unity,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def afftdn(
-    
+
     self,
 
 
@@ -2207,15 +2207,15 @@ References:
 
     *,
     noise_reduction: Float = Default('12'),noise_floor: Float = Default('-50'),noise_type: Int| Literal["white","w","vinyl","v","shellac","s","custom","c"] | Default = Default('white'),band_noise: String = Default(None),residual_floor: Float = Default('-38'),track_noise: Boolean = Default('false'),track_residual: Boolean = Default('false'),output_mode: Int| Literal["input","i","output","o","noise","n"] | Default = Default('output'),adaptivity: Float = Default('0.5'),floor_offset: Float = Default('1'),noise_link: Int| Literal["none","min","max","average"] | Default = Default('min'),band_multiplier: Float = Default('1.25'),sample_noise: Int| Literal["none","start","begin","stop","end"] | Default = Default('none'),gain_smooth: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Denoise audio samples with FFT.
 
 A description of the accepted parameters follows.
@@ -2246,7 +2246,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afftdn)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2254,60 +2254,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='afftdn', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "noise_reduction": noise_reduction,
-                
+
                 "noise_floor": noise_floor,
-                
+
                 "noise_type": noise_type,
-                
+
                 "band_noise": band_noise,
-                
+
                 "residual_floor": residual_floor,
-                
+
                 "track_noise": track_noise,
-                
+
                 "track_residual": track_residual,
-                
+
                 "output_mode": output_mode,
-                
+
                 "adaptivity": adaptivity,
-                
+
                 "floor_offset": floor_offset,
-                
+
                 "noise_link": noise_link,
-                
+
                 "band_multiplier": band_multiplier,
-                
+
                 "sample_noise": sample_noise,
-                
+
                 "gain_smooth": gain_smooth,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def afftfilt(
-    
+
     self,
 
 
@@ -2315,15 +2315,15 @@ References:
 
     *,
     real: String = Default('re'),imag: String = Default('im'),win_size: Int = Default('4096'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('hann'),overlap: Float = Default('0.75'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply arbitrary expressions to samples in frequency domain.
 
 
@@ -2343,7 +2343,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afftfilt)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2351,46 +2351,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='afftfilt', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "real": real,
-                
+
                 "imag": imag,
-                
+
                 "win_size": win_size,
-                
+
                 "win_func": win_func,
-                
+
                 "overlap": overlap,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def aformat(
-    
+
     self,
 
 
@@ -2398,12 +2398,12 @@ References:
 
     *,
     sample_fmts: Sample_fmt = Default(None),sample_rates: Int = Default(None),channel_layouts: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Set output format constraints for the input audio. The framework will
 negotiate the most appropriate format to minimize conversions.
 
@@ -2423,41 +2423,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aformat)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aformat', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sample_fmts": sample_fmts,
-                
+
                 "sample_rates": sample_rates,
-                
+
                 "channel_layouts": channel_layouts,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def afreqshift(
-    
+
     self,
 
 
@@ -2465,15 +2465,15 @@ References:
 
     *,
     shift: Double = Default('0'),level: Double = Default('1'),order: Int = Default('8'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply frequency shift to input audio samples.
 
 The filter accepts the following options:
@@ -2493,7 +2493,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afreqshift)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2501,38 +2501,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='afreqshift', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "shift": shift,
-                
+
                 "level": level,
-                
+
                 "order": order,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def afwtdn(
-    
+
     self,
 
 
@@ -2540,15 +2540,15 @@ References:
 
     *,
     sigma: Double = Default('0'),levels: Int = Default('10'),wavet: Int| Literal["sym2","sym4","rbior68","deb10","sym10","coif5","bl3"] | Default = Default('sym10'),percent: Double = Default('85'),profile: Boolean = Default('false'),adaptive: Boolean = Default('false'),samples: Int = Default('8192'),softness: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Reduce broadband noise from input samples using Wavelets.
 
 A description of the accepted options follows.
@@ -2573,7 +2573,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afwtdn)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2581,48 +2581,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='afwtdn', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sigma": sigma,
-                
+
                 "levels": levels,
-                
+
                 "wavet": wavet,
-                
+
                 "percent": percent,
-                
+
                 "profile": profile,
-                
+
                 "adaptive": adaptive,
-                
+
                 "samples": samples,
-                
+
                 "softness": softness,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def agate(
-    
+
     self,
 
 
@@ -2630,15 +2630,15 @@ References:
 
     *,
     level_in: Double = Default('1'),mode: Int| Literal["downward","upward"] | Default = Default('downward'),range: Double = Default('0.06125'),threshold: Double = Default('0.125'),ratio: Double = Default('2'),attack: Double = Default('20'),release: Double = Default('250'),makeup: Double = Default('1'),knee: Double = Default('2.82843'),detection: Int| Literal["peak","rms"] | Default = Default('rms'),link: Int| Literal["average","maximum"] | Default = Default('average'),level_sc: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 A gate is mainly used to reduce lower parts of a signal. This kind of signal
 processing reduces disturbing noise between useful signals.
 
@@ -2677,7 +2677,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#agate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2685,56 +2685,56 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='agate', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "mode": mode,
-                
+
                 "range": range,
-                
+
                 "threshold": threshold,
-                
+
                 "ratio": ratio,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "makeup": makeup,
-                
+
                 "knee": knee,
-                
+
                 "detection": detection,
-                
+
                 "link": link,
-                
+
                 "level_sc": level_sc,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def agraphmonitor(
-    
+
     self,
 
 
@@ -2742,12 +2742,12 @@ References:
 
     *,
     size: Image_size = Default('hd720'),opacity: Float = Default('0.9'),mode: Flags| Literal["full","compact","nozero","noeof","nodisabled"] | Default = Default('0'),flags: Flags| Literal["none","all","queue","frame_count_in","frame_count_out","frame_count_delta","pts","pts_delta","time","time_delta","timebase","format","size","rate","eof","sample_count_in","sample_count_out","sample_count_delta","disabled"] | Default = Default('all+queue'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 See graphmonitor.
 
 
@@ -2766,45 +2766,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#agraphmonitor)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='agraphmonitor', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "opacity": opacity,
-                
+
                 "mode": mode,
-                
+
                 "flags": flags,
-                
+
                 "rate": rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ahistogram(
-    
+
     self,
 
 
@@ -2812,12 +2812,12 @@ References:
 
     *,
     dmode: Int| Literal["single","separate"] | Default = Default('single'),rate: Video_rate = Default('25'),size: Image_size = Default('hd720'),scale: Int| Literal["log","sqrt","cbrt","lin","rlog"] | Default = Default('log'),ascale: Int| Literal["log","lin"] | Default = Default('log'),acount: Int = Default('1'),rheight: Float = Default('0.1'),slide: Int| Literal["replace","scroll"] | Default = Default('replace'),hmode: Int| Literal["abs","sign"] | Default = Default('abs'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a video output, displaying the volume histogram.
 
 The filter accepts the following options:
@@ -2842,53 +2842,53 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ahistogram)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ahistogram', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dmode": dmode,
-                
+
                 "rate": rate,
-                
+
                 "size": size,
-                
+
                 "scale": scale,
-                
+
                 "ascale": ascale,
-                
+
                 "acount": acount,
-                
+
                 "rheight": rheight,
-                
+
                 "slide": slide,
-                
+
                 "hmode": hmode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aiir(
-    
+
     self,
 
 
@@ -2896,12 +2896,12 @@ References:
 
     *,
     zeros: String = Default('1+0i 1-0i'),poles: String = Default('1+0i 1-0i'),gains: String = Default('1|1'),dry: Double = Default('1'),wet: Double = Default('1'),format: Int| Literal["ll","sf","tf","zp","pr","pd","sp"] | Default = Default('zp'),process: Int| Literal["d","s","p"] | Default = Default('s'),precision: Int| Literal["dbl","flt","i32","i16"] | Default = Default('dbl'),e: Int| Literal["dbl","flt","i32","i16"] | Default = Default('dbl'),normalize: Boolean = Default('true'),mix: Double = Default('1'),response: Boolean = Default('false'),channel: Int = Default('0'),size: Image_size = Default('hd720'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Apply an arbitrary Infinite Impulse Response filter.
 
 It accepts the following parameters:
@@ -2933,82 +2933,82 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aiir)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aiir', typings_input=('audio',), typings_output='[StreamType.audio] + [StreamType.video] if response else []'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "zeros": zeros,
-                
+
                 "poles": poles,
-                
+
                 "gains": gains,
-                
+
                 "dry": dry,
-                
+
                 "wet": wet,
-                
+
                 "format": format,
-                
+
                 "process": process,
-                
+
                 "precision": precision,
-                
+
                 "e": e,
-                
+
                 "normalize": normalize,
-                
+
                 "mix": mix,
-                
+
                 "response": response,
-                
+
                 "channel": channel,
-                
+
                 "size": size,
-                
+
                 "rate": rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aintegral(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Compute derivative/integral of audio stream.
 
 Applying both filters one after another produces original audio.
@@ -3025,7 +3025,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aderivative)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3033,50 +3033,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aintegral', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def alatency(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Measure filtering latency.
 
 Report previous filter filtering latency, delay in number of audio samples for audio filters
@@ -3097,7 +3097,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#latency)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3105,32 +3105,32 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='alatency', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def alimiter(
-    
+
     self,
 
 
@@ -3138,15 +3138,15 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),limit: Double = Default('1'),attack: Double = Default('5'),release: Double = Default('50'),asc: Boolean = Default('false'),asc_level: Double = Default('0.5'),level: Boolean = Default('true'),latency: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 The limiter prevents an input signal from rising over a desired threshold.
 This limiter uses lookahead technology to prevent your signal from distorting.
 It means that there is a small delay after the signal is processed. Keep in mind
@@ -3175,7 +3175,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#alimiter)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3183,50 +3183,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='alimiter', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "limit": limit,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "asc": asc,
-                
+
                 "asc_level": asc_level,
-                
+
                 "level": level,
-                
+
                 "latency": latency,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def allpass(
-    
+
     self,
 
 
@@ -3234,15 +3234,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.707'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),order: Int = Default('2'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a two-pole all-pass filter with central frequency (in Hz)
 frequency, and filter-width width.
 An all-pass filter changes the audio's frequency to phase relationship
@@ -3271,7 +3271,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allpass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3279,54 +3279,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='allpass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "order": order,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def aloop(
-    
+
     self,
 
 
@@ -3334,12 +3334,12 @@ References:
 
     *,
     loop: Int = Default('0'),size: Int64 = Default('0'),start: Int64 = Default('0'),time: Duration = Default('INT64_MAX'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Loop audio samples.
 
 The filter accepts the following options:
@@ -3359,49 +3359,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aloop)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aloop', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "loop": loop,
-                
+
                 "size": size,
-                
+
                 "start": start,
-                
+
                 "time": time,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def ametadata(
-    
+
     self,
 
 
@@ -3409,15 +3409,15 @@ References:
 
     *,
     mode: Int| Literal["select","add","modify","delete","print"] | Default = Default('select'),key: String = Default(None),value: String = Default(None),function: Int| Literal["same_str","starts_with","less","equal","greater","expr","ends_with"] | Default = Default('same_str'),expr: String = Default(None),file: String = Default(None),direct: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Manipulate frame metadata.
 
 This filter accepts the following options:
@@ -3441,7 +3441,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#metadata)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3449,73 +3449,73 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ametadata', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "key": key,
-                
+
                 "value": value,
-                
+
                 "function": function,
-                
+
                 "expr": expr,
-                
+
                 "file": file,
-                
+
                 "direct": direct,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def amultiply(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _multiply1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Multiply first audio stream with second audio stream and store result
 in output audio stream. Multiplication is done by multiplying each
 sample from first stream with sample at same position from second stream.
@@ -3534,43 +3534,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amultiply)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='amultiply', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _multiply1,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def anequalizer(
-    
+
     self,
 
 
@@ -3578,15 +3578,15 @@ References:
 
     *,
     params: String = Default(''),curves: Boolean = Default('false'),size: Image_size = Default('hd720'),mgain: Double = Default('60'),fscale: Int| Literal["lin","log"] | Default = Default('log'),colors: String = Default('red|green|blue|yellow|orange|lime|pink|magenta|brown'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 High-order parametric multiband equalizer for each channel.
 
 It accepts the following parameters:
@@ -3610,7 +3610,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anequalizer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3618,45 +3618,45 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='anequalizer', typings_input=('audio',), typings_output='[StreamType.audio] + [StreamType.video] if curves else []'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "params": params,
-                
+
                 "curves": curves,
-                
+
                 "size": size,
-                
+
                 "mgain": mgain,
-                
+
                 "fscale": fscale,
-                
+
                 "colors": colors,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def anlmdn(
-    
+
     self,
 
 
@@ -3664,15 +3664,15 @@ References:
 
     *,
     strength: Float = Default('1e-05'),patch: Duration = Default('0.002'),research: Duration = Default('0.006'),output: Int| Literal["i","o","n"] | Default = Default('o'),smooth: Float = Default('11'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Reduce broadband noise in audio samples using Non-Local Means algorithm.
 
 Each sample is adjusted by looking for other samples with similar contexts. This
@@ -3698,7 +3698,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anlmdn)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3706,66 +3706,66 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='anlmdn', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "strength": strength,
-                
+
                 "patch": patch,
-                
+
                 "research": research,
-                
+
                 "output": output,
-                
+
                 "smooth": smooth,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def anlmf(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('256'),mu: Float = Default('0.75'),eps: Float = Default('1'),leakage: Float = Default('0'),out_mode: Int| Literal["i","d","o","n","e"] | Default = Default('o'),precision: Int| Literal["auto","float","double"] | Default = Default('auto'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply Normalized Least-Mean-(Squares|Fourth) algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to mimic a desired filter by finding the filter coefficients that
@@ -3792,7 +3792,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anlmf)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3800,76 +3800,76 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='anlmf', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _desired,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "order": order,
-                
+
                 "mu": mu,
-                
+
                 "eps": eps,
-                
+
                 "leakage": leakage,
-                
+
                 "out_mode": out_mode,
-                
+
                 "precision": precision,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def anlms(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('256'),mu: Float = Default('0.75'),eps: Float = Default('1'),leakage: Float = Default('0'),out_mode: Int| Literal["i","d","o","n","e"] | Default = Default('o'),precision: Int| Literal["auto","float","double"] | Default = Default('auto'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply Normalized Least-Mean-(Squares|Fourth) algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to mimic a desired filter by finding the filter coefficients that
@@ -3896,7 +3896,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anlmf)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3904,67 +3904,67 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='anlms', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _desired,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "order": order,
-                
+
                 "mu": mu,
-                
+
                 "eps": eps,
-                
+
                 "leakage": leakage,
-                
+
                 "out_mode": out_mode,
-                
+
                 "precision": precision,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def anull(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Pass the audio source unchanged to the output.
 
 
@@ -3978,39 +3978,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anull)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='anull', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def apad(
-    
+
     self,
 
 
@@ -4018,15 +4018,15 @@ References:
 
     *,
     packet_size: Int = Default('4096'),pad_len: Int64 = Default('-1'),whole_len: Int64 = Default('-1'),pad_dur: Duration = Default('-0.000001'),whole_dur: Duration = Default('-0.000001'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Pad the end of an audio stream with silence.
 
 This can be used together with ffmpeg -shortest to
@@ -4051,7 +4051,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#apad)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4059,42 +4059,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='apad', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "packet_size": packet_size,
-                
+
                 "pad_len": pad_len,
-                
+
                 "whole_len": whole_len,
-                
+
                 "pad_dur": pad_dur,
-                
+
                 "whole_dur": whole_dur,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aperms(
-    
+
     self,
 
 
@@ -4102,15 +4102,15 @@ References:
 
     *,
     mode: Int| Literal["none","ro","rw","toggle","random"] | Default = Default('none'),seed: Int64 = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Set read/write permissions for the output frames.
 
 These filters are mainly aimed at developers to test direct path in the
@@ -4132,7 +4132,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#perms)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4140,36 +4140,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aperms', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "seed": seed,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aphasemeter(
-    
+
     self,
 
 
@@ -4177,12 +4177,12 @@ References:
 
     *,
     rate: Video_rate = Default('25'),size: Image_size = Default('800x400'),rc: Int = Default('2'),gc: Int = Default('7'),bc: Int = Default('1'),mpc: String = Default('none'),video: Boolean = Default('true'),phasing: Boolean = Default('false'),tolerance: Float = Default('0'),angle: Float = Default('170'),duration: Duration = Default('2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Measures phase of input audio, which is exported as metadata lavfi.aphasemeter.phase,
 representing mean phase of current audio frame. A video output can also be produced and is
 enabled by default. The audio is passed through as first output.
@@ -4216,58 +4216,58 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aphasemeter)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aphasemeter', typings_input=('audio',), typings_output='[StreamType.audio] + ([StreamType.video] if video else [])'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rate": rate,
-                
+
                 "size": size,
-                
+
                 "rc": rc,
-                
+
                 "gc": gc,
-                
+
                 "bc": bc,
-                
+
                 "mpc": mpc,
-                
+
                 "video": video,
-                
+
                 "phasing": phasing,
-                
+
                 "tolerance": tolerance,
-                
+
                 "angle": angle,
-                
+
                 "duration": duration,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aphaser(
-    
+
     self,
 
 
@@ -4275,12 +4275,12 @@ References:
 
     *,
     in_gain: Double = Default('0.4'),out_gain: Double = Default('0.74'),delay: Double = Default('3'),decay: Double = Default('0.4'),speed: Double = Default('0.5'),type: Int| Literal["triangular","t","sinusoidal","s"] | Default = Default('triangular'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Add a phasing effect to the input audio.
 
 A phaser filter creates series of peaks and troughs in the frequency spectrum.
@@ -4305,47 +4305,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aphaser)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aphaser', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "in_gain": in_gain,
-                
+
                 "out_gain": out_gain,
-                
+
                 "delay": delay,
-                
+
                 "decay": decay,
-                
+
                 "speed": speed,
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aphaseshift(
-    
+
     self,
 
 
@@ -4353,15 +4353,15 @@ References:
 
     *,
     shift: Double = Default('0'),level: Double = Default('1'),order: Int = Default('8'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply phase shift to input audio samples.
 
 The filter accepts the following options:
@@ -4381,7 +4381,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aphaseshift)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4389,62 +4389,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aphaseshift', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "shift": shift,
-                
+
                 "level": level,
-                
+
                 "order": order,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def apsnr(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _input1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Measure Audio Peak Signal-to-Noise Ratio.
 
 This filter takes two audio streams for input, and outputs first
@@ -4463,7 +4463,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#apsnr)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4471,40 +4471,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='apsnr', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _input1,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def apsyclip(
-    
+
     self,
 
 
@@ -4512,15 +4512,15 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),clip: Double = Default('1'),diff: Boolean = Default('false'),adaptive: Double = Default('0.5'),iterations: Int = Default('10'),level: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply Psychoacoustic clipper to input audio stream.
 
 The filter accepts the following options:
@@ -4544,7 +4544,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#apsyclip)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4552,46 +4552,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='apsyclip', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "clip": clip,
-                
+
                 "diff": diff,
-                
+
                 "adaptive": adaptive,
-                
+
                 "iterations": iterations,
-                
+
                 "level": level,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def apulsator(
-    
+
     self,
 
 
@@ -4599,12 +4599,12 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),mode: Int| Literal["sine","triangle","square","sawup","sawdown"] | Default = Default('sine'),amount: Double = Default('1'),offset_l: Double = Default('0'),offset_r: Double = Default('0.5'),width: Double = Default('1'),timing: Int| Literal["bpm","ms","hz"] | Default = Default('hz'),bpm: Double = Default('120'),ms: Int = Default('500'),hz: Double = Default('2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Audio pulsator is something between an autopanner and a tremolo.
 But it can produce funny stereo effects as well. Pulsator changes the volume
 of the left and right channel based on a LFO (low frequency oscillator) with
@@ -4643,57 +4643,57 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#apulsator)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='apulsator', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "mode": mode,
-                
+
                 "amount": amount,
-                
+
                 "offset_l": offset_l,
-                
+
                 "offset_r": offset_r,
-                
+
                 "width": width,
-                
+
                 "timing": timing,
-                
+
                 "bpm": bpm,
-                
+
                 "ms": ms,
-                
+
                 "hz": hz,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def arealtime(
-    
+
     self,
 
 
@@ -4701,12 +4701,12 @@ References:
 
     *,
     limit: Duration = Default('2'),speed: Double = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Slow down filtering to match real time approximately.
 
 These filters will pause the filtering for a variable amount of time to
@@ -4728,39 +4728,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#realtime)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='arealtime', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "limit": limit,
-                
+
                 "speed": speed,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aresample(
-    
+
     self,
 
 
@@ -4768,12 +4768,12 @@ References:
 
     *,
     sample_rate: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Resample the input audio to the specified parameters, using the
 libswresample library. If none are specified then the filter will
 automatically convert between its input and output.
@@ -4802,50 +4802,50 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aresample)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aresample', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sample_rate": sample_rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def areverse(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Reverse an audio clip.
 
 Warning: This filter requires memory to buffer the entire clip, so trimming
@@ -4862,59 +4862,59 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#areverse)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='areverse', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def arls(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('16'),_lambda: Float = Default('1'),delta: Float = Default('2'),out_mode: Int| Literal["i","d","o","n","e"] | Default = Default('o'),precision: Int| Literal["auto","float","double"] | Default = Default('auto'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply Recursive Least Squares algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to mimic a desired filter by recursively finding the filter coefficients that
@@ -4940,7 +4940,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#arls)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4948,50 +4948,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='arls', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _desired,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "order": order,
-                
+
                 "lambda": _lambda,
-                
+
                 "delta": delta,
-                
+
                 "out_mode": out_mode,
-                
+
                 "precision": precision,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def arnndn(
-    
+
     self,
 
 
@@ -4999,15 +4999,15 @@ References:
 
     *,
     model: String = Default(None),mix: Float = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Reduce noise from speech using Recurrent Neural Networks.
 
 This filter accepts the following options:
@@ -5026,7 +5026,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#arnndn)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5034,60 +5034,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='arnndn', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "model": model,
-                
+
                 "mix": mix,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asdr(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _input1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Measure Audio Signal-to-Distortion Ratio.
 
 This filter takes two audio streams for input, and outputs first
@@ -5106,7 +5106,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asdr)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5114,40 +5114,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asdr', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _input1,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asegment(
-    
+
     self,
 
 
@@ -5155,12 +5155,12 @@ References:
 
     *,
     timestamps: String = Default(None),samples: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Split single input stream into multiple streams.
 
 This filter does opposite of concat filters.
@@ -5183,40 +5183,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#segment)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asegment', typings_input=('audio',), typings_output="[StreamType.audio] * len(str(timestamps or samples).split('|'))"),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "timestamps": timestamps,
-                
+
                 "samples": samples,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aselect(
-    
+
     self,
 
 
@@ -5224,12 +5224,12 @@ References:
 
     *,
     expr: String = Default('1'),outputs: Int = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Select frames to pass in output.
 
 This filter accepts the following options:
@@ -5248,40 +5248,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#select)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aselect', typings_input=('audio',), typings_output='[StreamType.audio] * int(outputs)'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "expr": expr,
-                
+
                 "outputs": outputs,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asendcmd(
-    
+
     self,
 
 
@@ -5289,12 +5289,12 @@ References:
 
     *,
     commands: String = Default(None),filename: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Send commands to filters in the filtergraph.
 
 These filters read commands to be sent to other filters in the
@@ -5323,39 +5323,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sendcmd)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asendcmd', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "commands": commands,
-                
+
                 "filename": filename,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asetnsamples(
-    
+
     self,
 
 
@@ -5363,15 +5363,15 @@ References:
 
     *,
     nb_out_samples: Int = Default('1024'),pad: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Set the number of samples per each output audio frame.
 
 The last output packet may contain a different number of samples, as
@@ -5394,7 +5394,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asetnsamples)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5402,36 +5402,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asetnsamples', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "nb_out_samples": nb_out_samples,
-                
+
                 "pad": pad,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asetpts(
-    
+
     self,
 
 
@@ -5439,12 +5439,12 @@ References:
 
     *,
     expr: String = Default('PTS'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Change the PTS (presentation timestamp) of the input frames.
 
 setpts works on video frames, asetpts on audio frames.
@@ -5463,37 +5463,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setpts)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asetpts', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "expr": expr,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asetrate(
-    
+
     self,
 
 
@@ -5501,12 +5501,12 @@ References:
 
     *,
     sample_rate: Int = Default('44100'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Set the sample rate without altering the PCM data.
 This will result in a change of speed and pitch.
 
@@ -5524,37 +5524,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asetrate)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asetrate', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sample_rate": sample_rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asettb(
-    
+
     self,
 
 
@@ -5562,12 +5562,12 @@ References:
 
     *,
     expr: String = Default('intb'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Set the timebase to use for the output frames timestamps.
 It is mainly useful for testing timebase configuration.
 
@@ -5585,50 +5585,50 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#settb)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asettb', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "expr": expr,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ashowinfo(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Show a line containing various information for each input audio frame.
 The input audio is not modified.
 
@@ -5648,35 +5648,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ashowinfo)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ashowinfo', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asidedata(
-    
+
     self,
 
 
@@ -5684,15 +5684,15 @@ References:
 
     *,
     mode: Int| Literal["select","delete"] | Default = Default('select'),type: Int| Literal["PANSCAN","A53_CC","STEREO3D","MATRIXENCODING","DOWNMIX_INFO","REPLAYGAIN","DISPLAYMATRIX","AFD","MOTION_VECTORS","SKIP_SAMPLES","AUDIO_SERVICE_TYPE","MASTERING_DISPLAY_METADATA","GOP_TIMECODE","SPHERICAL","CONTENT_LIGHT_LEVEL","ICC_PROFILE","S12M_TIMECOD","DYNAMIC_HDR_PLUS","REGIONS_OF_INTEREST","VIDEO_ENC_PARAMS","SEI_UNREGISTERED","FILM_GRAIN_PARAMS","DETECTION_BOUNDING_BOXES","DETECTION_BBOXES","DOVI_RPU_BUFFER","DOVI_METADATA","DYNAMIC_HDR_VIVID","AMBIENT_VIEWING_ENVIRONMENT","VIDEO_HINT"] | Default = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Delete frame side data, or select frames based on it.
 
 This filter accepts the following options:
@@ -5711,7 +5711,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sidedata)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5719,60 +5719,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asidedata', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asisdr(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _input1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Measure Audio Scaled-Invariant Signal-to-Distortion Ratio.
 
 This filter takes two audio streams for input, and outputs first
@@ -5791,7 +5791,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asisdr)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5799,40 +5799,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asisdr', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _input1,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asoftclip(
-    
+
     self,
 
 
@@ -5840,15 +5840,15 @@ References:
 
     *,
     type: Int| Literal["hard","tanh","atan","cubic","exp","alg","quintic","sin","erf"] | Default = Default('tanh'),threshold: Double = Default('1'),output: Double = Default('1'),param: Double = Default('1'),oversample: Int = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply audio soft clipping.
 
 Soft clipping is a type of distortion effect where the amplitude of a signal is saturated
@@ -5873,7 +5873,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asoftclip)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5881,42 +5881,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asoftclip', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "type": type,
-                
+
                 "threshold": threshold,
-                
+
                 "output": output,
-                
+
                 "param": param,
-                
+
                 "oversample": oversample,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aspectralstats(
-    
+
     self,
 
 
@@ -5924,12 +5924,12 @@ References:
 
     *,
     win_size: Int = Default('2048'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('hann'),overlap: Float = Default('0.5'),measure: Flags| Literal["none","all","mean","variance","centroid","spread","skewness","kurtosis","entropy","flatness","crest","flux","slope","decrease","rolloff"] | Default = Default('all+mean+variance+centroid+spread+skewness+kurtosis+entropy+flatness+crest+flux+slope+decrease+rolloff'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Display frequency domain statistical information about the audio channels.
 Statistics are calculated and stored as metadata for each audio channel and for each audio frame.
 
@@ -5950,43 +5950,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aspectralstats)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aspectralstats', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "win_size": win_size,
-                
+
                 "win_func": win_func,
-                
+
                 "overlap": overlap,
-                
+
                 "measure": measure,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asplit(
-    
+
     self,
 
 
@@ -5994,12 +5994,12 @@ References:
 
     *,
     outputs: Int = Default('2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Split input into several identical outputs.
 
 asplit works with audio input, split with video.
@@ -6020,40 +6020,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#split)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asplit', typings_input=('audio',), typings_output='[StreamType.audio] * int(outputs)'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "outputs": outputs,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def astats(
-    
+
     self,
 
 
@@ -6061,12 +6061,12 @@ References:
 
     *,
     length: Double = Default('0.05'),metadata: Boolean = Default('false'),reset: Int = Default('0'),measure_perchannel: Flags| Literal["none","all","Bit_depth","Crest_factor","DC_offset","Dynamic_range","Entropy","Flat_factor","Max_difference","Max_level","Mean_difference","Min_difference","Min_level","Noise_floor","Noise_floor_count","Number_of_Infs","Number_of_NaNs","Number_of_denormals","Number_of_samples","Peak_count","Peak_level","RMS_difference","RMS_level","RMS_peak","RMS_trough","Zero_crossings","Zero_crossings_rate","Abs_Peak_count"] | Default = Default('all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate+Abs_Peak_count'),measure_overall: Flags| Literal["none","all","Bit_depth","Crest_factor","DC_offset","Dynamic_range","Entropy","Flat_factor","Max_difference","Max_level","Mean_difference","Min_difference","Min_level","Noise_floor","Noise_floor_count","Number_of_Infs","Number_of_NaNs","Number_of_denormals","Number_of_samples","Peak_count","Peak_level","RMS_difference","RMS_level","RMS_peak","RMS_trough","Zero_crossings","Zero_crossings_rate","Abs_Peak_count"] | Default = Default('all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate+Abs_Peak_count'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Display time domain statistical information about the audio channels.
 Statistics are calculated and displayed for each audio channel and,
 where applicable, an overall figure is also given.
@@ -6089,47 +6089,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#astats)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='astats', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "length": length,
-                
+
                 "metadata": metadata,
-                
+
                 "reset": reset,
-                
+
                 "measure_perchannel": measure_perchannel,
-                
+
                 "measure_overall": measure_overall,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def asubboost(
-    
+
     self,
 
 
@@ -6137,15 +6137,15 @@ References:
 
     *,
     dry: Double = Default('1'),wet: Double = Default('1'),boost: Double = Default('2'),decay: Double = Default('0'),feedback: Double = Default('0.9'),cutoff: Double = Default('100'),slope: Double = Default('0.5'),delay: Double = Default('20'),channels: String = Default('all'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Boost subwoofer frequencies.
 
 The filter accepts the following options:
@@ -6171,7 +6171,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asubboost)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6179,50 +6179,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asubboost', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dry": dry,
-                
+
                 "wet": wet,
-                
+
                 "boost": boost,
-                
+
                 "decay": decay,
-                
+
                 "feedback": feedback,
-                
+
                 "cutoff": cutoff,
-                
+
                 "slope": slope,
-                
+
                 "delay": delay,
-                
+
                 "channels": channels,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asubcut(
-    
+
     self,
 
 
@@ -6230,15 +6230,15 @@ References:
 
     *,
     cutoff: Double = Default('20'),order: Int = Default('10'),level: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Cut subwoofer frequencies.
 
 This filter allows to set custom, steeper
@@ -6262,7 +6262,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asubcut)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6270,38 +6270,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asubcut', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cutoff": cutoff,
-                
+
                 "order": order,
-                
+
                 "level": level,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asupercut(
-    
+
     self,
 
 
@@ -6309,15 +6309,15 @@ References:
 
     *,
     cutoff: Double = Default('20000'),order: Int = Default('10'),level: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Cut super frequencies.
 
 The filter accepts the following options:
@@ -6337,7 +6337,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asupercut)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6345,38 +6345,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asupercut', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cutoff": cutoff,
-                
+
                 "order": order,
-                
+
                 "level": level,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asuperpass(
-    
+
     self,
 
 
@@ -6384,15 +6384,15 @@ References:
 
     *,
     centerf: Double = Default('1000'),order: Int = Default('4'),qfactor: Double = Default('1'),level: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply high order Butterworth band-pass filter.
 
 The filter accepts the following options:
@@ -6413,7 +6413,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asuperpass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6421,40 +6421,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asuperpass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "centerf": centerf,
-                
+
                 "order": order,
-                
+
                 "qfactor": qfactor,
-                
+
                 "level": level,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asuperstop(
-    
+
     self,
 
 
@@ -6462,15 +6462,15 @@ References:
 
     *,
     centerf: Double = Default('1000'),order: Int = Default('4'),qfactor: Double = Default('1'),level: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply high order Butterworth band-stop filter.
 
 The filter accepts the following options:
@@ -6491,7 +6491,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asuperstop)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6499,42 +6499,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asuperstop', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "centerf": centerf,
-                
+
                 "order": order,
-                
+
                 "qfactor": qfactor,
-                
+
                 "level": level,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def atempo(
-    
+
     self,
 
 
@@ -6542,12 +6542,12 @@ References:
 
     *,
     tempo: Double = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Adjust audio tempo.
 
 The filter accepts exactly one parameter, the audio tempo. If not
@@ -6571,37 +6571,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#atempo)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='atempo', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "tempo": tempo,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def atilt(
-    
+
     self,
 
 
@@ -6609,15 +6609,15 @@ References:
 
     *,
     freq: Double = Default('10000'),slope: Double = Default('0'),width: Double = Default('1000'),order: Int = Default('5'),level: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply spectral tilt filter to audio stream.
 
 This filter apply any spectral roll-off slope over any specified frequency band.
@@ -6641,7 +6641,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#atilt)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6649,42 +6649,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='atilt', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "freq": freq,
-                
+
                 "slope": slope,
-                
+
                 "width": width,
-                
+
                 "order": order,
-                
+
                 "level": level,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def atrim(
-    
+
     self,
 
 
@@ -6692,12 +6692,12 @@ References:
 
     *,
     start: Duration = Default('INT64_MAX'),end: Duration = Default('INT64_MAX'),start_pts: Int64 = Default('I64_MIN'),end_pts: Int64 = Default('I64_MIN'),duration: Duration = Default('0'),start_sample: Int64 = Default('-1'),end_sample: Int64 = Default('I64_MAX'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Trim the input so that the output contains one continuous subpart of the input.
 
 It accepts the following parameters:
@@ -6720,49 +6720,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#atrim)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='atrim', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "start": start,
-                
+
                 "end": end,
-                
+
                 "start_pts": start_pts,
-                
+
                 "end_pts": end_pts,
-                
+
                 "duration": duration,
-                
+
                 "start_sample": start_sample,
-                
+
                 "end_sample": end_sample,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def avectorscope(
-    
+
     self,
 
 
@@ -6770,12 +6770,12 @@ References:
 
     *,
     mode: Int| Literal["lissajous","lissajous_xy","polar"] | Default = Default('lissajous'),rate: Video_rate = Default('25'),size: Image_size = Default('400x400'),rc: Int = Default('40'),gc: Int = Default('160'),bc: Int = Default('80'),ac: Int = Default('255'),rf: Int = Default('15'),gf: Int = Default('10'),bf: Int = Default('5'),af: Int = Default('5'),zoom: Double = Default('1'),draw: Int| Literal["dot","line","aaline"] | Default = Default('dot'),scale: Int| Literal["lin","sqrt","cbrt","log"] | Default = Default('lin'),swap: Boolean = Default('true'),mirror: Int| Literal["none","x","y","xy"] | Default = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a video output, representing the audio vector
 scope.
 
@@ -6815,94 +6815,94 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#avectorscope)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='avectorscope', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "rate": rate,
-                
+
                 "size": size,
-                
+
                 "rc": rc,
-                
+
                 "gc": gc,
-                
+
                 "bc": bc,
-                
+
                 "ac": ac,
-                
+
                 "rf": rf,
-                
+
                 "gf": gf,
-                
+
                 "bf": bf,
-                
+
                 "af": af,
-                
+
                 "zoom": zoom,
-                
+
                 "draw": draw,
-                
+
                 "scale": scale,
-                
+
                 "swap": swap,
-                
+
                 "mirror": mirror,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def axcorrelate(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _axcorrelate1: AudioStream,
-        
-    
+
+
 
 
     *,
     size: Int = Default('256'),algo: Int| Literal["slow","fast","best"] | Default = Default('best'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Calculate normalized windowed cross-correlation between two input audio streams.
 
 Resulted samples are always between -1 and 1 inclusive.
@@ -6926,47 +6926,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#axcorrelate)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='axcorrelate', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _axcorrelate1,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "algo": algo,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def azmq(
-    
+
     self,
 
 
@@ -6974,12 +6974,12 @@ References:
 
     *,
     bind_address: String = Default('tcp://*:5555'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Receive commands sent through a libzmq client, and forward them to
 filters in the filtergraph.
 
@@ -7038,39 +7038,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#zmq)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='azmq', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "bind_address": bind_address,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def bandpass(
-    
+
     self,
 
 
@@ -7078,15 +7078,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),csg: Boolean = Default('false'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a two-pole Butterworth band-pass filter with central
 frequency frequency, and (3dB-point) band-width width.
 The csg option selects a constant skirt gain (peak gain = Q)
@@ -7117,7 +7117,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bandpass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7125,52 +7125,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bandpass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "csg": csg,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def bandreject(
-    
+
     self,
 
 
@@ -7178,15 +7178,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a two-pole Butterworth band-reject filter with central
 frequency frequency, and (3dB-point) band-width width.
 The filter roll off at 6dB per octave (20dB per decade).
@@ -7214,7 +7214,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bandreject)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7222,50 +7222,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bandreject', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def bass(
-    
+
     self,
 
 
@@ -7273,15 +7273,15 @@ References:
 
     *,
     frequency: Double = Default('100'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),gain: Double = Default('0'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Boost or cut the bass (lower) frequencies of the audio using a two-pole
 shelving filter with a response similar to that of a standard
 hi-fi's tone-controls. This is also known as shelving equalisation (EQ).
@@ -7311,7 +7311,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7319,60 +7319,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "gain": gain,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def biquad(
-    
+
     self,
 
 
@@ -7380,15 +7380,15 @@ References:
 
     *,
     a0: Double = Default('1'),a1: Double = Default('0'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a biquad IIR filter with the given coefficients.
 Where b0, b1, b2 and a0, a1, a2
 are the numerator and denominator coefficients respectively.
@@ -7415,7 +7415,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#biquad)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7423,78 +7423,78 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='biquad', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "a0": a0,
-                
+
                 "a1": a1,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def channelmap(
-    
+
     self,
 
 
@@ -7502,12 +7502,12 @@ References:
 
     *,
     map: String = Default(None),channel_layout: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Remap input channels to new locations.
 
 It accepts the following parameters:
@@ -7525,39 +7525,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#channelmap)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='channelmap', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "map": map,
-                
+
                 "channel_layout": channel_layout,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def channelsplit(
-    
+
     self,
 
 
@@ -7565,12 +7565,12 @@ References:
 
     *,
     channel_layout: String = Default('stereo'),channels: String = Default('all'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Split each channel from an input audio stream into a separate output stream.
 
 It accepts the following parameters:
@@ -7589,40 +7589,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#channelsplit)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='channelsplit', typings_input=('audio',), typings_output='[StreamType.audio] * CHANNEL_LAYOUT[str(channel_layout)]'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "channel_layout": channel_layout,
-                
+
                 "channels": channels,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def chorus(
-    
+
     self,
 
 
@@ -7630,12 +7630,12 @@ References:
 
     *,
     in_gain: Float = Default('0.4'),out_gain: Float = Default('0.4'),delays: String = Default(None),decays: String = Default(None),speeds: String = Default(None),depths: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Add a chorus effect to the audio.
 
 Can make a single vocal sound like a chorus, but can also be applied to instrumentation.
@@ -7666,91 +7666,91 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#chorus)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='chorus', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "in_gain": in_gain,
-                
+
                 "out_gain": out_gain,
-                
+
                 "delays": delays,
-                
+
                 "decays": decays,
-                
+
                 "speeds": speeds,
-                
+
                 "depths": depths,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def compand(
-    
+
     self,
 
 
@@ -7758,12 +7758,12 @@ References:
 
     *,
     attacks: String = Default('0'),decays: String = Default('0.8'),points: String = Default('-70/-70|-60/-20|1/0'),soft_knee: Double = Default('0.01'),gain: Double = Default('0'),volume: Double = Default('0'),delay: Double = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Compress or expand the audio's dynamic range.
 
 It accepts the following parameters:
@@ -7786,49 +7786,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#compand)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='compand', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "attacks": attacks,
-                
+
                 "decays": decays,
-                
+
                 "points": points,
-                
+
                 "soft-knee": soft_knee,
-                
+
                 "gain": gain,
-                
+
                 "volume": volume,
-                
+
                 "delay": delay,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def compensationdelay(
-    
+
     self,
 
 
@@ -7836,15 +7836,15 @@ References:
 
     *,
     mm: Int = Default('0'),cm: Int = Default('0'),m: Int = Default('0'),dry: Double = Default('0'),wet: Double = Default('1'),temp: Int = Default('20'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Compensation Delay Line is a metric based delay to compensate differing
 positions of microphones or speakers.
 
@@ -7883,7 +7883,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#compensationdelay)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7891,62 +7891,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='compensationdelay', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mm": mm,
-                
+
                 "cm": cm,
-                
+
                 "m": m,
-                
+
                 "dry": dry,
-                
+
                 "wet": wet,
-                
+
                 "temp": temp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def crossfeed(
-    
+
     self,
 
 
@@ -7954,15 +7954,15 @@ References:
 
     *,
     strength: Double = Default('0.2'),range: Double = Default('0.5'),slope: Double = Default('0.5'),level_in: Double = Default('0.9'),level_out: Double = Default('1'),block_size: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply headphone crossfeed filter.
 
 Crossfeed is the process of blending the left and right channels of stereo
@@ -7991,7 +7991,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#crossfeed)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7999,44 +7999,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='crossfeed', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "strength": strength,
-                
+
                 "range": range,
-                
+
                 "slope": slope,
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "block_size": block_size,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def crystalizer(
-    
+
     self,
 
 
@@ -8044,15 +8044,15 @@ References:
 
     *,
     i: Float = Default('2'),c: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Simple algorithm for audio noise sharpening.
 
 This filter linearly increases differences between each audio sample.
@@ -8073,7 +8073,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#crystalizer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8081,44 +8081,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='crystalizer', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "i": i,
-                
+
                 "c": c,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def dcshift(
-    
+
     self,
 
 
@@ -8126,15 +8126,15 @@ References:
 
     *,
     shift: Double = Default('0'),limitergain: Double = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a DC shift to the audio.
 
 This can be useful to remove a DC offset (caused perhaps by a hardware problem
@@ -8156,7 +8156,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dcshift)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8164,48 +8164,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dcshift', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "shift": shift,
-                
+
                 "limitergain": limitergain,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def deesser(
-    
+
     self,
 
 
@@ -8213,15 +8213,15 @@ References:
 
     *,
     i: Double = Default('0'),m: Double = Default('0.5'),f: Double = Default('0.5'),s: Int| Literal["i","o","e"] | Default = Default('o'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply de-essing to the audio samples.
 
 
@@ -8240,7 +8240,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deesser)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8248,60 +8248,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deesser', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "i": i,
-                
+
                 "m": m,
-                
+
                 "f": f,
-                
+
                 "s": s,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def dialoguenhance(
-    
+
     self,
 
 
@@ -8309,15 +8309,15 @@ References:
 
     *,
     original: Double = Default('1'),enhance: Double = Default('1'),voice: Double = Default('2'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Enhance dialogue in stereo audio.
 
 This filter accepts stereo input and produce surround (3.0) channels output.
@@ -8342,7 +8342,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dialoguenhance)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8350,56 +8350,56 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dialoguenhance', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "original": original,
-                
+
                 "enhance": enhance,
-                
+
                 "voice": voice,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def drmeter(
-    
+
     self,
 
 
@@ -8407,12 +8407,12 @@ References:
 
     *,
     length: Double = Default('3'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Measure audio dynamic range.
 
 DR values of 14 and higher is found in very dynamic material. DR of 8 to 13
@@ -8433,37 +8433,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#drmeter)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='drmeter', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "length": length,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dynaudnorm(
-    
+
     self,
 
 
@@ -8471,15 +8471,15 @@ References:
 
     *,
     framelen: Int = Default('500'),gausssize: Int = Default('31'),peak: Double = Default('0.95'),maxgain: Double = Default('10'),targetrms: Double = Default('0'),coupling: Boolean = Default('true'),correctdc: Boolean = Default('false'),altboundary: Boolean = Default('false'),compress: Double = Default('0'),threshold: Double = Default('0'),channels: String = Default('all'),overlap: Double = Default('0'),curve: String = Default(None),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Dynamic Audio Normalizer.
 
 This filter applies a certain amount of gain to the input audio in order
@@ -8519,7 +8519,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dynaudnorm)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8527,71 +8527,71 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dynaudnorm', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "framelen": framelen,
-                
+
                 "gausssize": gausssize,
-                
+
                 "peak": peak,
-                
+
                 "maxgain": maxgain,
-                
+
                 "targetrms": targetrms,
-                
+
                 "coupling": coupling,
-                
+
                 "correctdc": correctdc,
-                
+
                 "altboundary": altboundary,
-                
+
                 "compress": compress,
-                
+
                 "threshold": threshold,
-                
+
                 "channels": channels,
-                
+
                 "overlap": overlap,
-                
+
                 "curve": curve,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def earwax(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Make audio easier to listen to on headphones.
 
 This filter adds `cues' to 44.1kHz stereo (i.e. audio CD format) audio
@@ -8612,35 +8612,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#earwax)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='earwax', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ebur128(
-    
+
     self,
 
 
@@ -8648,12 +8648,12 @@ References:
 
     *,
     video: Boolean = Default('false'),size: Image_size = Default('640x480'),meter: Int = Default('9'),framelog: Int| Literal["quiet","info","verbose"] | Default = Default('-1'),metadata: Boolean = Default('false'),peak: Flags| Literal["none","sample","true"] | Default = Default('0'),dualmono: Boolean = Default('false'),panlaw: Double = Default('-3.0103'),target: Int = Default('-23'),gauge: Int| Literal["momentary","m","shortterm","s"] | Default = Default('momentary'),scale: Int| Literal["absolute","LUFS","relative","LU"] | Default = Default('absolute'),integrated: Double = Default('0'),range: Double = Default('0'),lra_low: Double = Default('0'),lra_high: Double = Default('0'),sample_peak: Double = Default('0'),true_peak: Double = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 EBU R128 scanner filter. This filter takes an audio stream and analyzes its loudness
 level. By default, it logs a message at a frequency of 10Hz with the
 Momentary loudness (identified by M), Short-term loudness (S),
@@ -8709,80 +8709,80 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ebur128)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ebur128', typings_input=('audio',), typings_output='[StreamType.video] if video else [] + [StreamType.audio]'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "video": video,
-                
+
                 "size": size,
-                
+
                 "meter": meter,
-                
+
                 "framelog": framelog,
-                
+
                 "metadata": metadata,
-                
+
                 "peak": peak,
-                
+
                 "dualmono": dualmono,
-                
+
                 "panlaw": panlaw,
-                
+
                 "target": target,
-                
+
                 "gauge": gauge,
-                
+
                 "scale": scale,
-                
+
                 "integrated": integrated,
-                
+
                 "range": range,
-                
+
                 "lra_low": lra_low,
-                
+
                 "lra_high": lra_high,
-                
+
                 "sample_peak": sample_peak,
-                
+
                 "true_peak": true_peak,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def equalizer(
-    
+
     self,
 
 
@@ -8790,15 +8790,15 @@ References:
 
     *,
     frequency: Double = Default('0'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('1'),gain: Double = Default('0'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a two-pole peaking equalisation (EQ) filter. With this
 filter, the signal-level at and around a selected frequency can
 be increased or decreased, whilst (unlike bandpass and bandreject
@@ -8831,7 +8831,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#equalizer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8839,62 +8839,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='equalizer', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "gain": gain,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def extrastereo(
-    
+
     self,
 
 
@@ -8902,15 +8902,15 @@ References:
 
     *,
     m: Float = Default('2.5'),c: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Linearly increases the difference between left and right channels which
 adds some sort of "live" effect to playback.
 
@@ -8930,7 +8930,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#extrastereo)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8938,56 +8938,56 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='extrastereo', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "m": m,
-                
+
                 "c": c,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def firequalizer(
-    
+
     self,
 
 
@@ -8995,12 +8995,12 @@ References:
 
     *,
     gain: String = Default('gain_interpolate(f)'),gain_entry: String = Default(None),delay: Double = Default('0.01'),accuracy: Double = Default('5'),wfunc: Int| Literal["rectangular","hann","hamming","blackman","nuttall3","mnuttall3","nuttall","bnuttall","bharris","tukey"] | Default = Default('hann'),fixed: Boolean = Default('false'),multi: Boolean = Default('false'),zero_phase: Boolean = Default('false'),scale: Int| Literal["linlin","linlog","loglin","loglog"] | Default = Default('linlog'),dumpfile: String = Default(None),dumpscale: Int| Literal["linlin","linlog","loglin","loglog"] | Default = Default('linlog'),fft2: Boolean = Default('false'),min_phase: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply FIR Equalization using arbitrary frequency response.
 
 The filter accepts the following option:
@@ -9029,61 +9029,61 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#firequalizer)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='firequalizer', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "gain": gain,
-                
+
                 "gain_entry": gain_entry,
-                
+
                 "delay": delay,
-                
+
                 "accuracy": accuracy,
-                
+
                 "wfunc": wfunc,
-                
+
                 "fixed": fixed,
-                
+
                 "multi": multi,
-                
+
                 "zero_phase": zero_phase,
-                
+
                 "scale": scale,
-                
+
                 "dumpfile": dumpfile,
-                
+
                 "dumpscale": dumpscale,
-                
+
                 "fft2": fft2,
-                
+
                 "min_phase": min_phase,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def flanger(
-    
+
     self,
 
 
@@ -9091,12 +9091,12 @@ References:
 
     *,
     delay: Double = Default('0'),depth: Double = Default('2'),regen: Double = Default('0'),width: Double = Default('71'),speed: Double = Default('0.5'),shape: Int| Literal["triangular","t","sinusoidal","s"] | Default = Default('sinusoidal'),phase: Double = Default('25'),interp: Int| Literal["linear","quadratic"] | Default = Default('linear'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a flanging effect to the audio.
 
 The filter accepts the following options:
@@ -9120,87 +9120,87 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#flanger)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='flanger', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "delay": delay,
-                
+
                 "depth": depth,
-                
+
                 "regen": regen,
-                
+
                 "width": width,
-                
+
                 "speed": speed,
-                
+
                 "shape": shape,
-                
+
                 "phase": phase,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def haas(
-    
+
     self,
 
 
@@ -9208,12 +9208,12 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),side_gain: Double = Default('1'),middle_source: Int| Literal["left","right","mid","side"] | Default = Default('mid'),middle_phase: Boolean = Default('false'),left_delay: Double = Default('2.05'),left_balance: Double = Default('-1'),left_gain: Double = Default('1'),left_phase: Boolean = Default('false'),right_delay: Double = Default('2.12'),right_balance: Double = Default('1'),right_gain: Double = Default('1'),right_phase: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply Haas effect to audio.
 
 Note that this makes most sense to apply on mono signals.
@@ -9246,65 +9246,65 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#haas)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='haas', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "side_gain": side_gain,
-                
+
                 "middle_source": middle_source,
-                
+
                 "middle_phase": middle_phase,
-                
+
                 "left_delay": left_delay,
-                
+
                 "left_balance": left_balance,
-                
+
                 "left_gain": left_gain,
-                
+
                 "left_phase": left_phase,
-                
+
                 "right_delay": right_delay,
-                
+
                 "right_balance": right_balance,
-                
+
                 "right_gain": right_gain,
-                
+
                 "right_phase": right_phase,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def hdcd(
-    
+
     self,
 
 
@@ -9312,12 +9312,12 @@ References:
 
     *,
     disable_autoconvert: Boolean = Default('true'),process_stereo: Boolean = Default('true'),cdt_ms: Int = Default('2000'),force_pe: Boolean = Default('false'),analyze_mode: Int| Literal["off","lle","pe","cdt","tgm"] | Default = Default('off'),bits_per_sample: Int| Literal["16","20","24"] | Default = Default('16'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Decodes High Definition Compatible Digital (HDCD) data. A 16-bit PCM stream with
 embedded HDCD codes is expanded into a 20-bit PCM stream.
 
@@ -9355,51 +9355,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hdcd)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hdcd', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "disable_autoconvert": disable_autoconvert,
-                
+
                 "process_stereo": process_stereo,
-                
+
                 "cdt_ms": cdt_ms,
-                
+
                 "force_pe": force_pe,
-                
+
                 "analyze_mode": analyze_mode,
-                
+
                 "bits_per_sample": bits_per_sample,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def highpass(
-    
+
     self,
 
 
@@ -9407,15 +9407,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.707'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a high-pass filter with 3dB point frequency.
 The filter can be either single-pole, or double-pole (the default).
 The filter roll off at 6dB per pole per octave (20dB per pole per decade).
@@ -9444,7 +9444,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#highpass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9452,52 +9452,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='highpass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def highshelf(
-    
+
     self,
 
 
@@ -9505,15 +9505,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),gain: Double = Default('0'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Boost or cut treble (upper) frequencies of the audio using a two-pole
 shelving filter with a response similar to that of a standard
 hi-fi's tone-controls. This is also known as shelving equalisation (EQ).
@@ -9543,7 +9543,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#treble)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9551,116 +9551,116 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='highshelf', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "gain": gain,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def loudnorm(
-    
+
     self,
 
 
@@ -9668,12 +9668,12 @@ References:
 
     *,
     I: Double = Default('-24'),LRA: Double = Default('7'),TP: Double = Default('-2'),measured_I: Double = Default('0'),measured_LRA: Double = Default('0'),measured_TP: Double = Default('99'),measured_thresh: Double = Default('-70'),offset: Double = Default('0'),linear: Boolean = Default('true'),dual_mono: Boolean = Default('false'),print_format: Int| Literal["none","json","summary"] | Default = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 EBU R128 loudness normalization. Includes both dynamic and linear normalization modes.
 Support for both single pass (livestreams, files) and double pass (files) modes.
 This algorithm can target IL, LRA, and maximum true peak. In dynamic mode, to accurately
@@ -9704,57 +9704,57 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#loudnorm)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='loudnorm', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "I": I,
-                
+
                 "LRA": LRA,
-                
+
                 "TP": TP,
-                
+
                 "measured_I": measured_I,
-                
+
                 "measured_LRA": measured_LRA,
-                
+
                 "measured_TP": measured_TP,
-                
+
                 "measured_thresh": measured_thresh,
-                
+
                 "offset": offset,
-                
+
                 "linear": linear,
-                
+
                 "dual_mono": dual_mono,
-                
+
                 "print_format": print_format,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lowpass(
-    
+
     self,
 
 
@@ -9762,15 +9762,15 @@ References:
 
     *,
     frequency: Double = Default('500'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.707'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a low-pass filter with 3dB point frequency.
 The filter can be either single-pole or double-pole (the default).
 The filter roll off at 6dB per pole per octave (20dB per pole per decade).
@@ -9799,7 +9799,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lowpass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9807,52 +9807,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lowpass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lowshelf(
-    
+
     self,
 
 
@@ -9860,15 +9860,15 @@ References:
 
     *,
     frequency: Double = Default('100'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),gain: Double = Default('0'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Boost or cut the bass (lower) frequencies of the audio using a two-pole
 shelving filter with a response similar to that of a standard
 hi-fi's tone-controls. This is also known as shelving equalisation (EQ).
@@ -9898,7 +9898,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9906,84 +9906,84 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lowshelf', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "gain": gain,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def mcompand(
-    
+
     self,
 
 
@@ -9991,12 +9991,12 @@ References:
 
     *,
     args: String = Default('0.005,0.1 6 -47/-40,-34/-34,-17/-33 100 | 0.003,0.05 6 -47/-40,-34/-34,-17/-33 400 | 0.000625,0.0125 6 -47/-40,-34/-34,-15/-33 1600 | 0.0001,0.025 6 -47/-40,-34/-34,-31/-31,-0/-30 6400 | 0,0.025 6 -38/-31,-28/-28,-0/-25 22000'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Multiband Compress or expand the audio's dynamic range.
 
 The input audio is divided into bands using 4th order Linkwitz-Riley IIRs.
@@ -10017,111 +10017,111 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mcompand)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='mcompand', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "args": args,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def pan(
-    
+
     self,
 
 
@@ -10129,12 +10129,12 @@ References:
 
     *,
     args: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Mix channels with specific gain levels. The filter accepts the output
 channel layout followed by a set of channels definitions.
 
@@ -10146,7 +10146,7 @@ The filter accepts parameters of the form:
 
 
 Args:
-    args: 
+    args:
     extra_options: Extra options for the filter
 
 Returns:
@@ -10156,93 +10156,93 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pan)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pan', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "args": args,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def replaygain(
-    
+
     self,
 
 
@@ -10250,12 +10250,12 @@ References:
 
     *,
     track_gain: Float = Default('0'),track_peak: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 ReplayGain scanner filter. This filter takes an audio stream as an input and
 outputs it unchanged.
 At end of filtering it displays track_gain and track_peak.
@@ -10275,93 +10275,93 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#replaygain)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='replaygain', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "track_gain": track_gain,
-                
+
                 "track_peak": track_peak,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def showcqt(
-    
+
     self,
 
 
@@ -10369,12 +10369,12 @@ References:
 
     *,
     size: Image_size = Default('1920x1080'),fps: Video_rate = Default('25'),bar_h: Int = Default('-1'),axis_h: Int = Default('-1'),sono_h: Int = Default('-1'),fullhd: Boolean = Default('true'),sono_v: String = Default('16'),bar_v: String = Default('sono_v'),sono_g: Float = Default('3'),bar_g: Float = Default('1'),bar_t: Float = Default('1'),timeclamp: Double = Default('0.17'),attack: Double = Default('0'),basefreq: Double = Default('20.0152'),endfreq: Double = Default('20495.6'),coeffclamp: Float = Default('1'),tlength: String = Default('384*tc/(384+tc*f)'),count: Int = Default('6'),fcount: Int = Default('0'),fontfile: String = Default(None),font: String = Default(None),fontcolor: String = Default('st(0, (midi(f)-59.5)/12);st(1, if(between(ld(0),0,1), 0.5-0.5*cos(2*PI*ld(0)), 0));r(1-ld(1)) + b(ld(1))'),axisfile: String = Default(None),axis: Boolean = Default('true'),csp: Int| Literal["unspecified","bt709","fcc","bt470bg","smpte170m","smpte240m","bt2020ncl"] | Default = Default('unspecified'),cscheme: String = Default('1|0.5|0|0|0.5|1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a video output representing frequency spectrum
 logarithmically using Brown-Puckette constant Q transform algorithm with
 direct frequency domain coefficient calculation (but the transform itself
@@ -10420,87 +10420,87 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showcqt)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showcqt', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "fps": fps,
-                
+
                 "bar_h": bar_h,
-                
+
                 "axis_h": axis_h,
-                
+
                 "sono_h": sono_h,
-                
+
                 "fullhd": fullhd,
-                
+
                 "sono_v": sono_v,
-                
+
                 "bar_v": bar_v,
-                
+
                 "sono_g": sono_g,
-                
+
                 "bar_g": bar_g,
-                
+
                 "bar_t": bar_t,
-                
+
                 "timeclamp": timeclamp,
-                
+
                 "attack": attack,
-                
+
                 "basefreq": basefreq,
-                
+
                 "endfreq": endfreq,
-                
+
                 "coeffclamp": coeffclamp,
-                
+
                 "tlength": tlength,
-                
+
                 "count": count,
-                
+
                 "fcount": fcount,
-                
+
                 "fontfile": fontfile,
-                
+
                 "font": font,
-                
+
                 "fontcolor": fontcolor,
-                
+
                 "axisfile": axisfile,
-                
+
                 "axis": axis,
-                
+
                 "csp": csp,
-                
+
                 "cscheme": cscheme,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showcwt(
-    
+
     self,
 
 
@@ -10508,12 +10508,12 @@ References:
 
     *,
     size: Image_size = Default('640x512'),rate: String = Default('25'),scale: Int| Literal["linear","log","bark","mel","erbs","sqrt","cbrt","qdrt","fm"] | Default = Default('linear'),iscale: Int| Literal["linear","log","sqrt","cbrt","qdrt"] | Default = Default('log'),min: Float = Default('20'),max: Float = Default('20000'),imin: Float = Default('0'),imax: Float = Default('1'),logb: Float = Default('0.0001'),deviation: Float = Default('1'),pps: Int = Default('64'),mode: Int| Literal["magnitude","phase","magphase","channel","stereo"] | Default = Default('magnitude'),slide: Int| Literal["replace","scroll","frame"] | Default = Default('replace'),direction: Int| Literal["lr","rl","ud","du"] | Default = Default('lr'),bar: Float = Default('0'),rotation: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to video output representing frequency spectrum
 using Continuous Wavelet Transform and Morlet wavelet.
 
@@ -10546,67 +10546,67 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showcwt)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showcwt', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "rate": rate,
-                
+
                 "scale": scale,
-                
+
                 "iscale": iscale,
-                
+
                 "min": min,
-                
+
                 "max": max,
-                
+
                 "imin": imin,
-                
+
                 "imax": imax,
-                
+
                 "logb": logb,
-                
+
                 "deviation": deviation,
-                
+
                 "pps": pps,
-                
+
                 "mode": mode,
-                
+
                 "slide": slide,
-                
+
                 "direction": direction,
-                
+
                 "bar": bar,
-                
+
                 "rotation": rotation,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showfreqs(
-    
+
     self,
 
 
@@ -10614,12 +10614,12 @@ References:
 
     *,
     size: Image_size = Default('1024x512'),rate: Video_rate = Default('25'),mode: Int| Literal["line","bar","dot"] | Default = Default('bar'),ascale: Int| Literal["lin","sqrt","cbrt","log"] | Default = Default('log'),fscale: Int| Literal["lin","log","rlog"] | Default = Default('lin'),win_size: Int = Default('2048'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('hann'),overlap: Float = Default('1'),averaging: Int = Default('1'),colors: String = Default('red|green|blue|yellow|orange|lime|pink|magenta|brown'),cmode: Int| Literal["combined","separate"] | Default = Default('combined'),minamp: Float = Default('1e-06'),data: Int| Literal["magnitude","phase","delay"] | Default = Default('magnitude'),channels: String = Default('all'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to video output representing the audio power spectrum.
 Audio amplitude is on Y-axis while frequency is on X-axis.
 
@@ -10650,67 +10650,67 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showfreqs)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showfreqs', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "rate": rate,
-                
+
                 "mode": mode,
-                
+
                 "ascale": ascale,
-                
+
                 "fscale": fscale,
-                
+
                 "win_size": win_size,
-                
+
                 "win_func": win_func,
-                
+
                 "overlap": overlap,
-                
+
                 "averaging": averaging,
-                
+
                 "colors": colors,
-                
+
                 "cmode": cmode,
-                
+
                 "minamp": minamp,
-                
+
                 "data": data,
-                
+
                 "channels": channels,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def showspatial(
-    
+
     self,
 
 
@@ -10718,12 +10718,12 @@ References:
 
     *,
     size: Image_size = Default('512x512'),win_size: Int = Default('4096'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('hann'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert stereo input audio to a video output, representing the spatial relationship
 between two channels.
 
@@ -10744,43 +10744,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showspatial)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showspatial', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "win_size": win_size,
-                
+
                 "win_func": win_func,
-                
+
                 "rate": rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showspectrum(
-    
+
     self,
 
 
@@ -10788,12 +10788,12 @@ References:
 
     *,
     size: Image_size = Default('640x512'),slide: Int| Literal["replace","scroll","fullframe","rscroll","lreplace"] | Default = Default('replace'),mode: Int| Literal["combined","separate"] | Default = Default('combined'),color: Int| Literal["channel","intensity","rainbow","moreland","nebulae","fire","fiery","fruit","cool","magma","green","viridis","plasma","cividis","terrain"] | Default = Default('channel'),scale: Int| Literal["lin","sqrt","cbrt","log","4thrt","5thrt"] | Default = Default('sqrt'),fscale: Int| Literal["lin","log"] | Default = Default('lin'),saturation: Float = Default('1'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('hann'),orientation: Int| Literal["vertical","horizontal"] | Default = Default('vertical'),overlap: Float = Default('0'),gain: Float = Default('1'),data: Int| Literal["magnitude","phase","uphase"] | Default = Default('magnitude'),rotation: Float = Default('0'),start: Int = Default('0'),stop: Int = Default('0'),fps: String = Default('auto'),legend: Boolean = Default('false'),drange: Float = Default('120'),limit: Float = Default('0'),opacity: Float = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a video output, representing the audio frequency
 spectrum.
 
@@ -10830,75 +10830,75 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showspectrum)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showspectrum', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "slide": slide,
-                
+
                 "mode": mode,
-                
+
                 "color": color,
-                
+
                 "scale": scale,
-                
+
                 "fscale": fscale,
-                
+
                 "saturation": saturation,
-                
+
                 "win_func": win_func,
-                
+
                 "orientation": orientation,
-                
+
                 "overlap": overlap,
-                
+
                 "gain": gain,
-                
+
                 "data": data,
-                
+
                 "rotation": rotation,
-                
+
                 "start": start,
-                
+
                 "stop": stop,
-                
+
                 "fps": fps,
-                
+
                 "legend": legend,
-                
+
                 "drange": drange,
-                
+
                 "limit": limit,
-                
+
                 "opacity": opacity,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showspectrumpic(
-    
+
     self,
 
 
@@ -10906,12 +10906,12 @@ References:
 
     *,
     size: Image_size = Default('4096x2048'),mode: Int| Literal["combined","separate"] | Default = Default('combined'),color: Int| Literal["channel","intensity","rainbow","moreland","nebulae","fire","fiery","fruit","cool","magma","green","viridis","plasma","cividis","terrain"] | Default = Default('intensity'),scale: Int| Literal["lin","sqrt","cbrt","log","4thrt","5thrt"] | Default = Default('log'),fscale: Int| Literal["lin","log"] | Default = Default('lin'),saturation: Float = Default('1'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('hann'),orientation: Int| Literal["vertical","horizontal"] | Default = Default('vertical'),gain: Float = Default('1'),legend: Boolean = Default('true'),rotation: Float = Default('0'),start: Int = Default('0'),stop: Int = Default('0'),drange: Float = Default('120'),limit: Float = Default('0'),opacity: Float = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a single video frame, representing the audio frequency
 spectrum.
 
@@ -10944,67 +10944,67 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showspectrumpic)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showspectrumpic', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "mode": mode,
-                
+
                 "color": color,
-                
+
                 "scale": scale,
-                
+
                 "fscale": fscale,
-                
+
                 "saturation": saturation,
-                
+
                 "win_func": win_func,
-                
+
                 "orientation": orientation,
-                
+
                 "gain": gain,
-                
+
                 "legend": legend,
-                
+
                 "rotation": rotation,
-                
+
                 "start": start,
-                
+
                 "stop": stop,
-                
+
                 "drange": drange,
-                
+
                 "limit": limit,
-                
+
                 "opacity": opacity,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showvolume(
-    
+
     self,
 
 
@@ -11012,12 +11012,12 @@ References:
 
     *,
     rate: Video_rate = Default('25'),b: Int = Default('1'),w: Int = Default('400'),h: Int = Default('20'),f: Double = Default('0.95'),c: String = Default('PEAK*255+floor((1-PEAK)*255)*256+0xff000000'),t: Boolean = Default('true'),v: Boolean = Default('true'),dm: Double = Default('0'),dmc: Color = Default('orange'),o: Int| Literal["h","v"] | Default = Default('h'),s: Int = Default('0'),p: Float = Default('0'),m: Int| Literal["p","r"] | Default = Default('p'),ds: Int| Literal["lin","log"] | Default = Default('lin'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio volume to a video output.
 
 The filter accepts the following options:
@@ -11048,65 +11048,65 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showvolume)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showvolume', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rate": rate,
-                
+
                 "b": b,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "f": f,
-                
+
                 "c": c,
-                
+
                 "t": t,
-                
+
                 "v": v,
-                
+
                 "dm": dm,
-                
+
                 "dmc": dmc,
-                
+
                 "o": o,
-                
+
                 "s": s,
-                
+
                 "p": p,
-                
+
                 "m": m,
-                
+
                 "ds": ds,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showwaves(
-    
+
     self,
 
 
@@ -11114,12 +11114,12 @@ References:
 
     *,
     size: Image_size = Default('600x240'),mode: Int| Literal["point","line","p2p","cline"] | Default = Default('point'),n: Rational = Default('0/1'),rate: Video_rate = Default('25'),split_channels: Boolean = Default('false'),colors: String = Default('red|green|blue|yellow|orange|lime|pink|magenta|brown'),scale: Int| Literal["lin","log","sqrt","cbrt"] | Default = Default('lin'),draw: Int| Literal["scale","full"] | Default = Default('scale'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a video output, representing the samples waves.
 
 The filter accepts the following options:
@@ -11143,51 +11143,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showwaves)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showwaves', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "mode": mode,
-                
+
                 "n": n,
-                
+
                 "rate": rate,
-                
+
                 "split_channels": split_channels,
-                
+
                 "colors": colors,
-                
+
                 "scale": scale,
-                
+
                 "draw": draw,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showwavespic(
-    
+
     self,
 
 
@@ -11195,12 +11195,12 @@ References:
 
     *,
     size: Image_size = Default('600x240'),split_channels: Boolean = Default('false'),colors: String = Default('red|green|blue|yellow|orange|lime|pink|magenta|brown'),scale: Int| Literal["lin","log","sqrt","cbrt"] | Default = Default('lin'),draw: Int| Literal["scale","full"] | Default = Default('scale'),filter: Int| Literal["average","peak"] | Default = Default('average'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a single video frame, representing the samples waves.
 
 The filter accepts the following options:
@@ -11222,74 +11222,74 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showwavespic)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showwavespic', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "split_channels": split_channels,
-                
+
                 "colors": colors,
-                
+
                 "scale": scale,
-                
+
                 "draw": draw,
-                
+
                 "filter": filter,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def sidechaincompress(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _sidechain: AudioStream,
-        
-    
+
+
 
 
     *,
     level_in: Double = Default('1'),mode: Int| Literal["downward","upward"] | Default = Default('downward'),threshold: Double = Default('0.125'),ratio: Double = Default('2'),attack: Double = Default('20'),release: Double = Default('250'),makeup: Double = Default('1'),knee: Double = Default('2.82843'),link: Int| Literal["average","maximum"] | Default = Default('average'),detection: Int| Literal["peak","rms"] | Default = Default('rms'),level_sc: Double = Default('1'),mix: Double = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 This filter acts like normal compressor but has the ability to compress
 detected signal using second input signal.
 It needs two input streams and returns one output stream.
@@ -11322,91 +11322,91 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sidechaincompress)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sidechaincompress', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _sidechain,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "mode": mode,
-                
+
                 "threshold": threshold,
-                
+
                 "ratio": ratio,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "makeup": makeup,
-                
+
                 "knee": knee,
-                
+
                 "link": link,
-                
+
                 "detection": detection,
-                
+
                 "level_sc": level_sc,
-                
+
                 "mix": mix,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def sidechaingate(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _sidechain: AudioStream,
-        
-    
+
+
 
 
     *,
     level_in: Double = Default('1'),mode: Int| Literal["downward","upward"] | Default = Default('downward'),range: Double = Default('0.06125'),threshold: Double = Default('0.125'),ratio: Double = Default('2'),attack: Double = Default('20'),release: Double = Default('250'),makeup: Double = Default('1'),knee: Double = Default('2.82843'),detection: Int| Literal["peak","rms"] | Default = Default('rms'),link: Int| Literal["average","maximum"] | Default = Default('average'),level_sc: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 A sidechain gate acts like a normal (wideband) gate but has the ability to
 filter the detected signal before sending it to the gain reduction stage.
 Normally a gate uses the full range signal to detect a level above the
@@ -11445,7 +11445,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sidechaingate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11453,72 +11453,72 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sidechaingate', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _sidechain,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "mode": mode,
-                
+
                 "range": range,
-                
+
                 "threshold": threshold,
-                
+
                 "ratio": ratio,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "makeup": makeup,
-                
+
                 "knee": knee,
-                
+
                 "detection": detection,
-                
+
                 "link": link,
-                
+
                 "level_sc": level_sc,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def silencedetect(
-    
+
     self,
 
 
@@ -11526,12 +11526,12 @@ References:
 
     *,
     n: Double = Default('0.001'),d: Duration = Default('2'),mono: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Detect silence in an audio stream.
 
 This filter logs a message when it detects that the input audio volume is less
@@ -11565,41 +11565,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#silencedetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='silencedetect', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "n": n,
-                
+
                 "d": d,
-                
+
                 "mono": mono,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def silenceremove(
-    
+
     self,
 
 
@@ -11607,15 +11607,15 @@ References:
 
     *,
     start_periods: Int = Default('0'),start_duration: Duration = Default('0'),start_threshold: Double = Default('0'),start_silence: Duration = Default('0'),start_mode: Int| Literal["any","all"] | Default = Default('any'),stop_periods: Int = Default('0'),stop_duration: Duration = Default('0'),stop_threshold: Double = Default('0'),stop_silence: Duration = Default('0'),stop_mode: Int| Literal["any","all"] | Default = Default('all'),detection: Int| Literal["avg","rms","peak","median","ptp","dev"] | Default = Default('rms'),window: Duration = Default('0.02'),timestamp: Int| Literal["write","copy"] | Default = Default('write'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Remove silence from the beginning, middle or end of the audio.
 
 The filter accepts the following options:
@@ -11645,7 +11645,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#silenceremove)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11653,76 +11653,76 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='silenceremove', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "start_periods": start_periods,
-                
+
                 "start_duration": start_duration,
-                
+
                 "start_threshold": start_threshold,
-                
+
                 "start_silence": start_silence,
-                
+
                 "start_mode": start_mode,
-                
+
                 "stop_periods": stop_periods,
-                
+
                 "stop_duration": stop_duration,
-                
+
                 "stop_threshold": stop_threshold,
-                
+
                 "stop_silence": stop_silence,
-                
+
                 "stop_mode": stop_mode,
-                
+
                 "detection": detection,
-                
+
                 "window": window,
-                
+
                 "timestamp": timestamp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def speechnorm(
-    
+
     self,
 
 
@@ -11730,15 +11730,15 @@ References:
 
     *,
     peak: Double = Default('0.95'),expansion: Double = Default('2'),compression: Double = Default('2'),threshold: Double = Default('0'),_raise: Double = Default('0.001'),fall: Double = Default('0.001'),channels: String = Default('all'),invert: Boolean = Default('false'),link: Boolean = Default('false'),rms: Double = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Speech Normalizer.
 
 This filter expands or compresses each half-cycle of audio samples
@@ -11769,7 +11769,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#speechnorm)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11777,62 +11777,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='speechnorm', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "peak": peak,
-                
+
                 "expansion": expansion,
-                
+
                 "compression": compression,
-                
+
                 "threshold": threshold,
-                
+
                 "raise": _raise,
-                
+
                 "fall": fall,
-                
+
                 "channels": channels,
-                
+
                 "invert": invert,
-                
+
                 "link": link,
-                
+
                 "rms": rms,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def stereotools(
-    
+
     self,
 
 
@@ -11840,15 +11840,15 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),balance_in: Double = Default('0'),balance_out: Double = Default('0'),softclip: Boolean = Default('false'),mutel: Boolean = Default('false'),muter: Boolean = Default('false'),phasel: Boolean = Default('false'),phaser: Boolean = Default('false'),mode: Int| Literal["lr>lr","lr>ms","ms>lr","lr>ll","lr>rr","lr>l+r","lr>rl","ms>ll","ms>rr","ms>rl","lr>l-r"] | Default = Default('lr>lr'),slev: Double = Default('1'),sbal: Double = Default('0'),mlev: Double = Default('1'),mpan: Double = Default('0'),base: Double = Default('0'),delay: Double = Default('0'),sclevel: Double = Default('1'),phase: Double = Default('0'),bmode_in: Int| Literal["balance","amplitude","power"] | Default = Default('balance'),bmode_out: Int| Literal["balance","amplitude","power"] | Default = Default('balance'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 This filter has some handy utilities to manage stereo signals, for converting
 M/S stereo recordings to L/R signal while having control over the parameters
 or spreading the stereo image of master track.
@@ -11887,7 +11887,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#stereotools)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11895,72 +11895,72 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='stereotools', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "balance_in": balance_in,
-                
+
                 "balance_out": balance_out,
-                
+
                 "softclip": softclip,
-                
+
                 "mutel": mutel,
-                
+
                 "muter": muter,
-                
+
                 "phasel": phasel,
-                
+
                 "phaser": phaser,
-                
+
                 "mode": mode,
-                
+
                 "slev": slev,
-                
+
                 "sbal": sbal,
-                
+
                 "mlev": mlev,
-                
+
                 "mpan": mpan,
-                
+
                 "base": base,
-                
+
                 "delay": delay,
-                
+
                 "sclevel": sclevel,
-                
+
                 "phase": phase,
-                
+
                 "bmode_in": bmode_in,
-                
+
                 "bmode_out": bmode_out,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def stereowiden(
-    
+
     self,
 
 
@@ -11968,15 +11968,15 @@ References:
 
     *,
     delay: Float = Default('20'),feedback: Float = Default('0.3'),crossfeed: Float = Default('0.3'),drymix: Float = Default('0.8'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 This filter enhance the stereo effect by suppressing signal common to both
 channels and by delaying the signal of left into right and vice versa,
 thereby widening the stereo effect.
@@ -11999,7 +11999,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#stereowiden)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12007,46 +12007,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='stereowiden', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "delay": delay,
-                
+
                 "feedback": feedback,
-                
+
                 "crossfeed": crossfeed,
-                
+
                 "drymix": drymix,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def superequalizer(
-    
+
     self,
 
 
@@ -12054,12 +12054,12 @@ References:
 
     *,
     _1b: Float = Default('1'),_2b: Float = Default('1'),_3b: Float = Default('1'),_4b: Float = Default('1'),_5b: Float = Default('1'),_6b: Float = Default('1'),_7b: Float = Default('1'),_8b: Float = Default('1'),_9b: Float = Default('1'),_10b: Float = Default('1'),_11b: Float = Default('1'),_12b: Float = Default('1'),_13b: Float = Default('1'),_14b: Float = Default('1'),_15b: Float = Default('1'),_16b: Float = Default('1'),_17b: Float = Default('1'),_18b: Float = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply 18 band equalizer.
 
 The filter accepts the following options:
@@ -12093,71 +12093,71 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#superequalizer)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='superequalizer', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "1b": _1b,
-                
+
                 "2b": _2b,
-                
+
                 "3b": _3b,
-                
+
                 "4b": _4b,
-                
+
                 "5b": _5b,
-                
+
                 "6b": _6b,
-                
+
                 "7b": _7b,
-                
+
                 "8b": _8b,
-                
+
                 "9b": _9b,
-                
+
                 "10b": _10b,
-                
+
                 "11b": _11b,
-                
+
                 "12b": _12b,
-                
+
                 "13b": _13b,
-                
+
                 "14b": _14b,
-                
+
                 "15b": _15b,
-                
+
                 "16b": _16b,
-                
+
                 "17b": _17b,
-                
+
                 "18b": _18b,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def surround(
-    
+
     self,
 
 
@@ -12165,12 +12165,12 @@ References:
 
     *,
     chl_out: String = Default('5.1'),chl_in: String = Default('stereo'),level_in: Float = Default('1'),level_out: Float = Default('1'),lfe: Boolean = Default('true'),lfe_low: Int = Default('128'),lfe_high: Int = Default('256'),lfe_mode: Int| Literal["add","sub"] | Default = Default('add'),smooth: Float = Default('0'),angle: Float = Default('90'),focus: Float = Default('0'),fc_in: Float = Default('1'),fc_out: Float = Default('1'),fl_in: Float = Default('1'),fl_out: Float = Default('1'),fr_in: Float = Default('1'),fr_out: Float = Default('1'),sl_in: Float = Default('1'),sl_out: Float = Default('1'),sr_in: Float = Default('1'),sr_out: Float = Default('1'),bl_in: Float = Default('1'),bl_out: Float = Default('1'),br_in: Float = Default('1'),br_out: Float = Default('1'),bc_in: Float = Default('1'),bc_out: Float = Default('1'),lfe_in: Float = Default('1'),lfe_out: Float = Default('1'),allx: Float = Default('-1'),ally: Float = Default('-1'),fcx: Float = Default('0.5'),flx: Float = Default('0.5'),frx: Float = Default('0.5'),blx: Float = Default('0.5'),brx: Float = Default('0.5'),slx: Float = Default('0.5'),srx: Float = Default('0.5'),bcx: Float = Default('0.5'),fcy: Float = Default('0.5'),fly: Float = Default('0.5'),fry: Float = Default('0.5'),bly: Float = Default('0.5'),bry: Float = Default('0.5'),sly: Float = Default('0.5'),sry: Float = Default('0.5'),bcy: Float = Default('0.5'),win_size: Int = Default('4096'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('hann'),overlap: Float = Default('0.5'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply audio surround upmix filter.
 
 This filter allows to produce multichannel output from audio stream.
@@ -12238,157 +12238,157 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#surround)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='surround', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "chl_out": chl_out,
-                
+
                 "chl_in": chl_in,
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "lfe": lfe,
-                
+
                 "lfe_low": lfe_low,
-                
+
                 "lfe_high": lfe_high,
-                
+
                 "lfe_mode": lfe_mode,
-                
+
                 "smooth": smooth,
-                
+
                 "angle": angle,
-                
+
                 "focus": focus,
-                
+
                 "fc_in": fc_in,
-                
+
                 "fc_out": fc_out,
-                
+
                 "fl_in": fl_in,
-                
+
                 "fl_out": fl_out,
-                
+
                 "fr_in": fr_in,
-                
+
                 "fr_out": fr_out,
-                
+
                 "sl_in": sl_in,
-                
+
                 "sl_out": sl_out,
-                
+
                 "sr_in": sr_in,
-                
+
                 "sr_out": sr_out,
-                
+
                 "bl_in": bl_in,
-                
+
                 "bl_out": bl_out,
-                
+
                 "br_in": br_in,
-                
+
                 "br_out": br_out,
-                
+
                 "bc_in": bc_in,
-                
+
                 "bc_out": bc_out,
-                
+
                 "lfe_in": lfe_in,
-                
+
                 "lfe_out": lfe_out,
-                
+
                 "allx": allx,
-                
+
                 "ally": ally,
-                
+
                 "fcx": fcx,
-                
+
                 "flx": flx,
-                
+
                 "frx": frx,
-                
+
                 "blx": blx,
-                
+
                 "brx": brx,
-                
+
                 "slx": slx,
-                
+
                 "srx": srx,
-                
+
                 "bcx": bcx,
-                
+
                 "fcy": fcy,
-                
+
                 "fly": fly,
-                
+
                 "fry": fry,
-                
+
                 "bly": bly,
-                
+
                 "bry": bry,
-                
+
                 "sly": sly,
-                
+
                 "sry": sry,
-                
+
                 "bcy": bcy,
-                
+
                 "win_size": win_size,
-                
+
                 "win_func": win_func,
-                
+
                 "overlap": overlap,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def tiltshelf(
-    
+
     self,
 
 
@@ -12396,15 +12396,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),gain: Double = Default('0'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Boost or cut the lower frequencies and cut or boost higher frequencies
 of the audio using a two-pole shelving filter with a response similar to
 that of a standard hi-fi's tone-controls.
@@ -12435,7 +12435,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tiltshelf)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12443,78 +12443,78 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tiltshelf', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "gain": gain,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def treble(
-    
+
     self,
 
 
@@ -12522,15 +12522,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),gain: Double = Default('0'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Boost or cut treble (upper) frequencies of the audio using a two-pole
 shelving filter with a response similar to that of a standard
 hi-fi's tone-controls. This is also known as shelving equalisation (EQ).
@@ -12560,7 +12560,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#treble)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12568,54 +12568,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='treble', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "gain": gain,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tremolo(
-    
+
     self,
 
 
@@ -12623,15 +12623,15 @@ References:
 
     *,
     f: Double = Default('5'),d: Double = Default('0.5'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Sinusoidal amplitude modulation.
 
 The filter accepts the following options:
@@ -12650,7 +12650,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tremolo)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12658,62 +12658,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tremolo', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "f": f,
-                
+
                 "d": d,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def vibrato(
-    
+
     self,
 
 
@@ -12721,15 +12721,15 @@ References:
 
     *,
     f: Double = Default('5'),d: Double = Default('0.5'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Sinusoidal phase modulation.
 
 The filter accepts the following options:
@@ -12748,7 +12748,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vibrato)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12756,44 +12756,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vibrato', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "f": f,
-                
+
                 "d": d,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def virtualbass(
-    
+
     self,
 
 
@@ -12801,15 +12801,15 @@ References:
 
     *,
     cutoff: Double = Default('250'),strength: Double = Default('3'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply audio Virtual Bass filter.
 
 This filter accepts stereo input and produce stereo with LFE (2.1) channels output.
@@ -12832,7 +12832,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#virtualbass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12840,38 +12840,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='virtualbass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cutoff": cutoff,
-                
+
                 "strength": strength,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def volume(
-    
+
     self,
 
 
@@ -12879,15 +12879,15 @@ References:
 
     *,
     volume: String = Default('1.0'),precision: Int| Literal["fixed","float","double"] | Default = Default('float'),eval: Int| Literal["once","frame"] | Default = Default('once'),replaygain: Int| Literal["drop","ignore","track","album"] | Default = Default('drop'),replaygain_preamp: Double = Default('0'),replaygain_noclip: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Adjust the input audio volume.
 
 It accepts the following parameters:
@@ -12910,7 +12910,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#volume)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12918,57 +12918,57 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='volume', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "volume": volume,
-                
+
                 "precision": precision,
-                
+
                 "eval": eval,
-                
+
                 "replaygain": replaygain,
-                
+
                 "replaygain_preamp": replaygain_preamp,
-                
+
                 "replaygain_noclip": replaygain_noclip,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def volumedetect(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Detect the volume of the input video.
 
 The filter has no parameters. It supports only 16-bit signed integer samples,
@@ -12993,67 +12993,23 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#volumedetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='volumedetect', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
-
-
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    

--- a/packages/v7/src/ffmpeg/streams/video.py
+++ b/packages/v7/src/ffmpeg/streams/video.py
@@ -48,38 +48,38 @@ class VideoStream(FilterableStream):
     Video stream.
     """
 
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def addroi(
-    
+
     self,
 
 
@@ -87,12 +87,12 @@ class VideoStream(FilterableStream):
 
     *,
     x: String = Default('0'),y: String = Default('0'),w: String = Default('0'),h: String = Default('0'),qoffset: Rational = Default('-1/10'),clear: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Mark a region of interest in a video frame.
 
 The frame data is passed through unchanged, but metadata is attached
@@ -117,132 +117,132 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#addroi)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='addroi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "qoffset": qoffset,
-                
+
                 "clear": clear,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def alphaextract(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Extract the alpha component from the input as a grayscale video. This
 is especially useful with the alphamerge filter.
 
@@ -257,64 +257,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#alphaextract)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='alphaextract', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def alphamerge(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _alpha: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Add or replace the alpha component of the primary input with the
 grayscale value of a second input. This is intended for use with
 alphaextract to allow the transmission or storage of frame
@@ -340,7 +340,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#alphamerge)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -351,50 +351,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='alphamerge', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _alpha,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def amplify(
-    
+
     self,
 
 
@@ -402,15 +402,15 @@ References:
 
     *,
     radius: Int = Default('2'),factor: Float = Default('2'),threshold: Float = Default('10'),tolerance: Float = Default('0'),low: Float = Default('65535'),high: Float = Default('65535'),planes: Flags = Default('7'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Amplify differences between current pixel and pixels of adjacent frames in
 same pixel location.
 
@@ -435,7 +435,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amplify)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -443,118 +443,118 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='amplify', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "radius": radius,
-                
+
                 "factor": factor,
-                
+
                 "threshold": threshold,
-                
+
                 "tolerance": tolerance,
-                
+
                 "low": low,
-                
+
                 "high": high,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def ass(
-    
+
     self,
 
 
@@ -562,12 +562,12 @@ References:
 
     *,
     filename: String = Default(None),original_size: Image_size = Default(None),fontsdir: String = Default(None),alpha: Boolean = Default('false'),shaping: Int| Literal["auto","simple","complex"] | Default = Default('auto'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Same as the subtitles filter, except that it doesn't require libavcodec
 and libavformat to work. On the other hand, it is limited to ASS (Advanced
 Substation Alpha) subtitles files.
@@ -591,59 +591,59 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ass)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ass', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "filename": filename,
-                
+
                 "original_size": original_size,
-                
+
                 "fontsdir": fontsdir,
-                
+
                 "alpha": alpha,
-                
+
                 "shaping": shaping,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def atadenoise(
-    
+
     self,
 
 
@@ -651,15 +651,15 @@ References:
 
     *,
     _0a: Float = Default('0.02'),_0b: Float = Default('0.04'),_1a: Float = Default('0.02'),_1b: Float = Default('0.04'),_2a: Float = Default('0.02'),_2b: Float = Default('0.04'),s: Int = Default('9'),p: Flags = Default('7'),a: Int| Literal["p","s"] | Default = Default('p'),_0s: Float = Default('32767'),_1s: Float = Default('32767'),_2s: Float = Default('32767'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply an Adaptive Temporal Averaging Denoiser to the video input.
 
 The filter accepts the following options:
@@ -688,7 +688,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#atadenoise)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -696,64 +696,64 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='atadenoise', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "0a": _0a,
-                
+
                 "0b": _0b,
-                
+
                 "1a": _1a,
-                
+
                 "1b": _1b,
-                
+
                 "2a": _2a,
-                
+
                 "2b": _2b,
-                
+
                 "s": s,
-                
+
                 "p": p,
-                
+
                 "a": a,
-                
+
                 "0s": _0s,
-                
+
                 "1s": _1s,
-                
+
                 "2s": _2s,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def avgblur(
-    
+
     self,
 
 
@@ -761,15 +761,15 @@ References:
 
     *,
     sizeX: Int = Default('1'),planes: Int = Default('15'),sizeY: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply average blur filter.
 
 The filter accepts the following options:
@@ -789,7 +789,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#avgblur)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -797,38 +797,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='avgblur', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sizeX": sizeX,
-                
+
                 "planes": planes,
-                
+
                 "sizeY": sizeY,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def avgblur_opencl(
-    
+
     self,
 
 
@@ -836,12 +836,12 @@ References:
 
     *,
     sizeX: Int = Default('1'),planes: Int = Default('15'),sizeY: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply average blur filter.
 
 The filter accepts the following options:
@@ -860,47 +860,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#avgblur_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='avgblur_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sizeX": sizeX,
-                
+
                 "planes": planes,
-                
+
                 "sizeY": sizeY,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def backgroundkey(
-    
+
     self,
 
 
@@ -908,15 +908,15 @@ References:
 
     *,
     threshold: Float = Default('0.08'),similarity: Float = Default('0.1'),blend: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Turns a static background into transparency.
 
 The filter accepts the following option:
@@ -936,7 +936,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#backgroundkey)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -944,44 +944,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='backgroundkey', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold": threshold,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def bbox(
-    
+
     self,
 
 
@@ -989,15 +989,15 @@ References:
 
     *,
     min_val: Int = Default('16'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Compute the bounding box for the non-black pixels in the input frame
 luma plane.
 
@@ -1021,7 +1021,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bbox)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1029,34 +1029,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bbox', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "min_val": min_val,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def bench(
-    
+
     self,
 
 
@@ -1064,12 +1064,12 @@ References:
 
     *,
     action: Int| Literal["start","stop"] | Default = Default('start'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Benchmark part of a filtergraph.
 
 The filter accepts the following options:
@@ -1086,37 +1086,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bench)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bench', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "action": action,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def bilateral(
-    
+
     self,
 
 
@@ -1124,15 +1124,15 @@ References:
 
     *,
     sigmaS: Float = Default('0.1'),sigmaR: Float = Default('0.1'),planes: Int = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply bilateral filter, spatial smoothing while preserving edges.
 
 The filter accepts the following options:
@@ -1152,7 +1152,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bilateral)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1160,40 +1160,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bilateral', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sigmaS": sigmaS,
-                
+
                 "sigmaR": sigmaR,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def bitplanenoise(
-    
+
     self,
 
 
@@ -1201,15 +1201,15 @@ References:
 
     *,
     bitplane: Int = Default('1'),filter: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Show and measure bit plane noise.
 
 The filter accepts the following options:
@@ -1228,7 +1228,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bitplanenoise)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1236,36 +1236,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bitplanenoise', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "bitplane": bitplane,
-                
+
                 "filter": filter,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def blackdetect(
-    
+
     self,
 
 
@@ -1273,12 +1273,12 @@ References:
 
     *,
     d: Double = Default('2'),picture_black_ratio_th: Double = Default('0.98'),pixel_black_th: Double = Default('0.1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect video intervals that are (almost) completely black. Can be
 useful to detect chapter transitions, commercials, or invalid
 recordings.
@@ -1312,41 +1312,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blackdetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='blackdetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "d": d,
-                
+
                 "picture_black_ratio_th": picture_black_ratio_th,
-                
+
                 "pixel_black_th": pixel_black_th,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def blackframe(
-    
+
     self,
 
 
@@ -1354,12 +1354,12 @@ References:
 
     *,
     amount: Int = Default('98'),threshold: Int = Default('32'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect frames that are (almost) completely black. Can be useful to
 detect chapter transitions or commercials. Output lines consist of
 the frame number of the detected frame, the percentage of blackness,
@@ -1387,68 +1387,68 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blackframe)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='blackframe', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "amount": amount,
-                
+
                 "threshold": threshold,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def blend(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _bottom: VideoStream,
-        
-    
+
+
 
 
     *,
     c0_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c1_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c2_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c3_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),all_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('-1'),c0_expr: String = Default(None),c1_expr: String = Default(None),c2_expr: String = Default(None),c3_expr: String = Default(None),all_expr: String = Default(None),c0_opacity: Double = Default('1'),c1_opacity: Double = Default('1'),c2_opacity: Double = Default('1'),c3_opacity: Double = Default('1'),all_opacity: Double = Default('1'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Blend two video frames into each other.
 
 The blend filter takes two input streams and outputs one
@@ -1489,7 +1489,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blend)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -1500,72 +1500,72 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='blend', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _bottom,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "c0_mode": c0_mode,
-                
+
                 "c1_mode": c1_mode,
-                
+
                 "c2_mode": c2_mode,
-                
+
                 "c3_mode": c3_mode,
-                
+
                 "all_mode": all_mode,
-                
+
                 "c0_expr": c0_expr,
-                
+
                 "c1_expr": c1_expr,
-                
+
                 "c2_expr": c2_expr,
-                
+
                 "c3_expr": c3_expr,
-                
+
                 "all_expr": all_expr,
-                
+
                 "c0_opacity": c0_opacity,
-                
+
                 "c1_opacity": c1_opacity,
-                
+
                 "c2_opacity": c2_opacity,
-                
+
                 "c3_opacity": c3_opacity,
-                
+
                 "all_opacity": all_opacity,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def blockdetect(
-    
+
     self,
 
 
@@ -1573,12 +1573,12 @@ References:
 
     *,
     period_min: Int = Default('3'),period_max: Int = Default('24'),planes: Int = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Determines blockiness of frames without altering the input frames.
 
 Based on Remco Muijs and Ihor Kirenko: "A no-reference blocking artifact measure for adaptive video processing." 2005 13th European signal processing conference.
@@ -1599,41 +1599,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blockdetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='blockdetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "period_min": period_min,
-                
+
                 "period_max": period_max,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def blurdetect(
-    
+
     self,
 
 
@@ -1641,12 +1641,12 @@ References:
 
     *,
     high: Float = Default('0.117647'),low: Float = Default('0.0588235'),radius: Int = Default('50'),block_pct: Int = Default('80'),block_width: Int = Default('-1'),planes: Int = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Determines blurriness of frames without altering the input frames.
 
 Based on Marziliano, Pina, et al. "A no-reference perceptual blur metric."
@@ -1671,49 +1671,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blurdetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='blurdetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "high": high,
-                
+
                 "low": low,
-                
+
                 "radius": radius,
-                
+
                 "block_pct": block_pct,
-                
+
                 "block_width": block_width,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def boxblur(
-    
+
     self,
 
 
@@ -1721,15 +1721,15 @@ References:
 
     *,
     luma_radius: String = Default('2'),luma_power: Int = Default('2'),chroma_radius: String = Default(None),chroma_power: Int = Default('-1'),alpha_radius: String = Default(None),alpha_power: Int = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a boxblur algorithm to the input video.
 
 It accepts the following parameters:
@@ -1752,7 +1752,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#boxblur)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1760,44 +1760,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='boxblur', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_radius": luma_radius,
-                
+
                 "luma_power": luma_power,
-                
+
                 "chroma_radius": chroma_radius,
-                
+
                 "chroma_power": chroma_power,
-                
+
                 "alpha_radius": alpha_radius,
-                
+
                 "alpha_power": alpha_power,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def boxblur_opencl(
-    
+
     self,
 
 
@@ -1805,12 +1805,12 @@ References:
 
     *,
     luma_radius: String = Default('2'),luma_power: Int = Default('2'),chroma_radius: String = Default(None),chroma_power: Int = Default('-1'),alpha_radius: String = Default(None),alpha_power: Int = Default('-1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a boxblur algorithm to the input video.
 
 It accepts the following parameters:
@@ -1832,51 +1832,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#boxblur_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='boxblur_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_radius": luma_radius,
-                
+
                 "luma_power": luma_power,
-                
+
                 "chroma_radius": chroma_radius,
-                
+
                 "chroma_power": chroma_power,
-                
+
                 "alpha_radius": alpha_radius,
-                
+
                 "alpha_power": alpha_power,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def bwdif(
-    
+
     self,
 
 
@@ -1884,15 +1884,15 @@ References:
 
     *,
     mode: Int| Literal["send_frame","send_field"] | Default = Default('send_field'),parity: Int| Literal["tff","bff","auto"] | Default = Default('auto'),deint: Int| Literal["all","interlaced"] | Default = Default('all'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlace the input video ("bwdif" stands for "Bob Weaver
 Deinterlacing Filter").
 
@@ -1915,7 +1915,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bwdif)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1923,38 +1923,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bwdif', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "parity": parity,
-                
+
                 "deint": deint,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def cas(
-    
+
     self,
 
 
@@ -1962,15 +1962,15 @@ References:
 
     *,
     strength: Float = Default('0'),planes: Flags = Default('7'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Contrast Adaptive Sharpen filter to video stream.
 
 The filter accepts the following options:
@@ -1989,7 +1989,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#cas)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1997,49 +1997,49 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='cas', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "strength": strength,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ccrepack(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Repack CEA-708 closed captioning side data
 
 This filter fixes various issues seen with commerical encoders
@@ -2059,43 +2059,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ccrepack)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ccrepack', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def chromahold(
-    
+
     self,
 
 
@@ -2103,15 +2103,15 @@ References:
 
     *,
     color: Color = Default('black'),similarity: Float = Default('0.01'),blend: Float = Default('0'),yuv: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove all color information for all colors except for certain one.
 
 The filter accepts the following options:
@@ -2132,7 +2132,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#chromahold)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2140,40 +2140,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='chromahold', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "color": color,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
                 "yuv": yuv,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def chromakey(
-    
+
     self,
 
 
@@ -2181,15 +2181,15 @@ References:
 
     *,
     color: Color = Default('black'),similarity: Float = Default('0.01'),blend: Float = Default('0'),yuv: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 YUV colorspace color/chroma keying.
 
 The filter accepts the following options:
@@ -2210,7 +2210,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#chromakey)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2218,40 +2218,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='chromakey', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "color": color,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
                 "yuv": yuv,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def chromanr(
-    
+
     self,
 
 
@@ -2259,15 +2259,15 @@ References:
 
     *,
     thres: Float = Default('30'),sizew: Int = Default('5'),sizeh: Int = Default('5'),stepw: Int = Default('1'),steph: Int = Default('1'),threy: Float = Default('200'),threu: Float = Default('200'),threv: Float = Default('200'),distance: Int| Literal["manhattan","euclidean"] | Default = Default('manhattan'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reduce chrominance noise.
 
 The filter accepts the following options:
@@ -2293,7 +2293,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#chromanr)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2301,50 +2301,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='chromanr', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "thres": thres,
-                
+
                 "sizew": sizew,
-                
+
                 "sizeh": sizeh,
-                
+
                 "stepw": stepw,
-                
+
                 "steph": steph,
-                
+
                 "threy": threy,
-                
+
                 "threu": threu,
-                
+
                 "threv": threv,
-                
+
                 "distance": distance,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def chromashift(
-    
+
     self,
 
 
@@ -2352,15 +2352,15 @@ References:
 
     *,
     cbh: Int = Default('0'),cbv: Int = Default('0'),crh: Int = Default('0'),crv: Int = Default('0'),edge: Int| Literal["smear","wrap"] | Default = Default('smear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Shift chroma pixels horizontally and/or vertically.
 
 The filter accepts the following options:
@@ -2382,7 +2382,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#chromashift)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2390,42 +2390,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='chromashift', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cbh": cbh,
-                
+
                 "cbv": cbv,
-                
+
                 "crh": crh,
-                
+
                 "crv": crv,
-                
+
                 "edge": edge,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ciescope(
-    
+
     self,
 
 
@@ -2433,12 +2433,12 @@ References:
 
     *,
     system: Int| Literal["ntsc","470m","ebu","470bg","smpte","240m","apple","widergb","cie1931","hdtv","rec709","uhdtv","rec2020","dcip3"] | Default = Default('hdtv'),cie: Int| Literal["xyy","ucs","luv"] | Default = Default('xyy'),gamuts: Flags| Literal["ntsc","470m","ebu","470bg","smpte","240m","apple","widergb","cie1931","hdtv","rec709","uhdtv","rec2020","dcip3"] | Default = Default('0'),size: Int = Default('512'),intensity: Float = Default('0.001'),contrast: Float = Default('0.75'),corrgamma: Boolean = Default('true'),showwhite: Boolean = Default('false'),gamma: Double = Default('2.6'),fill: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Display CIE color diagram with pixels overlaid onto it.
 
 The filter accepts the following options:
@@ -2464,55 +2464,55 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ciescope)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ciescope', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "system": system,
-                
+
                 "cie": cie,
-                
+
                 "gamuts": gamuts,
-                
+
                 "size": size,
-                
+
                 "intensity": intensity,
-                
+
                 "contrast": contrast,
-                
+
                 "corrgamma": corrgamma,
-                
+
                 "showwhite": showwhite,
-                
+
                 "gamma": gamma,
-                
+
                 "fill": fill,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def codecview(
-    
+
     self,
 
 
@@ -2520,15 +2520,15 @@ References:
 
     *,
     mv: Flags| Literal["pf","bf","bb"] | Default = Default('0'),qp: Boolean = Default('false'),mv_type: Flags| Literal["fp","bp"] | Default = Default('0'),frame_type: Flags| Literal["if","pf","bf"] | Default = Default('0'),block: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Visualize information exported by some codecs.
 
 Some codecs can export information through frames using side-data or other
@@ -2554,7 +2554,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#codecview)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2562,44 +2562,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='codecview', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mv": mv,
-                
+
                 "qp": qp,
-                
+
                 "mv_type": mv_type,
-                
+
                 "frame_type": frame_type,
-                
+
                 "block": block,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def colorbalance(
-    
+
     self,
 
 
@@ -2607,15 +2607,15 @@ References:
 
     *,
     rs: Float = Default('0'),gs: Float = Default('0'),bs: Float = Default('0'),rm: Float = Default('0'),gm: Float = Default('0'),bm: Float = Default('0'),rh: Float = Default('0'),gh: Float = Default('0'),bh: Float = Default('0'),pl: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Modify intensity of primary colors (red, green and blue) of input frames.
 
 The filter allows an input frame to be adjusted in the shadows, midtones or highlights
@@ -2648,7 +2648,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorbalance)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2656,52 +2656,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorbalance', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rs": rs,
-                
+
                 "gs": gs,
-                
+
                 "bs": bs,
-                
+
                 "rm": rm,
-                
+
                 "gm": gm,
-                
+
                 "bm": bm,
-                
+
                 "rh": rh,
-                
+
                 "gh": gh,
-                
+
                 "bh": bh,
-                
+
                 "pl": pl,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorchannelmixer(
-    
+
     self,
 
 
@@ -2709,15 +2709,15 @@ References:
 
     *,
     rr: Double = Default('1'),rg: Double = Default('0'),rb: Double = Default('0'),ra: Double = Default('0'),gr: Double = Default('0'),gg: Double = Default('1'),gb: Double = Default('0'),ga: Double = Default('0'),br: Double = Default('0'),bg: Double = Default('0'),bb: Double = Default('1'),ba: Double = Default('0'),ar: Double = Default('0'),ag: Double = Default('0'),ab: Double = Default('0'),aa: Double = Default('1'),pc: Int| Literal["none","lum","max","avg","sum","nrm","pwr"] | Default = Default('none'),pa: Double = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust video input frames by re-mixing color channels.
 
 This filter modifies a color channel by adding the values associated to
@@ -2759,7 +2759,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorchannelmixer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2767,70 +2767,70 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorchannelmixer', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rr": rr,
-                
+
                 "rg": rg,
-                
+
                 "rb": rb,
-                
+
                 "ra": ra,
-                
+
                 "gr": gr,
-                
+
                 "gg": gg,
-                
+
                 "gb": gb,
-                
+
                 "ga": ga,
-                
+
                 "br": br,
-                
+
                 "bg": bg,
-                
+
                 "bb": bb,
-                
+
                 "ba": ba,
-                
+
                 "ar": ar,
-                
+
                 "ag": ag,
-                
+
                 "ab": ab,
-                
+
                 "aa": aa,
-                
+
                 "pc": pc,
-                
+
                 "pa": pa,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def colorcontrast(
-    
+
     self,
 
 
@@ -2838,15 +2838,15 @@ References:
 
     *,
     rc: Float = Default('0'),gm: Float = Default('0'),by: Float = Default('0'),rcw: Float = Default('0'),gmw: Float = Default('0'),byw: Float = Default('0'),pl: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust color contrast between RGB components.
 
 The filter accepts the following options:
@@ -2870,7 +2870,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorcontrast)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2878,46 +2878,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorcontrast', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rc": rc,
-                
+
                 "gm": gm,
-                
+
                 "by": by,
-                
+
                 "rcw": rcw,
-                
+
                 "gmw": gmw,
-                
+
                 "byw": byw,
-                
+
                 "pl": pl,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorcorrect(
-    
+
     self,
 
 
@@ -2925,15 +2925,15 @@ References:
 
     *,
     rl: Float = Default('0'),bl: Float = Default('0'),rh: Float = Default('0'),bh: Float = Default('0'),saturation: Float = Default('1'),analyze: Int| Literal["manual","average","minmax","median"] | Default = Default('manual'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust color white balance selectively for blacks and whites.
 This filter operates in YUV colorspace.
 
@@ -2957,7 +2957,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorcorrect)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2965,44 +2965,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorcorrect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rl": rl,
-                
+
                 "bl": bl,
-                
+
                 "rh": rh,
-                
+
                 "bh": bh,
-                
+
                 "saturation": saturation,
-                
+
                 "analyze": analyze,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorhold(
-    
+
     self,
 
 
@@ -3010,15 +3010,15 @@ References:
 
     *,
     color: Color = Default('black'),similarity: Float = Default('0.01'),blend: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove all color information for all RGB colors except for certain one.
 
 The filter accepts the following options:
@@ -3038,7 +3038,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorhold)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3046,38 +3046,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorhold', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "color": color,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorize(
-    
+
     self,
 
 
@@ -3085,15 +3085,15 @@ References:
 
     *,
     hue: Float = Default('0'),saturation: Float = Default('0.5'),lightness: Float = Default('0.5'),mix: Float = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Overlay a solid color on the video stream.
 
 The filter accepts the following options:
@@ -3114,7 +3114,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorize)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3122,40 +3122,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorize', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "hue": hue,
-                
+
                 "saturation": saturation,
-                
+
                 "lightness": lightness,
-                
+
                 "mix": mix,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorkey(
-    
+
     self,
 
 
@@ -3163,15 +3163,15 @@ References:
 
     *,
     color: Color = Default('black'),similarity: Float = Default('0.01'),blend: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 RGB colorspace color keying.
 This filter operates on 8-bit RGB format frames by setting the alpha component of each pixel
 which falls within the similarity radius of the key color to 0. The alpha value for pixels outside
@@ -3194,7 +3194,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorkey)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3202,38 +3202,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorkey', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "color": color,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorkey_opencl(
-    
+
     self,
 
 
@@ -3241,12 +3241,12 @@ References:
 
     *,
     color: Color = Default('black'),similarity: Float = Default('0.01'),blend: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 RGB colorspace color keying.
 
 The filter accepts the following options:
@@ -3265,41 +3265,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorkey_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorkey_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "color": color,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorlevels(
-    
+
     self,
 
 
@@ -3307,15 +3307,15 @@ References:
 
     *,
     rimin: Double = Default('0'),gimin: Double = Default('0'),bimin: Double = Default('0'),aimin: Double = Default('0'),rimax: Double = Default('1'),gimax: Double = Default('1'),bimax: Double = Default('1'),aimax: Double = Default('1'),romin: Double = Default('0'),gomin: Double = Default('0'),bomin: Double = Default('0'),aomin: Double = Default('0'),romax: Double = Default('1'),gomax: Double = Default('1'),bomax: Double = Default('1'),aomax: Double = Default('1'),preserve: Int| Literal["none","lum","max","avg","sum","nrm","pwr"] | Default = Default('none'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust video input frames using levels.
 
 The filter accepts the following options:
@@ -3349,7 +3349,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorlevels)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3357,94 +3357,94 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorlevels', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rimin": rimin,
-                
+
                 "gimin": gimin,
-                
+
                 "bimin": bimin,
-                
+
                 "aimin": aimin,
-                
+
                 "rimax": rimax,
-                
+
                 "gimax": gimax,
-                
+
                 "bimax": bimax,
-                
+
                 "aimax": aimax,
-                
+
                 "romin": romin,
-                
+
                 "gomin": gomin,
-                
+
                 "bomin": bomin,
-                
+
                 "aomin": aomin,
-                
+
                 "romax": romax,
-                
+
                 "gomax": gomax,
-                
+
                 "bomax": bomax,
-                
+
                 "aomax": aomax,
-                
+
                 "preserve": preserve,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colormap(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _target: VideoStream,
-        
-    
+
+
 
 
     *,
     patch_size: Image_size = Default('64x64'),nb_patches: Int = Default('0'),type: Int| Literal["relative","absolute"] | Default = Default('absolute'),kernel: Int| Literal["euclidean","weuclidean"] | Default = Default('euclidean'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply custom color maps to video stream.
 
 This filter needs three input video streams.
@@ -3470,7 +3470,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colormap)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3478,52 +3478,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colormap', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _source,
-                
-            
-                
+
+
+
                 _target,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "patch_size": patch_size,
-                
+
                 "nb_patches": nb_patches,
-                
+
                 "type": type,
-                
+
                 "kernel": kernel,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colormatrix(
-    
+
     self,
 
 
@@ -3531,15 +3531,15 @@ References:
 
     *,
     src: Int| Literal["bt709","fcc","bt601","bt470","bt470bg","smpte170m","smpte240m","bt2020"] | Default = Default('-1'),dst: Int| Literal["bt709","fcc","bt601","bt470","bt470bg","smpte170m","smpte240m","bt2020"] | Default = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert color matrix.
 
 The filter accepts the following options:
@@ -3558,7 +3558,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colormatrix)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3566,36 +3566,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colormatrix', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "src": src,
-                
+
                 "dst": dst,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorspace(
-    
+
     self,
 
 
@@ -3603,15 +3603,15 @@ References:
 
     *,
     all: Int| Literal["bt470m","bt470bg","bt601-6-525","bt601-6-625","bt709","smpte170m","smpte240m","bt2020"] | Default = Default('0'),space: Int| Literal["bt709","fcc","bt470bg","smpte170m","smpte240m","ycgco","gbr","bt2020nc","bt2020ncl"] | Default = Default('2'),range: Int| Literal["tv","mpeg","pc","jpeg"] | Default = Default('0'),primaries: Int| Literal["bt709","bt470m","bt470bg","smpte170m","smpte240m","smpte428","film","smpte431","smpte432","bt2020","jedec-p22","ebu3213"] | Default = Default('2'),trc: Int| Literal["bt709","bt470m","gamma22","bt470bg","gamma28","smpte170m","smpte240m","linear","srgb","iec61966-2-1","xvycc","iec61966-2-4","bt2020-10","bt2020-12"] | Default = Default('2'),format: Int| Literal["yuv420p","yuv420p10","yuv420p12","yuv422p","yuv422p10","yuv422p12","yuv444p","yuv444p10","yuv444p12"] | Default = Default('-1'),fast: Boolean = Default('false'),dither: Int| Literal["none","fsb"] | Default = Default('none'),wpadapt: Int| Literal["bradford","vonkries","identity"] | Default = Default('bradford'),iall: Int| Literal["bt470m","bt470bg","bt601-6-525","bt601-6-625","bt709","smpte170m","smpte240m","bt2020"] | Default = Default('0'),ispace: Int| Literal["bt709","fcc","bt470bg","smpte170m","smpte240m","ycgco","gbr","bt2020nc","bt2020ncl"] | Default = Default('2'),irange: Int| Literal["tv","mpeg","pc","jpeg"] | Default = Default('0'),iprimaries: Int| Literal["bt709","bt470m","bt470bg","smpte170m","smpte240m","smpte428","film","smpte431","smpte432","bt2020","jedec-p22","ebu3213"] | Default = Default('2'),itrc: Int| Literal["bt709","bt470m","gamma22","bt470bg","gamma28","smpte170m","smpte240m","linear","srgb","iec61966-2-1","xvycc","iec61966-2-4","bt2020-10","bt2020-12"] | Default = Default('2'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert colorspace, transfer characteristics or color primaries.
 Input video needs to have an even size.
 
@@ -3643,7 +3643,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorspace)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3651,62 +3651,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorspace', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "all": all,
-                
+
                 "space": space,
-                
+
                 "range": range,
-                
+
                 "primaries": primaries,
-                
+
                 "trc": trc,
-                
+
                 "format": format,
-                
+
                 "fast": fast,
-                
+
                 "dither": dither,
-                
+
                 "wpadapt": wpadapt,
-                
+
                 "iall": iall,
-                
+
                 "ispace": ispace,
-                
+
                 "irange": irange,
-                
+
                 "iprimaries": iprimaries,
-                
+
                 "itrc": itrc,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def colortemperature(
-    
+
     self,
 
 
@@ -3714,15 +3714,15 @@ References:
 
     *,
     temperature: Float = Default('6500'),mix: Float = Default('1'),pl: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust color temperature in video to simulate variations in ambient color temperature.
 
 The filter accepts the following options:
@@ -3742,7 +3742,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colortemperature)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3750,44 +3750,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colortemperature', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "temperature": temperature,
-                
+
                 "mix": mix,
-                
+
                 "pl": pl,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def convolution(
-    
+
     self,
 
 
@@ -3795,15 +3795,15 @@ References:
 
     *,
     _0m: String = Default('0 0 0 0 1 0 0 0 0'),_1m: String = Default('0 0 0 0 1 0 0 0 0'),_2m: String = Default('0 0 0 0 1 0 0 0 0'),_3m: String = Default('0 0 0 0 1 0 0 0 0'),_0rdiv: Float = Default('0'),_1rdiv: Float = Default('0'),_2rdiv: Float = Default('0'),_3rdiv: Float = Default('0'),_0bias: Float = Default('0'),_1bias: Float = Default('0'),_2bias: Float = Default('0'),_3bias: Float = Default('0'),_0mode: Int| Literal["square","row","column"] | Default = Default('square'),_1mode: Int| Literal["square","row","column"] | Default = Default('square'),_2mode: Int| Literal["square","row","column"] | Default = Default('square'),_3mode: Int| Literal["square","row","column"] | Default = Default('square'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply convolution of 3x3, 5x5, 7x7 or horizontal/vertical up to 49 elements.
 
 The filter accepts the following options:
@@ -3836,7 +3836,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#convolution)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3844,64 +3844,64 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='convolution', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "0m": _0m,
-                
+
                 "1m": _1m,
-                
+
                 "2m": _2m,
-                
+
                 "3m": _3m,
-                
+
                 "0rdiv": _0rdiv,
-                
+
                 "1rdiv": _1rdiv,
-                
+
                 "2rdiv": _2rdiv,
-                
+
                 "3rdiv": _3rdiv,
-                
+
                 "0bias": _0bias,
-                
+
                 "1bias": _1bias,
-                
+
                 "2bias": _2bias,
-                
+
                 "3bias": _3bias,
-                
+
                 "0mode": _0mode,
-                
+
                 "1mode": _1mode,
-                
+
                 "2mode": _2mode,
-                
+
                 "3mode": _3mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def convolution_opencl(
-    
+
     self,
 
 
@@ -3909,12 +3909,12 @@ References:
 
     *,
     _0m: String = Default('0 0 0 0 1 0 0 0 0'),_2m: String = Default('0 0 0 0 1 0 0 0 0'),_3m: String = Default('0 0 0 0 1 0 0 0 0'),_0rdiv: Float = Default('1'),_1rdiv: Float = Default('1'),_2rdiv: Float = Default('1'),_3rdiv: Float = Default('1'),_0bias: Float = Default('0'),_1bias: Float = Default('0'),_2bias: Float = Default('0'),_3bias: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply convolution of 3x3, 5x5, 7x7 matrix.
 
 The filter accepts the following options:
@@ -3941,86 +3941,86 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#convolution_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='convolution_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "0m": _0m,
-                
+
                 "2m": _2m,
-                
+
                 "3m": _3m,
-                
+
                 "0rdiv": _0rdiv,
-                
+
                 "1rdiv": _1rdiv,
-                
+
                 "2rdiv": _2rdiv,
-                
+
                 "3rdiv": _3rdiv,
-                
+
                 "0bias": _0bias,
-                
+
                 "1bias": _1bias,
-                
+
                 "2bias": _2bias,
-                
+
                 "3bias": _3bias,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def convolve(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _impulse: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('7'),impulse: Int| Literal["first","all"] | Default = Default('all'),noise: Float = Default('1e-07'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply 2D convolution of video stream in frequency domain using second stream
 as impulse.
 
@@ -4042,7 +4042,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#convolve)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -4053,61 +4053,61 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='convolve', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _impulse,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "impulse": impulse,
-                
+
                 "noise": noise,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def copy(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Copy the input video source unchanged to the output. This is mainly useful for
 testing purposes.
 
@@ -4124,64 +4124,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#copy)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='copy', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def corr(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the correlation between two input videos.
 
 This filter takes two input videos.
@@ -4217,7 +4217,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#corr)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -4228,42 +4228,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='corr', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def cover_rect(
-    
+
     self,
 
 
@@ -4271,12 +4271,12 @@ References:
 
     *,
     cover: String = Default(None),mode: Int| Literal["cover","blur"] | Default = Default('blur'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Cover a rectangular object
 
 It accepts the following options:
@@ -4294,39 +4294,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#cover_rect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='cover_rect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cover": cover,
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def crop(
-    
+
     self,
 
 
@@ -4334,12 +4334,12 @@ References:
 
     *,
     out_w: String = Default('iw'),out_h: String = Default('ih'),x: String = Default('(in_w-out_w)/2'),y: String = Default('(in_h-out_h)/2'),keep_aspect: Boolean = Default('false'),exact: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Crop the input video to given dimensions.
 
 It accepts the following parameters:
@@ -4361,47 +4361,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#crop)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='crop', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "out_w": out_w,
-                
+
                 "out_h": out_h,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "keep_aspect": keep_aspect,
-                
+
                 "exact": exact,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def cropdetect(
-    
+
     self,
 
 
@@ -4409,15 +4409,15 @@ References:
 
     *,
     limit: Float = Default('0.0941176'),round: Int = Default('16'),reset: Int = Default('0'),skip: Int = Default('2'),reset_count: Int = Default('0'),max_outliers: Int = Default('0'),mode: Int| Literal["black","mvedges"] | Default = Default('black'),high: Float = Default('0.0980392'),low: Float = Default('0.0588235'),mv_threshold: Int = Default('8'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Auto-detect the crop size.
 
 It calculates the necessary cropping parameters and prints the
@@ -4448,7 +4448,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#cropdetect)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4456,56 +4456,56 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='cropdetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "limit": limit,
-                
+
                 "round": round,
-                
+
                 "reset": reset,
-                
+
                 "skip": skip,
-                
+
                 "reset_count": reset_count,
-                
+
                 "max_outliers": max_outliers,
-                
+
                 "mode": mode,
-                
+
                 "high": high,
-                
+
                 "low": low,
-                
+
                 "mv_threshold": mv_threshold,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def cue(
-    
+
     self,
 
 
@@ -4513,12 +4513,12 @@ References:
 
     *,
     cue: Int64 = Default('0'),preroll: Duration = Default('0'),buffer: Duration = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Delay video filtering until a given wallclock timestamp. The filter first
 passes on preroll amount of frames, then it buffers at most
 buffer amount of frames and waits for the cue. After reaching the cue
@@ -4547,41 +4547,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#cue)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='cue', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cue": cue,
-                
+
                 "preroll": preroll,
-                
+
                 "buffer": buffer,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def curves(
-    
+
     self,
 
 
@@ -4589,15 +4589,15 @@ References:
 
     *,
     preset: Int| Literal["none","color_negative","cross_process","darker","increase_contrast","lighter","linear_contrast","medium_contrast","negative","strong_contrast","vintage"] | Default = Default('none'),master: String = Default(None),red: String = Default(None),green: String = Default(None),blue: String = Default(None),all: String = Default(None),psfile: String = Default(None),plot: String = Default(None),interp: Int| Literal["natural","pchip"] | Default = Default('natural'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply color adjustments using curves.
 
 This filter is similar to the Adobe Photoshop and GIMP curves tools. Each
@@ -4644,7 +4644,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#curves)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4652,50 +4652,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='curves', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "preset": preset,
-                
+
                 "master": master,
-                
+
                 "red": red,
-                
+
                 "green": green,
-                
+
                 "blue": blue,
-                
+
                 "all": all,
-                
+
                 "psfile": psfile,
-                
+
                 "plot": plot,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def datascope(
-    
+
     self,
 
 
@@ -4703,12 +4703,12 @@ References:
 
     *,
     size: Image_size = Default('hd720'),x: Int = Default('0'),y: Int = Default('0'),mode: Int| Literal["mono","color","color2"] | Default = Default('mono'),axis: Boolean = Default('false'),opacity: Float = Default('0.75'),format: Int| Literal["hex","dec"] | Default = Default('hex'),components: Int = Default('15'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Video data analysis filter.
 
 This filter shows hexadecimal pixel values of part of video.
@@ -4734,51 +4734,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#datascope)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='datascope', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "mode": mode,
-                
+
                 "axis": axis,
-                
+
                 "opacity": opacity,
-                
+
                 "format": format,
-                
+
                 "components": components,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dblur(
-    
+
     self,
 
 
@@ -4786,15 +4786,15 @@ References:
 
     *,
     angle: Float = Default('45'),radius: Float = Default('5'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Directional blur filter.
 
 The filter accepts the following options:
@@ -4814,7 +4814,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dblur)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4822,40 +4822,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dblur', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "angle": angle,
-                
+
                 "radius": radius,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def dctdnoiz(
-    
+
     self,
 
 
@@ -4863,15 +4863,15 @@ References:
 
     *,
     sigma: Float = Default('0'),overlap: Int = Default('-1'),expr: String = Default(None),n: Int = Default('3'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Denoise frames using 2D DCT (frequency domain filtering).
 
 This filter is not designed for real time.
@@ -4894,7 +4894,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dctdnoiz)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4902,40 +4902,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dctdnoiz', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sigma": sigma,
-                
+
                 "overlap": overlap,
-                
+
                 "expr": expr,
-                
+
                 "n": n,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def deband(
-    
+
     self,
 
 
@@ -4943,15 +4943,15 @@ References:
 
     *,
     _1thr: Float = Default('0.02'),_2thr: Float = Default('0.02'),_3thr: Float = Default('0.02'),_4thr: Float = Default('0.02'),range: Int = Default('16'),direction: Float = Default('6.28319'),blur: Boolean = Default('true'),coupling: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove banding artifacts from input video.
 It works by replacing banded pixels with average value of referenced pixels.
 
@@ -4977,7 +4977,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deband)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4985,48 +4985,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deband', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "1thr": _1thr,
-                
+
                 "2thr": _2thr,
-                
+
                 "3thr": _3thr,
-                
+
                 "4thr": _4thr,
-                
+
                 "range": range,
-                
+
                 "direction": direction,
-                
+
                 "blur": blur,
-                
+
                 "coupling": coupling,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def deblock(
-    
+
     self,
 
 
@@ -5034,15 +5034,15 @@ References:
 
     *,
     filter: Int| Literal["weak","strong"] | Default = Default('strong'),block: Int = Default('8'),alpha: Float = Default('0.098'),beta: Float = Default('0.05'),gamma: Float = Default('0.05'),delta: Float = Default('0.05'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove blocking artifacts from input video.
 
 The filter accepts the following options:
@@ -5066,7 +5066,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deblock)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5074,77 +5074,77 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deblock', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "filter": filter,
-                
+
                 "block": block,
-                
+
                 "alpha": alpha,
-                
+
                 "beta": beta,
-                
+
                 "gamma": gamma,
-                
+
                 "delta": delta,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def deconvolve(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _impulse: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('7'),impulse: Int| Literal["first","all"] | Default = Default('all'),noise: Float = Default('1e-07'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply 2D deconvolution of video stream in frequency domain using second stream
 as impulse.
 
@@ -5166,7 +5166,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deconvolve)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -5177,48 +5177,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deconvolve', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _impulse,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "impulse": impulse,
-                
+
                 "noise": noise,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dedot(
-    
+
     self,
 
 
@@ -5226,15 +5226,15 @@ References:
 
     *,
     m: Flags| Literal["dotcrawl","rainbows"] | Default = Default('dotcrawl+rainbows'),lt: Float = Default('0.079'),tl: Float = Default('0.079'),tc: Float = Default('0.058'),ct: Float = Default('0.019'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reduce cross-luminance (dot-crawl) and cross-color (rainbows) from video.
 
 It accepts the following options:
@@ -5256,7 +5256,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dedot)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5264,44 +5264,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dedot', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "m": m,
-                
+
                 "lt": lt,
-                
+
                 "tl": tl,
-                
+
                 "tc": tc,
-                
+
                 "ct": ct,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def deflate(
-    
+
     self,
 
 
@@ -5309,15 +5309,15 @@ References:
 
     *,
     threshold0: Int = Default('65535'),threshold1: Int = Default('65535'),threshold2: Int = Default('65535'),threshold3: Int = Default('65535'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply deflate effect to the video.
 
 This filter replaces the pixel by the local(3x3) average by taking into account
@@ -5341,7 +5341,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deflate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5349,40 +5349,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deflate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold0": threshold0,
-                
+
                 "threshold1": threshold1,
-                
+
                 "threshold2": threshold2,
-                
+
                 "threshold3": threshold3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def deflicker(
-    
+
     self,
 
 
@@ -5390,12 +5390,12 @@ References:
 
     *,
     size: Int = Default('5'),mode: Int| Literal["am","gm","hm","qm","cm","pm","median"] | Default = Default('am'),bypass: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove temporal frame luminance variations.
 
 It accepts the following options:
@@ -5414,41 +5414,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deflicker)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deflicker', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "mode": mode,
-                
+
                 "bypass": bypass,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def deinterlace_vaapi(
-    
+
     self,
 
 
@@ -5456,12 +5456,12 @@ References:
 
     *,
     mode: Int| Literal["default","bob","weave","motion_adaptive","motion_compensated"] | Default = Default('default'),rate: Int| Literal["frame","field"] | Default = Default('frame'),auto: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlacing of VAAPI surfaces
 
 
@@ -5478,41 +5478,41 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deinterlace_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "rate": rate,
-                
+
                 "auto": auto,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dejudder(
-    
+
     self,
 
 
@@ -5520,12 +5520,12 @@ References:
 
     *,
     cycle: Int = Default('4'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove judder produced by partially interlaced telecined content.
 
 Judder can be introduced, for instance, by pullup filter. If the original
@@ -5548,37 +5548,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dejudder)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dejudder', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cycle": cycle,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def delogo(
-    
+
     self,
 
 
@@ -5586,15 +5586,15 @@ References:
 
     *,
     x: String = Default('-1'),y: String = Default('-1'),w: String = Default('-1'),h: String = Default('-1'),show: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Suppress a TV station logo by a simple interpolation of the surrounding
 pixels. Just set a rectangle covering the logo and watch it disappear
 (and sometimes something even uglier appear - your mileage may vary).
@@ -5618,7 +5618,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#delogo)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5626,42 +5626,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='delogo', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "show": show,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def denoise_vaapi(
-    
+
     self,
 
 
@@ -5669,12 +5669,12 @@ References:
 
     *,
     denoise: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 VAAPI VPP for de-noise
 
 
@@ -5689,37 +5689,37 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='denoise_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "denoise": denoise,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def deshake(
-    
+
     self,
 
 
@@ -5727,12 +5727,12 @@ References:
 
     *,
     x: Int = Default('-1'),y: Int = Default('-1'),w: Int = Default('-1'),h: Int = Default('-1'),rx: Int = Default('16'),ry: Int = Default('16'),edge: Int| Literal["blank","original","clamp","mirror"] | Default = Default('mirror'),blocksize: Int = Default('8'),contrast: Int = Default('125'),search: Int| Literal["exhaustive","less"] | Default = Default('exhaustive'),filename: String = Default(None),opencl: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Attempt to fix small changes in horizontal and/or vertical shift. This
 filter helps remove camera shake from hand-holding a camera, bumping a
 tripod, moving on a vehicle, etc.
@@ -5762,59 +5762,59 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deshake)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deshake', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "rx": rx,
-                
+
                 "ry": ry,
-                
+
                 "edge": edge,
-                
+
                 "blocksize": blocksize,
-                
+
                 "contrast": contrast,
-                
+
                 "search": search,
-                
+
                 "filename": filename,
-                
+
                 "opencl": opencl,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def deshake_opencl(
-    
+
     self,
 
 
@@ -5822,12 +5822,12 @@ References:
 
     *,
     tripod: Boolean = Default('false'),debug: Boolean = Default('false'),adaptive_crop: Boolean = Default('true'),refine_features: Boolean = Default('true'),smooth_strength: Float = Default('0'),smooth_window_multiplier: Float = Default('2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Feature-point based video stabilization filter.
 
 The filter accepts the following options:
@@ -5849,47 +5849,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deshake_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deshake_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "tripod": tripod,
-                
+
                 "debug": debug,
-                
+
                 "adaptive_crop": adaptive_crop,
-                
+
                 "refine_features": refine_features,
-                
+
                 "smooth_strength": smooth_strength,
-                
+
                 "smooth_window_multiplier": smooth_window_multiplier,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def despill(
-    
+
     self,
 
 
@@ -5897,15 +5897,15 @@ References:
 
     *,
     type: Int| Literal["green","blue"] | Default = Default('green'),mix: Float = Default('0.5'),expand: Float = Default('0'),red: Float = Default('0'),green: Float = Default('-1'),blue: Float = Default('0'),brightness: Float = Default('0'),alpha: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove unwanted contamination of foreground colors, caused by reflected color of
 greenscreen or bluescreen.
 
@@ -5931,7 +5931,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#despill)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5939,48 +5939,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='despill', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "type": type,
-                
+
                 "mix": mix,
-                
+
                 "expand": expand,
-                
+
                 "red": red,
-                
+
                 "green": green,
-                
+
                 "blue": blue,
-                
+
                 "brightness": brightness,
-                
+
                 "alpha": alpha,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def detelecine(
-    
+
     self,
 
 
@@ -5988,12 +5988,12 @@ References:
 
     *,
     first_field: Int| Literal["top","t","bottom","b"] | Default = Default('top'),pattern: String = Default('23'),start_frame: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply an exact inverse of the telecine operation. It requires a predefined
 pattern specified using the pattern option which must be the same as that passed
 to the telecine filter.
@@ -6014,43 +6014,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#detelecine)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='detelecine', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "first_field": first_field,
-                
+
                 "pattern": pattern,
-                
+
                 "start_frame": start_frame,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def dilation(
-    
+
     self,
 
 
@@ -6058,15 +6058,15 @@ References:
 
     *,
     coordinates: Int = Default('255'),threshold0: Int = Default('65535'),threshold1: Int = Default('65535'),threshold2: Int = Default('65535'),threshold3: Int = Default('65535'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply dilation effect to the video.
 
 This filter replaces the pixel by the local(3x3) maximum.
@@ -6090,7 +6090,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dilation)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6098,42 +6098,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dilation', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "coordinates": coordinates,
-                
+
                 "threshold0": threshold0,
-                
+
                 "threshold1": threshold1,
-                
+
                 "threshold2": threshold2,
-                
+
                 "threshold3": threshold3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dilation_opencl(
-    
+
     self,
 
 
@@ -6141,12 +6141,12 @@ References:
 
     *,
     threshold0: Float = Default('65535'),threshold1: Float = Default('65535'),threshold2: Float = Default('65535'),threshold3: Float = Default('65535'),coordinates: Int = Default('255'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply dilation effect to the video.
 
 This filter replaces the pixel by the local(3x3) maximum.
@@ -6169,73 +6169,73 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dilation_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dilation_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold0": threshold0,
-                
+
                 "threshold1": threshold1,
-                
+
                 "threshold2": threshold2,
-                
+
                 "threshold3": threshold3,
-                
+
                 "coordinates": coordinates,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def displace(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _xmap: VideoStream,
-        
-    
-        
+
+
+
         _ymap: VideoStream,
-        
-    
+
+
 
 
     *,
     edge: Int| Literal["blank","smear","wrap","mirror"] | Default = Default('smear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Displace pixels as indicated by second and third input stream.
 
 It takes three input streams and outputs one stream, the first input is the
@@ -6264,7 +6264,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#displace)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6272,46 +6272,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='displace', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _xmap,
-                
-            
-                
+
+
+
                 _ymap,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "edge": edge,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def doubleweave(
-    
+
     self,
 
 
@@ -6319,12 +6319,12 @@ References:
 
     *,
     first_field: Int| Literal["top","t","bottom","b"] | Default = Default('top'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The weave takes a field-based video input and join
 each two sequential fields into single frame, producing a new double
 height clip with half the frame rate and half the frame count.
@@ -6346,37 +6346,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#weave)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='doubleweave', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "first_field": first_field,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def drawbox(
-    
+
     self,
 
 
@@ -6384,15 +6384,15 @@ References:
 
     *,
     x: String = Default('0'),y: String = Default('0'),width: String = Default('0'),height: String = Default('0'),color: String = Default('black'),thickness: String = Default('3'),replace: Boolean = Default('false'),box_source: String = Default(None),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw a colored box on the input image.
 
 It accepts the following parameters:
@@ -6417,7 +6417,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#drawbox)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6425,48 +6425,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='drawbox', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "color": color,
-                
+
                 "thickness": thickness,
-                
+
                 "replace": replace,
-                
+
                 "box_source": box_source,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def drawbox_vaapi(
-    
+
     self,
 
 
@@ -6474,12 +6474,12 @@ References:
 
     *,
     x: String = Default('0'),y: String = Default('0'),width: String = Default('0'),height: String = Default('0'),color: Color = Default('black'),thickness: String = Default('3'),replace: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw a colored box on the input image.
 
 It accepts the following parameters:
@@ -6502,49 +6502,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#drawbox_vaapi)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='drawbox_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "color": color,
-                
+
                 "thickness": thickness,
-                
+
                 "replace": replace,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def drawgraph(
-    
+
     self,
 
 
@@ -6552,12 +6552,12 @@ References:
 
     *,
     m1: String = Default(''),fg1: String = Default('0xffff0000'),m2: String = Default(''),fg2: String = Default('0xff00ff00'),m3: String = Default(''),fg3: String = Default('0xffff00ff'),m4: String = Default(''),fg4: String = Default('0xffffff00'),bg: Color = Default('white'),min: Float = Default('-1'),max: Float = Default('1'),mode: Int| Literal["bar","dot","line"] | Default = Default('line'),slide: Int| Literal["frame","replace","scroll","rscroll","picture"] | Default = Default('frame'),size: Image_size = Default('900x256'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw a graph using input video metadata.
 
 It accepts the following parameters:
@@ -6588,65 +6588,65 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#drawgraph)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='drawgraph', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "m1": m1,
-                
+
                 "fg1": fg1,
-                
+
                 "m2": m2,
-                
+
                 "fg2": fg2,
-                
+
                 "m3": m3,
-                
+
                 "fg3": fg3,
-                
+
                 "m4": m4,
-                
+
                 "fg4": fg4,
-                
+
                 "bg": bg,
-                
+
                 "min": min,
-                
+
                 "max": max,
-                
+
                 "mode": mode,
-                
+
                 "slide": slide,
-                
+
                 "size": size,
-                
+
                 "rate": rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def drawgrid(
-    
+
     self,
 
 
@@ -6654,15 +6654,15 @@ References:
 
     *,
     x: String = Default('0'),y: String = Default('0'),width: String = Default('0'),height: String = Default('0'),color: String = Default('black'),thickness: String = Default('1'),replace: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw a grid on the input image.
 
 It accepts the following parameters:
@@ -6686,7 +6686,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#drawgrid)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6694,46 +6694,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='drawgrid', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "color": color,
-                
+
                 "thickness": thickness,
-                
+
                 "replace": replace,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def drawtext(
-    
+
     self,
 
 
@@ -6741,15 +6741,15 @@ References:
 
     *,
     fontfile: String = Default(None),text: String = Default(None),textfile: String = Default(None),fontcolor: Color = Default('black'),fontcolor_expr: String = Default(''),boxcolor: Color = Default('white'),bordercolor: Color = Default('black'),shadowcolor: Color = Default('black'),box: Boolean = Default('false'),boxborderw: String = Default('0'),line_spacing: Int = Default('0'),fontsize: String = Default(None),text_align: Flags| Literal["left","L","right","R","center","C","top","T","bottom","B","middle","M"] | Default = Default('0'),x: String = Default('0'),y: String = Default('0'),boxw: Int = Default('0'),boxh: Int = Default('0'),shadowx: Int = Default('0'),shadowy: Int = Default('0'),borderw: Int = Default('0'),tabsize: Int = Default('4'),basetime: Int64 = Default('I64_MIN'),font: String = Default('Sans'),expansion: Int| Literal["none","normal","strftime"] | Default = Default('normal'),y_align: Int| Literal["text","baseline","font"] | Default = Default('text'),timecode: String = Default(None),tc24hmax: Boolean = Default('false'),timecode_rate: Rational = Default('0/1'),reload: Int = Default('0'),alpha: String = Default('1'),fix_bounds: Boolean = Default('false'),start_number: Int = Default('0'),text_source: String = Default(None),text_shaping: Boolean = Default('true'),ft_load_flags: Flags| Literal["default","no_scale","no_hinting","render","no_bitmap","vertical_layout","force_autohint","crop_bitmap","pedantic","ignore_global_advance_width","no_recurse","ignore_transform","monochrome","linear_design","no_autohint"] | Default = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw a text string or text from a specified file on top of a video, using the
 libfreetype library.
 
@@ -6807,7 +6807,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#drawtext)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6815,110 +6815,110 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='drawtext', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "fontfile": fontfile,
-                
+
                 "text": text,
-                
+
                 "textfile": textfile,
-                
+
                 "fontcolor": fontcolor,
-                
+
                 "fontcolor_expr": fontcolor_expr,
-                
+
                 "boxcolor": boxcolor,
-                
+
                 "bordercolor": bordercolor,
-                
+
                 "shadowcolor": shadowcolor,
-                
+
                 "box": box,
-                
+
                 "boxborderw": boxborderw,
-                
+
                 "line_spacing": line_spacing,
-                
+
                 "fontsize": fontsize,
-                
+
                 "text_align": text_align,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "boxw": boxw,
-                
+
                 "boxh": boxh,
-                
+
                 "shadowx": shadowx,
-                
+
                 "shadowy": shadowy,
-                
+
                 "borderw": borderw,
-                
+
                 "tabsize": tabsize,
-                
+
                 "basetime": basetime,
-                
+
                 "font": font,
-                
+
                 "expansion": expansion,
-                
+
                 "y_align": y_align,
-                
+
                 "timecode": timecode,
-                
+
                 "tc24hmax": tc24hmax,
-                
+
                 "timecode_rate": timecode_rate,
-                
+
                 "reload": reload,
-                
+
                 "alpha": alpha,
-                
+
                 "fix_bounds": fix_bounds,
-                
+
                 "start_number": start_number,
-                
+
                 "text_source": text_source,
-                
+
                 "text_shaping": text_shaping,
-                
+
                 "ft_load_flags": ft_load_flags,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def edgedetect(
-    
+
     self,
 
 
@@ -6926,15 +6926,15 @@ References:
 
     *,
     high: Double = Default('0.196078'),low: Double = Default('0.0784314'),mode: Int| Literal["wires","colormix","canny"] | Default = Default('wires'),planes: Flags| Literal["y","u","v","r","g","b"] | Default = Default('y+u+v+r+g+b'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect and draw edges. The filter uses the Canny Edge Detection algorithm.
 
 The filter accepts the following options:
@@ -6955,7 +6955,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#edgedetect)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6963,40 +6963,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='edgedetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "high": high,
-                
+
                 "low": low,
-                
+
                 "mode": mode,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def elbg(
-    
+
     self,
 
 
@@ -7004,12 +7004,12 @@ References:
 
     *,
     codebook_length: Int = Default('256'),nb_steps: Int = Default('1'),seed: Int64 = Default('-1'),pal8: Boolean = Default('false'),use_alpha: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a posterize effect using the ELBG (Enhanced LBG) algorithm.
 
 For each input image, the filter will compute the optimal mapping from
@@ -7034,45 +7034,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#elbg)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='elbg', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "codebook_length": codebook_length,
-                
+
                 "nb_steps": nb_steps,
-                
+
                 "seed": seed,
-                
+
                 "pal8": pal8,
-                
+
                 "use_alpha": use_alpha,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def entropy(
-    
+
     self,
 
 
@@ -7080,15 +7080,15 @@ References:
 
     *,
     mode: Int| Literal["normal","diff"] | Default = Default('normal'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Measure graylevel entropy in histogram of color channels of video frames.
 
 It accepts the following parameters:
@@ -7106,7 +7106,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#entropy)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7114,34 +7114,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='entropy', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def epx(
-    
+
     self,
 
 
@@ -7149,12 +7149,12 @@ References:
 
     *,
     n: Int = Default('3'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply the EPX magnification filter which is designed for pixel art.
 
 It accepts the following option:
@@ -7171,37 +7171,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#epx)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='epx', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "n": n,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def eq(
-    
+
     self,
 
 
@@ -7209,15 +7209,15 @@ References:
 
     *,
     contrast: String = Default('1.0'),brightness: String = Default('0.0'),saturation: String = Default('1.0'),gamma: String = Default('1.0'),gamma_r: String = Default('1.0'),gamma_g: String = Default('1.0'),gamma_b: String = Default('1.0'),gamma_weight: String = Default('1.0'),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Set brightness, contrast, saturation and approximate gamma adjustment.
 
 The filter accepts the following options:
@@ -7243,7 +7243,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#eq)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7251,52 +7251,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='eq', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "contrast": contrast,
-                
+
                 "brightness": brightness,
-                
+
                 "saturation": saturation,
-                
+
                 "gamma": gamma,
-                
+
                 "gamma_r": gamma_r,
-                
+
                 "gamma_g": gamma_g,
-                
+
                 "gamma_b": gamma_b,
-                
+
                 "gamma_weight": gamma_weight,
-                
+
                 "eval": eval,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def erosion(
-    
+
     self,
 
 
@@ -7304,15 +7304,15 @@ References:
 
     *,
     coordinates: Int = Default('255'),threshold0: Int = Default('65535'),threshold1: Int = Default('65535'),threshold2: Int = Default('65535'),threshold3: Int = Default('65535'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply erosion effect to the video.
 
 This filter replaces the pixel by the local(3x3) minimum.
@@ -7336,7 +7336,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#erosion)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7344,42 +7344,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='erosion', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "coordinates": coordinates,
-                
+
                 "threshold0": threshold0,
-                
+
                 "threshold1": threshold1,
-                
+
                 "threshold2": threshold2,
-                
+
                 "threshold3": threshold3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def erosion_opencl(
-    
+
     self,
 
 
@@ -7387,12 +7387,12 @@ References:
 
     *,
     threshold0: Float = Default('65535'),threshold1: Float = Default('65535'),threshold2: Float = Default('65535'),threshold3: Float = Default('65535'),coordinates: Int = Default('255'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply erosion effect to the video.
 
 This filter replaces the pixel by the local(3x3) minimum.
@@ -7415,45 +7415,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#erosion_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='erosion_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold0": threshold0,
-                
+
                 "threshold1": threshold1,
-                
+
                 "threshold2": threshold2,
-                
+
                 "threshold3": threshold3,
-                
+
                 "coordinates": coordinates,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def estdif(
-    
+
     self,
 
 
@@ -7461,15 +7461,15 @@ References:
 
     *,
     mode: Int| Literal["frame","field"] | Default = Default('field'),parity: Int| Literal["tff","bff","auto"] | Default = Default('auto'),deint: Int| Literal["all","interlaced"] | Default = Default('all'),rslope: Int = Default('1'),redge: Int = Default('2'),ecost: Int = Default('2'),mcost: Int = Default('1'),dcost: Int = Default('1'),interp: Int| Literal["2p","4p","6p"] | Default = Default('4p'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlace the input video ("estdif" stands for "Edge Slope
 Tracing Deinterlacing Filter").
 
@@ -7498,7 +7498,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#estdif)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7506,50 +7506,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='estdif', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "parity": parity,
-                
+
                 "deint": deint,
-                
+
                 "rslope": rslope,
-                
+
                 "redge": redge,
-                
+
                 "ecost": ecost,
-                
+
                 "mcost": mcost,
-                
+
                 "dcost": dcost,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def exposure(
-    
+
     self,
 
 
@@ -7557,15 +7557,15 @@ References:
 
     *,
     exposure: Float = Default('0'),black: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust exposure of the video stream.
 
 The filter accepts the following options:
@@ -7584,7 +7584,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#exposure)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7592,36 +7592,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='exposure', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "exposure": exposure,
-                
+
                 "black": black,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def extractplanes(
-    
+
     self,
 
 
@@ -7629,12 +7629,12 @@ References:
 
     *,
     planes: Flags| Literal["y","u","v","r","g","b","a"] | Default = Default('r'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Extract color channel components from input video stream into
 separate grayscale video streams.
 
@@ -7653,40 +7653,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#extractplanes)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='extractplanes', typings_input=('video',), typings_output="[StreamType.video] * len(planes.split('+'))"),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def fade(
-    
+
     self,
 
 
@@ -7694,15 +7694,15 @@ References:
 
     *,
     type: Int| Literal["in","out"] | Default = Default('in'),start_frame: Int = Default('0'),nb_frames: Int = Default('25'),alpha: Boolean = Default('false'),start_time: Duration = Default('0'),duration: Duration = Default('0'),color: Color = Default('black'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a fade-in/out effect to the input video.
 
 It accepts the following parameters:
@@ -7726,7 +7726,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fade)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7734,80 +7734,80 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fade', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "type": type,
-                
+
                 "start_frame": start_frame,
-                
+
                 "nb_frames": nb_frames,
-                
+
                 "alpha": alpha,
-                
+
                 "start_time": start_time,
-                
+
                 "duration": duration,
-                
+
                 "color": color,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def feedback(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _feedin: VideoStream,
-        
-    
+
+
 
 
     *,
     x: Int = Default('0'),w: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> tuple[
-    
-        
+
+
             VideoStream,
-        
-    
-        
+
+
+
             VideoStream,
-        
-    
+
+
 ]:
         """
-        
+
 Apply feedback video filter.
 
 This filter pass cropped input frames to 2nd output.
@@ -7835,7 +7835,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#feedback)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7843,55 +7843,55 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='feedback', typings_input=('video', 'video'), typings_output=('video', 'video')),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _feedin,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "w": w,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return (
-            
-                
+
+
                     filter_node.video(0),
-                
-            
-                
+
+
+
                     filter_node.video(1),
-                
-            
+
+
         )
 
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fftdnoiz(
-    
+
     self,
 
 
@@ -7899,15 +7899,15 @@ References:
 
     *,
     sigma: Float = Default('1'),amount: Float = Default('1'),block: Int = Default('32'),overlap: Float = Default('0.5'),method: Int| Literal["wiener","hard"] | Default = Default('wiener'),prev: Int = Default('0'),next: Int = Default('0'),planes: Int = Default('7'),window: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('hann'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Denoise frames using 3D FFT (frequency domain filtering).
 
 The filter accepts the following options:
@@ -7933,7 +7933,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fftdnoiz)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7941,50 +7941,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fftdnoiz', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sigma": sigma,
-                
+
                 "amount": amount,
-                
+
                 "block": block,
-                
+
                 "overlap": overlap,
-                
+
                 "method": method,
-                
+
                 "prev": prev,
-                
+
                 "next": next,
-                
+
                 "planes": planes,
-                
+
                 "window": window,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fftfilt(
-    
+
     self,
 
 
@@ -7992,15 +7992,15 @@ References:
 
     *,
     dc_Y: Int = Default('0'),dc_U: Int = Default('0'),dc_V: Int = Default('0'),weight_Y: String = Default('1'),weight_U: String = Default(None),weight_V: String = Default(None),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply arbitrary expressions to samples in frequency domain
 
 
@@ -8022,7 +8022,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fftfilt)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8030,46 +8030,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fftfilt', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dc_Y": dc_Y,
-                
+
                 "dc_U": dc_U,
-                
+
                 "dc_V": dc_V,
-                
+
                 "weight_Y": weight_Y,
-                
+
                 "weight_U": weight_U,
-                
+
                 "weight_V": weight_V,
-                
+
                 "eval": eval,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def field(
-    
+
     self,
 
 
@@ -8077,12 +8077,12 @@ References:
 
     *,
     type: Int| Literal["top","bottom"] | Default = Default('top'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Extract a single field from an interlaced image using stride
 arithmetic to avoid wasting CPU time. The output frames are marked as
 non-interlaced.
@@ -8101,37 +8101,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#field)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='field', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fieldhint(
-    
+
     self,
 
 
@@ -8139,12 +8139,12 @@ References:
 
     *,
     hint: String = Default(None),mode: Int| Literal["absolute","relative","pattern"] | Default = Default('absolute'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Create new frames by copying the top and bottom fields from surrounding frames
 supplied as numbers by the hint file.
 
@@ -8161,41 +8161,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fieldhint)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fieldhint', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "hint": hint,
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def fieldorder(
-    
+
     self,
 
 
@@ -8203,15 +8203,15 @@ References:
 
     *,
     order: Int| Literal["bff","tff"] | Default = Default('tff'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Transform the field order of the input video.
 
 It accepts the following parameters:
@@ -8229,7 +8229,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fieldorder)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8237,34 +8237,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fieldorder', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "order": order,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fillborders(
-    
+
     self,
 
 
@@ -8272,15 +8272,15 @@ References:
 
     *,
     left: Int = Default('0'),right: Int = Default('0'),top: Int = Default('0'),bottom: Int = Default('0'),mode: Int| Literal["smear","mirror","fixed","reflect","wrap","fade","margins"] | Default = Default('smear'),color: Color = Default('black'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Fill borders of the input video, without changing video stream dimensions.
 Sometimes video can have garbage at the four edges and you may not want to
 crop video input to keep size multiple of some number.
@@ -8305,7 +8305,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fillborders)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8313,44 +8313,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fillborders', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "left": left,
-                
+
                 "right": right,
-                
+
                 "top": top,
-                
+
                 "bottom": bottom,
-                
+
                 "mode": mode,
-                
+
                 "color": color,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def find_rect(
-    
+
     self,
 
 
@@ -8358,12 +8358,12 @@ References:
 
     *,
     object: String = Default(None),threshold: Float = Default('0.5'),mipmaps: Int = Default('3'),xmin: Int = Default('0'),discard: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Find a rectangular object in the input video.
 
 The object to search for must be specified as a gray8 image specified with the
@@ -8394,49 +8394,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#find_rect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='find_rect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "object": object,
-                
+
                 "threshold": threshold,
-                
+
                 "mipmaps": mipmaps,
-                
+
                 "xmin": xmin,
-                
+
                 "discard": discard,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def floodfill(
-    
+
     self,
 
 
@@ -8444,15 +8444,15 @@ References:
 
     *,
     x: Int = Default('0'),y: Int = Default('0'),s0: Int = Default('0'),s1: Int = Default('0'),s2: Int = Default('0'),s3: Int = Default('0'),d0: Int = Default('0'),d1: Int = Default('0'),d2: Int = Default('0'),d3: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Flood area with values of same pixel components with another values.
 
 It accepts the following options:
@@ -8479,7 +8479,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#floodfill)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8487,52 +8487,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='floodfill', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "s0": s0,
-                
+
                 "s1": s1,
-                
+
                 "s2": s2,
-                
+
                 "s3": s3,
-                
+
                 "d0": d0,
-                
+
                 "d1": d1,
-                
+
                 "d2": d2,
-                
+
                 "d3": d3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def format(
-    
+
     self,
 
 
@@ -8540,12 +8540,12 @@ References:
 
     *,
     pix_fmts: String = Default(None),color_spaces: String = Default(None),color_ranges: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert the input video to one of the specified pixel formats.
 Libavfilter will try to pick one that is suitable as input to
 the next filter.
@@ -8566,41 +8566,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#format)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='format', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "pix_fmts": pix_fmts,
-                
+
                 "color_spaces": color_spaces,
-                
+
                 "color_ranges": color_ranges,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fps(
-    
+
     self,
 
 
@@ -8608,12 +8608,12 @@ References:
 
     *,
     fps: String = Default('25'),start_time: Double = Default('DBL_MAX'),round: Int| Literal["zero","inf","down","up","near"] | Default = Default('near'),eof_action: Int| Literal["round","pass"] | Default = Default('round'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert the video to specified constant frame rate by duplicating or dropping
 frames as necessary.
 
@@ -8634,64 +8634,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fps)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fps', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "fps": fps,
-                
+
                 "start_time": start_time,
-                
+
                 "round": round,
-                
+
                 "eof_action": eof_action,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def framepack(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _right: VideoStream,
-        
-    
+
+
 
 
     *,
     format: Int| Literal["sbs","tab","frameseq","lines","columns"] | Default = Default('sbs'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pack two different video streams into a stereoscopic video, setting proper
 metadata on supported codecs. The two views should have the same size and
 framerate and processing will stop when the shorter video ends. Please note
@@ -8712,45 +8712,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#framepack)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='framepack', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _right,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "format": format,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def framerate(
-    
+
     self,
 
 
@@ -8758,12 +8758,12 @@ References:
 
     *,
     fps: Video_rate = Default('50'),interp_start: Int = Default('15'),interp_end: Int = Default('240'),scene: Double = Default('8.2'),flags: Flags| Literal["scene_change_detect","scd"] | Default = Default('scene_change_detect+scd'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Change the frame rate by interpolating new video output frames from the source
 frames.
 
@@ -8789,45 +8789,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#framerate)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='framerate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "fps": fps,
-                
+
                 "interp_start": interp_start,
-                
+
                 "interp_end": interp_end,
-                
+
                 "scene": scene,
-                
+
                 "flags": flags,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def framestep(
-    
+
     self,
 
 
@@ -8835,15 +8835,15 @@ References:
 
     *,
     step: Int = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Select one frame every N-th frame.
 
 This filter accepts the following option:
@@ -8861,7 +8861,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#framestep)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8869,34 +8869,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='framestep', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "step": step,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def freezedetect(
-    
+
     self,
 
 
@@ -8904,12 +8904,12 @@ References:
 
     *,
     n: Double = Default('0.001'),d: Duration = Default('2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect frozen video.
 
 This filter logs a message and sets frame metadata when it detects that the
@@ -8940,60 +8940,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#freezedetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='freezedetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "n": n,
-                
+
                 "d": d,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def freezeframes(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _replace: VideoStream,
-        
-    
+
+
 
 
     *,
     first: Int64 = Default('0'),last: Int64 = Default('0'),replace: Int64 = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Freeze video frames.
 
 This filter freezes video frames using frame from 2nd input.
@@ -9014,49 +9014,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#freezeframes)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='freezeframes', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _replace,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "first": first,
-                
+
                 "last": last,
-                
+
                 "replace": replace,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fspp(
-    
+
     self,
 
 
@@ -9064,15 +9064,15 @@ References:
 
     *,
     quality: Int = Default('4'),qp: Int = Default('0'),strength: Int = Default('0'),use_bframe_qp: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply fast and simple postprocessing. It is a faster version of spp.
 
 It splits (I)DCT into horizontal/vertical passes. Unlike the simple post-
@@ -9097,7 +9097,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fspp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9105,40 +9105,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fspp', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "quality": quality,
-                
+
                 "qp": qp,
-                
+
                 "strength": strength,
-                
+
                 "use_bframe_qp": use_bframe_qp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fsync(
-    
+
     self,
 
 
@@ -9146,12 +9146,12 @@ References:
 
     *,
     file: String = Default(''),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Synchronize video frames with an external mapping from a file.
 
 For each input PTS given in the map file it either drops or creates as many
@@ -9185,37 +9185,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fsync)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fsync', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "file": file,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def gblur(
-    
+
     self,
 
 
@@ -9223,15 +9223,15 @@ References:
 
     *,
     sigma: Float = Default('0.5'),steps: Int = Default('1'),planes: Int = Default('15'),sigmaV: Float = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Gaussian blur filter.
 
 The filter accepts the following options:
@@ -9252,7 +9252,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#gblur)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9260,40 +9260,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='gblur', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sigma": sigma,
-                
+
                 "steps": steps,
-                
+
                 "planes": planes,
-                
+
                 "sigmaV": sigmaV,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def geq(
-    
+
     self,
 
 
@@ -9301,15 +9301,15 @@ References:
 
     *,
     lum_expr: String = Default(None),cb_expr: String = Default(None),cr_expr: String = Default(None),alpha_expr: String = Default(None),red_expr: String = Default(None),green_expr: String = Default(None),blue_expr: String = Default(None),interpolation: Int| Literal["nearest","n","bilinear","b"] | Default = Default('bilinear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply generic equation to each pixel.
 
 The filter accepts the following options:
@@ -9334,7 +9334,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#geq)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9342,48 +9342,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='geq', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "lum_expr": lum_expr,
-                
+
                 "cb_expr": cb_expr,
-                
+
                 "cr_expr": cr_expr,
-                
+
                 "alpha_expr": alpha_expr,
-                
+
                 "red_expr": red_expr,
-                
+
                 "green_expr": green_expr,
-                
+
                 "blue_expr": blue_expr,
-                
+
                 "interpolation": interpolation,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def gradfun(
-    
+
     self,
 
 
@@ -9391,15 +9391,15 @@ References:
 
     *,
     strength: Float = Default('1.2'),radius: Int = Default('16'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Fix the banding artifacts that are sometimes introduced into nearly flat
 regions by truncation to 8-bit color depth.
 Interpolate the gradients that should go where the bands are, and
@@ -9425,7 +9425,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#gradfun)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9433,38 +9433,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='gradfun', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "strength": strength,
-                
+
                 "radius": radius,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def graphmonitor(
-    
+
     self,
 
 
@@ -9472,12 +9472,12 @@ References:
 
     *,
     size: Image_size = Default('hd720'),opacity: Float = Default('0.9'),mode: Flags| Literal["full","compact","nozero","noeof","nodisabled"] | Default = Default('0'),flags: Flags| Literal["none","all","queue","frame_count_in","frame_count_out","frame_count_delta","pts","pts_delta","time","time_delta","timebase","format","size","rate","eof","sample_count_in","sample_count_out","sample_count_delta","disabled"] | Default = Default('all+queue'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Show various filtergraph stats.
 
 With this filter one can debug complete filtergraph.
@@ -9501,61 +9501,61 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#graphmonitor)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='graphmonitor', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "opacity": opacity,
-                
+
                 "mode": mode,
-                
+
                 "flags": flags,
-                
+
                 "rate": rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def grayworld(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 A color constancy filter that applies color correction based on the grayworld assumption
 
 See: https://www.researchgate.net/publication/275213614_A_New_Color_Correction_Method_for_Underwater_Imaging
@@ -9579,7 +9579,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#grayworld)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9587,32 +9587,32 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='grayworld', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def greyedge(
-    
+
     self,
 
 
@@ -9620,15 +9620,15 @@ References:
 
     *,
     difford: Int = Default('1'),minknorm: Int = Default('1'),sigma: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 A color constancy variation filter which estimates scene illumination via grey edge algorithm
 and corrects the scene colors accordingly.
 
@@ -9651,7 +9651,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#greyedge)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9659,71 +9659,71 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='greyedge', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "difford": difford,
-                
+
                 "minknorm": minknorm,
-                
+
                 "sigma": sigma,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def haldclut(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _clut: VideoStream,
-        
-    
+
+
 
 
     *,
     clut: Int| Literal["first","all"] | Default = Default('all'),interp: Int| Literal["nearest","trilinear","tetrahedral","pyramid","prism"] | Default = Default('tetrahedral'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a Hald CLUT to a video stream.
 
 First input is the video stream to process, and second one is the Hald CLUT.
@@ -9746,7 +9746,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#haldclut)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -9757,68 +9757,68 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='haldclut', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _clut,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "clut": clut,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def hflip(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Flip the input video horizontally.
 
 For example, to horizontally flip the input video with ffmpeg:
@@ -9838,7 +9838,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hflip)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9846,38 +9846,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hflip', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def histeq(
-    
+
     self,
 
 
@@ -9885,15 +9885,15 @@ References:
 
     *,
     strength: Float = Default('0.2'),intensity: Float = Default('0.21'),antibanding: Int| Literal["none","weak","strong"] | Default = Default('none'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 This filter applies a global color histogram equalization on a
 per-frame basis.
 
@@ -9921,7 +9921,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#histeq)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9929,38 +9929,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='histeq', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "strength": strength,
-                
+
                 "intensity": intensity,
-                
+
                 "antibanding": antibanding,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def histogram(
-    
+
     self,
 
 
@@ -9968,12 +9968,12 @@ References:
 
     *,
     level_height: Int = Default('200'),scale_height: Int = Default('12'),display_mode: Int| Literal["overlay","parade","stack"] | Default = Default('stack'),levels_mode: Int| Literal["linear","logarithmic"] | Default = Default('linear'),components: Int = Default('7'),fgopacity: Float = Default('0.7'),bgopacity: Float = Default('0.5'),colors_mode: Int| Literal["whiteonblack","blackonwhite","whiteongray","blackongray","coloronblack","coloronwhite","colorongray","blackoncolor","whiteoncolor","grayoncolor"] | Default = Default('whiteonblack'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Compute and draw a color distribution histogram for the input video.
 
 The computed histogram is a representation of the color component
@@ -10005,51 +10005,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#histogram)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='histogram', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_height": level_height,
-                
+
                 "scale_height": scale_height,
-                
+
                 "display_mode": display_mode,
-                
+
                 "levels_mode": levels_mode,
-                
+
                 "components": components,
-                
+
                 "fgopacity": fgopacity,
-                
+
                 "bgopacity": bgopacity,
-                
+
                 "colors_mode": colors_mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hqdn3d(
-    
+
     self,
 
 
@@ -10057,15 +10057,15 @@ References:
 
     *,
     luma_spatial: Double = Default('0'),chroma_spatial: Double = Default('0'),luma_tmp: Double = Default('0'),chroma_tmp: Double = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 This is a high precision/quality 3d denoise filter. It aims to reduce
 image noise, producing smooth images and making still images really
 still. It should enhance compressibility.
@@ -10088,7 +10088,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hqdn3d)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -10096,40 +10096,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hqdn3d', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_spatial": luma_spatial,
-                
+
                 "chroma_spatial": chroma_spatial,
-                
+
                 "luma_tmp": luma_tmp,
-                
+
                 "chroma_tmp": chroma_tmp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hqx(
-    
+
     self,
 
 
@@ -10137,12 +10137,12 @@ References:
 
     *,
     n: Int = Default('3'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a high-quality magnification filter designed for pixel art. This filter
 was originally created by Maxim Stepin.
 
@@ -10160,41 +10160,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hqx)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hqx', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "n": n,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def hsvhold(
-    
+
     self,
 
 
@@ -10202,15 +10202,15 @@ References:
 
     *,
     hue: Float = Default('0'),sat: Float = Default('0'),val: Float = Default('0'),similarity: Float = Default('0.01'),blend: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Turns a certain HSV range into gray values.
 
 This filter measures color difference between set HSV color in options
@@ -10236,7 +10236,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hsvhold)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -10244,42 +10244,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hsvhold', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "hue": hue,
-                
+
                 "sat": sat,
-                
+
                 "val": val,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hsvkey(
-    
+
     self,
 
 
@@ -10287,15 +10287,15 @@ References:
 
     *,
     hue: Float = Default('0'),sat: Float = Default('0'),val: Float = Default('0'),similarity: Float = Default('0.01'),blend: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Turns a certain HSV range into transparency.
 
 This filter measures color difference between set HSV color in options
@@ -10321,7 +10321,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hsvkey)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -10329,42 +10329,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hsvkey', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "hue": hue,
-                
+
                 "sat": sat,
-                
+
                 "val": val,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hue(
-    
+
     self,
 
 
@@ -10372,15 +10372,15 @@ References:
 
     *,
     h: String = Default(None),s: String = Default('1'),H: String = Default(None),b: String = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Modify the hue and/or the saturation of the input.
 
 It accepts the following parameters:
@@ -10401,7 +10401,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hue)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -10409,40 +10409,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hue', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "h": h,
-                
+
                 "s": s,
-                
+
                 "H": H,
-                
+
                 "b": b,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def huesaturation(
-    
+
     self,
 
 
@@ -10450,15 +10450,15 @@ References:
 
     *,
     hue: Float = Default('0'),saturation: Float = Default('0'),intensity: Float = Default('0'),colors: Flags| Literal["r","y","g","c","b","m","a"] | Default = Default('r+y+g+c+b+m+a'),strength: Float = Default('1'),rw: Float = Default('0.333'),gw: Float = Default('0.334'),bw: Float = Default('0.333'),lightness: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply hue-saturation-intensity adjustments to input video stream.
 
 This filter operates in RGB colorspace.
@@ -10486,7 +10486,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#huesaturation)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -10494,63 +10494,63 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='huesaturation', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "hue": hue,
-                
+
                 "saturation": saturation,
-                
+
                 "intensity": intensity,
-                
+
                 "colors": colors,
-                
+
                 "strength": strength,
-                
+
                 "rw": rw,
-                
+
                 "gw": gw,
-                
+
                 "bw": bw,
-                
+
                 "lightness": lightness,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hwdownload(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Download hardware frames to system memory.
 
 The input must be in hardware frames, and the output a non-hardware format.
@@ -10569,35 +10569,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hwdownload)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hwdownload', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hwmap(
-    
+
     self,
 
 
@@ -10605,12 +10605,12 @@ References:
 
     *,
     mode: Flags| Literal["read","write","overwrite","direct"] | Default = Default('read+write'),derive_device: String = Default(None),reverse: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Map hardware frames to system memory or to another device.
 
 This filter has several different modes of operation; which one is used depends
@@ -10630,41 +10630,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hwmap)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hwmap', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "derive_device": derive_device,
-                
+
                 "reverse": reverse,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hwupload(
-    
+
     self,
 
 
@@ -10672,12 +10672,12 @@ References:
 
     *,
     derive_device: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Upload system memory frames to hardware surfaces.
 
 The device to upload to must be supplied when the filter is initialised.  If
@@ -10701,66 +10701,66 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hwupload)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hwupload', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "derive_device": derive_device,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hysteresis(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _alt: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),threshold: Int = Default('0'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Grow first stream into second stream by connecting components.
 This makes it possible to build more robust edge masks.
 
@@ -10781,7 +10781,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hysteresis)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -10792,75 +10792,75 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hysteresis', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _alt,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "threshold": threshold,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def identity(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the identity score between two input videos.
 
 This filter takes two input videos.
@@ -10896,7 +10896,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#identity)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -10907,42 +10907,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='identity', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def idet(
-    
+
     self,
 
 
@@ -10950,12 +10950,12 @@ References:
 
     *,
     intl_thres: Float = Default('1.04'),prog_thres: Float = Default('1.5'),rep_thres: Float = Default('3'),half_life: Float = Default('0'),analyze_interlaced_flag: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect video interlacing type.
 
 This filter tries to detect if the input frames are interlaced, progressive,
@@ -10983,45 +10983,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#idet)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='idet', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "intl_thres": intl_thres,
-                
+
                 "prog_thres": prog_thres,
-                
+
                 "rep_thres": rep_thres,
-                
+
                 "half_life": half_life,
-                
+
                 "analyze_interlaced_flag": analyze_interlaced_flag,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def il(
-    
+
     self,
 
 
@@ -11029,15 +11029,15 @@ References:
 
     *,
     luma_mode: Int| Literal["none","interleave","i","deinterleave","d"] | Default = Default('none'),chroma_mode: Int| Literal["none","interleave","i","deinterleave","d"] | Default = Default('none'),alpha_mode: Int| Literal["none","interleave","i","deinterleave","d"] | Default = Default('none'),luma_swap: Boolean = Default('false'),chroma_swap: Boolean = Default('false'),alpha_swap: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterleave or interleave fields.
 
 This filter allows one to process interlaced images fields without
@@ -11066,7 +11066,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#il)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11074,44 +11074,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='il', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_mode": luma_mode,
-                
+
                 "chroma_mode": chroma_mode,
-                
+
                 "alpha_mode": alpha_mode,
-                
+
                 "luma_swap": luma_swap,
-                
+
                 "chroma_swap": chroma_swap,
-                
+
                 "alpha_swap": alpha_swap,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def inflate(
-    
+
     self,
 
 
@@ -11119,15 +11119,15 @@ References:
 
     *,
     threshold0: Int = Default('65535'),threshold1: Int = Default('65535'),threshold2: Int = Default('65535'),threshold3: Int = Default('65535'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply inflate effect to the video.
 
 This filter replaces the pixel by the local(3x3) average by taking into account
@@ -11151,7 +11151,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#inflate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11159,40 +11159,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='inflate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold0": threshold0,
-                
+
                 "threshold1": threshold1,
-                
+
                 "threshold2": threshold2,
-                
+
                 "threshold3": threshold3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def interlace(
-    
+
     self,
 
 
@@ -11200,12 +11200,12 @@ References:
 
     *,
     scan: Int| Literal["tff","bff"] | Default = Default('tff'),lowpass: Int| Literal["off","linear","complex"] | Default = Default('linear'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Simple interlacing filter from progressive contents. This interleaves upper (or
 lower) lines from odd frames with lower (or upper) lines from even frames,
 halving the frame rate and preserving image height.
@@ -11237,43 +11237,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#interlace)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='interlace', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "scan": scan,
-                
+
                 "lowpass": lowpass,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def kerndeint(
-    
+
     self,
 
 
@@ -11281,12 +11281,12 @@ References:
 
     *,
     thresh: Int = Default('10'),map: Boolean = Default('false'),order: Boolean = Default('false'),sharp: Boolean = Default('false'),twoway: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlace input video by applying Donald Graft's adaptive kernel
 deinterling. Work on interlaced parts of a video to produce
 progressive frames.
@@ -11309,45 +11309,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#kerndeint)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='kerndeint', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "thresh": thresh,
-                
+
                 "map": map,
-                
+
                 "order": order,
-                
+
                 "sharp": sharp,
-                
+
                 "twoway": twoway,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def kirsch(
-    
+
     self,
 
 
@@ -11355,15 +11355,15 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply kirsch operator to input video stream.
 
 The filter accepts the following option:
@@ -11383,7 +11383,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#kirsch)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11391,38 +11391,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='kirsch', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lagfun(
-    
+
     self,
 
 
@@ -11430,15 +11430,15 @@ References:
 
     *,
     decay: Float = Default('0.95'),planes: Flags = Default('F'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Slowly update darker pixels.
 
 This filter makes short flashes of light appear longer.
@@ -11458,7 +11458,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lagfun)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11466,52 +11466,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lagfun', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "decay": decay,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def latency(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Measure filtering latency.
 
 Report previous filter filtering latency, delay in number of audio samples for audio filters
@@ -11532,7 +11532,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#latency)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11540,32 +11540,32 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='latency', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lenscorrection(
-    
+
     self,
 
 
@@ -11573,15 +11573,15 @@ References:
 
     *,
     cx: Double = Default('0.5'),cy: Double = Default('0.5'),k1: Double = Default('0'),k2: Double = Default('0'),i: Int| Literal["nearest","bilinear"] | Default = Default('nearest'),fc: Color = Default('black@0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Correct radial lens distortion
 
 This filter can be used to correct for radial distortion as can result from the use
@@ -11617,7 +11617,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lenscorrection)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11625,48 +11625,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lenscorrection', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cx": cx,
-                
+
                 "cy": cy,
-                
+
                 "k1": k1,
-                
+
                 "k2": k2,
-                
+
                 "i": i,
-                
+
                 "fc": fc,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def limiter(
-    
+
     self,
 
 
@@ -11674,15 +11674,15 @@ References:
 
     *,
     min: Int = Default('0'),max: Int = Default('65535'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Limits the pixel components values to the specified range [min, max].
 
 The filter accepts the following options:
@@ -11702,7 +11702,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#limiter)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11710,38 +11710,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='limiter', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "min": min,
-                
+
                 "max": max,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def loop(
-    
+
     self,
 
 
@@ -11749,12 +11749,12 @@ References:
 
     *,
     loop: Int = Default('0'),size: Int64 = Default('0'),start: Int64 = Default('0'),time: Duration = Default('INT64_MAX'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Loop video frames.
 
 The filter accepts the following options:
@@ -11774,49 +11774,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#loop)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='loop', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "loop": loop,
-                
+
                 "size": size,
-                
+
                 "start": start,
-                
+
                 "time": time,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def lumakey(
-    
+
     self,
 
 
@@ -11824,15 +11824,15 @@ References:
 
     *,
     threshold: Double = Default('0'),tolerance: Double = Default('0.01'),softness: Double = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Turn certain luma values into transparency.
 
 The filter accepts the following options:
@@ -11852,7 +11852,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lumakey)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11860,38 +11860,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lumakey', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold": threshold,
-                
+
                 "tolerance": tolerance,
-                
+
                 "softness": softness,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lut(
-    
+
     self,
 
 
@@ -11899,15 +11899,15 @@ References:
 
     *,
     c0: String = Default('clipval'),c1: String = Default('clipval'),c2: String = Default('clipval'),c3: String = Default('clipval'),y: String = Default('clipval'),u: String = Default('clipval'),v: String = Default('clipval'),r: String = Default('clipval'),g: String = Default('clipval'),b: String = Default('clipval'),a: String = Default('clipval'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Compute a look-up table for binding each pixel component input value
 to an output value, and apply it to the input video.
 
@@ -11939,7 +11939,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11947,54 +11947,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lut', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "c0": c0,
-                
+
                 "c1": c1,
-                
+
                 "c2": c2,
-                
+
                 "c3": c3,
-                
+
                 "y": y,
-                
+
                 "u": u,
-                
+
                 "v": v,
-                
+
                 "r": r,
-                
+
                 "g": g,
-                
+
                 "b": b,
-                
+
                 "a": a,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lut1d(
-    
+
     self,
 
 
@@ -12002,15 +12002,15 @@ References:
 
     *,
     file: String = Default(None),interp: Int| Literal["nearest","linear","cosine","cubic","spline"] | Default = Default('linear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a 1D LUT to an input video.
 
 The filter accepts the following options:
@@ -12029,7 +12029,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut1d)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12037,65 +12037,65 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lut1d', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "file": file,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lut2(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _srcy: VideoStream,
-        
-    
+
+
 
 
     *,
     c0: String = Default('x'),c1: String = Default('x'),c2: String = Default('x'),c3: String = Default('x'),d: Int = Default('0'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The lut2 filter takes two input streams and outputs one
 stream.
 
@@ -12122,7 +12122,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut2)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -12133,52 +12133,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lut2', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _srcy,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "c0": c0,
-                
+
                 "c1": c1,
-                
+
                 "c2": c2,
-                
+
                 "c3": c3,
-                
+
                 "d": d,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lut3d(
-    
+
     self,
 
 
@@ -12186,15 +12186,15 @@ References:
 
     *,
     file: String = Default(None),clut: Int| Literal["first","all"] | Default = Default('all'),interp: Int| Literal["nearest","trilinear","tetrahedral","pyramid","prism"] | Default = Default('tetrahedral'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a 3D LUT to an input video.
 
 The filter accepts the following options:
@@ -12214,7 +12214,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut3d)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12222,38 +12222,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lut3d', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "file": file,
-                
+
                 "clut": clut,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lutrgb(
-    
+
     self,
 
 
@@ -12261,15 +12261,15 @@ References:
 
     *,
     c0: String = Default('clipval'),c1: String = Default('clipval'),c2: String = Default('clipval'),c3: String = Default('clipval'),y: String = Default('clipval'),u: String = Default('clipval'),v: String = Default('clipval'),r: String = Default('clipval'),g: String = Default('clipval'),b: String = Default('clipval'),a: String = Default('clipval'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Compute a look-up table for binding each pixel component input value
 to an output value, and apply it to the input video.
 
@@ -12301,7 +12301,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12309,54 +12309,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lutrgb', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "c0": c0,
-                
+
                 "c1": c1,
-                
+
                 "c2": c2,
-                
+
                 "c3": c3,
-                
+
                 "y": y,
-                
+
                 "u": u,
-                
+
                 "v": v,
-                
+
                 "r": r,
-                
+
                 "g": g,
-                
+
                 "b": b,
-                
+
                 "a": a,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lutyuv(
-    
+
     self,
 
 
@@ -12364,15 +12364,15 @@ References:
 
     *,
     c0: String = Default('clipval'),c1: String = Default('clipval'),c2: String = Default('clipval'),c3: String = Default('clipval'),y: String = Default('clipval'),u: String = Default('clipval'),v: String = Default('clipval'),r: String = Default('clipval'),g: String = Default('clipval'),b: String = Default('clipval'),a: String = Default('clipval'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Compute a look-up table for binding each pixel component input value
 to an output value, and apply it to the input video.
 
@@ -12404,7 +12404,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12412,84 +12412,84 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lutyuv', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "c0": c0,
-                
+
                 "c1": c1,
-                
+
                 "c2": c2,
-                
+
                 "c3": c3,
-                
+
                 "y": y,
-                
+
                 "u": u,
-                
+
                 "v": v,
-                
+
                 "r": r,
-                
+
                 "g": g,
-                
+
                 "b": b,
-                
+
                 "a": a,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def maskedclamp(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _dark: VideoStream,
-        
-    
-        
+
+
+
         _bright: VideoStream,
-        
-    
+
+
 
 
     *,
     undershoot: Int = Default('0'),overshoot: Int = Default('0'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Clamp the first input stream with the second input and third input stream.
 
 Returns the value of first stream to be between second input
@@ -12512,7 +12512,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedclamp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12520,78 +12520,78 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='maskedclamp', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _dark,
-                
-            
-                
+
+
+
                 _bright,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "undershoot": undershoot,
-                
+
                 "overshoot": overshoot,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def maskedmax(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _filter1: VideoStream,
-        
-    
-        
+
+
+
         _filter2: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Merge the second and third input stream into output stream using absolute differences
 between second input stream and first input stream and absolute difference between
 third input stream and first input stream. The picked value will be from second input
@@ -12613,7 +12613,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedmax)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12621,74 +12621,74 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='maskedmax', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _filter1,
-                
-            
-                
+
+
+
                 _filter2,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def maskedmerge(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _overlay: VideoStream,
-        
-    
-        
+
+
+
         _mask: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Merge the first input stream with the second input stream using per pixel
 weights in the third input stream.
 
@@ -12713,7 +12713,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedmerge)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12721,74 +12721,74 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='maskedmerge', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _overlay,
-                
-            
-                
+
+
+
                 _mask,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def maskedmin(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _filter1: VideoStream,
-        
-    
-        
+
+
+
         _filter2: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Merge the second and third input stream into output stream using absolute differences
 between second input stream and first input stream and absolute difference between
 third input stream and first input stream. The picked value will be from second input
@@ -12810,7 +12810,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedmin)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12818,70 +12818,70 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='maskedmin', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _filter1,
-                
-            
-                
+
+
+
                 _filter2,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def maskedthreshold(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     threshold: Int = Default('1'),planes: Int = Default('15'),mode: Int| Literal["abs","diff"] | Default = Default('abs'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pick pixels comparing absolute difference of two video streams with fixed
 threshold.
 
@@ -12907,7 +12907,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedthreshold)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12915,46 +12915,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='maskedthreshold', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "threshold": threshold,
-                
+
                 "planes": planes,
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def maskfun(
-    
+
     self,
 
 
@@ -12962,15 +12962,15 @@ References:
 
     *,
     low: Int = Default('10'),high: Int = Default('10'),planes: Int = Default('15'),fill: Int = Default('0'),sum: Int = Default('10'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Create mask from input video.
 
 For example it is useful to create motion masks after tblend filter.
@@ -12994,7 +12994,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskfun)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -13002,42 +13002,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='maskfun', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "low": low,
-                
+
                 "high": high,
-                
+
                 "planes": planes,
-                
+
                 "fill": fill,
-                
+
                 "sum": sum,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def mcdeint(
-    
+
     self,
 
 
@@ -13045,12 +13045,12 @@ References:
 
     *,
     mode: Int| Literal["fast","medium","slow","extra_slow"] | Default = Default('fast'),parity: Int| Literal["tff","bff"] | Default = Default('bff'),qp: Int = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply motion-compensation deinterlacing.
 
 It needs one field per frame as input and must thus be used together
@@ -13072,43 +13072,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mcdeint)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='mcdeint', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "parity": parity,
-                
+
                 "qp": qp,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def median(
-    
+
     self,
 
 
@@ -13116,15 +13116,15 @@ References:
 
     *,
     radius: Int = Default('1'),planes: Int = Default('15'),radiusV: Int = Default('0'),percentile: Float = Default('0.5'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pick median pixel from certain rectangle defined by radius.
 
 This filter accepts the following options:
@@ -13145,7 +13145,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#median)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -13153,42 +13153,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='median', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "radius": radius,
-                
+
                 "planes": planes,
-                
+
                 "radiusV": radiusV,
-                
+
                 "percentile": percentile,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def mestimate(
-    
+
     self,
 
 
@@ -13196,12 +13196,12 @@ References:
 
     *,
     method: Int| Literal["esa","tss","tdls","ntss","fss","ds","hexbs","epzs","umh"] | Default = Default('esa'),mb_size: Int = Default('16'),search_param: Int = Default('7'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Estimate and export motion vectors using block matching algorithms.
 Motion vectors are stored in frame side data to be used by other filters.
 
@@ -13221,41 +13221,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mestimate)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='mestimate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "method": method,
-                
+
                 "mb_size": mb_size,
-                
+
                 "search_param": search_param,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def metadata(
-    
+
     self,
 
 
@@ -13263,15 +13263,15 @@ References:
 
     *,
     mode: Int| Literal["select","add","modify","delete","print"] | Default = Default('select'),key: String = Default(None),value: String = Default(None),function: Int| Literal["same_str","starts_with","less","equal","greater","expr","ends_with"] | Default = Default('same_str'),expr: String = Default(None),file: String = Default(None),direct: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Manipulate frame metadata.
 
 This filter accepts the following options:
@@ -13295,7 +13295,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#metadata)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -13303,70 +13303,70 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='metadata', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "key": key,
-                
+
                 "value": value,
-                
+
                 "function": function,
-                
+
                 "expr": expr,
-                
+
                 "file": file,
-                
+
                 "direct": direct,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def midequalizer(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _in1: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Midway Image Equalization effect using two video streams.
 
 Midway Image Equalization adjusts a pair of images to have the same
@@ -13392,7 +13392,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#midequalizer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -13400,42 +13400,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='midequalizer', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _in1,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def minterpolate(
-    
+
     self,
 
 
@@ -13443,12 +13443,12 @@ References:
 
     *,
     fps: Video_rate = Default('60'),mi_mode: Int| Literal["dup","blend","mci"] | Default = Default('mci'),mc_mode: Int| Literal["obmc","aobmc"] | Default = Default('obmc'),me_mode: Int| Literal["bidir","bilat"] | Default = Default('bilat'),me: Int| Literal["esa","tss","tdls","ntss","fss","ds","hexbs","epzs","umh"] | Default = Default('epzs'),mb_size: Int = Default('16'),search_param: Int = Default('32'),vsbmc: Int = Default('0'),scd: Int| Literal["none","fdiff"] | Default = Default('fdiff'),scd_threshold: Double = Default('10'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert the video to specified frame rate using motion interpolation.
 
 This filter accepts the following options:
@@ -13474,57 +13474,57 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#minterpolate)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='minterpolate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "fps": fps,
-                
+
                 "mi_mode": mi_mode,
-                
+
                 "mc_mode": mc_mode,
-                
+
                 "me_mode": me_mode,
-                
+
                 "me": me,
-                
+
                 "mb_size": mb_size,
-                
+
                 "search_param": search_param,
-                
+
                 "vsbmc": vsbmc,
-                
+
                 "scd": scd,
-                
+
                 "scd_threshold": scd_threshold,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def monochrome(
-    
+
     self,
 
 
@@ -13532,15 +13532,15 @@ References:
 
     *,
     cb: Float = Default('0'),cr: Float = Default('0'),size: Float = Default('1'),high: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert video to gray using custom color filter.
 
 A description of the accepted options follows.
@@ -13561,7 +13561,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#monochrome)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -13569,69 +13569,69 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='monochrome', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cb": cb,
-                
+
                 "cr": cr,
-                
+
                 "size": size,
-                
+
                 "high": high,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def morpho(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _structure: VideoStream,
-        
-    
+
+
 
 
     *,
     mode: Int| Literal["erode","dilate","open","close","gradient","tophat","blackhat"] | Default = Default('erode'),planes: Int = Default('7'),structure: Int| Literal["first","all"] | Default = Default('all'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 This filter allows to apply main morphological grayscale transforms,
 erode and dilate with arbitrary structures set in second input stream.
 
@@ -13657,7 +13657,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#morpho)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -13668,50 +13668,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='morpho', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _structure,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "planes": planes,
-                
+
                 "structure": structure,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def mpdecimate(
-    
+
     self,
 
 
@@ -13719,12 +13719,12 @@ References:
 
     *,
     max: Int = Default('0'),keep: Int = Default('0'),hi: Int = Default('768'),lo: Int = Default('320'),frac: Float = Default('0.33'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Drop frames that do not differ greatly from the previous frame in
 order to reduce frame rate.
 
@@ -13750,76 +13750,76 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mpdecimate)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='mpdecimate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "max": max,
-                
+
                 "keep": keep,
-                
+
                 "hi": hi,
-                
+
                 "lo": lo,
-                
+
                 "frac": frac,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def msad(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the MSAD (Mean Sum of Absolute Differences) between two input videos.
 
 This filter takes two input videos.
@@ -13855,7 +13855,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#msad)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -13866,66 +13866,66 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='msad', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def multiply(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _factor: VideoStream,
-        
-    
+
+
 
 
     *,
     scale: Float = Default('1'),offset: Float = Default('0.5'),planes: Flags = Default('F'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Multiply first video stream pixels values with second video stream pixels values.
 
 The filter accepts the following options:
@@ -13945,7 +13945,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#multiply)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -13953,46 +13953,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='multiply', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _factor,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "scale": scale,
-                
+
                 "offset": offset,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def negate(
-    
+
     self,
 
 
@@ -14000,15 +14000,15 @@ References:
 
     *,
     components: Flags| Literal["y","u","v","r","g","b","a"] | Default = Default('y+u+v+r+g+b'),negate_alpha: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Negate (invert) the input video.
 
 It accepts the following option:
@@ -14027,7 +14027,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#negate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14035,36 +14035,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='negate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "components": components,
-                
+
                 "negate_alpha": negate_alpha,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def nlmeans(
-    
+
     self,
 
 
@@ -14072,15 +14072,15 @@ References:
 
     *,
     s: Double = Default('1'),p: Int = Default('7'),pc: Int = Default('0'),r: Int = Default('15'),rc: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Denoise frames using Non-Local Means algorithm.
 
 Each pixel is adjusted by looking for other pixels with similar contexts. This
@@ -14110,7 +14110,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#nlmeans)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14118,42 +14118,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='nlmeans', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "s": s,
-                
+
                 "p": p,
-                
+
                 "pc": pc,
-                
+
                 "r": r,
-                
+
                 "rc": rc,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def nlmeans_opencl(
-    
+
     self,
 
 
@@ -14161,12 +14161,12 @@ References:
 
     *,
     s: Double = Default('1'),p: Int = Default('7'),pc: Int = Default('0'),r: Int = Default('15'),rc: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Non-local Means denoise filter through OpenCL, this filter accepts same options as nlmeans.
 
 
@@ -14185,45 +14185,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#nlmeans_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='nlmeans_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "s": s,
-                
+
                 "p": p,
-                
+
                 "pc": pc,
-                
+
                 "r": r,
-                
+
                 "rc": rc,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def nnedi(
-    
+
     self,
 
 
@@ -14231,15 +14231,15 @@ References:
 
     *,
     weights: String = Default('nnedi3_weights.bin'),deint: Int| Literal["all","interlaced"] | Default = Default('all'),field: Int| Literal["af","a","t","b","tf","bf"] | Default = Default('a'),planes: Int = Default('7'),nsize: Int| Literal["s8x6","s16x6","s32x6","s48x6","s8x4","s16x4","s32x4"] | Default = Default('s32x4'),nns: Int| Literal["n16","n32","n64","n128","n256"] | Default = Default('n32'),qual: Int| Literal["fast","slow"] | Default = Default('fast'),etype: Int| Literal["a","abs","s","mse"] | Default = Default('a'),pscrn: Int| Literal["none","original","new","new2","new3"] | Default = Default('new'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlace video using neural network edge directed interpolation.
 
 This filter accepts the following options:
@@ -14265,7 +14265,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#nnedi)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14273,50 +14273,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='nnedi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "weights": weights,
-                
+
                 "deint": deint,
-                
+
                 "field": field,
-                
+
                 "planes": planes,
-                
+
                 "nsize": nsize,
-                
+
                 "nns": nns,
-                
+
                 "qual": qual,
-                
+
                 "etype": etype,
-                
+
                 "pscrn": pscrn,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def noformat(
-    
+
     self,
 
 
@@ -14324,12 +14324,12 @@ References:
 
     *,
     pix_fmts: String = Default(None),color_spaces: String = Default(None),color_ranges: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Force libavfilter not to use any of the specified pixel formats for the
 input to the next filter.
 
@@ -14349,41 +14349,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#noformat)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='noformat', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "pix_fmts": pix_fmts,
-                
+
                 "color_spaces": color_spaces,
-                
+
                 "color_ranges": color_ranges,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def noise(
-    
+
     self,
 
 
@@ -14391,15 +14391,15 @@ References:
 
     *,
     all_seed: Int = Default('-1'),all_strength: Int = Default('0'),all_flags: Flags| Literal["a","p","t","u"] | Default = Default('0'),c0_seed: Int = Default('-1'),c0_strength: Int = Default('0'),c0_flags: Flags| Literal["a","p","t","u"] | Default = Default('0'),c1_seed: Int = Default('-1'),c1_strength: Int = Default('0'),c1_flags: Flags| Literal["a","p","t","u"] | Default = Default('0'),c2_seed: Int = Default('-1'),c2_strength: Int = Default('0'),c2_flags: Flags| Literal["a","p","t","u"] | Default = Default('0'),c3_seed: Int = Default('-1'),c3_strength: Int = Default('0'),c3_flags: Flags| Literal["a","p","t","u"] | Default = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Add noise on video input frame.
 
 The filter accepts the following options:
@@ -14431,7 +14431,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#noise)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14439,62 +14439,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='noise', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "all_seed": all_seed,
-                
+
                 "all_strength": all_strength,
-                
+
                 "all_flags": all_flags,
-                
+
                 "c0_seed": c0_seed,
-                
+
                 "c0_strength": c0_strength,
-                
+
                 "c0_flags": c0_flags,
-                
+
                 "c1_seed": c1_seed,
-                
+
                 "c1_strength": c1_strength,
-                
+
                 "c1_flags": c1_flags,
-                
+
                 "c2_seed": c2_seed,
-                
+
                 "c2_strength": c2_strength,
-                
+
                 "c2_flags": c2_flags,
-                
+
                 "c3_seed": c3_seed,
-                
+
                 "c3_strength": c3_strength,
-                
+
                 "c3_flags": c3_flags,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def normalize(
-    
+
     self,
 
 
@@ -14502,15 +14502,15 @@ References:
 
     *,
     blackpt: Color = Default('black'),whitept: Color = Default('white'),smoothing: Int = Default('0'),independence: Float = Default('1'),strength: Float = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Normalize RGB video (aka histogram stretching, contrast stretching).
 See: https://en.wikipedia.org/wiki/Normalization_(image_processing)
 
@@ -14549,7 +14549,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#normalize)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14557,55 +14557,55 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='normalize', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "blackpt": blackpt,
-                
+
                 "whitept": whitept,
-                
+
                 "smoothing": smoothing,
-                
+
                 "independence": independence,
-                
+
                 "strength": strength,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def null(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pass the video source unchanged to the output.
 
 
@@ -14619,41 +14619,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#null)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='null', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def oscilloscope(
-    
+
     self,
 
 
@@ -14661,15 +14661,15 @@ References:
 
     *,
     x: Float = Default('0.5'),y: Float = Default('0.5'),s: Float = Default('0.8'),t: Float = Default('0.5'),o: Float = Default('0.8'),tx: Float = Default('0.5'),ty: Float = Default('0.9'),tw: Float = Default('0.8'),th: Float = Default('0.3'),c: Int = Default('7'),g: Boolean = Default('true'),st: Boolean = Default('true'),sc: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 2D Video Oscilloscope.
 
 Useful to measure spatial impulse, step responses, chroma delays, etc.
@@ -14701,7 +14701,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#oscilloscope)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14709,87 +14709,87 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='oscilloscope', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "s": s,
-                
+
                 "t": t,
-                
+
                 "o": o,
-                
+
                 "tx": tx,
-                
+
                 "ty": ty,
-                
+
                 "tw": tw,
-                
+
                 "th": th,
-                
+
                 "c": c,
-                
+
                 "g": g,
-                
+
                 "st": st,
-                
+
                 "sc": sc,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def overlay(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _overlay: VideoStream,
-        
-    
+
+
 
 
     *,
     x: String = Default('0'),y: String = Default('0'),eof_action: Int| Literal["repeat","endall","pass"] | Default = Default('repeat'),eval: Int| Literal["init","frame"] | Default = Default('frame'),shortest: Boolean = Default('false'),format: Int| Literal["yuv420","yuv420p10","yuv422","yuv422p10","yuv444","yuv444p10","rgb","gbrp","auto"] | Default = Default('yuv420'),repeatlast: Boolean = Default('true'),alpha: Int| Literal["straight","premultiplied"] | Default = Default('straight'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
-    
-    
-    
-    
-    
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Overlay one video on top of another.
 
 It takes two inputs and has one output. The first input is the "main"
@@ -14820,7 +14820,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14828,79 +14828,79 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='overlay', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _overlay,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "eof_action": eof_action,
-                
+
                 "eval": eval,
-                
+
                 "shortest": shortest,
-                
+
                 "format": format,
-                
+
                 "repeatlast": repeatlast,
-                
+
                 "alpha": alpha,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def overlay_opencl(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _overlay: VideoStream,
-        
-    
+
+
 
 
     *,
     x: Int = Default('0'),y: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Overlay one video on top of another.
 
 It takes two inputs and has one output. The first input is the "main" video on which the second input is overlaid.
@@ -14921,73 +14921,73 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='overlay_opencl', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _overlay,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def overlay_vaapi(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _overlay: VideoStream,
-        
-    
+
+
 
 
     *,
     x: String = Default('0'),y: String = Default('0'),w: String = Default('overlay_iw'),h: String = Default('overlay_ih*w/overlay_iw'),alpha: Float = Default('1'),eof_action: Int| Literal["repeat","endall","pass"] | Default = Default('repeat'),shortest: Boolean = Default('false'),repeatlast: Boolean = Default('true'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
-    
-    
-    
-    
-    
+
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Overlay one video on the top of another.
 
 It takes two inputs and has one output. The first input is the "main" video on which the second input is overlaid.
@@ -15014,61 +15014,61 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay_vaapi)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='overlay_vaapi', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _overlay,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "alpha": alpha,
-                
+
                 "eof_action": eof_action,
-                
+
                 "shortest": shortest,
-                
+
                 "repeatlast": repeatlast,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def owdenoise(
-    
+
     self,
 
 
@@ -15076,15 +15076,15 @@ References:
 
     *,
     depth: Int = Default('8'),luma_strength: Double = Default('1'),chroma_strength: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Overcomplete Wavelet denoiser.
 
 The filter accepts the following options:
@@ -15104,7 +15104,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#owdenoise)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -15112,38 +15112,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='owdenoise', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "depth": depth,
-                
+
                 "luma_strength": luma_strength,
-                
+
                 "chroma_strength": chroma_strength,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pad(
-    
+
     self,
 
 
@@ -15151,12 +15151,12 @@ References:
 
     *,
     width: String = Default('iw'),height: String = Default('ih'),x: String = Default('0'),y: String = Default('0'),color: Color = Default('black'),eval: Int| Literal["init","frame"] | Default = Default('init'),aspect: Rational = Default('0/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Add paddings to the input image, and place the original input at the
 provided x, y coordinates.
 
@@ -15180,49 +15180,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pad)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pad', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "color": color,
-                
+
                 "eval": eval,
-                
+
                 "aspect": aspect,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pad_opencl(
-    
+
     self,
 
 
@@ -15230,12 +15230,12 @@ References:
 
     *,
     width: String = Default('iw'),height: String = Default('ih'),x: String = Default('0'),y: String = Default('0'),color: Color = Default('black'),aspect: Rational = Default('0/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Add paddings to the input image, and place the original input at the
 provided x, y coordinates.
 
@@ -15258,47 +15258,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pad_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pad_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "color": color,
-                
+
                 "aspect": aspect,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pad_vaapi(
-    
+
     self,
 
 
@@ -15306,12 +15306,12 @@ References:
 
     *,
     width: String = Default('iw'),height: String = Default('ih'),x: String = Default('0'),y: String = Default('0'),color: Color = Default('black'),aspect: Rational = Default('0/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Add paddings to the input image, and place the original input at the
 provided x, y coordinates.
 
@@ -15334,51 +15334,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pad_vaapi)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pad_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "color": color,
-                
+
                 "aspect": aspect,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def palettegen(
-    
+
     self,
 
 
@@ -15386,12 +15386,12 @@ References:
 
     *,
     max_colors: Int = Default('256'),reserve_transparent: Boolean = Default('true'),transparency_color: Color = Default('lime'),stats_mode: Int| Literal["full","diff","single"] | Default = Default('full'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Generate one palette for a whole video stream.
 
 It accepts the following options:
@@ -15411,64 +15411,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#palettegen)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='palettegen', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "max_colors": max_colors,
-                
+
                 "reserve_transparent": reserve_transparent,
-                
+
                 "transparency_color": transparency_color,
-                
+
                 "stats_mode": stats_mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def paletteuse(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _palette: VideoStream,
-        
-    
+
+
 
 
     *,
     dither: Int| Literal["bayer","heckbert","floyd_steinberg","sierra2","sierra2_4a","sierra3","burkes","atkinson"] | Default = Default('sierra2_4a'),bayer_scale: Int = Default('2'),diff_mode: Int| Literal["rectangle"] | Default = Default('0'),new: Boolean = Default('false'),alpha_threshold: Int = Default('128'),debug_kdtree: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Use a palette to downsample an input video stream.
 
 The filter takes two inputs: one video stream and a palette. The palette must
@@ -15493,59 +15493,59 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#paletteuse)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='paletteuse', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _palette,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "dither": dither,
-                
+
                 "bayer_scale": bayer_scale,
-                
+
                 "diff_mode": diff_mode,
-                
+
                 "new": new,
-                
+
                 "alpha_threshold": alpha_threshold,
-                
+
                 "debug_kdtree": debug_kdtree,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def perms(
-    
+
     self,
 
 
@@ -15553,15 +15553,15 @@ References:
 
     *,
     mode: Int| Literal["none","ro","rw","toggle","random"] | Default = Default('none'),seed: Int64 = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Set read/write permissions for the output frames.
 
 These filters are mainly aimed at developers to test direct path in the
@@ -15583,7 +15583,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#perms)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -15591,36 +15591,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='perms', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "seed": seed,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def perspective(
-    
+
     self,
 
 
@@ -15628,15 +15628,15 @@ References:
 
     *,
     x0: String = Default('0'),y0: String = Default('0'),x1: String = Default('W'),y1: String = Default('0'),x2: String = Default('0'),y2: String = Default('H'),x3: String = Default('W'),y3: String = Default('H'),interpolation: Int| Literal["linear","cubic"] | Default = Default('linear'),sense: Int| Literal["source","destination"] | Default = Default('source'),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Correct perspective of video not recorded perpendicular to the screen.
 
 A description of the accepted parameters follows.
@@ -15664,7 +15664,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#perspective)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -15672,54 +15672,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='perspective', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x0": x0,
-                
+
                 "y0": y0,
-                
+
                 "x1": x1,
-                
+
                 "y1": y1,
-                
+
                 "x2": x2,
-                
+
                 "y2": y2,
-                
+
                 "x3": x3,
-                
+
                 "y3": y3,
-                
+
                 "interpolation": interpolation,
-                
+
                 "sense": sense,
-                
+
                 "eval": eval,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def phase(
-    
+
     self,
 
 
@@ -15727,15 +15727,15 @@ References:
 
     *,
     mode: Int| Literal["p","t","b","T","B","u","U","a","A"] | Default = Default('A'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Delay interlaced video by one field time so that the field order changes.
 
 The intended use is to fix PAL movies that have been captured with the
@@ -15756,7 +15756,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#phase)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -15764,34 +15764,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='phase', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def photosensitivity(
-    
+
     self,
 
 
@@ -15799,12 +15799,12 @@ References:
 
     *,
     frames: Int = Default('30'),threshold: Float = Default('1'),skip: Int = Default('1'),bypass: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reduce various flashes in video, so to help users with epilepsy.
 
 It accepts the following options:
@@ -15824,56 +15824,56 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#photosensitivity)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='photosensitivity', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frames": frames,
-                
+
                 "threshold": threshold,
-                
+
                 "skip": skip,
-                
+
                 "bypass": bypass,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pixdesctest(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pixel format descriptor test filter, mainly useful for internal
 testing. The output video should be equal to the input video.
 
@@ -15895,35 +15895,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pixdesctest)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pixdesctest', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pixelize(
-    
+
     self,
 
 
@@ -15931,15 +15931,15 @@ References:
 
     *,
     width: Int = Default('16'),height: Int = Default('16'),mode: Int| Literal["avg","min","max"] | Default = Default('avg'),planes: Flags = Default('F'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply pixelization to video stream.
 
 The filter accepts the following options:
@@ -15960,7 +15960,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pixelize)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -15968,40 +15968,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pixelize', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "mode": mode,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pixscope(
-    
+
     self,
 
 
@@ -16009,15 +16009,15 @@ References:
 
     *,
     x: Float = Default('0.5'),y: Float = Default('0.5'),w: Int = Default('7'),h: Int = Default('7'),o: Float = Default('0.5'),wx: Float = Default('-1'),wy: Float = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Display sample values of color channels. Mainly useful for checking color
 and levels. Minimum supported resolution is 640x480.
 
@@ -16042,7 +16042,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pixscope)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -16050,46 +16050,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pixscope', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "o": o,
-                
+
                 "wx": wx,
-                
+
                 "wy": wy,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pp(
-    
+
     self,
 
 
@@ -16097,15 +16097,15 @@ References:
 
     *,
     subfilters: String = Default('de'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Enable the specified chain of postprocessing subfilters using libpostproc. This
 library should be automatically selected with a GPL build (--enable-gpl).
 Subfilters must be separated by '/' and can be disabled by prepending a '-'.
@@ -16127,7 +16127,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -16135,34 +16135,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pp', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "subfilters": subfilters,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pp7(
-    
+
     self,
 
 
@@ -16170,15 +16170,15 @@ References:
 
     *,
     qp: Int = Default('0'),mode: Int| Literal["hard","soft","medium"] | Default = Default('medium'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Postprocessing filter 7. It is variant of the spp filter,
 similar to spp = 6 with 7 point DCT, where only the center sample is
 used after IDCT.
@@ -16199,7 +16199,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pp7)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -16207,38 +16207,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pp7', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "qp": qp,
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def prewitt(
-    
+
     self,
 
 
@@ -16246,15 +16246,15 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply prewitt operator to input video stream.
 
 The filter accepts the following option:
@@ -16274,7 +16274,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#prewitt)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -16282,38 +16282,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='prewitt', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def prewitt_opencl(
-    
+
     self,
 
 
@@ -16321,12 +16321,12 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply the Prewitt operator (https://en.wikipedia.org/wiki/Prewitt_operator) to input video stream.
 
 The filter accepts the following option:
@@ -16345,41 +16345,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#prewitt_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='prewitt_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def procamp_vaapi(
-    
+
     self,
 
 
@@ -16387,12 +16387,12 @@ References:
 
     *,
     b: Float = Default('0'),s: Float = Default('1'),c: Float = Default('1'),h: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 ProcAmp (color balance) adjustments for hue, saturation, brightness, contrast
 
 
@@ -16410,45 +16410,45 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='procamp_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "b": b,
-                
+
                 "s": s,
-                
+
                 "c": c,
-                
+
                 "h": h,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def pseudocolor(
-    
+
     self,
 
 
@@ -16456,15 +16456,15 @@ References:
 
     *,
     c0: String = Default('val'),c1: String = Default('val'),c2: String = Default('val'),c3: String = Default('val'),index: Int = Default('0'),preset: Int| Literal["none","magma","inferno","plasma","viridis","turbo","cividis","range1","range2","shadows","highlights","solar","nominal","preferred","total","spectral","cool","heat","fiery","blues","green","helix"] | Default = Default('none'),opacity: Float = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Alter frame colors in video with pseudocolors.
 
 This filter accepts the following options:
@@ -16488,7 +16488,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pseudocolor)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -16496,75 +16496,75 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pseudocolor', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "c0": c0,
-                
+
                 "c1": c1,
-                
+
                 "c2": c2,
-                
+
                 "c3": c3,
-                
+
                 "index": index,
-                
+
                 "preset": preset,
-                
+
                 "opacity": opacity,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def psnr(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),stats_version: Int = Default('1'),output_max: Boolean = Default('false'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the average, maximum and minimum PSNR (Peak Signal to Noise
 Ratio) between two input videos.
 
@@ -16608,7 +16608,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#psnr)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -16619,48 +16619,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='psnr', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "stats_file": stats_file,
-                
+
                 "stats_version": stats_version,
-                
+
                 "output_max": output_max,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pullup(
-    
+
     self,
 
 
@@ -16668,12 +16668,12 @@ References:
 
     *,
     jl: Int = Default('1'),jr: Int = Default('1'),jt: Int = Default('4'),jb: Int = Default('4'),sb: Boolean = Default('false'),mp: Int| Literal["y","u","v"] | Default = Default('y'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pulldown reversal (inverse telecine) filter, capable of handling mixed
 hard-telecine, 24000/1001 fps progressive, and 30000/1001 fps progressive
 content.
@@ -16706,47 +16706,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pullup)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pullup', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "jl": jl,
-                
+
                 "jr": jr,
-                
+
                 "jt": jt,
-                
+
                 "jb": jb,
-                
+
                 "sb": sb,
-                
+
                 "mp": mp,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def qp(
-    
+
     self,
 
 
@@ -16754,15 +16754,15 @@ References:
 
     *,
     qp: String = Default(None),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Change video quantization parameters (QP).
 
 The filter accepts the following option:
@@ -16780,7 +16780,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#qp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -16788,34 +16788,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='qp', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "qp": qp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def random(
-    
+
     self,
 
 
@@ -16823,12 +16823,12 @@ References:
 
     *,
     frames: Int = Default('30'),seed: Int64 = Default('-1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Flush video frames from internal cache of frames into a random order.
 No frame is discarded.
 Inspired by frei0r nervous filter.
@@ -16846,39 +16846,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#random)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='random', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frames": frames,
-                
+
                 "seed": seed,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def readeia608(
-    
+
     self,
 
 
@@ -16886,15 +16886,15 @@ References:
 
     *,
     scan_min: Int = Default('0'),scan_max: Int = Default('29'),spw: Float = Default('0.27'),chp: Boolean = Default('false'),lp: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Read closed captioning (EIA-608) information from the top lines of a video frame.
 
 This filter adds frame metadata for lavfi.readeia608.X.cc and
@@ -16918,7 +16918,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#readeia608)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -16926,42 +16926,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='readeia608', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "scan_min": scan_min,
-                
+
                 "scan_max": scan_max,
-                
+
                 "spw": spw,
-                
+
                 "chp": chp,
-                
+
                 "lp": lp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def readvitc(
-    
+
     self,
 
 
@@ -16969,12 +16969,12 @@ References:
 
     *,
     scan_max: Int = Default('45'),thr_b: Double = Default('0.2'),thr_w: Double = Default('0.6'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Read vertical interval timecode (VITC) information from the top lines of a
 video frame.
 
@@ -16999,41 +16999,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#readvitc)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='readvitc', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "scan_max": scan_max,
-                
+
                 "thr_b": thr_b,
-                
+
                 "thr_w": thr_w,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def realtime(
-    
+
     self,
 
 
@@ -17041,12 +17041,12 @@ References:
 
     *,
     limit: Duration = Default('2'),speed: Double = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Slow down filtering to match real time approximately.
 
 These filters will pause the filtering for a variable amount of time to
@@ -17068,64 +17068,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#realtime)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='realtime', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "limit": limit,
-                
+
                 "speed": speed,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def remap(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _xmap: VideoStream,
-        
-    
-        
+
+
+
         _ymap: VideoStream,
-        
-    
+
+
 
 
     *,
     format: Int| Literal["color","gray"] | Default = Default('color'),fill: Color = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remap pixels using 2nd: Xmap and 3rd: Ymap input video stream.
 
 Destination pixel at position (X, Y) will be picked from source (x, y) position
@@ -17149,76 +17149,76 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#remap)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='remap', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _xmap,
-                
-            
-                
+
+
+
                 _ymap,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "format": format,
-                
+
                 "fill": fill,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def remap_opencl(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _xmap: VideoStream,
-        
-    
-        
+
+
+
         _ymap: VideoStream,
-        
-    
+
+
 
 
     *,
     interp: Int| Literal["near","linear"] | Default = Default('linear'),fill: Color = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remap pixels using 2nd: Xmap and 3rd: Ymap input video stream.
 
 Destination pixel at position (X, Y) will be picked from source (x, y) position
@@ -17242,51 +17242,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#remap_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='remap_opencl', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _xmap,
-                
-            
-                
+
+
+
                 _ymap,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "interp": interp,
-                
+
                 "fill": fill,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def removegrain(
-    
+
     self,
 
 
@@ -17294,15 +17294,15 @@ References:
 
     *,
     m0: Int = Default('0'),m1: Int = Default('0'),m2: Int = Default('0'),m3: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The removegrain filter is a spatial denoiser for progressive video.
 
 
@@ -17321,7 +17321,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#removegrain)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -17329,40 +17329,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='removegrain', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "m0": m0,
-                
+
                 "m1": m1,
-                
+
                 "m2": m2,
-                
+
                 "m3": m3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def removelogo(
-    
+
     self,
 
 
@@ -17370,15 +17370,15 @@ References:
 
     *,
     filename: String = Default(None),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Suppress a TV station logo, using an image file to determine which
 pixels comprise the logo. It works by filling in the pixels that
 comprise the logo with neighboring pixels.
@@ -17398,7 +17398,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#removelogo)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -17406,47 +17406,47 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='removelogo', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "filename": filename,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def repeatfields(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 This filter uses the repeat_field flag from the Video ES headers and hard repeats
 fields based on its value.
 
@@ -17461,50 +17461,50 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#repeatfields)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='repeatfields', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def reverse(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reverse a video clip.
 
 Warning: This filter requires memory to buffer the entire clip, so trimming
@@ -17521,35 +17521,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#reverse)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='reverse', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def rgbashift(
-    
+
     self,
 
 
@@ -17557,15 +17557,15 @@ References:
 
     *,
     rh: Int = Default('0'),rv: Int = Default('0'),gh: Int = Default('0'),gv: Int = Default('0'),bh: Int = Default('0'),bv: Int = Default('0'),ah: Int = Default('0'),av: Int = Default('0'),edge: Int| Literal["smear","wrap"] | Default = Default('smear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Shift R/G/B/A pixels horizontally and/or vertically.
 
 The filter accepts the following options:
@@ -17591,7 +17591,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#rgbashift)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -17599,52 +17599,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='rgbashift', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rh": rh,
-                
+
                 "rv": rv,
-                
+
                 "gh": gh,
-                
+
                 "gv": gv,
-                
+
                 "bh": bh,
-                
+
                 "bv": bv,
-                
+
                 "ah": ah,
-                
+
                 "av": av,
-                
+
                 "edge": edge,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def roberts(
-    
+
     self,
 
 
@@ -17652,15 +17652,15 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply roberts cross operator to input video stream.
 
 The filter accepts the following option:
@@ -17680,7 +17680,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#roberts)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -17688,38 +17688,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='roberts', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def roberts_opencl(
-    
+
     self,
 
 
@@ -17727,12 +17727,12 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply the Roberts cross operator (https://en.wikipedia.org/wiki/Roberts_cross) to input video stream.
 
 The filter accepts the following option:
@@ -17751,41 +17751,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#roberts_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='roberts_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def rotate(
-    
+
     self,
 
 
@@ -17793,15 +17793,15 @@ References:
 
     *,
     angle: String = Default('0'),out_w: String = Default('iw'),out_h: String = Default('ih'),fillcolor: String = Default('black'),bilinear: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Rotate video by an arbitrary angle expressed in radians.
 
 The filter accepts the following options:
@@ -17825,7 +17825,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#rotate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -17833,42 +17833,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='rotate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "angle": angle,
-                
+
                 "out_w": out_w,
-                
+
                 "out_h": out_h,
-                
+
                 "fillcolor": fillcolor,
-                
+
                 "bilinear": bilinear,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def sab(
-    
+
     self,
 
 
@@ -17876,15 +17876,15 @@ References:
 
     *,
     luma_radius: Float = Default('1'),luma_pre_filter_radius: Float = Default('1'),luma_strength: Float = Default('1'),chroma_radius: Float = Default('-0.9'),chroma_pre_filter_radius: Float = Default('-0.9'),chroma_strength: Float = Default('-0.9'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Shape Adaptive Blur.
 
 The filter accepts the following options:
@@ -17907,7 +17907,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sab)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -17915,63 +17915,63 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sab', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_radius": luma_radius,
-                
+
                 "luma_pre_filter_radius": luma_pre_filter_radius,
-                
+
                 "luma_strength": luma_strength,
-                
+
                 "chroma_radius": chroma_radius,
-                
+
                 "chroma_pre_filter_radius": chroma_pre_filter_radius,
-                
+
                 "chroma_strength": chroma_strength,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def scale(
-    
+
     self,
 
 
-    
+
 
 
     *,
     w: String = Default(None),h: String = Default(None),flags: String = Default(''),interl: Boolean = Default('false'),size: String = Default(None),in_color_matrix: Int| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default('auto'),out_color_matrix: Int| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default('2'),in_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),out_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),in_chroma_loc: Int| Literal["auto","unknown","left","center","topleft","top","bottomleft","bottom"] | Default = Default('auto'),out_chroma_loc: Int| Literal["auto","unknown","left","center","topleft","top","bottomleft","bottom"] | Default = Default('auto'),in_v_chr_pos: Int = Default('-513'),in_h_chr_pos: Int = Default('-513'),out_v_chr_pos: Int = Default('-513'),out_h_chr_pos: Int = Default('-513'),force_original_aspect_ratio: Int| Literal["disable","decrease","increase"] | Default = Default('disable'),force_divisible_by: Int = Default('1'),param0: Double = Default('DBL_MAX'),param1: Double = Default('DBL_MAX'),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Scale (resize) the input video, using the libswscale library.
 
 The scale filter forces the output display aspect ratio to be the same
@@ -18013,7 +18013,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#scale)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -18021,104 +18021,104 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='scale', typings_input=(), typings_output=('video',)),
-            
+
             self,
 
 
-            
+
 
 
             **merge({
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "flags": flags,
-                
+
                 "interl": interl,
-                
+
                 "size": size,
-                
+
                 "in_color_matrix": in_color_matrix,
-                
+
                 "out_color_matrix": out_color_matrix,
-                
+
                 "in_range": in_range,
-                
+
                 "out_range": out_range,
-                
+
                 "in_chroma_loc": in_chroma_loc,
-                
+
                 "out_chroma_loc": out_chroma_loc,
-                
+
                 "in_v_chr_pos": in_v_chr_pos,
-                
+
                 "in_h_chr_pos": in_h_chr_pos,
-                
+
                 "out_v_chr_pos": out_v_chr_pos,
-                
+
                 "out_h_chr_pos": out_h_chr_pos,
-                
+
                 "force_original_aspect_ratio": force_original_aspect_ratio,
-                
+
                 "force_divisible_by": force_divisible_by,
-                
+
                 "param0": param0,
-                
+
                 "param1": param1,
-                
+
                 "eval": eval,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def scale2ref(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _ref: VideoStream,
-        
-    
+
+
 
 
     *,
     w: String = Default(None),h: String = Default(None),flags: String = Default(''),interl: Boolean = Default('false'),size: String = Default(None),in_color_matrix: Int| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default('auto'),out_color_matrix: Int| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default('2'),in_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),out_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),in_chroma_loc: Int| Literal["auto","unknown","left","center","topleft","top","bottomleft","bottom"] | Default = Default('auto'),out_chroma_loc: Int| Literal["auto","unknown","left","center","topleft","top","bottomleft","bottom"] | Default = Default('auto'),in_v_chr_pos: Int = Default('-513'),in_h_chr_pos: Int = Default('-513'),out_v_chr_pos: Int = Default('-513'),out_h_chr_pos: Int = Default('-513'),force_original_aspect_ratio: Int| Literal["disable","decrease","increase"] | Default = Default('disable'),force_divisible_by: Int = Default('1'),param0: Double = Default('DBL_MAX'),param1: Double = Default('DBL_MAX'),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> tuple[
-    
-        
+
+
             VideoStream,
-        
-    
-        
+
+
+
             VideoStream,
-        
-    
+
+
 ]:
         """
-        
+
 Scale the input video size and/or convert the image format to the given reference.
 
 
@@ -18153,94 +18153,94 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='scale2ref', typings_input=('video', 'video'), typings_output=('video', 'video')),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _ref,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "flags": flags,
-                
+
                 "interl": interl,
-                
+
                 "size": size,
-                
+
                 "in_color_matrix": in_color_matrix,
-                
+
                 "out_color_matrix": out_color_matrix,
-                
+
                 "in_range": in_range,
-                
+
                 "out_range": out_range,
-                
+
                 "in_chroma_loc": in_chroma_loc,
-                
+
                 "out_chroma_loc": out_chroma_loc,
-                
+
                 "in_v_chr_pos": in_v_chr_pos,
-                
+
                 "in_h_chr_pos": in_h_chr_pos,
-                
+
                 "out_v_chr_pos": out_v_chr_pos,
-                
+
                 "out_h_chr_pos": out_h_chr_pos,
-                
+
                 "force_original_aspect_ratio": force_original_aspect_ratio,
-                
+
                 "force_divisible_by": force_divisible_by,
-                
+
                 "param0": param0,
-                
+
                 "param1": param1,
-                
+
                 "eval": eval,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return (
-            
-                
+
+
                     filter_node.video(0),
-                
-            
-                
+
+
+
                     filter_node.video(1),
-                
-            
+
+
         )
 
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def scale_vaapi(
-    
+
     self,
 
 
@@ -18248,12 +18248,12 @@ References:
 
     *,
     w: String = Default('iw'),h: String = Default('ih'),format: String = Default(None),mode: Int| Literal["default","fast","hq","nl_anamorphic"] | Default = Default('hq'),out_color_matrix: String = Default(None),out_range: Int| Literal["full","limited","jpeg","mpeg","tv","pc"] | Default = Default('0'),out_color_primaries: String = Default(None),out_color_transfer: String = Default(None),out_chroma_location: String = Default(None),force_original_aspect_ratio: Int| Literal["disable","decrease","increase"] | Default = Default('disable'),force_divisible_by: Int = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Scale to/from VAAPI surfaces.
 
 
@@ -18278,57 +18278,57 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='scale_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "format": format,
-                
+
                 "mode": mode,
-                
+
                 "out_color_matrix": out_color_matrix,
-                
+
                 "out_range": out_range,
-                
+
                 "out_color_primaries": out_color_primaries,
-                
+
                 "out_color_transfer": out_color_transfer,
-                
+
                 "out_chroma_location": out_chroma_location,
-                
+
                 "force_original_aspect_ratio": force_original_aspect_ratio,
-                
+
                 "force_divisible_by": force_divisible_by,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def scdet(
-    
+
     self,
 
 
@@ -18336,12 +18336,12 @@ References:
 
     *,
     threshold: Double = Default('10'),sc_pass: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect video scene change.
 
 This filter sets frame metadata with mafd between frame, the scene score, and
@@ -18374,39 +18374,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#scdet)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='scdet', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold": threshold,
-                
+
                 "sc_pass": sc_pass,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def scharr(
-    
+
     self,
 
 
@@ -18414,15 +18414,15 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply scharr operator to input video stream.
 
 The filter accepts the following option:
@@ -18442,7 +18442,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#scharr)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -18450,38 +18450,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='scharr', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def scroll(
-    
+
     self,
 
 
@@ -18489,15 +18489,15 @@ References:
 
     *,
     horizontal: Float = Default('0'),vertical: Float = Default('0'),hpos: Float = Default('0'),vpos: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Scroll input video horizontally and/or vertically by constant speed.
 
 The filter accepts the following options:
@@ -18518,7 +18518,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#scroll)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -18526,40 +18526,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='scroll', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "horizontal": horizontal,
-                
+
                 "vertical": vertical,
-                
+
                 "hpos": hpos,
-                
+
                 "vpos": vpos,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def segment(
-    
+
     self,
 
 
@@ -18567,12 +18567,12 @@ References:
 
     *,
     timestamps: String = Default(None),frames: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Split single input stream into multiple streams.
 
 This filter does opposite of concat filters.
@@ -18595,40 +18595,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#segment)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='segment', typings_input=('video',), typings_output="[StreamType.video] * len((str(timestamps or frames)).split('|'))"),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "timestamps": timestamps,
-                
+
                 "frames": frames,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def select(
-    
+
     self,
 
 
@@ -18636,12 +18636,12 @@ References:
 
     *,
     expr: String = Default('1'),outputs: Int = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Select frames to pass in output.
 
 This filter accepts the following options:
@@ -18660,40 +18660,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#select)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='select', typings_input=('video',), typings_output='[StreamType.video] * int(outputs)'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "expr": expr,
-                
+
                 "outputs": outputs,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def selectivecolor(
-    
+
     self,
 
 
@@ -18701,15 +18701,15 @@ References:
 
     *,
     correction_method: Int| Literal["absolute","relative"] | Default = Default('absolute'),reds: String = Default(None),yellows: String = Default(None),greens: String = Default(None),cyans: String = Default(None),blues: String = Default(None),magentas: String = Default(None),whites: String = Default(None),neutrals: String = Default(None),blacks: String = Default(None),psfile: String = Default(None),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust cyan, magenta, yellow and black (CMYK) to certain ranges of colors (such
 as "reds", "yellows", "greens", "cyans", ...). The adjustment range is defined
 by the "purity" of the color (that is, how saturated it already is).
@@ -18741,7 +18741,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#selectivecolor)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -18749,54 +18749,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='selectivecolor', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "correction_method": correction_method,
-                
+
                 "reds": reds,
-                
+
                 "yellows": yellows,
-                
+
                 "greens": greens,
-                
+
                 "cyans": cyans,
-                
+
                 "blues": blues,
-                
+
                 "magentas": magentas,
-                
+
                 "whites": whites,
-                
+
                 "neutrals": neutrals,
-                
+
                 "blacks": blacks,
-                
+
                 "psfile": psfile,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def sendcmd(
-    
+
     self,
 
 
@@ -18804,12 +18804,12 @@ References:
 
     *,
     commands: String = Default(None),filename: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Send commands to filters in the filtergraph.
 
 These filters read commands to be sent to other filters in the
@@ -18838,52 +18838,52 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sendcmd)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sendcmd', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "commands": commands,
-                
+
                 "filename": filename,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def separatefields(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The separatefields takes a frame-based video input and splits
 each frame into its components fields, producing a new half height clip
 with twice the frame rate and twice the frame count.
@@ -18903,35 +18903,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#separatefields)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='separatefields', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def setdar(
-    
+
     self,
 
 
@@ -18939,12 +18939,12 @@ References:
 
     *,
     dar: String = Default('0'),max: Int = Default('100'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The setdar filter sets the Display Aspect Ratio for the filter
 output video.
 
@@ -18986,39 +18986,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setdar)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='setdar', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dar": dar,
-                
+
                 "max": max,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def setfield(
-    
+
     self,
 
 
@@ -19026,12 +19026,12 @@ References:
 
     *,
     mode: Int| Literal["auto","bff","tff","prog"] | Default = Default('auto'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Force field for the output video frame.
 
 The setfield filter marks the interlace type field for the
@@ -19053,37 +19053,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setfield)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='setfield', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def setparams(
-    
+
     self,
 
 
@@ -19091,12 +19091,12 @@ References:
 
     *,
     field_mode: Int| Literal["auto","bff","tff","prog"] | Default = Default('auto'),range: Int| Literal["auto","unspecified","unknown","limited","tv","mpeg","full","pc","jpeg"] | Default = Default('auto'),color_primaries: Int| Literal["auto","bt709","unknown","bt470m","bt470bg","smpte170m","smpte240m","film","bt2020","smpte428","smpte431","smpte432","jedec-p22","ebu3213"] | Default = Default('auto'),color_trc: Int| Literal["auto","bt709","unknown","bt470m","bt470bg","smpte170m","smpte240m","linear","log100","log316","iec61966-2-4","bt1361e","iec61966-2-1","bt2020-10","bt2020-12","smpte2084","smpte428","arib-std-b67"] | Default = Default('auto'),colorspace: Int| Literal["auto","gbr","bt709","unknown","fcc","bt470bg","smpte170m","smpte240m","ycgco","ycgco-re","ycgco-ro","bt2020nc","bt2020c","smpte2085","chroma-derived-nc","chroma-derived-c","ictcp","ipt-c2"] | Default = Default('auto'),chroma_location: Int| Literal["auto","unspecified","unknown","left","center","topleft","top","bottomleft","bottom"] | Default = Default('auto'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Force frame parameter for the output video frame.
 
 The setparams filter marks interlace and color range for the
@@ -19121,47 +19121,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setparams)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='setparams', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "field_mode": field_mode,
-                
+
                 "range": range,
-                
+
                 "color_primaries": color_primaries,
-                
+
                 "color_trc": color_trc,
-                
+
                 "colorspace": colorspace,
-                
+
                 "chroma_location": chroma_location,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def setpts(
-    
+
     self,
 
 
@@ -19169,12 +19169,12 @@ References:
 
     *,
     expr: String = Default('PTS'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Change the PTS (presentation timestamp) of the input frames.
 
 setpts works on video frames, asetpts on audio frames.
@@ -19193,37 +19193,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setpts)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='setpts', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "expr": expr,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def setrange(
-    
+
     self,
 
 
@@ -19231,12 +19231,12 @@ References:
 
     *,
     range: Int| Literal["auto","unspecified","unknown","limited","tv","mpeg","full","pc","jpeg"] | Default = Default('auto'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Force color range for the output video frame.
 
 The setrange filter marks the color range property for the
@@ -19258,37 +19258,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setrange)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='setrange', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "range": range,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def setsar(
-    
+
     self,
 
 
@@ -19296,12 +19296,12 @@ References:
 
     *,
     sar: String = Default('0'),max: Int = Default('100'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The setdar filter sets the Display Aspect Ratio for the filter
 output video.
 
@@ -19343,39 +19343,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setdar)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='setsar', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sar": sar,
-                
+
                 "max": max,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def settb(
-    
+
     self,
 
 
@@ -19383,12 +19383,12 @@ References:
 
     *,
     expr: String = Default('intb'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Set the timebase to use for the output frames timestamps.
 It is mainly useful for testing timebase configuration.
 
@@ -19406,37 +19406,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#settb)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='settb', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "expr": expr,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def sharpness_vaapi(
-    
+
     self,
 
 
@@ -19444,12 +19444,12 @@ References:
 
     *,
     sharpness: Int = Default('44'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 VAAPI VPP for sharpness
 
 
@@ -19464,37 +19464,37 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sharpness_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sharpness": sharpness,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def shear(
-    
+
     self,
 
 
@@ -19502,15 +19502,15 @@ References:
 
     *,
     shx: Float = Default('0'),shy: Float = Default('0'),fillcolor: String = Default('black'),interp: Int| Literal["nearest","bilinear"] | Default = Default('bilinear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply shear transform to input video.
 
 This filter supports the following options:
@@ -19531,7 +19531,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#shear)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -19539,46 +19539,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='shear', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "shx": shx,
-                
+
                 "shy": shy,
-                
+
                 "fillcolor": fillcolor,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def showinfo(
-    
+
     self,
 
 
@@ -19586,12 +19586,12 @@ References:
 
     *,
     checksum: Boolean = Default('true'),udu_sei_as_ascii: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Show a line containing various information for each input video frame.
 The input video is not modified.
 
@@ -19610,39 +19610,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showinfo)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showinfo', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "checksum": checksum,
-                
+
                 "udu_sei_as_ascii": udu_sei_as_ascii,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showpalette(
-    
+
     self,
 
 
@@ -19650,12 +19650,12 @@ References:
 
     *,
     s: Int = Default('30'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Displays the 256 colors palette of each frame. This filter is only relevant for
 pal8 pixel format frames.
 
@@ -19673,49 +19673,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showpalette)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showpalette', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "s": s,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def shuffleframes(
-    
+
     self,
 
 
@@ -19723,15 +19723,15 @@ References:
 
     *,
     mapping: String = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reorder and/or duplicate and/or drop video frames.
 
 It accepts the following parameters:
@@ -19749,7 +19749,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#shuffleframes)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -19757,34 +19757,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='shuffleframes', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mapping": mapping,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def shufflepixels(
-    
+
     self,
 
 
@@ -19792,15 +19792,15 @@ References:
 
     *,
     direction: Int| Literal["forward","inverse"] | Default = Default('forward'),mode: Int| Literal["horizontal","vertical","block"] | Default = Default('horizontal'),width: Int = Default('10'),height: Int = Default('10'),seed: Int64 = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reorder pixels in video frames.
 
 This filter accepts the following options:
@@ -19822,7 +19822,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#shufflepixels)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -19830,42 +19830,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='shufflepixels', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "direction": direction,
-                
+
                 "mode": mode,
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "seed": seed,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def shuffleplanes(
-    
+
     self,
 
 
@@ -19873,15 +19873,15 @@ References:
 
     *,
     map0: Int = Default('0'),map1: Int = Default('1'),map2: Int = Default('2'),map3: Int = Default('3'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reorder and/or duplicate video planes.
 
 It accepts the following parameters:
@@ -19902,7 +19902,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#shuffleplanes)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -19910,44 +19910,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='shuffleplanes', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "map0": map0,
-                
+
                 "map1": map1,
-                
+
                 "map2": map2,
-                
+
                 "map3": map3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def sidedata(
-    
+
     self,
 
 
@@ -19955,15 +19955,15 @@ References:
 
     *,
     mode: Int| Literal["select","delete"] | Default = Default('select'),type: Int| Literal["PANSCAN","A53_CC","STEREO3D","MATRIXENCODING","DOWNMIX_INFO","REPLAYGAIN","DISPLAYMATRIX","AFD","MOTION_VECTORS","SKIP_SAMPLES","AUDIO_SERVICE_TYPE","MASTERING_DISPLAY_METADATA","GOP_TIMECODE","SPHERICAL","CONTENT_LIGHT_LEVEL","ICC_PROFILE","S12M_TIMECOD","DYNAMIC_HDR_PLUS","REGIONS_OF_INTEREST","VIDEO_ENC_PARAMS","SEI_UNREGISTERED","FILM_GRAIN_PARAMS","DETECTION_BOUNDING_BOXES","DETECTION_BBOXES","DOVI_RPU_BUFFER","DOVI_METADATA","DYNAMIC_HDR_VIVID","AMBIENT_VIEWING_ENVIRONMENT","VIDEO_HINT"] | Default = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Delete frame side data, or select frames based on it.
 
 This filter accepts the following options:
@@ -19982,7 +19982,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sidedata)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -19990,38 +19990,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sidedata', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def signalstats(
-    
+
     self,
 
 
@@ -20029,12 +20029,12 @@ References:
 
     *,
     stat: Flags| Literal["tout","vrep","brng"] | Default = Default('0'),out: Int| Literal["tout","vrep","brng"] | Default = Default('-1'),c: Color = Default('yellow'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Evaluate various visual metrics that assist in determining issues associated
 with the digitization of analog video media.
 
@@ -20054,51 +20054,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#signalstats)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='signalstats', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "stat": stat,
-                
+
                 "out": out,
-                
+
                 "c": c,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def siti(
-    
+
     self,
 
 
@@ -20106,12 +20106,12 @@ References:
 
     *,
     print_summary: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Calculate Spatial Information (SI) and Temporal Information (TI) scores for a video,
 as defined in ITU-T Rec. P.910 (11/21): Subjective video quality assessment methods
 for multimedia applications. Available PDF at https://www.itu.int/rec/T-REC-P.910-202111-S/en.
@@ -20132,37 +20132,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#siti)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='siti', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "print_summary": print_summary,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def smartblur(
-    
+
     self,
 
 
@@ -20170,15 +20170,15 @@ References:
 
     *,
     luma_radius: Float = Default('1'),luma_strength: Float = Default('1'),luma_threshold: Int = Default('0'),chroma_radius: Float = Default('-0.9'),chroma_strength: Float = Default('-2'),chroma_threshold: Int = Default('-31'),alpha_radius: Float = Default('-0.9'),alpha_strength: Float = Default('-2'),alpha_threshold: Int = Default('-31'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Blur the input video without impacting the outlines.
 
 It accepts the following options:
@@ -20204,7 +20204,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#smartblur)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -20212,54 +20212,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='smartblur', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_radius": luma_radius,
-                
+
                 "luma_strength": luma_strength,
-                
+
                 "luma_threshold": luma_threshold,
-                
+
                 "chroma_radius": chroma_radius,
-                
+
                 "chroma_strength": chroma_strength,
-                
+
                 "chroma_threshold": chroma_threshold,
-                
+
                 "alpha_radius": alpha_radius,
-                
+
                 "alpha_strength": alpha_strength,
-                
+
                 "alpha_threshold": alpha_threshold,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def sobel(
-    
+
     self,
 
 
@@ -20267,15 +20267,15 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply sobel operator to input video stream.
 
 The filter accepts the following option:
@@ -20295,7 +20295,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sobel)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -20303,38 +20303,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sobel', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def sobel_opencl(
-    
+
     self,
 
 
@@ -20342,12 +20342,12 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply the Sobel operator (https://en.wikipedia.org/wiki/Sobel_operator) to input video stream.
 
 The filter accepts the following option:
@@ -20366,62 +20366,62 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sobel_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sobel_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def spectrumsynth(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _phase: VideoStream,
-        
-    
+
+
 
 
     *,
     sample_rate: Int = Default('44100'),channels: Int = Default('1'),scale: Int| Literal["lin","log"] | Default = Default('log'),slide: Int| Literal["replace","scroll","fullframe","rscroll"] | Default = Default('fullframe'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('rect'),overlap: Float = Default('1'),orientation: Int| Literal["vertical","horizontal"] | Default = Default('vertical'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Synthesize audio from 2 input video spectrums, first input stream represents
 magnitude across time and second represents phase across time.
 The filter will transform from frequency domain as displayed in videos back
@@ -20458,59 +20458,59 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#spectrumsynth)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='spectrumsynth', typings_input=('video', 'video'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _phase,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "sample_rate": sample_rate,
-                
+
                 "channels": channels,
-                
+
                 "scale": scale,
-                
+
                 "slide": slide,
-                
+
                 "win_func": win_func,
-                
+
                 "overlap": overlap,
-                
+
                 "orientation": orientation,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def split(
-    
+
     self,
 
 
@@ -20518,12 +20518,12 @@ References:
 
     *,
     outputs: Int = Default('2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Split input into several identical outputs.
 
 asplit works with audio input, split with video.
@@ -20544,38 +20544,38 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#split)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='split', typings_input=('video',), typings_output='[StreamType.video] * int(outputs)'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "outputs": outputs,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def spp(
-    
+
     self,
 
 
@@ -20583,15 +20583,15 @@ References:
 
     *,
     quality: Int = Default('3'),qp: Int = Default('0'),mode: Int| Literal["hard","soft"] | Default = Default('hard'),use_bframe_qp: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a simple postprocessing filter that compresses and decompresses the image
 at several (or - in the case of quality level 6 - all) shifts
 and average the results.
@@ -20614,7 +20614,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#spp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -20622,69 +20622,69 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='spp', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "quality": quality,
-                
+
                 "qp": qp,
-                
+
                 "mode": mode,
-                
+
                 "use_bframe_qp": use_bframe_qp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ssim(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the SSIM (Structural SImilarity Metric) between two input videos.
 
 This filter takes in input two input videos, the first input is
@@ -20714,7 +20714,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ssim)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -20725,70 +20725,70 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ssim', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "stats_file": stats_file,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ssim360(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),compute_chroma: Int = Default('1'),frame_skip_ratio: Int = Default('0'),ref_projection: Int| Literal["e","equirect","c3x2","c2x3","barrel","barrelsplit"] | Default = Default('e'),main_projection: Int| Literal["e","equirect","c3x2","c2x3","barrel","barrelsplit"] | Default = Default('5'),ref_stereo: Int| Literal["mono","tb","lr"] | Default = Default('mono'),main_stereo: Int| Literal["mono","tb","lr"] | Default = Default('3'),ref_pad: Float = Default('0'),main_pad: Float = Default('0'),use_tape: Int = Default('0'),heatmap_str: String = Default(None),default_heatmap_width: Int = Default('32'),default_heatmap_height: Int = Default('16'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Calculate the SSIM between two 360 video streams.
 
 
@@ -20816,7 +20816,7 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -20824,66 +20824,66 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ssim360', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "stats_file": stats_file,
-                
+
                 "compute_chroma": compute_chroma,
-                
+
                 "frame_skip_ratio": frame_skip_ratio,
-                
+
                 "ref_projection": ref_projection,
-                
+
                 "main_projection": main_projection,
-                
+
                 "ref_stereo": ref_stereo,
-                
+
                 "main_stereo": main_stereo,
-                
+
                 "ref_pad": ref_pad,
-                
+
                 "main_pad": main_pad,
-                
+
                 "use_tape": use_tape,
-                
+
                 "heatmap_str": heatmap_str,
-                
+
                 "default_heatmap_width": default_heatmap_width,
-                
+
                 "default_heatmap_height": default_heatmap_height,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def stereo3d(
-    
+
     self,
 
 
@@ -20891,12 +20891,12 @@ References:
 
     *,
     _in: Int| Literal["ab2l","tb2l","ab2r","tb2r","abl","tbl","abr","tbr","al","ar","sbs2l","sbs2r","sbsl","sbsr","irl","irr","icl","icr"] | Default = Default('sbsl'),out: Int| Literal["ab2l","tb2l","ab2r","tb2r","abl","tbl","abr","tbr","agmc","agmd","agmg","agmh","al","ar","arbg","arcc","arcd","arcg","arch","argg","aybc","aybd","aybg","aybh","irl","irr","ml","mr","sbs2l","sbs2r","sbsl","sbsr","chl","chr","icl","icr","hdmi"] | Default = Default('arcd'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert between different stereoscopic image formats.
 
 The filters accept the following options:
@@ -20914,45 +20914,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#stereo3d)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='stereo3d', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "in": _in,
-                
+
                 "out": out,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def subtitles(
-    
+
     self,
 
 
@@ -20960,12 +20960,12 @@ References:
 
     *,
     filename: String = Default(None),original_size: Image_size = Default(None),fontsdir: String = Default(None),alpha: Boolean = Default('false'),charenc: String = Default(None),stream_index: Int = Default('-1'),force_style: String = Default(None),wrap_unicode: Boolean = Default('auto'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw subtitles on top of input video using the libass library.
 
 To enable compilation of this filter you need to configure FFmpeg with
@@ -20994,64 +20994,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#subtitles)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='subtitles', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "filename": filename,
-                
+
                 "original_size": original_size,
-                
+
                 "fontsdir": fontsdir,
-                
+
                 "alpha": alpha,
-                
+
                 "charenc": charenc,
-                
+
                 "stream_index": stream_index,
-                
+
                 "force_style": force_style,
-                
+
                 "wrap_unicode": wrap_unicode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def super2xsai(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Scale the input by 2x and smooth using the Super2xSaI (Scale and
 Interpolate) pixel art scaling algorithm.
 
@@ -21068,39 +21068,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#super2xsai)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='super2xsai', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def swaprect(
-    
+
     self,
 
 
@@ -21108,15 +21108,15 @@ References:
 
     *,
     w: String = Default('w/2'),h: String = Default('h/2'),x1: String = Default('w/2'),y1: String = Default('h/2'),x2: String = Default('0'),y2: String = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Swap two rectangular objects in video.
 
 This filter accepts the following options:
@@ -21139,7 +21139,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#swaprect)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -21147,60 +21147,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='swaprect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "x1": x1,
-                
+
                 "y1": y1,
-                
+
                 "x2": x2,
-                
+
                 "y2": y2,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def swapuv(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Swap U & V plane.
 
 
@@ -21215,7 +21215,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#swapuv)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -21223,32 +21223,32 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='swapuv', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tblend(
-    
+
     self,
 
 
@@ -21256,15 +21256,15 @@ References:
 
     *,
     c0_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c1_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c2_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c3_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),all_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('-1'),c0_expr: String = Default(None),c1_expr: String = Default(None),c2_expr: String = Default(None),c3_expr: String = Default(None),all_expr: String = Default(None),c0_opacity: Double = Default('1'),c1_opacity: Double = Default('1'),c2_opacity: Double = Default('1'),c3_opacity: Double = Default('1'),all_opacity: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Blend successive video frames.
 
 See blend
@@ -21296,7 +21296,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tblend)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -21304,62 +21304,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tblend', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "c0_mode": c0_mode,
-                
+
                 "c1_mode": c1_mode,
-                
+
                 "c2_mode": c2_mode,
-                
+
                 "c3_mode": c3_mode,
-                
+
                 "all_mode": all_mode,
-                
+
                 "c0_expr": c0_expr,
-                
+
                 "c1_expr": c1_expr,
-                
+
                 "c2_expr": c2_expr,
-                
+
                 "c3_expr": c3_expr,
-                
+
                 "all_expr": all_expr,
-                
+
                 "c0_opacity": c0_opacity,
-                
+
                 "c1_opacity": c1_opacity,
-                
+
                 "c2_opacity": c2_opacity,
-                
+
                 "c3_opacity": c3_opacity,
-                
+
                 "all_opacity": all_opacity,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def telecine(
-    
+
     self,
 
 
@@ -21367,12 +21367,12 @@ References:
 
     *,
     first_field: Int| Literal["top","t","bottom","b"] | Default = Default('top'),pattern: String = Default('23'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply telecine process to the video.
 
 This filter accepts the following options:
@@ -21390,43 +21390,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#telecine)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='telecine', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "first_field": first_field,
-                
+
                 "pattern": pattern,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def thistogram(
-    
+
     self,
 
 
@@ -21434,12 +21434,12 @@ References:
 
     *,
     width: Int = Default('0'),display_mode: Int| Literal["overlay","parade","stack"] | Default = Default('stack'),levels_mode: Int| Literal["linear","logarithmic"] | Default = Default('linear'),components: Int = Default('7'),bgopacity: Float = Default('0.9'),envelope: Boolean = Default('false'),ecolor: Color = Default('gold'),slide: Int| Literal["frame","replace","scroll","rscroll","picture"] | Default = Default('replace'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Compute and draw a color distribution histogram for the input video across time.
 
 Unlike histogram video filter which only shows histogram of single input frame
@@ -21470,83 +21470,83 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#thistogram)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='thistogram', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "width": width,
-                
+
                 "display_mode": display_mode,
-                
+
                 "levels_mode": levels_mode,
-                
+
                 "components": components,
-                
+
                 "bgopacity": bgopacity,
-                
+
                 "envelope": envelope,
-                
+
                 "ecolor": ecolor,
-                
+
                 "slide": slide,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def threshold(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _threshold: VideoStream,
-        
-    
-        
+
+
+
         _min: VideoStream,
-        
-    
-        
+
+
+
         _max: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply threshold effect to video stream.
 
 This filter needs four video streams to perform thresholding.
@@ -21569,7 +21569,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#threshold)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -21577,50 +21577,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='threshold', typings_input=('video', 'video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _threshold,
-                
-            
-                
+
+
+
                 _min,
-                
-            
-                
+
+
+
                 _max,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def thumbnail(
-    
+
     self,
 
 
@@ -21628,15 +21628,15 @@ References:
 
     *,
     n: Int = Default('100'),log: Int| Literal["quiet","info","verbose"] | Default = Default('info'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Select the most representative frame in a given sequence of consecutive frames.
 
 The filter accepts the following options:
@@ -21655,7 +21655,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#thumbnail)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -21663,36 +21663,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='thumbnail', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "n": n,
-                
+
                 "log": log,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tile(
-    
+
     self,
 
 
@@ -21700,12 +21700,12 @@ References:
 
     *,
     layout: Image_size = Default('6x5'),nb_frames: Int = Default('0'),margin: Int = Default('0'),padding: Int = Default('0'),color: Color = Default('black'),overlap: Int = Default('0'),init_padding: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Tile several successive frames together.
 
 The untile filter can do the reverse.
@@ -21730,49 +21730,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tile)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tile', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "layout": layout,
-                
+
                 "nb_frames": nb_frames,
-                
+
                 "margin": margin,
-                
+
                 "padding": padding,
-                
+
                 "color": color,
-                
+
                 "overlap": overlap,
-                
+
                 "init_padding": init_padding,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tiltandshift(
-    
+
     self,
 
 
@@ -21780,12 +21780,12 @@ References:
 
     *,
     tilt: Int = Default('1'),start: Int| Literal["none","frame","black"] | Default = Default('none'),end: Int| Literal["none","frame","black"] | Default = Default('none'),hold: Int = Default('0'),pad: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply tilt-and-shift effect.
 
 What happens when you invert time and space?
@@ -21827,47 +21827,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tiltandshift)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tiltandshift', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "tilt": tilt,
-                
+
                 "start": start,
-                
+
                 "end": end,
-                
+
                 "hold": hold,
-                
+
                 "pad": pad,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def tinterlace(
-    
+
     self,
 
 
@@ -21875,12 +21875,12 @@ References:
 
     *,
     mode: Int| Literal["merge","drop_even","drop_odd","pad","interleave_top","interleave_bottom","interlacex2","mergex2"] | Default = Default('merge'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Perform various types of temporal field interlacing.
 
 Frames are counted starting from 1, so the first input frame is
@@ -21900,37 +21900,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tinterlace)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tinterlace', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tlut2(
-    
+
     self,
 
 
@@ -21938,15 +21938,15 @@ References:
 
     *,
     c0: String = Default('x'),c1: String = Default('x'),c2: String = Default('x'),c3: String = Default('x'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The lut2 filter takes two input streams and outputs one
 stream.
 
@@ -21971,7 +21971,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut2)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -21979,40 +21979,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tlut2', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "c0": c0,
-                
+
                 "c1": c1,
-                
+
                 "c2": c2,
-                
+
                 "c3": c3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tmedian(
-    
+
     self,
 
 
@@ -22020,15 +22020,15 @@ References:
 
     *,
     radius: Int = Default('1'),planes: Int = Default('15'),percentile: Float = Default('0.5'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pick median pixels from several successive input video frames.
 
 The filter accepts the following options:
@@ -22048,7 +22048,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tmedian)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -22056,38 +22056,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tmedian', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "radius": radius,
-                
+
                 "planes": planes,
-                
+
                 "percentile": percentile,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tmidequalizer(
-    
+
     self,
 
 
@@ -22095,15 +22095,15 @@ References:
 
     *,
     radius: Int = Default('5'),sigma: Float = Default('0.5'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Temporal Midway Video Equalization effect.
 
 Midway Video Equalization adjusts a sequence of video frames to have the same
@@ -22127,7 +22127,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tmidequalizer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -22135,38 +22135,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tmidequalizer', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "radius": radius,
-                
+
                 "sigma": sigma,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tmix(
-    
+
     self,
 
 
@@ -22174,15 +22174,15 @@ References:
 
     *,
     frames: Int = Default('3'),weights: String = Default('1 1 1'),scale: Float = Default('0'),planes: Flags = Default('F'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Mix successive video frames.
 
 A description of the accepted options follows.
@@ -22203,7 +22203,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tmix)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -22211,40 +22211,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tmix', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frames": frames,
-                
+
                 "weights": weights,
-                
+
                 "scale": scale,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tonemap(
-    
+
     self,
 
 
@@ -22252,12 +22252,12 @@ References:
 
     *,
     tonemap: Int| Literal["none","linear","gamma","clip","reinhard","hable","mobius"] | Default = Default('none'),param: Double = Default('nan'),desat: Double = Default('2'),peak: Double = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Tone map colors from different dynamic ranges.
 
 This filter expects data in single precision floating point, as it needs to
@@ -22286,43 +22286,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tonemap)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tonemap', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "tonemap": tonemap,
-                
+
                 "param": param,
-                
+
                 "desat": desat,
-                
+
                 "peak": peak,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tonemap_opencl(
-    
+
     self,
 
 
@@ -22330,12 +22330,12 @@ References:
 
     *,
     tonemap: Int| Literal["none","linear","gamma","clip","reinhard","hable","mobius"] | Default = Default('none'),transfer: Int| Literal["bt709","bt2020"] | Default = Default('bt709'),matrix: Int| Literal["bt709","bt2020"] | Default = Default('-1'),primaries: Int| Literal["bt709","bt2020"] | Default = Default('-1'),range: Int| Literal["tv","pc","limited","full"] | Default = Default('-1'),format: Pix_fmt = Default('none'),peak: Double = Default('0'),param: Double = Default('nan'),desat: Double = Default('0.5'),threshold: Double = Default('0.2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Perform HDR(PQ/HLG) to SDR conversion with tone-mapping.
 
 It accepts the following parameters:
@@ -22361,55 +22361,55 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tonemap_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tonemap_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "tonemap": tonemap,
-                
+
                 "transfer": transfer,
-                
+
                 "matrix": matrix,
-                
+
                 "primaries": primaries,
-                
+
                 "range": range,
-                
+
                 "format": format,
-                
+
                 "peak": peak,
-                
+
                 "param": param,
-                
+
                 "desat": desat,
-                
+
                 "threshold": threshold,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tonemap_vaapi(
-    
+
     self,
 
 
@@ -22417,12 +22417,12 @@ References:
 
     *,
     format: String = Default(None),matrix: String = Default(None),primaries: String = Default(None),transfer: String = Default(None),display: String = Default(None),light: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Perform HDR-to-SDR or HDR-to-HDR tone-mapping.
 It currently only accepts HDR10 as input.
 
@@ -22445,47 +22445,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tonemap_vaapi)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tonemap_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "format": format,
-                
+
                 "matrix": matrix,
-                
+
                 "primaries": primaries,
-                
+
                 "transfer": transfer,
-                
+
                 "display": display,
-                
+
                 "light": light,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tpad(
-    
+
     self,
 
 
@@ -22493,12 +22493,12 @@ References:
 
     *,
     start: Int = Default('0'),stop: Int = Default('0'),start_mode: Int| Literal["add","clone"] | Default = Default('add'),stop_mode: Int| Literal["add","clone"] | Default = Default('add'),start_duration: Duration = Default('0'),stop_duration: Duration = Default('0'),color: Color = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Temporarily pad video frames.
 
 The filter accepts the following options:
@@ -22521,49 +22521,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tpad)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tpad', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "start": start,
-                
+
                 "stop": stop,
-                
+
                 "start_mode": start_mode,
-                
+
                 "stop_mode": stop_mode,
-                
+
                 "start_duration": start_duration,
-                
+
                 "stop_duration": stop_duration,
-                
+
                 "color": color,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def transpose(
-    
+
     self,
 
 
@@ -22571,12 +22571,12 @@ References:
 
     *,
     dir: Int| Literal["cclock_flip","clock","cclock","clock_flip"] | Default = Default('cclock_flip'),passthrough: Int| Literal["none","portrait","landscape"] | Default = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Transpose rows with columns in the input video and optionally flip it.
 
 It accepts the following parameters:
@@ -22594,39 +22594,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#transpose)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='transpose', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dir": dir,
-                
+
                 "passthrough": passthrough,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def transpose_opencl(
-    
+
     self,
 
 
@@ -22634,12 +22634,12 @@ References:
 
     *,
     dir: Int| Literal["cclock_flip","clock","cclock","clock_flip"] | Default = Default('cclock_flip'),passthrough: Int| Literal["none","portrait","landscape"] | Default = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Transpose input video
 
 
@@ -22655,39 +22655,39 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='transpose_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dir": dir,
-                
+
                 "passthrough": passthrough,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def transpose_vaapi(
-    
+
     self,
 
 
@@ -22695,12 +22695,12 @@ References:
 
     *,
     dir: Int| Literal["cclock_flip","clock","cclock","clock_flip","reversal","hflip","vflip"] | Default = Default('cclock_flip'),passthrough: Int| Literal["none","portrait","landscape"] | Default = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 VAAPI VPP for transpose
 
 
@@ -22716,43 +22716,43 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='transpose_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dir": dir,
-                
+
                 "passthrough": passthrough,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def trim(
-    
+
     self,
 
 
@@ -22760,12 +22760,12 @@ References:
 
     *,
     start: Duration = Default('INT64_MAX'),end: Duration = Default('INT64_MAX'),start_pts: Int64 = Default('I64_MIN'),end_pts: Int64 = Default('I64_MIN'),duration: Duration = Default('0'),start_frame: Int64 = Default('-1'),end_frame: Int64 = Default('I64_MAX'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Trim the input so that the output contains one continuous subpart of the input.
 
 It accepts the following parameters:
@@ -22788,51 +22788,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#trim)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='trim', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "start": start,
-                
+
                 "end": end,
-                
+
                 "start_pts": start_pts,
-                
+
                 "end_pts": end_pts,
-                
+
                 "duration": duration,
-                
+
                 "start_frame": start_frame,
-                
+
                 "end_frame": end_frame,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def unsharp(
-    
+
     self,
 
 
@@ -22840,15 +22840,15 @@ References:
 
     *,
     luma_msize_x: Int = Default('5'),luma_msize_y: Int = Default('5'),luma_amount: Float = Default('1'),chroma_msize_x: Int = Default('5'),chroma_msize_y: Int = Default('5'),chroma_amount: Float = Default('0'),alpha_msize_x: Int = Default('5'),alpha_msize_y: Int = Default('5'),alpha_amount: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Sharpen or blur the input video.
 
 It accepts the following parameters:
@@ -22874,7 +22874,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#unsharp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -22882,50 +22882,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='unsharp', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_msize_x": luma_msize_x,
-                
+
                 "luma_msize_y": luma_msize_y,
-                
+
                 "luma_amount": luma_amount,
-                
+
                 "chroma_msize_x": chroma_msize_x,
-                
+
                 "chroma_msize_y": chroma_msize_y,
-                
+
                 "chroma_amount": chroma_amount,
-                
+
                 "alpha_msize_x": alpha_msize_x,
-                
+
                 "alpha_msize_y": alpha_msize_y,
-                
+
                 "alpha_amount": alpha_amount,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def unsharp_opencl(
-    
+
     self,
 
 
@@ -22933,12 +22933,12 @@ References:
 
     *,
     luma_msize_x: Float = Default('5'),luma_msize_y: Float = Default('5'),luma_amount: Float = Default('1'),chroma_msize_x: Float = Default('5'),chroma_msize_y: Float = Default('5'),chroma_amount: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Sharpen or blur the input video.
 
 It accepts the following parameters:
@@ -22960,47 +22960,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#unsharp_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='unsharp_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_msize_x": luma_msize_x,
-                
+
                 "luma_msize_y": luma_msize_y,
-                
+
                 "luma_amount": luma_amount,
-                
+
                 "chroma_msize_x": chroma_msize_x,
-                
+
                 "chroma_msize_y": chroma_msize_y,
-                
+
                 "chroma_amount": chroma_amount,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def untile(
-    
+
     self,
 
 
@@ -23008,12 +23008,12 @@ References:
 
     *,
     layout: Image_size = Default('6x5'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Decompose a video made of tiled images into the individual images.
 
 The frame rate of the output video is the frame rate of the input video
@@ -23035,37 +23035,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#untile)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='untile', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "layout": layout,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def uspp(
-    
+
     self,
 
 
@@ -23073,15 +23073,15 @@ References:
 
     *,
     quality: Int = Default('3'),qp: Int = Default('0'),use_bframe_qp: Boolean = Default('false'),codec: String = Default('snow'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply ultra slow/simple postprocessing filter that compresses and decompresses
 the image at several (or - in the case of quality level 8 - all)
 shifts and average the results.
@@ -23110,7 +23110,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#uspp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -23118,40 +23118,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='uspp', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "quality": quality,
-                
+
                 "qp": qp,
-                
+
                 "use_bframe_qp": use_bframe_qp,
-                
+
                 "codec": codec,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def v360(
-    
+
     self,
 
 
@@ -23159,12 +23159,12 @@ References:
 
     *,
     input: Int| Literal["e","equirect","c3x2","c6x1","eac","dfisheye","flat","rectilinear","gnomonic","barrel","fb","c1x6","sg","mercator","ball","hammer","sinusoidal","fisheye","pannini","cylindrical","tetrahedron","barrelsplit","tsp","hequirect","he","equisolid","og","octahedron","cylindricalea"] | Default = Default('e'),output: Int| Literal["e","equirect","c3x2","c6x1","eac","dfisheye","flat","rectilinear","gnomonic","barrel","fb","c1x6","sg","mercator","ball","hammer","sinusoidal","fisheye","pannini","cylindrical","perspective","tetrahedron","barrelsplit","tsp","hequirect","he","equisolid","og","octahedron","cylindricalea"] | Default = Default('c3x2'),interp: Int| Literal["near","nearest","line","linear","lagrange9","cube","cubic","lanc","lanczos","sp16","spline16","gauss","gaussian","mitchell"] | Default = Default('line'),w: Int = Default('0'),h: Int = Default('0'),in_stereo: Int| Literal["2d","sbs","tb"] | Default = Default('2d'),out_stereo: Int| Literal["2d","sbs","tb"] | Default = Default('2d'),in_forder: String = Default('rludfb'),out_forder: String = Default('rludfb'),in_frot: String = Default('000000'),out_frot: String = Default('000000'),in_pad: Float = Default('0'),out_pad: Float = Default('0'),fin_pad: Int = Default('0'),fout_pad: Int = Default('0'),yaw: Float = Default('0'),pitch: Float = Default('0'),roll: Float = Default('0'),rorder: String = Default('ypr'),h_fov: Float = Default('0'),v_fov: Float = Default('0'),d_fov: Float = Default('0'),h_flip: Boolean = Default('false'),v_flip: Boolean = Default('false'),d_flip: Boolean = Default('false'),ih_flip: Boolean = Default('false'),iv_flip: Boolean = Default('false'),in_trans: Boolean = Default('false'),out_trans: Boolean = Default('false'),ih_fov: Float = Default('0'),iv_fov: Float = Default('0'),id_fov: Float = Default('0'),h_offset: Float = Default('0'),v_offset: Float = Default('0'),alpha_mask: Boolean = Default('false'),reset_rot: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert 360 videos between various formats.
 
 The filter accepts the following options:
@@ -23216,107 +23216,107 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#v360)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='v360', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "input": input,
-                
+
                 "output": output,
-                
+
                 "interp": interp,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "in_stereo": in_stereo,
-                
+
                 "out_stereo": out_stereo,
-                
+
                 "in_forder": in_forder,
-                
+
                 "out_forder": out_forder,
-                
+
                 "in_frot": in_frot,
-                
+
                 "out_frot": out_frot,
-                
+
                 "in_pad": in_pad,
-                
+
                 "out_pad": out_pad,
-                
+
                 "fin_pad": fin_pad,
-                
+
                 "fout_pad": fout_pad,
-                
+
                 "yaw": yaw,
-                
+
                 "pitch": pitch,
-                
+
                 "roll": roll,
-                
+
                 "rorder": rorder,
-                
+
                 "h_fov": h_fov,
-                
+
                 "v_fov": v_fov,
-                
+
                 "d_fov": d_fov,
-                
+
                 "h_flip": h_flip,
-                
+
                 "v_flip": v_flip,
-                
+
                 "d_flip": d_flip,
-                
+
                 "ih_flip": ih_flip,
-                
+
                 "iv_flip": iv_flip,
-                
+
                 "in_trans": in_trans,
-                
+
                 "out_trans": out_trans,
-                
+
                 "ih_fov": ih_fov,
-                
+
                 "iv_fov": iv_fov,
-                
+
                 "id_fov": id_fov,
-                
+
                 "h_offset": h_offset,
-                
+
                 "v_offset": v_offset,
-                
+
                 "alpha_mask": alpha_mask,
-                
+
                 "reset_rot": reset_rot,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vaguedenoiser(
-    
+
     self,
 
 
@@ -23324,15 +23324,15 @@ References:
 
     *,
     threshold: Float = Default('2'),method: Int| Literal["hard","soft","garrote"] | Default = Default('garrote'),nsteps: Int = Default('6'),percent: Float = Default('85'),planes: Int = Default('15'),type: Int| Literal["universal","bayes"] | Default = Default('universal'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a wavelet based denoiser.
 
 It transforms each frame from the video input into the wavelet domain,
@@ -23361,7 +23361,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vaguedenoiser)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -23369,73 +23369,73 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vaguedenoiser', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold": threshold,
-                
+
                 "method": method,
-                
+
                 "nsteps": nsteps,
-                
+
                 "percent": percent,
-                
+
                 "planes": planes,
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def varblur(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _radius: VideoStream,
-        
-    
+
+
 
 
     *,
     min_r: Int = Default('0'),max_r: Int = Default('8'),planes: Int = Default('15'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply variable blur filter by using 2nd video stream to set blur radius.
 The 2nd stream must have the same dimensions.
 
@@ -23457,7 +23457,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#varblur)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -23468,48 +23468,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='varblur', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _radius,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "min_r": min_r,
-                
+
                 "max_r": max_r,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vectorscope(
-    
+
     self,
 
 
@@ -23517,12 +23517,12 @@ References:
 
     *,
     mode: Int| Literal["gray","tint","color","color2","color3","color4","color5"] | Default = Default('gray'),x: Int = Default('1'),y: Int = Default('2'),intensity: Float = Default('0.004'),envelope: Int| Literal["none","instant","peak","peak+instant"] | Default = Default('none'),graticule: Int| Literal["none","green","color","invert"] | Default = Default('none'),opacity: Float = Default('0.75'),flags: Flags| Literal["white","black","name"] | Default = Default('name'),bgopacity: Float = Default('0.3'),lthreshold: Float = Default('0'),hthreshold: Float = Default('1'),colorspace: Int| Literal["auto","601","709"] | Default = Default('auto'),tint0: Float = Default('0'),tint1: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Display 2 color component values in the two dimensional graph (which is called
 a vectorscope).
 
@@ -23553,79 +23553,79 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vectorscope)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vectorscope', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "intensity": intensity,
-                
+
                 "envelope": envelope,
-                
+
                 "graticule": graticule,
-                
+
                 "opacity": opacity,
-                
+
                 "flags": flags,
-                
+
                 "bgopacity": bgopacity,
-                
+
                 "lthreshold": lthreshold,
-                
+
                 "hthreshold": hthreshold,
-                
+
                 "colorspace": colorspace,
-                
+
                 "tint0": tint0,
-                
+
                 "tint1": tint1,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vflip(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Flip the input video vertically.
 
 For example, to vertically flip a video with ffmpeg:
@@ -23645,7 +23645,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vflip)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -23653,45 +23653,45 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vflip', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vfrdet(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect variable frame rate video.
 
 This filter tries to detect if the input is variable or constant frame rate.
@@ -23712,35 +23712,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vfrdet)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vfrdet', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vibrance(
-    
+
     self,
 
 
@@ -23748,15 +23748,15 @@ References:
 
     *,
     intensity: Float = Default('0'),rbal: Float = Default('1'),gbal: Float = Default('1'),bbal: Float = Default('1'),rlum: Float = Default('0.072186'),glum: Float = Default('0.715158'),blum: Float = Default('0.212656'),alternate: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Boost or alter saturation.
 
 The filter accepts the following options:
@@ -23781,7 +23781,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vibrance)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -23789,50 +23789,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vibrance', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "intensity": intensity,
-                
+
                 "rbal": rbal,
-                
+
                 "gbal": gbal,
-                
+
                 "bbal": bbal,
-                
+
                 "rlum": rlum,
-                
+
                 "glum": glum,
-                
+
                 "blum": blum,
-                
+
                 "alternate": alternate,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def vidstabdetect(
-    
+
     self,
 
 
@@ -23840,12 +23840,12 @@ References:
 
     *,
     result: String = Default('transforms.trf'),shakiness: Int = Default('5'),accuracy: Int = Default('15'),stepsize: Int = Default('6'),mincontrast: Double = Default('0.25'),show: Int = Default('0'),tripod: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Analyze video stabilization/deshaking. Perform pass 1 of 2, see
 vidstabtransform for pass 2.
 
@@ -23876,49 +23876,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vidstabdetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vidstabdetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "result": result,
-                
+
                 "shakiness": shakiness,
-                
+
                 "accuracy": accuracy,
-                
+
                 "stepsize": stepsize,
-                
+
                 "mincontrast": mincontrast,
-                
+
                 "show": show,
-                
+
                 "tripod": tripod,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vidstabtransform(
-    
+
     self,
 
 
@@ -23926,12 +23926,12 @@ References:
 
     *,
     input: String = Default('transforms.trf'),smoothing: Int = Default('15'),optalgo: Int| Literal["opt","gauss","avg"] | Default = Default('opt'),maxshift: Int = Default('-1'),maxangle: Double = Default('-1'),crop: Int| Literal["keep","black"] | Default = Default('keep'),invert: Int = Default('0'),relative: Int = Default('1'),zoom: Double = Default('0'),optzoom: Int = Default('1'),zoomspeed: Double = Default('0.25'),interpol: Int| Literal["no","linear","bilinear","bicubic"] | Default = Default('bilinear'),tripod: Boolean = Default('false'),debug: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Video stabilization/deshaking: pass 2 of 2,
 see vidstabdetect for pass 1.
 
@@ -23969,92 +23969,92 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vidstabtransform)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vidstabtransform', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "input": input,
-                
+
                 "smoothing": smoothing,
-                
+
                 "optalgo": optalgo,
-                
+
                 "maxshift": maxshift,
-                
+
                 "maxangle": maxangle,
-                
+
                 "crop": crop,
-                
+
                 "invert": invert,
-                
+
                 "relative": relative,
-                
+
                 "zoom": zoom,
-                
+
                 "optzoom": optzoom,
-                
+
                 "zoomspeed": zoomspeed,
-                
+
                 "interpol": interpol,
-                
+
                 "tripod": tripod,
-                
+
                 "debug": debug,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vif(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the average VIF (Visual Information Fidelity) between two input videos.
 
 This filter takes two input videos.
@@ -24091,7 +24091,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vif)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -24102,42 +24102,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vif', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vignette(
-    
+
     self,
 
 
@@ -24145,15 +24145,15 @@ References:
 
     *,
     angle: String = Default('PI/5'),x0: String = Default('w/2'),y0: String = Default('h/2'),mode: Int| Literal["forward","backward"] | Default = Default('forward'),eval: Int| Literal["init","frame"] | Default = Default('init'),dither: Boolean = Default('true'),aspect: Rational = Default('1/1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Make or reverse a natural vignetting effect.
 
 The filter accepts the following options:
@@ -24177,7 +24177,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vignette)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -24185,48 +24185,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vignette', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "angle": angle,
-                
+
                 "x0": x0,
-                
+
                 "y0": y0,
-                
+
                 "mode": mode,
-                
+
                 "eval": eval,
-                
+
                 "dither": dither,
-                
+
                 "aspect": aspect,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def vmafmotion(
-    
+
     self,
 
 
@@ -24234,12 +24234,12 @@ References:
 
     *,
     stats_file: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the average VMAF motion score of a video.
 It is one of the component metrics of VMAF.
 
@@ -24259,45 +24259,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vmafmotion)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vmafmotion', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "stats_file": stats_file,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def w3fdif(
-    
+
     self,
 
 
@@ -24305,15 +24305,15 @@ References:
 
     *,
     filter: Int| Literal["simple","complex"] | Default = Default('complex'),mode: Int| Literal["frame","field"] | Default = Default('field'),parity: Int| Literal["tff","bff","auto"] | Default = Default('auto'),deint: Int| Literal["all","interlaced"] | Default = Default('all'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlace the input video ("w3fdif" stands for "Weston 3 Field
 Deinterlacing Filter").
 
@@ -24346,7 +24346,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#w3fdif)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -24354,40 +24354,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='w3fdif', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "filter": filter,
-                
+
                 "mode": mode,
-                
+
                 "parity": parity,
-                
+
                 "deint": deint,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def waveform(
-    
+
     self,
 
 
@@ -24395,12 +24395,12 @@ References:
 
     *,
     mode: Int| Literal["row","column"] | Default = Default('column'),intensity: Float = Default('0.04'),mirror: Boolean = Default('true'),display: Int| Literal["overlay","stack","parade"] | Default = Default('stack'),components: Int = Default('1'),envelope: Int| Literal["none","instant","peak","peak+instant"] | Default = Default('none'),filter: Int| Literal["lowpass","flat","aflat","chroma","color","acolor","xflat","yflat"] | Default = Default('lowpass'),graticule: Int| Literal["none","green","orange","invert"] | Default = Default('none'),opacity: Float = Default('0.75'),flags: Flags| Literal["numbers","dots"] | Default = Default('numbers'),scale: Int| Literal["digital","millivolts","ire"] | Default = Default('digital'),bgopacity: Float = Default('0.75'),tint0: Float = Default('0'),tint1: Float = Default('0'),fitmode: Int| Literal["none","size"] | Default = Default('none'),input: Int| Literal["all","first"] | Default = Default('first'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Video waveform monitor.
 
 The waveform monitor plots color component intensity. By default luma
@@ -24436,67 +24436,67 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#waveform)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='waveform', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "intensity": intensity,
-                
+
                 "mirror": mirror,
-                
+
                 "display": display,
-                
+
                 "components": components,
-                
+
                 "envelope": envelope,
-                
+
                 "filter": filter,
-                
+
                 "graticule": graticule,
-                
+
                 "opacity": opacity,
-                
+
                 "flags": flags,
-                
+
                 "scale": scale,
-                
+
                 "bgopacity": bgopacity,
-                
+
                 "tint0": tint0,
-                
+
                 "tint1": tint1,
-                
+
                 "fitmode": fitmode,
-                
+
                 "input": input,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def weave(
-    
+
     self,
 
 
@@ -24504,12 +24504,12 @@ References:
 
     *,
     first_field: Int| Literal["top","t","bottom","b"] | Default = Default('top'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The weave takes a field-based video input and join
 each two sequential fields into single frame, producing a new double
 height clip with half the frame rate and half the frame count.
@@ -24531,37 +24531,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#weave)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='weave', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "first_field": first_field,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def xbr(
-    
+
     self,
 
 
@@ -24569,12 +24569,12 @@ References:
 
     *,
     n: Int = Default('3'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply the xBR high-quality magnification filter which is designed for pixel
 art. It follows a set of edge-detection rules, see
 https://forums.libretro.com/t/xbr-algorithm-tutorial/123.
@@ -24593,66 +24593,66 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xbr)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='xbr', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "n": n,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def xcorrelate(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _secondary: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('7'),secondary: Int| Literal["first","all"] | Default = Default('all'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply normalized cross-correlation between first and second input video stream.
 
 Second input video stream dimensions must be lower than first input video stream.
@@ -24674,7 +24674,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xcorrelate)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -24685,67 +24685,67 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='xcorrelate', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _secondary,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "secondary": secondary,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def xfade(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _xfade: VideoStream,
-        
-    
+
+
 
 
     *,
     transition: Int| Literal["custom","fade","wipeleft","wiperight","wipeup","wipedown","slideleft","slideright","slideup","slidedown","circlecrop","rectcrop","distance","fadeblack","fadewhite","radial","smoothleft","smoothright","smoothup","smoothdown","circleopen","circleclose","vertopen","vertclose","horzopen","horzclose","dissolve","pixelize","diagtl","diagtr","diagbl","diagbr","hlslice","hrslice","vuslice","vdslice","hblur","fadegrays","wipetl","wipetr","wipebl","wipebr","squeezeh","squeezev","zoomin","fadefast","fadeslow","hlwind","hrwind","vuwind","vdwind","coverleft","coverright","coverup","coverdown","revealleft","revealright","revealup","revealdown"] | Default = Default('fade'),duration: Duration = Default('1'),offset: Duration = Default('0'),expr: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply cross fade from one input video stream to another input video stream.
 The cross fade is applied for specified duration.
 
@@ -24769,72 +24769,72 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xfade)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='xfade', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _xfade,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "transition": transition,
-                
+
                 "duration": duration,
-                
+
                 "offset": offset,
-                
+
                 "expr": expr,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def xfade_opencl(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _xfade: VideoStream,
-        
-    
+
+
 
 
     *,
     transition: Int| Literal["custom","fade","wipeleft","wiperight","wipeup","wipedown","slideleft","slideright","slideup","slidedown"] | Default = Default('fade'),source: String = Default(None),kernel: String = Default(None),duration: Duration = Default('1'),offset: Duration = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Cross fade two videos with custom transition effect by using OpenCL.
 
 It accepts the following options:
@@ -24855,84 +24855,84 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xfade_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='xfade_opencl', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _xfade,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "transition": transition,
-                
+
                 "source": source,
-                
+
                 "kernel": kernel,
-                
+
                 "duration": duration,
-                
+
                 "offset": offset,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def xpsnr(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the average (across all input frames) and minimum (across all color plane averages)
 eXtended Perceptually weighted peak Signal-to-Noise Ratio (XPSNR) between two input videos.
 
@@ -24958,7 +24958,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xpsnr)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -24969,48 +24969,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='xpsnr', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "stats_file": stats_file,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def yadif(
-    
+
     self,
 
 
@@ -25018,15 +25018,15 @@ References:
 
     *,
     mode: Int| Literal["send_frame","send_field","send_frame_nospatial","send_field_nospatial"] | Default = Default('send_frame'),parity: Int| Literal["tff","bff","auto"] | Default = Default('auto'),deint: Int| Literal["all","interlaced"] | Default = Default('all'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlace the input video ("yadif" means "yet another deinterlacing
 filter").
 
@@ -25047,7 +25047,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#yadif)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -25055,38 +25055,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='yadif', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "parity": parity,
-                
+
                 "deint": deint,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def yaepblur(
-    
+
     self,
 
 
@@ -25094,15 +25094,15 @@ References:
 
     *,
     radius: Int = Default('3'),planes: Int = Default('1'),sigma: Int = Default('128'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply blur filter while preserving edges ("yaepblur" means "yet another edge preserving blur filter").
 The algorithm is described in
 "J. S. Lee, Digital image enhancement and noise filtering by use of local statistics, IEEE Trans. Pattern Anal. Mach. Intell. PAMI-2, 1980."
@@ -25124,7 +25124,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#yaepblur)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -25132,40 +25132,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='yaepblur', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "radius": radius,
-                
+
                 "planes": planes,
-                
+
                 "sigma": sigma,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def zmq(
-    
+
     self,
 
 
@@ -25173,12 +25173,12 @@ References:
 
     *,
     bind_address: String = Default('tcp://*:5555'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Receive commands sent through a libzmq client, and forward them to
 filters in the filtergraph.
 
@@ -25237,39 +25237,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#zmq)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='zmq', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "bind_address": bind_address,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def zoompan(
-    
+
     self,
 
 
@@ -25277,12 +25277,12 @@ References:
 
     *,
     zoom: String = Default('1'),x: String = Default('0'),y: String = Default('0'),d: String = Default('90'),s: Image_size = Default('hd720'),fps: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Zoom & Pan effect.
 
 This filter accepts the following options:
@@ -25304,47 +25304,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#zoompan)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='zoompan', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "zoom": zoom,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "d": d,
-                
+
                 "s": s,
-                
+
                 "fps": fps,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def zscale(
-    
+
     self,
 
 
@@ -25352,12 +25352,12 @@ References:
 
     *,
     w: String = Default(None),h: String = Default(None),size: String = Default(None),dither: Int| Literal["none","ordered","random","error_diffusion"] | Default = Default('none'),filter: Int| Literal["point","bilinear","bicubic","spline16","spline36","lanczos"] | Default = Default('bilinear'),out_range: Int| Literal["input","limited","full","unknown","tv","pc"] | Default = Default('input'),primaries: Int| Literal["input","709","unspecified","170m","240m","2020","unknown","bt709","bt470m","bt470bg","smpte170m","smpte240m","film","bt2020","smpte428","smpte431","smpte432","jedec-p22","ebu3213"] | Default = Default('input'),transfer: Int| Literal["input","709","unspecified","601","linear","2020_10","2020_12","unknown","bt470m","bt470bg","smpte170m","smpte240m","bt709","log100","log316","bt2020-10","bt2020-12","smpte2084","iec61966-2-4","iec61966-2-1","arib-std-b67"] | Default = Default('input'),matrix: Int| Literal["input","709","unspecified","470bg","170m","2020_ncl","2020_cl","unknown","gbr","bt709","fcc","bt470bg","smpte170m","smpte240m","ycgco","bt2020nc","bt2020c","chroma-derived-nc","chroma-derived-c","ictcp"] | Default = Default('input'),in_range: Int| Literal["input","limited","full","unknown","tv","pc"] | Default = Default('input'),primariesin: Int| Literal["input","709","unspecified","170m","240m","2020","unknown","bt709","bt470m","bt470bg","smpte170m","smpte240m","film","bt2020","smpte428","smpte431","smpte432","jedec-p22","ebu3213"] | Default = Default('input'),transferin: Int| Literal["input","709","unspecified","601","linear","2020_10","2020_12","unknown","bt470m","bt470bg","smpte170m","smpte240m","bt709","log100","log316","bt2020-10","bt2020-12","smpte2084","iec61966-2-4","iec61966-2-1","arib-std-b67"] | Default = Default('input'),matrixin: Int| Literal["input","709","unspecified","470bg","170m","2020_ncl","2020_cl","unknown","gbr","bt709","fcc","bt470bg","smpte170m","smpte240m","ycgco","bt2020nc","bt2020c","chroma-derived-nc","chroma-derived-c","ictcp"] | Default = Default('input'),chromal: Int| Literal["input","left","center","topleft","top","bottomleft","bottom"] | Default = Default('input'),chromalin: Int| Literal["input","left","center","topleft","top","bottomleft","bottom"] | Default = Default('input'),npl: Double = Default('nan'),agamma: Boolean = Default('true'),param_a: Double = Default('nan'),param_b: Double = Default('nan'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Scale (resize) the input video, using the z.lib library:
 https://github.com/sekrit-twc/zimg. To enable compilation of this
 filter, you need to configure FFmpeg with --enable-libzimg.
@@ -25399,65 +25399,61 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#zscale)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='zscale', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "size": size,
-                
+
                 "dither": dither,
-                
+
                 "filter": filter,
-                
+
                 "out_range": out_range,
-                
+
                 "primaries": primaries,
-                
+
                 "transfer": transfer,
-                
+
                 "matrix": matrix,
-                
+
                 "in_range": in_range,
-                
+
                 "primariesin": primariesin,
-                
+
                 "transferin": transferin,
-                
+
                 "matrixin": matrixin,
-                
+
                 "chromal": chromal,
-                
+
                 "chromalin": chromalin,
-                
+
                 "npl": npl,
-                
+
                 "agamma": agamma,
-                
+
                 "param_a": param_a,
-                
+
                 "param_b": param_b,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
-
-
-        
-    

--- a/packages/v8/pyproject.toml
+++ b/packages/v8/pyproject.toml
@@ -42,7 +42,7 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "syrupy>=5.0",
-    "ruff>=0.9.6",
+    "ruff==0.12.2",
 ]
 
 [build-system]

--- a/packages/v8/src/ffmpeg/codecs/decoders.py
+++ b/packages/v8/src/ffmpeg/codecs/decoders.py
@@ -446,311 +446,311 @@ from ..streams.audio import AudioStream
 
 
 def _012v(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed 4:2:2 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def _4xm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     4X Movie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def _8bps(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QuickTime 8BPS video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def aasc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Autodesk RLE
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def agm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Amuse Graphics Movie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def aic(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Apple Intermediate Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def alias_pix(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Alias/Wavefront PIX image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def amv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AMV Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def anm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Deluxe Paint Animation
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ansi(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ASCII/ANSI art
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def apng(
-    
+
 ) -> FFMpegDecoderOption:
     """
     APNG (Animated Portable Network Graphics) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def apv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Advanced Professional Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def arbc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Gryphon's Anim Compressor
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def argo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Argonaut Games Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def asv1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ASUS V1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def asv2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ASUS V2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def aura(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Auravision AURA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def aura2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Auravision Aura 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def libdav1d(
-    
+
     tilethreads: int | None = None,
-    
+
     framethreads: int | None = None,
-    
+
     max_frame_delay: int | None = None,
-    
+
     filmgrain: bool | None = None,
-    
+
     oppoint: int | None = None,
-    
+
     alllayers: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     dav1d AV1 decoder by VideoLAN (codec av1)
-    
+
     Args:
         tilethreads: Tile threads (from 0 to 256) (default 0)
         framethreads: Frame threads (from 0 to 256) (default 0)
@@ -763,31 +763,31 @@ def libdav1d(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "tilethreads": tilethreads,
-        
+
         "framethreads": framethreads,
-        
+
         "max_frame_delay": max_frame_delay,
-        
+
         "filmgrain": filmgrain,
-        
+
         "oppoint": oppoint,
-        
+
         "alllayers": alllayers,
-        
+
     }))
 
 
 
 def av1(
-    
+
     operating_point: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Alliance for Open Media AV1
-    
+
     Args:
         operating_point: Select an operating point of the scalable bitstream (from 0 to 31) (default 0)
 
@@ -795,651 +795,651 @@ def av1(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "operating_point": operating_point,
-        
+
     }))
 
 
 
 def avrn(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Avid AVI Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def avrp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Avid 1:1 10-bit RGB Packer
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def avs(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AVS (Audio Video Standard) video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def avui(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Avid Meridien Uncompressed
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bethsoftvid(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bethesda VID video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bfi(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Brute Force & Ignorance
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def binkvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bink video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bintext(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Binary text
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bitpacked(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bitpacked
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bmp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     BMP (Windows and OS/2 bitmap)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bmv_video(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Discworld II BMV video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def brender_pix(
-    
+
 ) -> FFMpegDecoderOption:
     """
     BRender PIX image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def c93(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Interplay C93
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cavs(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Chinese AVS (Audio Video Standard) (AVS1-P2, JiZhun profile)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cdgraphics(
-    
+
 ) -> FFMpegDecoderOption:
     """
     CD Graphics video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cdtoons(
-    
+
 ) -> FFMpegDecoderOption:
     """
     CDToons video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cdxl(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Commodore CDXL video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cfhd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     GoPro CineForm HD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cinepak(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Cinepak
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def clearvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Iterated Systems ClearVideo
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cljr(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Cirrus Logic AccuPak
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cllc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Canopus Lossless Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def eacmv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Electronic Arts CMV video (codec cmv)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cpia(
-    
+
 ) -> FFMpegDecoderOption:
     """
     CPiA video format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cri(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Cintel RAW
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def camstudio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     CamStudio (codec cscd)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cyuv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Creative YUV (CYUV)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dds(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DirectDraw Surface image decoder
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dfa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Chronomaster DFA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dirac(
-    
+
 ) -> FFMpegDecoderOption:
     """
     BBC Dirac VC-2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dnxhd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     VC3/DNxHD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dpx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPX (Digital Picture Exchange) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dsicinvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Delphine Software International CIN video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dvvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DV (Digital Video)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dxa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Feeble Files/ScummVM DXA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dxtory(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Dxtory
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dxv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Resolume DXV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def escape124(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Escape 124
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def escape130(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Escape 130
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def exr(
-    
+
     layer: str | None = None,
-    
+
     part: int | None = None,
-    
+
     gamma: float | None = None,
-    
+
     apply_trc: int | None| Literal["bt709", "gamma", "gamma22", "gamma28", "smpte170m", "smpte240m", "linear", "log", "log_sqrt", "iec61966_2_4", "bt1361", "iec61966_2_1", "bt2020_10bit", "bt2020_12bit", "smpte2084", "smpte428_1"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     OpenEXR image
-    
+
     Args:
         layer: Set the decoding layer (default "")
         part: Set the decoding part (from 0 to INT_MAX) (default 0)
@@ -1450,59 +1450,59 @@ def exr(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "layer": layer,
-        
+
         "part": part,
-        
+
         "gamma": gamma,
-        
+
         "apply_trc": apply_trc,
-        
+
     }))
 
 
 
 def ffv1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     FFmpeg video codec #1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ffvhuff(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Huffyuv FFmpeg variant
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def fic(
-    
+
     skip_cursor: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Mirillis FIC
-    
+
     Args:
         skip_cursor: skip the cursor (default false)
 
@@ -1510,21 +1510,21 @@ def fic(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "skip_cursor": skip_cursor,
-        
+
     }))
 
 
 
 def fits(
-    
+
     blank_value: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Flexible Image Transport System
-    
+
     Args:
         blank_value: value that is used to replace BLANK pixels in data array (from 0 to 65535) (default 0)
 
@@ -1532,117 +1532,117 @@ def fits(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "blank_value": blank_value,
-        
+
     }))
 
 
 
 def flashsv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Flash Screen Video v1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def flashsv2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Flash Screen Video v2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def flic(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Autodesk Animator Flic video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def flv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     FLV / Sorenson Spark / Sorenson H.263 (Flash Video) (codec flv1)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def fmvc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     FM Screen Capture Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def fraps(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Fraps
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def frwu(
-    
+
     change_field_order: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Forward Uncompressed
-    
+
     Args:
         change_field_order: Change field order (default false)
 
@@ -1650,69 +1650,69 @@ def frwu(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "change_field_order": change_field_order,
-        
+
     }))
 
 
 
 def g2m(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Go2Meeting
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def gdv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Gremlin Digital Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def gem(
-    
+
 ) -> FFMpegDecoderOption:
     """
     GEM Raster image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def gif(
-    
+
     trans_color: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     GIF (Graphics Interchange Format)
-    
+
     Args:
         trans_color: color value (ARGB) that is used instead of transparent color (from 0 to UINT32_MAX) (default 16777215)
 
@@ -1720,55 +1720,55 @@ def gif(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "trans_color": trans_color,
-        
+
     }))
 
 
 
 def h261(
-    
+
 ) -> FFMpegDecoderOption:
     """
     H.261
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def h263(
-    
+
 ) -> FFMpegDecoderOption:
     """
     H.263 / H.263-1996, H.263+ / H.263-1998 / H.263 version 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def h263_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem H.263 decoder wrapper (codec h263)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -1777,65 +1777,65 @@ def h263_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def h263i(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Intel H.263
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def h263p(
-    
+
 ) -> FFMpegDecoderOption:
     """
     H.263 / H.263-1996, H.263+ / H.263-1998 / H.263 version 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def h264(
-    
+
     is_avc: bool | None = None,
-    
+
     nal_length_size: int | None = None,
-    
+
     enable_er: bool | None = None,
-    
+
     x264_build: int | None = None,
-    
+
     skip_gray: bool | None = None,
-    
+
     noref_gray: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10
-    
+
     Args:
         is_avc: is avc (default false)
         nal_length_size: nal_length_size (from 0 to 4) (default 0)
@@ -1848,33 +1848,33 @@ def h264(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "is_avc": is_avc,
-        
+
         "nal_length_size": nal_length_size,
-        
+
         "enable_er": enable_er,
-        
+
         "x264_build": x264_build,
-        
+
         "skip_gray": skip_gray,
-        
+
         "noref_gray": noref_gray,
-        
+
     }))
 
 
 
 def h264_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem H.264 decoder wrapper (codec h264)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -1883,63 +1883,63 @@ def h264_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def hap(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Vidvox Hap
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hdr(
-    
+
 ) -> FFMpegDecoderOption:
     """
     HDR (Radiance RGBE format) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hevc(
-    
+
     apply_defdispwin: bool | None = None,
-    
+
     strict_displaywin: bool | None = None,
-    
+
     view_ids: int | None = None,
-    
+
     view_ids_available: int | None = None,
-    
+
     view_pos_available: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     HEVC (High Efficiency Video Coding)
-    
+
     Args:
         apply_defdispwin: Apply default display window from VUI (default false)
         strict_displaywin: strictly apply default display window size (default false)
@@ -1951,31 +1951,31 @@ def hevc(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "apply_defdispwin": apply_defdispwin,
-        
+
         "strict-displaywin": strict_displaywin,
-        
+
         "view_ids": view_ids,
-        
+
         "view_ids_available": view_ids_available,
-        
+
         "view_pos_available": view_pos_available,
-        
+
     }))
 
 
 
 def hevc_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem HEVC decoder wrapper (codec hevc)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -1984,279 +1984,279 @@ def hevc_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def hnm4video(
-    
+
 ) -> FFMpegDecoderOption:
     """
     HNM 4 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hq_hqa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Canopus HQ/HQA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hqx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Canopus HQX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def huffyuv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Huffyuv / HuffYUV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hymt(
-    
+
 ) -> FFMpegDecoderOption:
     """
     HuffYUV MT
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def idcinvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     id Quake II CIN video (codec idcin)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def idf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     iCEDraw text
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def iff(
-    
+
 ) -> FFMpegDecoderOption:
     """
     IFF ACBM/ANIM/DEEP/ILBM/PBM/RGB8/RGBN (codec iff_ilbm)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def imm4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Infinity IMM4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def imm5(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Infinity IMM5
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def indeo2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Intel Indeo 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def indeo3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Intel Indeo 3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def indeo4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Intel Indeo Video Interactive 4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def indeo5(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Intel Indeo Video Interactive 5
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def interplayvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Interplay MVE video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ipu(
-    
+
 ) -> FFMpegDecoderOption:
     """
     IPU Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def jpeg2000(
-    
+
     lowres: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     JPEG 2000
-    
+
     Args:
         lowres: Lower the decoding resolution by a power of two (from 0 to 33) (default 0)
 
@@ -2264,245 +2264,245 @@ def jpeg2000(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "lowres": lowres,
-        
+
     }))
 
 
 
 def jpegls(
-    
+
 ) -> FFMpegDecoderOption:
     """
     JPEG-LS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def jv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bitmap Brothers JV video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def kgv1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Kega Game Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def kmvc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Karl Morton's video codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def lagarith(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Lagarith lossless
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def lead(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LEAD MCMP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def loco(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LOCO
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def lscr(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LEAD Screen Capture
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def m101(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Matrox Uncompressed SD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def eamad(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Electronic Arts Madcow Video (codec mad)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def magicyuv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MagicYUV video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mdec(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sony PlayStation MDEC (Motion DECoder)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def media100(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Media 100
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mimic(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Mimic
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mjpeg(
-    
+
     extern_huff: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     MJPEG (Motion JPEG)
-    
+
     Args:
         extern_huff: Use external huffman table. (default false)
 
@@ -2510,103 +2510,103 @@ def mjpeg(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "extern_huff": extern_huff,
-        
+
     }))
 
 
 
 def mjpegb(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Apple MJPEG-B
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mmvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     American Laser Games MM Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mobiclip(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MobiClip Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def motionpixels(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Motion Pixels video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpeg1video(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-1 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpeg1_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem MPEG1 decoder wrapper (codec mpeg1video)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -2615,23 +2615,23 @@ def mpeg1_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def mpeg2video(
-    
+
     cc_format: int | None| Literal["auto", "a53", "scte20", "dvd", "dish"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-2 video
-    
+
     Args:
         cc_format: extract a specific Closed Captions format (from 0 to 4) (default auto)
 
@@ -2639,39 +2639,39 @@ def mpeg2video(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "cc_format": cc_format,
-        
+
     }))
 
 
 
 def mpegvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-1 video (codec mpeg2video)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpeg2_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem MPEG2 decoder wrapper (codec mpeg2video)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -2680,41 +2680,41 @@ def mpeg2_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def mpeg4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-4 part 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpeg4_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem MPEG4 decoder wrapper (codec mpeg4)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -2723,519 +2723,519 @@ def mpeg4_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def msa1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MS ATC Screen
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mscc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Mandsoft Screen Capture Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msmpeg4v1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-4 part 2 Microsoft variant version 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msmpeg4v2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-4 part 2 Microsoft variant version 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msmpeg4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-4 part 2 Microsoft variant version 3 (codec msmpeg4v3)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msp2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Microsoft Paint (MSP) version 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msrle(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Microsoft RLE
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mss1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MS Screen 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mss2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MS Windows Media Video V9 Screen
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def msvideo1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Microsoft Video 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mszh(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LCL (LossLess Codec Library) MSZH
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mts2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MS Expression Encoder Screen
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mv30(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MidiVid 3.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mvc1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Silicon Graphics Motion Video Compressor 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mvc2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Silicon Graphics Motion Video Compressor 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mvdv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MidiVid VQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mvha(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MidiVid Archive Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mwsc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MatchWare Screen Capture Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mxpeg(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Mobotix MxPEG video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def notchlc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     NotchLC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def nuv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     NuppelVideo/RTJPEG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def paf_video(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Amazing Studio Packed Animation File Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pam(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PAM (Portable AnyMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pbm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PBM (Portable BitMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PC Paintbrush PCX image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pdv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PDV (PlayDate Video)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pfm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PFM (Portable FloatMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pgm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PGM (Portable GrayMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pgmyuv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PGMYUV (Portable GrayMap YUV) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pgx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PGX (JPEG2000 Test Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def phm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PHM (Portable HalfFloatMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def photocd(
-    
+
     lowres: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Kodak Photo CD
-    
+
     Args:
         lowres: Lower the decoding resolution by a power of two (from 0 to 4) (default 0)
 
@@ -3243,261 +3243,261 @@ def photocd(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "lowres": lowres,
-        
+
     }))
 
 
 
 def pictor(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Pictor/PC Paint
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pixlet(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Apple Pixlet
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def png(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PNG (Portable Network Graphics) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ppm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PPM (Portable PixelMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def prores(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Apple ProRes (iCodec Pro)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def prores_raw(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Apple ProRes RAW
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def prosumer(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Brooktree ProSumer Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def psd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Photoshop PSD file
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ptx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     V.Flash PTX image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qdraw(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Apple QuickDraw
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qoi(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QOI (Quite OK Image format) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qpeg(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Q-team QPEG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qtrle(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QuickTime Animation (RLE) video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def r10k(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AJA Kona 10-bit RGB Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def r210(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed RGB 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rasc(
-    
+
     skip_cursor: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     RemotelyAnywhere Screen Capture
-    
+
     Args:
         skip_cursor: skip the cursor (default false)
 
@@ -3505,21 +3505,21 @@ def rasc(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "skip_cursor": skip_cursor,
-        
+
     }))
 
 
 
 def rawvideo(
-    
+
     top: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     raw video
-    
+
     Args:
         top: top field first (default auto)
 
@@ -3527,601 +3527,601 @@ def rawvideo(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "top": top,
-        
+
     }))
 
 
 
 def rl2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RL2 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def roqvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     id RoQ video (codec roq)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rpza(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QuickTime video (RPZA)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rscc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     innoHeim/Rsupport Screen Capture Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rtv1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RTV1 (RivaTuner Video)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rv10(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealVideo 1.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rv20(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealVideo 2.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rv30(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealVideo 3.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rv40(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealVideo 4.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rv60(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealVideo 6.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sanm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LucasArts SANM/Smush video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def scpr(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ScreenPressor
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def screenpresso(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Screenpresso
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sga(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Digital Pictures SGA Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sgi(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SGI image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sgirle(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Silicon Graphics RLE 8-bit video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sheervideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     BitJazz SheerVideo
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def simbiosis_imx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Simbiosis Interactive IMX Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def smackvid(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Smacker video (codec smackvideo)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def smc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QuickTime Graphics (SMC)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def smvjpeg(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SMV JPEG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def snow(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Snow
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sp5x(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sunplus JPEG (SP5X)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def speedhq(
-    
+
 ) -> FFMpegDecoderOption:
     """
     NewTek SpeedHQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def srgc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Screen Recorder Gold Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sunrast(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sun Rasterfile image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def svq1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sorenson Vector Quantizer 1 / Sorenson Video 1 / SVQ1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def svq3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sorenson Vector Quantizer 3 / Sorenson Video 3 / SVQ3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def targa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Truevision Targa image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def targa_y216(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Pinnacle TARGA CineWave YUV16
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def tdsc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     TDSC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def eatgq(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Electronic Arts TGQ video (codec tgq)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def eatgv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Electronic Arts TGV video (codec tgv)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def theora(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Theora
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def thp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Nintendo Gamecube THP video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def tiertexseqvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Tiertex Limited SEQ video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def tiff(
-    
+
     subimage: bool | None = None,
-    
+
     thumbnail: bool | None = None,
-    
+
     page: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     TIFF image
-    
+
     Args:
         subimage: decode subimage instead if available (default false)
         thumbnail: decode embedded thumbnail subimage instead if available (default false)
@@ -4131,185 +4131,185 @@ def tiff(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "subimage": subimage,
-        
+
         "thumbnail": thumbnail,
-        
+
         "page": page,
-        
+
     }))
 
 
 
 def tmv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     8088flex TMV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def eatqi(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Electronic Arts TQI Video (codec tqi)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def truemotion1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Duck TrueMotion 1.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def truemotion2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Duck TrueMotion 2.0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def truemotion2rt(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Duck TrueMotion 2.0 Real Time
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def camtasia(
-    
+
 ) -> FFMpegDecoderOption:
     """
     TechSmith Screen Capture Codec (codec tscc)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def tscc2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     TechSmith Screen Codec 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def txd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Renderware TXD (TeXture Dictionary) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ultimotion(
-    
+
 ) -> FFMpegDecoderOption:
     """
     IBM UltiMotion (codec ulti)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def utvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Ut Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def v210(
-    
+
     custom_stride: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed 4:2:2 10-bit
-    
+
     Args:
         custom_stride: Custom V210 stride (from -1 to INT_MAX) (default 0)
 
@@ -4317,151 +4317,151 @@ def v210(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "custom_stride": custom_stride,
-        
+
     }))
 
 
 
 def v210x(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed 4:2:2 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def v308(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed packed 4:4:4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def v408(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed packed QT 4:4:4:4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def v410(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed 4:4:4 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vb(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Beam Software VB
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vble(
-    
+
 ) -> FFMpegDecoderOption:
     """
     VBLE Lossless Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vbn(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Vizrt Binary Image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vc1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SMPTE VC-1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vc1_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem VC1 decoder wrapper (codec vc1)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -4470,265 +4470,265 @@ def vc1_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def vc1image(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Video 9 Image v2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vcr1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATI VCR1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xl(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Miro VideoXL (codec vixl)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vmdvideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sierra VMD video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vmix(
-    
+
 ) -> FFMpegDecoderOption:
     """
     vMix Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vmnc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     VMware Screen Codec / VMware Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vnull(
-    
+
 ) -> FFMpegDecoderOption:
     """
     null video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp5(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP5
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp6(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP6
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp6a(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP6 (Flash version, with alpha channel)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp6f(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP6 (Flash version)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp7(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP7
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp8(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 VP8
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp8_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem VP8 decoder wrapper (codec vp8)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -4737,57 +4737,57 @@ def vp8_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def libvpx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     libvpx VP8 (codec vp8)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp9(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Google VP9
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vp9_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     V4L2 mem2mem VP9 decoder wrapper (codec vp9)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 2 to INT_MAX) (default 20)
@@ -4796,473 +4796,473 @@ def vp9_v4l2m2m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def vqc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ViewQuest VQC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vvc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     VVC (Versatile Video Coding)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wbmp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     WBMP (Wireless Application Protocol Bitmap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wcmv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     WinCAM Motion Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def webp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     WebP image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmv1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Video 7
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmv2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Video 8
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmv3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Video 9
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmv3image(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Video 9 Image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wnv1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Winnov WNV1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wrapped_avframe(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AVPacket to AVFrame passthrough
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vqavideo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Westwood Studios VQA (Vector Quantized Animation) video (codec ws_vqa)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xan_wc3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Wing Commander III / Xan
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xan_wc4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Wing Commander IV / Xxan
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xbin(
-    
+
 ) -> FFMpegDecoderOption:
     """
     eXtended BINary text
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xbm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     XBM (X BitMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xface(
-    
+
 ) -> FFMpegDecoderOption:
     """
     X-face image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xpm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     XPM (X PixMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xwd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     XWD (X Window Dump) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def y41p(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed YUV 4:1:1 12-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ylc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     YUY2 Lossless Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def yop(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Psygnosis YOP Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def yuv4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Uncompressed packed 4:2:0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def zerocodec(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ZeroCodec Lossless Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def zlib(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LCL (LossLess Codec Library) ZLIB
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def zmbv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Zip Motion Blocks Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def _8svx_exp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     8SVX exponential
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def _8svx_fib(
-    
+
 ) -> FFMpegDecoderOption:
     """
     8SVX fibonacci
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def aac(
-    
+
     dual_mono_mode: int | None| Literal["auto", "main", "sub", "both"] = None,
-    
+
     channel_order: int | None| Literal["default", "coded"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     AAC (Advanced Audio Coding)
-    
+
     Args:
         dual_mono_mode: Select the channel to decode for dual mono (from -1 to 2) (default auto)
         channel_order: Order in which the channels are to be exported (from 0 to 1) (default default)
@@ -5271,25 +5271,25 @@ def aac(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "dual_mono_mode": dual_mono_mode,
-        
+
         "channel_order": channel_order,
-        
+
     }))
 
 
 
 def aac_fixed(
-    
+
     dual_mono_mode: int | None| Literal["auto", "main", "sub", "both"] = None,
-    
+
     channel_order: int | None| Literal["default", "coded"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     AAC (Advanced Audio Coding) (codec aac)
-    
+
     Args:
         dual_mono_mode: Select the channel to decode for dual mono (from -1 to 2) (default auto)
         channel_order: Order in which the channels are to be exported (from 0 to 1) (default default)
@@ -5298,47 +5298,47 @@ def aac_fixed(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "dual_mono_mode": dual_mono_mode,
-        
+
         "channel_order": channel_order,
-        
+
     }))
 
 
 
 def aac_latm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AAC LATM (Advanced Audio Coding LATM syntax)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ac3(
-    
+
     cons_noisegen: bool | None = None,
-    
+
     drc_scale: float | None = None,
-    
+
     heavy_compr: bool | None = None,
-    
+
     target_level: int | None = None,
-    
+
     downmix: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATSC A/52A (AC-3)
-    
+
     Args:
         cons_noisegen: enable consistent noise generation (default false)
         drc_scale: percentage of dynamic range compression to apply (from 0 to 6) (default 1)
@@ -5350,35 +5350,35 @@ def ac3(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "cons_noisegen": cons_noisegen,
-        
+
         "drc_scale": drc_scale,
-        
+
         "heavy_compr": heavy_compr,
-        
+
         "target_level": target_level,
-        
+
         "downmix": downmix,
-        
+
     }))
 
 
 
 def ac3_fixed(
-    
+
     cons_noisegen: bool | None = None,
-    
+
     drc_scale: float | None = None,
-    
+
     heavy_compr: bool | None = None,
-    
+
     downmix: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATSC A/52A (AC-3) (codec ac3)
-    
+
     Args:
         cons_noisegen: enable consistent noise generation (default false)
         drc_scale: percentage of dynamic range compression to apply (from 0 to 6) (default 1)
@@ -5389,251 +5389,251 @@ def ac3_fixed(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "cons_noisegen": cons_noisegen,
-        
+
         "drc_scale": drc_scale,
-        
+
         "heavy_compr": heavy_compr,
-        
+
         "downmix": downmix,
-        
+
     }))
 
 
 
 def adpcm_4xm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM 4X Movie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_adx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SEGA CRI ADX ADPCM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_afc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Nintendo Gamecube AFC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_agm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM AmuseGraphics Movie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_aica(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Yamaha AICA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_argo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Argonaut Games
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ct(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Creative Technology
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_dtk(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Nintendo Gamecube DTK
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ea(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Electronic Arts
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ea_maxis_xa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Electronic Arts Maxis CDROM XA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ea_r1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Electronic Arts R1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ea_r2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Electronic Arts R2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ea_r3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Electronic Arts R3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ea_xas(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Electronic Arts XAS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def g722(
-    
+
     bits_per_codeword: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     G.722 ADPCM (codec adpcm_g722)
-    
+
     Args:
         bits_per_codeword: Bits per G722 codeword (from 6 to 8) (default 8)
 
@@ -5641,645 +5641,645 @@ def g722(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "bits_per_codeword": bits_per_codeword,
-        
+
     }))
 
 
 
 def g726(
-    
+
 ) -> FFMpegDecoderOption:
     """
     G.726 ADPCM (codec adpcm_g726)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def g726le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     G.726 ADPCM little-endian (codec adpcm_g726le)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_acorn(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Acorn Replay
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_alp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA High Voltage Software ALP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_amv(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA AMV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_apc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA CRYO APC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_apm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Ubisoft APM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_cunning(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Cunning Developments
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_dat4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Eurocom DAT4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_dk3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Duck DK3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_dk4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Duck DK4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_ea_eacs(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Electronic Arts EACS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_ea_sead(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Electronic Arts SEAD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_iss(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Funcom ISS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_moflex(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA MobiClip MOFLEX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_mtf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Capcom's MT Framework
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_oki(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Dialogic OKI
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_qt(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA QuickTime
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_rad(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Radical
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_smjpeg(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Loki SDL MJPEG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_ssi(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Simon & Schuster Interactive
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_wav(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA WAV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_ws(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Westwood
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ima_xbox(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM IMA Xbox
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_ms(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Microsoft
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_mtaf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM MTAF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_psx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Playstation
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_sanyo(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Sanyo
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_sbpro_2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Sound Blaster Pro 2-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_sbpro_3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Sound Blaster Pro 2.6-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_sbpro_4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Sound Blaster Pro 4-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_swf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Shockwave Flash
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_thp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Nintendo THP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_thp_le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Nintendo THP (little-endian)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_vima(
-    
+
 ) -> FFMpegDecoderOption:
     """
     LucasArts VIMA audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_xa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM CDROM XA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_xmd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Konami XMD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_yamaha(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Yamaha
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_zork(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADPCM Zork
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def alac(
-    
+
     extra_bits_bug: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     ALAC (Apple Lossless Audio Codec)
-    
+
     Args:
         extra_bits_bug: Force non-standard decoding process (default false)
 
@@ -6287,117 +6287,117 @@ def alac(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "extra_bits_bug": extra_bits_bug,
-        
+
     }))
 
 
 
 def amrnb(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AMR-NB (Adaptive Multi-Rate NarrowBand) (codec amr_nb)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def libopencore_amrnb(
-    
+
 ) -> FFMpegDecoderOption:
     """
     OpenCORE AMR-NB (Adaptive Multi-Rate Narrow-Band) (codec amr_nb)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def amrwb(
-    
+
 ) -> FFMpegDecoderOption:
     """
     AMR-WB (Adaptive Multi-Rate WideBand) (codec amr_wb)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def libopencore_amrwb(
-    
+
 ) -> FFMpegDecoderOption:
     """
     OpenCORE AMR-WB (Adaptive Multi-Rate Wide-Band) (codec amr_wb)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def anull(
-    
+
 ) -> FFMpegDecoderOption:
     """
     null audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def apac(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Marian's A-pac audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ape(
-    
+
     max_samples: int | None| Literal["all"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Monkey's Audio
-    
+
     Args:
         max_samples: maximum number of samples decoded per call (from 1 to INT_MAX) (default 4608)
 
@@ -6405,309 +6405,309 @@ def ape(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "max_samples": max_samples,
-        
+
     }))
 
 
 
 def aptx(
-    
+
 ) -> FFMpegDecoderOption:
     """
     aptX (Audio Processing Technology for Bluetooth)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def aptx_hd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     aptX HD (Audio Processing Technology for Bluetooth)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def atrac1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATRAC1 (Adaptive TRansform Acoustic Coding)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def atrac3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATRAC3 (Adaptive TRansform Acoustic Coding 3)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def atrac3al(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATRAC3 AL (Adaptive TRansform Acoustic Coding 3 Advanced Lossless)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def atrac3plus(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATRAC3+ (Adaptive TRansform Acoustic Coding 3+) (codec atrac3p)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def atrac3plusal(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATRAC3+ AL (Adaptive TRansform Acoustic Coding 3+ Advanced Lossless) (codec atrac3pal)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def atrac9(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATRAC9 (Adaptive TRansform Acoustic Coding 9)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def on2avc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     On2 Audio for Video Codec (codec avc)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def binkaudio_dct(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bink Audio (DCT)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def binkaudio_rdft(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bink Audio (RDFT)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bmv_audio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Discworld II BMV audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def bonk(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Bonk audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cbd2_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Cuberoot-Delta-Exact
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def comfortnoise(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RFC 3389 comfort noise generator
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def cook(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Cook / Cooker / Gecko (RealAudio G2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def derf_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Xilam DERF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dfpwm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DFPWM1a audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dolby_e(
-    
+
     channel_order: int | None| Literal["default", "coded"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Dolby E
-    
+
     Args:
         channel_order: Order in which the channels are to be exported (from 0 to 1) (default default)
 
@@ -6715,137 +6715,137 @@ def dolby_e(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "channel_order": channel_order,
-        
+
     }))
 
 
 
 def dsd_lsbf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DSD (Direct Stream Digital), least significant bit first
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dsd_lsbf_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DSD (Direct Stream Digital), least significant bit first, planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dsd_msbf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DSD (Direct Stream Digital), most significant bit first
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dsd_msbf_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DSD (Direct Stream Digital), most significant bit first, planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dsicinaudio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Delphine Software International CIN audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dss_sp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Digital Speech Standard - Standard Play mode (DSS SP)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dst(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DST (Digital Stream Transfer)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dca(
-    
+
     core_only: bool | None = None,
-    
+
     channel_order: int | None| Literal["default", "coded"] = None,
-    
+
     downmix: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     DCA (DTS Coherent Acoustics) (codec dts)
-    
+
     Args:
         core_only: Decode core only without extensions (default false)
         channel_order: Order in which the channels are to be exported (from 0 to 1) (default default)
@@ -6855,49 +6855,49 @@ def dca(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "core_only": core_only,
-        
+
         "channel_order": channel_order,
-        
+
         "downmix": downmix,
-        
+
     }))
 
 
 
 def dvaudio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Ulead DV Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def eac3(
-    
+
     cons_noisegen: bool | None = None,
-    
+
     drc_scale: float | None = None,
-    
+
     heavy_compr: bool | None = None,
-    
+
     target_level: int | None = None,
-    
+
     downmix: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     ATSC A/52B (AC-3, E-AC-3)
-    
+
     Args:
         cons_noisegen: enable consistent noise generation (default false)
         drc_scale: percentage of dynamic range compression to apply (from 0 to 6) (default 1)
@@ -6909,29 +6909,29 @@ def eac3(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "cons_noisegen": cons_noisegen,
-        
+
         "drc_scale": drc_scale,
-        
+
         "heavy_compr": heavy_compr,
-        
+
         "target_level": target_level,
-        
+
         "downmix": downmix,
-        
+
     }))
 
 
 
 def evrc(
-    
+
     postfilter: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     EVRC (Enhanced Variable Rate Codec)
-    
+
     Args:
         postfilter: enable postfilter (default true)
 
@@ -6939,37 +6939,37 @@ def evrc(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "postfilter": postfilter,
-        
+
     }))
 
 
 
 def fastaudio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MobiClip FastAudio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def flac(
-    
+
     use_buggy_lpc: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     FLAC (Free Lossless Audio Codec)
-    
+
     Args:
         use_buggy_lpc: emulate old buggy lavc behavior (default false)
 
@@ -6977,37 +6977,37 @@ def flac(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "use_buggy_lpc": use_buggy_lpc,
-        
+
     }))
 
 
 
 def ftr(
-    
+
 ) -> FFMpegDecoderOption:
     """
     FTR Voice
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def g723_1(
-    
+
     postfilter: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     G.723.1
-    
+
     Args:
         postfilter: enable postfilter (default true)
 
@@ -7015,277 +7015,277 @@ def g723_1(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "postfilter": postfilter,
-        
+
     }))
 
 
 
 def g728(
-    
+
 ) -> FFMpegDecoderOption:
     """
     G.728)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def g729(
-    
+
 ) -> FFMpegDecoderOption:
     """
     G.729
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def gremlin_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Gremlin
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def gsm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     GSM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def gsm_ms(
-    
+
 ) -> FFMpegDecoderOption:
     """
     GSM Microsoft variant
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hca(
-    
+
 ) -> FFMpegDecoderOption:
     """
     CRI HCA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def hcom(
-    
+
 ) -> FFMpegDecoderOption:
     """
     HCOM Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def iac(
-    
+
 ) -> FFMpegDecoderOption:
     """
     IAC (Indeo Audio Coder)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ilbc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     iLBC (Internet Low Bitrate Codec)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def imc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     IMC (Intel Music Coder)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def interplay_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Interplay
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def interplayacm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Interplay ACM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mace3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MACE (Macintosh Audio Compression/Expansion) 3:1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mace6(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MACE (Macintosh Audio Compression/Expansion) 6:1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def metasound(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Voxware MetaSound
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def misc4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Micronas SC-4 Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mlp(
-    
+
     downmix: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     MLP (Meridian Lossless Packing)
-    
+
     Args:
         downmix: Request a specific channel layout from the decoder
 
@@ -7293,181 +7293,181 @@ def mlp(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "downmix": downmix,
-        
+
     }))
 
 
 
 def mp1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP1 (MPEG audio layer 1)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp1float(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP1 (MPEG audio layer 1) (codec mp1)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP2 (MPEG audio layer 2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp2float(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP2 (MPEG audio layer 2) (codec mp2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp3float(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP3 (MPEG audio layer 3) (codec mp3)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp3(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP3 (MPEG audio layer 3)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp3adufloat(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADU (Application Data Unit) MP3 (MPEG audio layer 3) (codec mp3adu)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp3adu(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ADU (Application Data Unit) MP3 (MPEG audio layer 3)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp3on4float(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP3onMP4 (codec mp3on4)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mp3on4(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MP3onMP4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def als(
-    
+
     max_order: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPEG-4 Audio Lossless Coding (ALS) (codec mp4als)
-    
+
     Args:
         max_order: Sets the maximum order (ALS simple profile allows max 15) (from 0 to 1023) (default 1023)
 
@@ -7475,85 +7475,85 @@ def als(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "max_order": max_order,
-        
+
     }))
 
 
 
 def msnsiren(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MSN Siren
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpc7(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Musepack SV7 (codec musepack7)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mpc8(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Musepack SV8 (codec musepack8)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def nellymoser(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Nellymoser Asao
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def opus(
-    
+
     apply_phase_inv: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Opus
-    
+
     Args:
         apply_phase_inv: Apply intensity stereo phase inversion (default true)
 
@@ -7561,21 +7561,21 @@ def opus(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "apply_phase_inv": apply_phase_inv,
-        
+
     }))
 
 
 
 def libopus(
-    
+
     apply_phase_inv: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     libopus Opus (codec opus)
-    
+
     Args:
         apply_phase_inv: Apply intensity stereo phase inversion (default true)
 
@@ -7583,757 +7583,757 @@ def libopus(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "apply_phase_inv": apply_phase_inv,
-        
+
     }))
 
 
 
 def osq(
-    
+
 ) -> FFMpegDecoderOption:
     """
     OSQ (Original Sound Quality)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def paf_audio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Amazing Studio Packed Animation File Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_alaw(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM A-law / G.711 A-law
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_bluray(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 16|20|24-bit big-endian for Blu-ray media
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_dvd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 16|20|24-bit big-endian for DVD media
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f16le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM 16.8 floating point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f24le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM 24.0 floating point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f32be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM 32-bit floating point big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f32le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM 32-bit floating point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f64be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM 64-bit floating point big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f64le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM 64-bit floating point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_lxf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 20-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_mulaw(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM mu-law / G.711 mu-law
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 16-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16be_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 16-bit big-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 16-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16le_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 16-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 24-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24daud(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM D-Cinema audio signed 24-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 24-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24le_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 24-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s32be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 32-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s32le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 32-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s32le_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 32-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s64be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 64-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s64le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 64-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s8(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 8-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s8_planar(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM signed 8-bit planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_sga(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM SGA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u16be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 16-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u16le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 16-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u24be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 24-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u24le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 24-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u32be(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 32-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u32le(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 32-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u8(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM unsigned 8-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_vidc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     PCM Archimedes VIDC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qcelp(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QCELP / PureVoice
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qdm2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QDesign Music Codec 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qdmc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QDesign Music Codec 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def qoa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     QOA (Quite OK Audio)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def real_144(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealAudio 1.0 (14.4K) (codec ra_144)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def real_288(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealAudio 2.0 (28.8K) (codec ra_288)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ralf(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealAudio Lossless
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def rka(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RKA (RK Audio)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def roq_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM id RoQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def s302m(
-    
+
     non_pcm_mode: int | None| Literal["copy", "drop", "decode_copy", "decode_drop"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     SMPTE 302M
-    
+
     Args:
         non_pcm_mode: Chooses what to do with NON-PCM (from 0 to 3) (default decode_drop)
 
@@ -8341,181 +8341,181 @@ def s302m(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "non_pcm_mode": non_pcm_mode,
-        
+
     }))
 
 
 
 def sbc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SBC (low-complexity subband codec)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sdx2_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Squareroot-Delta-Exact
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def shorten(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Shorten
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sipr(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealAudio SIPR / ACELP.NET
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def siren(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Siren
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def smackaud(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Smacker audio (codec smackaudio)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sol_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Sol
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sonic(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sonic
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def speex(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Speex
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def tak(
-    
+
 ) -> FFMpegDecoderOption:
     """
     TAK (Tom's lossless Audio Kompressor)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def truehd(
-    
+
     downmix: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     TrueHD
-    
+
     Args:
         downmix: Request a specific channel layout from the decoder
 
@@ -8523,37 +8523,37 @@ def truehd(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "downmix": downmix,
-        
+
     }))
 
 
 
 def truespeech(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DSP Group TrueSpeech
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def tta(
-    
+
     password: str | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     TTA (True Audio)
-    
+
     Args:
         password: Set decoding password
 
@@ -8561,329 +8561,329 @@ def tta(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "password": password,
-        
+
     }))
 
 
 
 def twinvq(
-    
+
 ) -> FFMpegDecoderOption:
     """
     VQF TwinVQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vmdaudio(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Sierra VMD audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def vorbis(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Vorbis
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def libvorbis(
-    
+
 ) -> FFMpegDecoderOption:
     """
     libvorbis (codec vorbis)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wady_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Marble WADY
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wavarc(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Waveform Archiver
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wavesynth(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Wave synthesis pseudo-codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wavpack(
-    
+
 ) -> FFMpegDecoderOption:
     """
     WavPack
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ws_snd1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Westwood Audio (SND1) (codec westwood_snd1)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmalossless(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Audio Lossless
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmapro(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Audio 9 Professional
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmav1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Audio 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmav2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Audio 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def wmavoice(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Windows Media Audio Voice
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xan_dpcm(
-    
+
 ) -> FFMpegDecoderOption:
     """
     DPCM Xan
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xma1(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Xbox Media Audio 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xma2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     Xbox Media Audio 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ssa(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ASS (Advanced SubStation Alpha) subtitle (codec ass)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def ass(
-    
+
 ) -> FFMpegDecoderOption:
     """
     ASS (Advanced SubStation Alpha) subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def dvbsub(
-    
+
     compute_edt: bool | None = None,
-    
+
     compute_clut: bool | None = None,
-    
+
     dvb_substream: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     DVB subtitles (codec dvb_subtitle)
-    
+
     Args:
         compute_edt: compute end of time using pts or timeout (default false)
         compute_clut: compute clut when not available(-1) or only once (-2) or always(1) or never(0) (default auto)
@@ -8893,29 +8893,29 @@ def dvbsub(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "compute_edt": compute_edt,
-        
+
         "compute_clut": compute_clut,
-        
+
         "dvb_substream": dvb_substream,
-        
+
     }))
 
 
 
 def dvdsub(
-    
+
     palette: str | None = None,
-    
+
     ifo_palette: str | None = None,
-    
+
     forced_subs_only: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     DVD subtitles (codec dvd_subtitle)
-    
+
     Args:
         palette: set the global palette
         ifo_palette: obtain the global palette from .IFO file
@@ -8925,29 +8925,29 @@ def dvdsub(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "palette": palette,
-        
+
         "ifo_palette": ifo_palette,
-        
+
         "forced_subs_only": forced_subs_only,
-        
+
     }))
 
 
 
 def cc_dec(
-    
+
     real_time: bool | None = None,
-    
+
     real_time_latency_msec: int | None = None,
-    
+
     data_field: int | None| Literal["auto", "first", "second"] = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Closed Captions (EIA-608 / CEA-708) (codec eia_608)
-    
+
     Args:
         real_time: emit subtitle events as they are decoded for real-time display (default false)
         real_time_latency_msec: minimum elapsed time between emitting real-time subtitle events (from 0 to 500) (default 200)
@@ -8957,25 +8957,25 @@ def cc_dec(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "real_time": real_time,
-        
+
         "real_time_latency_msec": real_time_latency_msec,
-        
+
         "data_field": data_field,
-        
+
     }))
 
 
 
 def pgssub(
-    
+
     forced_subs_only: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     HDMV Presentation Graphic Stream subtitles (codec hdmv_pgs_subtitle)
-    
+
     Args:
         forced_subs_only: Only show forced subtitles (default false)
 
@@ -8983,55 +8983,55 @@ def pgssub(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "forced_subs_only": forced_subs_only,
-        
+
     }))
 
 
 
 def jacosub(
-    
+
 ) -> FFMpegDecoderOption:
     """
     JACOsub subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def microdvd(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MicroDVD subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def mov_text(
-    
+
     width: int | None = None,
-    
+
     height: int | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     3GPP Timed Text subtitle
-    
+
     Args:
         width: Frame width, usually video width (from 0 to INT_MAX) (default 0)
         height: Frame height, usually video height (from 0 to INT_MAX) (default 0)
@@ -9040,39 +9040,39 @@ def mov_text(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "width": width,
-        
+
         "height": height,
-        
+
     }))
 
 
 
 def mpl2(
-    
+
 ) -> FFMpegDecoderOption:
     """
     MPL2 subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def pjs(
-    
+
     keep_ass_markup: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     PJS subtitle
-    
+
     Args:
         keep_ass_markup: Set if ASS tags must be escaped (default false)
 
@@ -9080,53 +9080,53 @@ def pjs(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "keep_ass_markup": keep_ass_markup,
-        
+
     }))
 
 
 
 def realtext(
-    
+
 ) -> FFMpegDecoderOption:
     """
     RealText subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def sami(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SAMI subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def stl(
-    
+
     keep_ass_markup: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Spruce subtitle format
-    
+
     Args:
         keep_ass_markup: Set if ASS tags must be escaped (default false)
 
@@ -9134,69 +9134,69 @@ def stl(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "keep_ass_markup": keep_ass_markup,
-        
+
     }))
 
 
 
 def srt(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SubRip subtitle (codec subrip)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def subrip(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SubRip subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def subviewer(
-    
+
 ) -> FFMpegDecoderOption:
     """
     SubViewer subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def subviewer1(
-    
+
     keep_ass_markup: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     SubViewer1 subtitle
-    
+
     Args:
         keep_ass_markup: Set if ASS tags must be escaped (default false)
 
@@ -9204,21 +9204,21 @@ def subviewer1(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "keep_ass_markup": keep_ass_markup,
-        
+
     }))
 
 
 
 def text(
-    
+
     keep_ass_markup: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     Raw text subtitle
-    
+
     Args:
         keep_ass_markup: Set if ASS tags must be escaped (default false)
 
@@ -9226,21 +9226,21 @@ def text(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "keep_ass_markup": keep_ass_markup,
-        
+
     }))
 
 
 
 def vplayer(
-    
+
     keep_ass_markup: bool | None = None,
-    
+
 ) -> FFMpegDecoderOption:
     """
     VPlayer subtitle
-    
+
     Args:
         keep_ass_markup: Set if ASS tags must be escaped (default false)
 
@@ -9248,40 +9248,39 @@ def vplayer(
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
         "keep_ass_markup": keep_ass_markup,
-        
+
     }))
 
 
 
 def webvtt(
-    
+
 ) -> FFMpegDecoderOption:
     """
     WebVTT subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
+
     }))
 
 
 
 def xsub(
-    
+
 ) -> FFMpegDecoderOption:
     """
     XSUB
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDecoderOption(merge({
-        
-    }))
 
+    }))

--- a/packages/v8/src/ffmpeg/codecs/encoders.py
+++ b/packages/v8/src/ffmpeg/codecs/encoders.py
@@ -44,99 +44,99 @@ from ..streams.audio import AudioStream
 
 
 def a64multi(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Multicolor charset for Commodore 64 (codec a64_multi)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def a64multi5(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Multicolor charset for Commodore 64, extended with 5th color (colram) (codec a64_multi5)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def alias_pix(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Alias/Wavefront PIX image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def amv(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     AMV Video
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -163,63 +163,63 @@ def amv(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
     }))
 
 
 
 def apng(
-    
+
     dpi: int | None = None,
-    
+
     dpm: int | None = None,
-    
+
     pred: int | None| Literal["none", "sub", "up", "avg", "paeth", "mixed"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     APNG (Animated Portable Network Graphics) image
-    
+
     Args:
         dpi: Set image resolution (in dots per inch) (from 0 to 65536) (default 0)
         dpm: Set image resolution (in dots per meter) (from 0 to 65536) (default 0)
@@ -229,79 +229,79 @@ def apng(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "dpi": dpi,
-        
+
         "dpm": dpm,
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def asv1(
-    
+
 ) -> FFMpegEncoderOption:
     """
     ASUS V1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def asv2(
-    
+
 ) -> FFMpegEncoderOption:
     """
     ASUS V2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def av1_vaapi(
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     low_power: bool | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     rc_mode: int | None| Literal["auto", "CQP", "CBR", "VBR", "ICQ", "QVBR", "AVBR"] = None,
-    
+
     blbrc: bool | None = None,
-    
+
     profile: int | None| Literal["main", "high", "professional"] = None,
-    
+
     tier: int | None| Literal["main", "high"] = None,
-    
+
     level: int | None| Literal["2.0", "2.1", "3.0", "3.1", "4.0", "4.1", "5.0", "5.1", "5.2", "5.3", "6.0", "6.1", "6.2", "6.3"] = None,
-    
+
     tiles: str | None = None,
-    
+
     tile_groups: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     AV1 (VAAPI) (codec av1)
-    
+
     Args:
         idr_interval: Distance (in I-frames) between key frames (from 0 to INT_MAX) (default 0)
         b_depth: Maximum B-frame reference depth (from 1 to INT_MAX) (default 1)
@@ -320,107 +320,107 @@ def av1_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "low_power": low_power,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "rc_mode": rc_mode,
-        
+
         "blbrc": blbrc,
-        
+
         "profile": profile,
-        
+
         "tier": tier,
-        
+
         "level": level,
-        
+
         "tiles": tiles,
-        
+
         "tile_groups": tile_groups,
-        
+
     }))
 
 
 
 def avrp(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Avid 1:1 10-bit RGB Packer
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def avui(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Avid Meridien Uncompressed
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def bitpacked(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Bitpacked
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def bmp(
-    
+
 ) -> FFMpegEncoderOption:
     """
     BMP (Windows and OS/2 bitmap)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def cfhd(
-    
+
     quality: int | None| Literal["film3+", "film3", "film2+", "film2", "film1.5", "film1+", "film1", "high+", "high", "medium+", "medium", "low+", "low"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     GoPro CineForm HD
-    
+
     Args:
         quality: set quality (from 0 to 12) (default film3+)
 
@@ -428,29 +428,29 @@ def cfhd(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "quality": quality,
-        
+
     }))
 
 
 
 def cinepak(
-    
+
     max_extra_cb_iterations: int | None = None,
-    
+
     skip_empty_cb: bool | None = None,
-    
+
     max_strips: int | None = None,
-    
+
     min_strips: int | None = None,
-    
+
     strip_number_adaptivity: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Cinepak
-    
+
     Args:
         max_extra_cb_iterations: Max extra codebook recalculation passes, more is better and slower (from 0 to INT_MAX) (default 2)
         skip_empty_cb: Avoid wasting bytes, ignore vintage MacOS decoder (default false)
@@ -462,29 +462,29 @@ def cinepak(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "max_extra_cb_iterations": max_extra_cb_iterations,
-        
+
         "skip_empty_cb": skip_empty_cb,
-        
+
         "max_strips": max_strips,
-        
+
         "min_strips": min_strips,
-        
+
         "strip_number_adaptivity": strip_number_adaptivity,
-        
+
     }))
 
 
 
 def cljr(
-    
+
     dither_type: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Cirrus Logic AccuPak
-    
+
     Args:
         dither_type: Dither type (from 0 to 2) (default 1)
 
@@ -492,31 +492,31 @@ def cljr(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "dither_type": dither_type,
-        
+
     }))
 
 
 
 def vc2(
-    
+
     tolerance: float | None = None,
-    
+
     slice_width: int | None = None,
-    
+
     slice_height: int | None = None,
-    
+
     wavelet_depth: int | None = None,
-    
+
     wavelet_type: int | None| Literal["9_7", "5_3", "haar", "haar_noshift"] = None,
-    
+
     qm: int | None| Literal["default", "color", "flat"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     SMPTE VC-2 (codec dirac)
-    
+
     Args:
         tolerance: Max undershoot in percent (from 0 to 45) (default 5)
         slice_width: Slice width (from 32 to 1024) (default 32)
@@ -529,35 +529,35 @@ def vc2(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "tolerance": tolerance,
-        
+
         "slice_width": slice_width,
-        
+
         "slice_height": slice_height,
-        
+
         "wavelet_depth": wavelet_depth,
-        
+
         "wavelet_type": wavelet_type,
-        
+
         "qm": qm,
-        
+
     }))
 
 
 
 def dnxhd(
-    
+
     nitris_compat: bool | None = None,
-    
+
     ibias: int | None = None,
-    
+
     profile: int | None| Literal["dnxhd", "dnxhr_444", "dnxhr_hqx", "dnxhr_hq", "dnxhr_sq", "dnxhr_lb"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     VC3/DNxHD
-    
+
     Args:
         nitris_compat: encode with Avid Nitris compatibility (default false)
         ibias: intra quant bias (from INT_MIN to INT_MAX) (default 0)
@@ -567,41 +567,41 @@ def dnxhd(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "nitris_compat": nitris_compat,
-        
+
         "ibias": ibias,
-        
+
         "profile": profile,
-        
+
     }))
 
 
 
 def dpx(
-    
+
 ) -> FFMpegEncoderOption:
     """
     DPX (Digital Picture Exchange) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def dvvideo(
-    
+
     quant_deadzone: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     DV (Digital Video)
-    
+
     Args:
         quant_deadzone: Quantizer dead zone (from 0 to 1024) (default 7)
 
@@ -609,21 +609,21 @@ def dvvideo(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "quant_deadzone": quant_deadzone,
-        
+
     }))
 
 
 
 def dxv(
-    
+
     format: int | None| Literal["dxt1"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Resolume DXV
-    
+
     Args:
         format: (from 1.14664e+09 to 1.14664e+09) (default dxt1)
 
@@ -631,25 +631,25 @@ def dxv(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "format": format,
-        
+
     }))
 
 
 
 def exr(
-    
+
     compression: int | None| Literal["none", "rle", "zip1", "zip16"] = None,
-    
+
     format: int | None| Literal["half", "float"] = None,
-    
+
     gamma: float | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     OpenEXR image
-    
+
     Args:
         compression: set compression type (from 0 to 3) (default none)
         format: set pixel type (from 1 to 2) (default float)
@@ -659,35 +659,35 @@ def exr(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "compression": compression,
-        
+
         "format": format,
-        
+
         "gamma": gamma,
-        
+
     }))
 
 
 
 def ffv1(
-    
+
     slicecrc: int | None = None,
-    
+
     coder: int | None| Literal["rice", "range_def", "range_tab", "ac"] = None,
-    
+
     context: int | None = None,
-    
+
     qtable: int | None| Literal["default", "8bit", "greater8bit"] = None,
-    
+
     remap_mode: int | None| Literal["auto", "off", "dualrle", "flipdualrle"] = None,
-    
+
     remap_optimizer: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     FFmpeg video codec #1
-    
+
     Args:
         slicecrc: Protect slices with CRCs (from -1 to 2) (default -1)
         coder: Coder type (from -2 to 2) (default rice)
@@ -700,35 +700,35 @@ def ffv1(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "slicecrc": slicecrc,
-        
+
         "coder": coder,
-        
+
         "context": context,
-        
+
         "qtable": qtable,
-        
+
         "remap_mode": remap_mode,
-        
+
         "remap_optimizer": remap_optimizer,
-        
+
     }))
 
 
 
 def ffvhuff(
-    
+
     context: int | None = None,
-    
+
     non_deterministic: bool | None = None,
-    
+
     pred: int | None| Literal["left", "plane", "median"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Huffyuv FFmpeg variant
-    
+
     Args:
         context: Set per-frame huffman tables (from 0 to 1) (default 0)
         non_deterministic: Allow multithreading for e.g. context=1 at the expense of determinism (default false)
@@ -738,121 +738,121 @@ def ffvhuff(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "context": context,
-        
+
         "non_deterministic": non_deterministic,
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def fits(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Flexible Image Transport System
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def flashsv(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Flash Screen Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def flashsv2(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Flash Screen Video Version 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def flv(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     FLV / Sorenson Spark / Sorenson H.263 (Flash Video) (codec flv1)
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -884,73 +884,73 @@ def flv(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
         "sc_threshold": sc_threshold,
-        
+
     }))
 
 
 
 def gif(
-    
+
     gifflags: str | None = None,
-    
+
     gifimage: bool | None = None,
-    
+
     global_palette: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     GIF (Graphics Interchange Format)
-    
+
     Args:
         gifflags: set GIF flags (default offsetting+transdiff)
         gifimage: enable encoding only images per frame (default false)
@@ -960,73 +960,73 @@ def gif(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "gifflags": gifflags,
-        
+
         "gifimage": gifimage,
-        
+
         "global_palette": global_palette,
-        
+
     }))
 
 
 
 def h261(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     H.261
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -1058,121 +1058,121 @@ def h261(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
         "sc_threshold": sc_threshold,
-        
+
     }))
 
 
 
 def h263(
-    
+
     obmc: bool | None = None,
-    
+
     mb_info: int | None = None,
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     H.263 / H.263-1996
-    
+
     Args:
         obmc: use overlapped block motion compensation. (default false)
         mb_info: emit macroblock info for RFC 2190 packetization, the parameter value is the maximum payload size (from 0 to INT_MAX) (default 0)
@@ -1206,75 +1206,75 @@ def h263(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "obmc": obmc,
-        
+
         "mb_info": mb_info,
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
         "sc_threshold": sc_threshold,
-        
+
     }))
 
 
 
 def h263_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     V4L2 mem2mem H.263 encoder wrapper (codec h263)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 4 to INT_MAX) (default 4)
@@ -1283,79 +1283,79 @@ def h263_v4l2m2m(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def h263p(
-    
+
     umv: bool | None = None,
-    
+
     aiv: bool | None = None,
-    
+
     obmc: bool | None = None,
-    
+
     structured_slices: bool | None = None,
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     H.263+ / H.263-1998 / H.263 version 2
-    
+
     Args:
         umv: Use unlimited motion vectors. (default false)
         aiv: Use alternative inter VLC. (default false)
@@ -1391,169 +1391,169 @@ def h263p(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "umv": umv,
-        
+
         "aiv": aiv,
-        
+
         "obmc": obmc,
-        
+
         "structured_slices": structured_slices,
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
         "sc_threshold": sc_threshold,
-        
+
     }))
 
 
 
 def libx264(
-    
+
     preset: str | None = None,
-    
+
     tune: str | None = None,
-    
+
     profile: str | None = None,
-    
+
     fastfirstpass: bool | None = None,
-    
+
     level: str | None = None,
-    
+
     passlogfile: str | None = None,
-    
+
     wpredp: str | None = None,
-    
+
     a53cc: bool | None = None,
-    
+
     x264opts: str | None = None,
-    
+
     crf: float | None = None,
-    
+
     crf_max: float | None = None,
-    
+
     qp: int | None = None,
-    
+
     aq_mode: int | None| Literal["none", "variance", "autovariance", "autovariance-biased"] = None,
-    
+
     aq_strength: float | None = None,
-    
+
     psy: bool | None = None,
-    
+
     psy_rd: str | None = None,
-    
+
     rc_lookahead: int | None = None,
-    
+
     weightb: bool | None = None,
-    
+
     weightp: int | None| Literal["none", "simple", "smart"] = None,
-    
+
     ssim: bool | None = None,
-    
+
     intra_refresh: bool | None = None,
-    
+
     bluray_compat: bool | None = None,
-    
+
     b_bias: int | None = None,
-    
+
     b_pyramid: int | None| Literal["none", "strict", "normal"] = None,
-    
+
     mixed_refs: bool | None = None,
-    
+
     _8x8dct: bool | None = None,
-    
+
     fast_pskip: bool | None = None,
-    
+
     aud: bool | None = None,
-    
+
     mbtree: bool | None = None,
-    
+
     deblock: str | None = None,
-    
+
     cplxblur: float | None = None,
-    
+
     partitions: str | None = None,
-    
+
     direct_pred: int | None| Literal["none", "spatial", "temporal", "auto"] = None,
-    
+
     slice_max_size: int | None = None,
-    
+
     stats: str | None = None,
-    
+
     nal_hrd: int | None| Literal["none", "vbr", "cbr"] = None,
-    
+
     avcintra_class: int | None = None,
-    
+
     me_method: int | None| Literal["dia", "hex", "umh", "esa", "tesa"] = None,
-    
+
     forced_idr: bool | None = None,
-    
+
     coder: int | None| Literal["default", "cavlc", "cabac", "vlc", "ac"] = None,
-    
+
     b_strategy: int | None = None,
-    
+
     chromaoffset: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     udu_sei: bool | None = None,
-    
+
     x264_params: str | None = None,
-    
+
     mb_info: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libx264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 (codec h264)
-    
+
     Args:
         preset: Set the encoding preset (cf. x264 --fullhelp) (default "medium")
         tune: Tune the encoding params (cf. x264 --fullhelp)
@@ -1607,205 +1607,205 @@ def libx264(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "preset": preset,
-        
+
         "tune": tune,
-        
+
         "profile": profile,
-        
+
         "fastfirstpass": fastfirstpass,
-        
+
         "level": level,
-        
+
         "passlogfile": passlogfile,
-        
+
         "wpredp": wpredp,
-        
+
         "a53cc": a53cc,
-        
+
         "x264opts": x264opts,
-        
+
         "crf": crf,
-        
+
         "crf_max": crf_max,
-        
+
         "qp": qp,
-        
+
         "aq-mode": aq_mode,
-        
+
         "aq-strength": aq_strength,
-        
+
         "psy": psy,
-        
+
         "psy-rd": psy_rd,
-        
+
         "rc-lookahead": rc_lookahead,
-        
+
         "weightb": weightb,
-        
+
         "weightp": weightp,
-        
+
         "ssim": ssim,
-        
+
         "intra-refresh": intra_refresh,
-        
+
         "bluray-compat": bluray_compat,
-        
+
         "b-bias": b_bias,
-        
+
         "b-pyramid": b_pyramid,
-        
+
         "mixed-refs": mixed_refs,
-        
+
         "8x8dct": _8x8dct,
-        
+
         "fast-pskip": fast_pskip,
-        
+
         "aud": aud,
-        
+
         "mbtree": mbtree,
-        
+
         "deblock": deblock,
-        
+
         "cplxblur": cplxblur,
-        
+
         "partitions": partitions,
-        
+
         "direct-pred": direct_pred,
-        
+
         "slice-max-size": slice_max_size,
-        
+
         "stats": stats,
-        
+
         "nal-hrd": nal_hrd,
-        
+
         "avcintra-class": avcintra_class,
-        
+
         "me_method": me_method,
-        
+
         "forced-idr": forced_idr,
-        
+
         "coder": coder,
-        
+
         "b_strategy": b_strategy,
-        
+
         "chromaoffset": chromaoffset,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "udu_sei": udu_sei,
-        
+
         "x264-params": x264_params,
-        
+
         "mb_info": mb_info,
-        
+
     }))
 
 
 
 def libx264rgb(
-    
+
     preset: str | None = None,
-    
+
     tune: str | None = None,
-    
+
     profile: str | None = None,
-    
+
     fastfirstpass: bool | None = None,
-    
+
     level: str | None = None,
-    
+
     passlogfile: str | None = None,
-    
+
     wpredp: str | None = None,
-    
+
     a53cc: bool | None = None,
-    
+
     x264opts: str | None = None,
-    
+
     crf: float | None = None,
-    
+
     crf_max: float | None = None,
-    
+
     qp: int | None = None,
-    
+
     aq_mode: int | None| Literal["none", "variance", "autovariance", "autovariance-biased"] = None,
-    
+
     aq_strength: float | None = None,
-    
+
     psy: bool | None = None,
-    
+
     psy_rd: str | None = None,
-    
+
     rc_lookahead: int | None = None,
-    
+
     weightb: bool | None = None,
-    
+
     weightp: int | None| Literal["none", "simple", "smart"] = None,
-    
+
     ssim: bool | None = None,
-    
+
     intra_refresh: bool | None = None,
-    
+
     bluray_compat: bool | None = None,
-    
+
     b_bias: int | None = None,
-    
+
     b_pyramid: int | None| Literal["none", "strict", "normal"] = None,
-    
+
     mixed_refs: bool | None = None,
-    
+
     _8x8dct: bool | None = None,
-    
+
     fast_pskip: bool | None = None,
-    
+
     aud: bool | None = None,
-    
+
     mbtree: bool | None = None,
-    
+
     deblock: str | None = None,
-    
+
     cplxblur: float | None = None,
-    
+
     partitions: str | None = None,
-    
+
     direct_pred: int | None| Literal["none", "spatial", "temporal", "auto"] = None,
-    
+
     slice_max_size: int | None = None,
-    
+
     stats: str | None = None,
-    
+
     nal_hrd: int | None| Literal["none", "vbr", "cbr"] = None,
-    
+
     avcintra_class: int | None = None,
-    
+
     me_method: int | None| Literal["dia", "hex", "umh", "esa", "tesa"] = None,
-    
+
     forced_idr: bool | None = None,
-    
+
     coder: int | None| Literal["default", "cavlc", "cabac", "vlc", "ac"] = None,
-    
+
     b_strategy: int | None = None,
-    
+
     chromaoffset: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     udu_sei: bool | None = None,
-    
+
     x264_params: str | None = None,
-    
+
     mb_info: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libx264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 RGB (codec h264)
-    
+
     Args:
         preset: Set the encoding preset (cf. x264 --fullhelp) (default "medium")
         tune: Tune the encoding params (cf. x264 --fullhelp)
@@ -1859,115 +1859,115 @@ def libx264rgb(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "preset": preset,
-        
+
         "tune": tune,
-        
+
         "profile": profile,
-        
+
         "fastfirstpass": fastfirstpass,
-        
+
         "level": level,
-        
+
         "passlogfile": passlogfile,
-        
+
         "wpredp": wpredp,
-        
+
         "a53cc": a53cc,
-        
+
         "x264opts": x264opts,
-        
+
         "crf": crf,
-        
+
         "crf_max": crf_max,
-        
+
         "qp": qp,
-        
+
         "aq-mode": aq_mode,
-        
+
         "aq-strength": aq_strength,
-        
+
         "psy": psy,
-        
+
         "psy-rd": psy_rd,
-        
+
         "rc-lookahead": rc_lookahead,
-        
+
         "weightb": weightb,
-        
+
         "weightp": weightp,
-        
+
         "ssim": ssim,
-        
+
         "intra-refresh": intra_refresh,
-        
+
         "bluray-compat": bluray_compat,
-        
+
         "b-bias": b_bias,
-        
+
         "b-pyramid": b_pyramid,
-        
+
         "mixed-refs": mixed_refs,
-        
+
         "8x8dct": _8x8dct,
-        
+
         "fast-pskip": fast_pskip,
-        
+
         "aud": aud,
-        
+
         "mbtree": mbtree,
-        
+
         "deblock": deblock,
-        
+
         "cplxblur": cplxblur,
-        
+
         "partitions": partitions,
-        
+
         "direct-pred": direct_pred,
-        
+
         "slice-max-size": slice_max_size,
-        
+
         "stats": stats,
-        
+
         "nal-hrd": nal_hrd,
-        
+
         "avcintra-class": avcintra_class,
-        
+
         "me_method": me_method,
-        
+
         "forced-idr": forced_idr,
-        
+
         "coder": coder,
-        
+
         "b_strategy": b_strategy,
-        
+
         "chromaoffset": chromaoffset,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "udu_sei": udu_sei,
-        
+
         "x264-params": x264_params,
-        
+
         "mb_info": mb_info,
-        
+
     }))
 
 
 
 def h264_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     V4L2 mem2mem H.264 encoder wrapper (codec h264)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 4 to INT_MAX) (default 4)
@@ -1976,49 +1976,49 @@ def h264_v4l2m2m(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def h264_vaapi(
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     low_power: bool | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     rc_mode: int | None| Literal["auto", "CQP", "CBR", "VBR", "ICQ", "QVBR", "AVBR"] = None,
-    
+
     blbrc: bool | None = None,
-    
+
     qp: int | None = None,
-    
+
     quality: int | None = None,
-    
+
     coder: int | None| Literal["cavlc", "cabac", "vlc", "ac"] = None,
-    
+
     aud: bool | None = None,
-    
+
     sei: str | None = None,
-    
+
     profile: int | None| Literal["constrained_baseline", "main", "high", "high10"] = None,
-    
+
     level: int | None| Literal["1", "1.1", "1.2", "1.3", "2", "2.1", "2.2", "3", "3.1", "3.2", "4", "4.1", "4.2", "5", "5.1", "5.2", "6", "6.1", "6.2"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     H.264/AVC (VAAPI) (codec h264)
-    
+
     Args:
         idr_interval: Distance (in I-frames) between key frames (from 0 to INT_MAX) (default 0)
         b_depth: Maximum B-frame reference depth (from 1 to INT_MAX) (default 1)
@@ -2039,81 +2039,81 @@ def h264_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "low_power": low_power,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "rc_mode": rc_mode,
-        
+
         "blbrc": blbrc,
-        
+
         "qp": qp,
-        
+
         "quality": quality,
-        
+
         "coder": coder,
-        
+
         "aud": aud,
-        
+
         "sei": sei,
-        
+
         "profile": profile,
-        
+
         "level": level,
-        
+
     }))
 
 
 
 def hdr(
-    
+
 ) -> FFMpegEncoderOption:
     """
     HDR (Radiance RGBE format) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def libx265(
-    
+
     crf: float | None = None,
-    
+
     qp: int | None = None,
-    
+
     forced_idr: bool | None = None,
-    
+
     preset: str | None = None,
-    
+
     tune: str | None = None,
-    
+
     profile: str | None = None,
-    
+
     udu_sei: bool | None = None,
-    
+
     a53cc: bool | None = None,
-    
+
     x265_params: str | None = None,
-    
+
     dolbyvision: bool | None| Literal["auto"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libx265 H.265 / HEVC (codec hevc)
-    
+
     Args:
         crf: set the x265 crf (from -1 to FLT_MAX) (default -1)
         qp: set the x265 qp (from -1 to INT_MAX) (default -1)
@@ -2130,41 +2130,41 @@ def libx265(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "crf": crf,
-        
+
         "qp": qp,
-        
+
         "forced-idr": forced_idr,
-        
+
         "preset": preset,
-        
+
         "tune": tune,
-        
+
         "profile": profile,
-        
+
         "udu_sei": udu_sei,
-        
+
         "a53cc": a53cc,
-        
+
         "x265-params": x265_params,
-        
+
         "dolbyvision": dolbyvision,
-        
+
     }))
 
 
 
 def hevc_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     V4L2 mem2mem HEVC encoder wrapper (codec hevc)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 4 to INT_MAX) (default 4)
@@ -2173,49 +2173,49 @@ def hevc_v4l2m2m(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def hevc_vaapi(
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     low_power: bool | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     rc_mode: int | None| Literal["auto", "CQP", "CBR", "VBR", "ICQ", "QVBR", "AVBR"] = None,
-    
+
     blbrc: bool | None = None,
-    
+
     qp: int | None = None,
-    
+
     aud: bool | None = None,
-    
+
     profile: int | None| Literal["main", "main10", "rext"] = None,
-    
+
     tier: int | None| Literal["main", "high"] = None,
-    
+
     level: int | None| Literal["1", "2", "2.1", "3", "3.1", "4", "4.1", "5", "5.1", "5.2", "6", "6.1", "6.2"] = None,
-    
+
     sei: str | None = None,
-    
+
     tiles: str | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     H.265/HEVC (VAAPI) (codec hevc)
-    
+
     Args:
         idr_interval: Distance (in I-frames) between key frames (from 0 to INT_MAX) (default 0)
         b_depth: Maximum B-frame reference depth (from 1 to INT_MAX) (default 1)
@@ -2236,49 +2236,49 @@ def hevc_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "low_power": low_power,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "rc_mode": rc_mode,
-        
+
         "blbrc": blbrc,
-        
+
         "qp": qp,
-        
+
         "aud": aud,
-        
+
         "profile": profile,
-        
+
         "tier": tier,
-        
+
         "level": level,
-        
+
         "sei": sei,
-        
+
         "tiles": tiles,
-        
+
     }))
 
 
 
 def huffyuv(
-    
+
     non_deterministic: bool | None = None,
-    
+
     pred: int | None| Literal["left", "plane", "median"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Huffyuv / HuffYUV
-    
+
     Args:
         non_deterministic: Allow multithreading for e.g. context=1 at the expense of determinism (default false)
         pred: Prediction method (from 0 to 2) (default left)
@@ -2287,37 +2287,37 @@ def huffyuv(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "non_deterministic": non_deterministic,
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def jpeg2000(
-    
+
     format: int | None| Literal["j2k", "jp2"] = None,
-    
+
     tile_width: int | None = None,
-    
+
     tile_height: int | None = None,
-    
+
     pred: int | None| Literal["dwt97int", "dwt53"] = None,
-    
+
     sop: int | None = None,
-    
+
     eph: int | None = None,
-    
+
     prog: int | None| Literal["lrcp", "rlcp", "rpcl", "pcrl", "cprl"] = None,
-    
+
     layer_rates: str | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     JPEG 2000
-    
+
     Args:
         format: Codec Format (from 0 to 1) (default jp2)
         tile_width: Tile Width (from 1 to 1.07374e+09) (default 256)
@@ -2332,49 +2332,49 @@ def jpeg2000(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "format": format,
-        
+
         "tile_width": tile_width,
-        
+
         "tile_height": tile_height,
-        
+
         "pred": pred,
-        
+
         "sop": sop,
-        
+
         "eph": eph,
-        
+
         "prog": prog,
-        
+
         "layer_rates": layer_rates,
-        
+
     }))
 
 
 
 def libopenjpeg(
-    
+
     format: int | None| Literal["j2k", "jp2"] = None,
-    
+
     profile: int | None| Literal["jpeg2000", "cinema2k", "cinema4k"] = None,
-    
+
     cinema_mode: int | None| Literal["off", "2k_24", "2k_48", "4k_24"] = None,
-    
+
     prog_order: int | None| Literal["lrcp", "rlcp", "rpcl", "pcrl", "cprl"] = None,
-    
+
     numresolution: int | None = None,
-    
+
     irreversible: int | None = None,
-    
+
     disto_alloc: int | None = None,
-    
+
     fixed_quality: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     OpenJPEG JPEG 2000 (codec jpeg2000)
-    
+
     Args:
         format: Codec Format (from 0 to 2) (default jp2)
         profile: (from 0 to 4) (default jpeg2000)
@@ -2389,35 +2389,35 @@ def libopenjpeg(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "format": format,
-        
+
         "profile": profile,
-        
+
         "cinema_mode": cinema_mode,
-        
+
         "prog_order": prog_order,
-        
+
         "numresolution": numresolution,
-        
+
         "irreversible": irreversible,
-        
+
         "disto_alloc": disto_alloc,
-        
+
         "fixed_quality": fixed_quality,
-        
+
     }))
 
 
 
 def jpegls(
-    
+
     pred: int | None| Literal["left", "plane", "median"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     JPEG-LS
-    
+
     Args:
         pred: Prediction method (from 0 to 2) (default left)
 
@@ -2425,21 +2425,21 @@ def jpegls(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def ljpeg(
-    
+
     pred: int | None| Literal["left", "plane", "median"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Lossless JPEG
-    
+
     Args:
         pred: Prediction method (from 1 to 3) (default left)
 
@@ -2447,21 +2447,21 @@ def ljpeg(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def magicyuv(
-    
+
     pred: int | None| Literal["left", "gradient", "median"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MagicYUV video
-    
+
     Args:
         pred: Prediction method (from 1 to 3) (default left)
 
@@ -2469,63 +2469,63 @@ def magicyuv(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def mjpeg(
-    
+
     huffman: int | None| Literal["default", "optimal"] = None,
-    
+
     force_duplicated_matrix: bool | None = None,
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MJPEG (Motion JPEG)
-    
+
     Args:
         huffman: Huffman table strategy (from 0 to 1) (default optimal)
         force_duplicated_matrix: Always write luma and chroma matrix for mjpeg, useful for rtp streaming. (default false)
@@ -2554,75 +2554,75 @@ def mjpeg(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "huffman": huffman,
-        
+
         "force_duplicated_matrix": force_duplicated_matrix,
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
     }))
 
 
 
 def mjpeg_vaapi(
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     low_power: bool | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     jfif: bool | None = None,
-    
+
     huffman: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MJPEG (VAAPI) (codec mjpeg)
-    
+
     Args:
         idr_interval: Distance (in I-frames) between key frames (from 0 to INT_MAX) (default 0)
         b_depth: Maximum B-frame reference depth (from 1 to INT_MAX) (default 1)
@@ -2636,95 +2636,95 @@ def mjpeg_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "low_power": low_power,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "jfif": jfif,
-        
+
         "huffman": huffman,
-        
+
     }))
 
 
 
 def mpeg1video(
-    
+
     gop_timecode: str | None = None,
-    
+
     drop_frame_timecode: bool | None = None,
-    
+
     scan_offset: bool | None = None,
-    
+
     timecode_frame_start: int | None = None,
-    
+
     b_strategy: int | None = None,
-    
+
     b_sensitivity: int | None = None,
-    
+
     brd_scale: int | None = None,
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MPEG-1 video
-    
+
     Args:
         gop_timecode: MPEG GOP Timecode in hh:mm:ss[:;.]ff format. Overrides timecode_frame_start.
         drop_frame_timecode: Timecode is in drop frame format. (default false)
@@ -2763,157 +2763,157 @@ def mpeg1video(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "gop_timecode": gop_timecode,
-        
+
         "drop_frame_timecode": drop_frame_timecode,
-        
+
         "scan_offset": scan_offset,
-        
+
         "timecode_frame_start": timecode_frame_start,
-        
+
         "b_strategy": b_strategy,
-        
+
         "b_sensitivity": b_sensitivity,
-        
+
         "brd_scale": brd_scale,
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
         "sc_threshold": sc_threshold,
-        
+
     }))
 
 
 
 def mpeg2video(
-    
+
     gop_timecode: str | None = None,
-    
+
     drop_frame_timecode: bool | None = None,
-    
+
     scan_offset: bool | None = None,
-    
+
     timecode_frame_start: int | None = None,
-    
+
     b_strategy: int | None = None,
-    
+
     b_sensitivity: int | None = None,
-    
+
     brd_scale: int | None = None,
-    
+
     intra_vlc: bool | None = None,
-    
+
     non_linear_quant: bool | None = None,
-    
+
     alternate_scan: bool | None = None,
-    
+
     a53cc: bool | None = None,
-    
+
     seq_disp_ext: int | None| Literal["auto", "never", "always"] = None,
-    
+
     video_format: int | None| Literal["component", "pal", "ntsc", "secam", "mac", "unspecified"] = None,
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MPEG-2 video
-    
+
     Args:
         gop_timecode: MPEG GOP Timecode in hh:mm:ss[:;.]ff format. Overrides timecode_frame_start.
         drop_frame_timecode: Timecode is in drop frame format. (default false)
@@ -2958,111 +2958,111 @@ def mpeg2video(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "gop_timecode": gop_timecode,
-        
+
         "drop_frame_timecode": drop_frame_timecode,
-        
+
         "scan_offset": scan_offset,
-        
+
         "timecode_frame_start": timecode_frame_start,
-        
+
         "b_strategy": b_strategy,
-        
+
         "b_sensitivity": b_sensitivity,
-        
+
         "brd_scale": brd_scale,
-        
+
         "intra_vlc": intra_vlc,
-        
+
         "non_linear_quant": non_linear_quant,
-        
+
         "alternate_scan": alternate_scan,
-        
+
         "a53cc": a53cc,
-        
+
         "seq_disp_ext": seq_disp_ext,
-        
+
         "video_format": video_format,
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
         "sc_threshold": sc_threshold,
-        
+
     }))
 
 
 
 def mpeg2_vaapi(
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     low_power: bool | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     rc_mode: int | None| Literal["auto", "CQP", "CBR", "VBR", "ICQ", "QVBR", "AVBR"] = None,
-    
+
     blbrc: bool | None = None,
-    
+
     profile: int | None| Literal["simple", "main"] = None,
-    
+
     level: int | None| Literal["low", "main", "high_1440", "high"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MPEG-2 (VAAPI) (codec mpeg2video)
-    
+
     Args:
         idr_interval: Distance (in I-frames) between key frames (from 0 to INT_MAX) (default 0)
         b_depth: Maximum B-frame reference depth (from 1 to INT_MAX) (default 1)
@@ -3078,97 +3078,97 @@ def mpeg2_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "low_power": low_power,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "rc_mode": rc_mode,
-        
+
         "blbrc": blbrc,
-        
+
         "profile": profile,
-        
+
         "level": level,
-        
+
     }))
 
 
 
 def mpeg4(
-    
+
     data_partitioning: bool | None = None,
-    
+
     alternate_scan: bool | None = None,
-    
+
     mpeg_quant: int | None = None,
-    
+
     b_strategy: int | None = None,
-    
+
     b_sensitivity: int | None = None,
-    
+
     brd_scale: int | None = None,
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MPEG-4 part 2
-    
+
     Args:
         data_partitioning: Use data partitioning. (default false)
         alternate_scan: Enable alternate scantable. (default false)
@@ -3206,93 +3206,93 @@ def mpeg4(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "data_partitioning": data_partitioning,
-        
+
         "alternate_scan": alternate_scan,
-        
+
         "mpeg_quant": mpeg_quant,
-        
+
         "b_strategy": b_strategy,
-        
+
         "b_sensitivity": b_sensitivity,
-        
+
         "brd_scale": brd_scale,
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
         "sc_threshold": sc_threshold,
-        
+
     }))
 
 
 
 def libxvid(
-    
+
     lumi_aq: int | None = None,
-    
+
     variance_aq: int | None = None,
-    
+
     ssim: int | None| Literal["off", "avg", "frame"] = None,
-    
+
     ssim_acc: int | None = None,
-    
+
     gmc: int | None = None,
-    
+
     me_quality: int | None = None,
-    
+
     mpeg_quant: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libxvidcore MPEG-4 part 2 (codec mpeg4)
-    
+
     Args:
         lumi_aq: Luminance masking AQ (from 0 to 1) (default 0)
         variance_aq: Variance AQ (from 0 to 1) (default 0)
@@ -3306,35 +3306,35 @@ def libxvid(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "lumi_aq": lumi_aq,
-        
+
         "variance_aq": variance_aq,
-        
+
         "ssim": ssim,
-        
+
         "ssim_acc": ssim_acc,
-        
+
         "gmc": gmc,
-        
+
         "me_quality": me_quality,
-        
+
         "mpeg_quant": mpeg_quant,
-        
+
     }))
 
 
 
 def mpeg4_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     V4L2 mem2mem MPEG4 encoder wrapper (codec mpeg4)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 4 to INT_MAX) (default 4)
@@ -3343,71 +3343,71 @@ def mpeg4_v4l2m2m(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def msmpeg4v2(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MPEG-4 part 2 Microsoft variant version 2
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -3439,117 +3439,117 @@ def msmpeg4v2(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
         "sc_threshold": sc_threshold,
-        
+
     }))
 
 
 
 def msmpeg4(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MPEG-4 part 2 Microsoft variant version 3 (codec msmpeg4v3)
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -3581,217 +3581,217 @@ def msmpeg4(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
         "sc_threshold": sc_threshold,
-        
+
     }))
 
 
 
 def msrle(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Microsoft RLE
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def msvideo1(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Microsoft Video-1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pam(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PAM (Portable AnyMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pbm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PBM (Portable BitMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcx(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PC Paintbrush PCX image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pfm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PFM (Portable FloatMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pgm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PGM (Portable GrayMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pgmyuv(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PGMYUV (Portable GrayMap YUV) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def phm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PHM (Portable HalfFloatMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def png(
-    
+
     dpi: int | None = None,
-    
+
     dpm: int | None = None,
-    
+
     pred: int | None| Literal["none", "sub", "up", "avg", "paeth", "mixed"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     PNG (Portable Network Graphics) image
-    
+
     Args:
         dpi: Set image resolution (in dots per inch) (from 0 to 65536) (default 0)
         dpm: Set image resolution (in dots per meter) (from 0 to 65536) (default 0)
@@ -3801,41 +3801,41 @@ def png(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "dpi": dpi,
-        
+
         "dpm": dpm,
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def ppm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PPM (Portable PixelMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def prores(
-    
+
     vendor: str | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Apple ProRes
-    
+
     Args:
         vendor: vendor ID (default "fmpg")
 
@@ -3843,21 +3843,21 @@ def prores(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "vendor": vendor,
-        
+
     }))
 
 
 
 def prores_aw(
-    
+
     vendor: str | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Apple ProRes (codec prores)
-    
+
     Args:
         vendor: vendor ID (default "fmpg")
 
@@ -3865,31 +3865,31 @@ def prores_aw(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "vendor": vendor,
-        
+
     }))
 
 
 
 def prores_ks(
-    
+
     mbs_per_slice: int | None = None,
-    
+
     profile: int | None| Literal["auto", "proxy", "lt", "standard", "hq", "4444", "4444xq"] = None,
-    
+
     vendor: str | None = None,
-    
+
     bits_per_mb: int | None = None,
-    
+
     quant_mat: int | None| Literal["auto", "proxy", "lt", "standard", "hq", "default"] = None,
-    
+
     alpha_bits: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Apple ProRes (iCodec Pro) (codec prores)
-    
+
     Args:
         mbs_per_slice: macroblocks per slice (from 1 to 8) (default 8)
         profile: (from -1 to 5) (default auto)
@@ -3902,111 +3902,111 @@ def prores_ks(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mbs_per_slice": mbs_per_slice,
-        
+
         "profile": profile,
-        
+
         "vendor": vendor,
-        
+
         "bits_per_mb": bits_per_mb,
-        
+
         "quant_mat": quant_mat,
-        
+
         "alpha_bits": alpha_bits,
-        
+
     }))
 
 
 
 def qoi(
-    
+
 ) -> FFMpegEncoderOption:
     """
     QOI (Quite OK Image format) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def qtrle(
-    
+
 ) -> FFMpegEncoderOption:
     """
     QuickTime Animation (RLE) video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def r10k(
-    
+
 ) -> FFMpegEncoderOption:
     """
     AJA Kona 10-bit RGB Codec
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def r210(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed RGB 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def rawvideo(
-    
+
 ) -> FFMpegEncoderOption:
     """
     raw video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def roqvideo(
-    
+
     quake3_compat: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     id RoQ video (codec roq)
-    
+
     Args:
         quake3_compat: Whether to respect known limitations in Quake 3 decoder (default true)
 
@@ -4014,25 +4014,25 @@ def roqvideo(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "quake3_compat": quake3_compat,
-        
+
     }))
 
 
 
 def rpza(
-    
+
     skip_frame_thresh: int | None = None,
-    
+
     continue_one_color_thresh: int | None = None,
-    
+
     sixteen_color_thresh: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     QuickTime video (RPZA)
-    
+
     Args:
         skip_frame_thresh: (from 0 to 24) (default 1)
         continue_one_color_thresh: (from 0 to 24) (default 0)
@@ -4042,73 +4042,73 @@ def rpza(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "skip_frame_thresh": skip_frame_thresh,
-        
+
         "continue_one_color_thresh": continue_one_color_thresh,
-        
+
         "sixteen_color_thresh": sixteen_color_thresh,
-        
+
     }))
 
 
 
 def rv10(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     RealVideo 1.0
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -4140,117 +4140,117 @@ def rv10(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
         "sc_threshold": sc_threshold,
-        
+
     }))
 
 
 
 def rv20(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     RealVideo 2.0
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -4282,69 +4282,69 @@ def rv20(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
         "sc_threshold": sc_threshold,
-        
+
     }))
 
 
 
 def sgi(
-    
+
     rle: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     SGI image
-    
+
     Args:
         rle: Use run-length compression (from 0 to 1) (default 1)
 
@@ -4352,51 +4352,51 @@ def sgi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "rle": rle,
-        
+
     }))
 
 
 
 def smc(
-    
+
 ) -> FFMpegEncoderOption:
     """
     QuickTime Graphics (SMC)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def snow(
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone", "iter"] = None,
-    
+
     memc_only: bool | None = None,
-    
+
     no_bitstream: bool | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
     iterative_dia_size: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
     pred: int | None| Literal["dwt97", "dwt53"] = None,
-    
+
     rc_eq: str | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Snow
-    
+
     Args:
         motion_est: motion estimation algorithm (from 0 to 3) (default epzs)
         memc_only: Only do ME/MC (I frames -> ref, P frame -> ME+MC). (default false)
@@ -4411,83 +4411,83 @@ def snow(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "motion_est": motion_est,
-        
+
         "memc_only": memc_only,
-        
+
         "no_bitstream": no_bitstream,
-        
+
         "intra_penalty": intra_penalty,
-        
+
         "iterative_dia_size": iterative_dia_size,
-        
+
         "sc_threshold": sc_threshold,
-        
+
         "pred": pred,
-        
+
         "rc_eq": rc_eq,
-        
+
     }))
 
 
 
 def speedhq(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     NewTek SpeedHQ
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -4519,69 +4519,69 @@ def speedhq(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
         "sc_threshold": sc_threshold,
-        
+
     }))
 
 
 
 def sunrast(
-    
+
     rle: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Sun Rasterfile image
-    
+
     Args:
         rle: Use run-length compression (from 0 to 1) (default 1)
 
@@ -4589,21 +4589,21 @@ def sunrast(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "rle": rle,
-        
+
     }))
 
 
 
 def svq1(
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Sorenson Vector Quantizer 1 / Sorenson Video 1 / SVQ1
-    
+
     Args:
         motion_est: Motion estimation algorithm (from 0 to 2) (default epzs)
 
@@ -4611,21 +4611,21 @@ def svq1(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "motion-est": motion_est,
-        
+
     }))
 
 
 
 def targa(
-    
+
     rle: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Truevision Targa image
-    
+
     Args:
         rle: Use run-length compression (from 0 to 1) (default 1)
 
@@ -4633,21 +4633,21 @@ def targa(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "rle": rle,
-        
+
     }))
 
 
 
 def libtheora(
-    
+
     speed_level: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libtheora Theora (codec theora)
-    
+
     Args:
         speed_level: Sets the encoding speed level (from -1 to INT_MAX) (default -1)
 
@@ -4655,23 +4655,23 @@ def libtheora(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "speed_level": speed_level,
-        
+
     }))
 
 
 
 def tiff(
-    
+
     dpi: int | None = None,
-    
+
     compression_algo: int | None| Literal["packbits", "raw", "lzw", "deflate"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     TIFF image
-    
+
     Args:
         dpi: set the image resolution (in dpi) (from 1 to 65536) (default 72)
         compression_algo: (from 1 to 32946) (default packbits)
@@ -4680,23 +4680,23 @@ def tiff(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "dpi": dpi,
-        
+
         "compression_algo": compression_algo,
-        
+
     }))
 
 
 
 def utvideo(
-    
+
     pred: int | None| Literal["none", "left", "median"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Ut Video
-    
+
     Args:
         pred: Prediction method (from 0 to 3) (default left)
 
@@ -4704,85 +4704,85 @@ def utvideo(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "pred": pred,
-        
+
     }))
 
 
 
 def v210(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed 4:2:2 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def v308(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed packed 4:4:4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def v408(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed packed QT 4:4:4:4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def v410(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed 4:4:4 10-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def vbn(
-    
+
     format: int | None| Literal["raw", "dxt1", "dxt5"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Vizrt Binary Image
-    
+
     Args:
         format: Texture format (from 0 to 3) (default dxt5)
 
@@ -4790,83 +4790,83 @@ def vbn(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "format": format,
-        
+
     }))
 
 
 
 def vnull(
-    
+
 ) -> FFMpegEncoderOption:
     """
     null video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def libvpx(
-    
+
     lag_in_frames: int | None = None,
-    
+
     arnr_maxframes: int | None = None,
-    
+
     arnr_strength: int | None = None,
-    
+
     arnr_type: int | None| Literal["backward", "forward", "centered"] = None,
-    
+
     tune: int | None| Literal["psnr", "ssim"] = None,
-    
+
     deadline: int | None| Literal["best", "good", "realtime"] = None,
-    
+
     error_resilient: str | None = None,
-    
+
     max_intra_rate: int | None = None,
-    
+
     crf: int | None = None,
-    
+
     static_thresh: int | None = None,
-    
+
     drop_threshold: int | None = None,
-    
+
     noise_sensitivity: int | None = None,
-    
+
     undershoot_pct: int | None = None,
-    
+
     overshoot_pct: int | None = None,
-    
+
     ts_parameters: str | None = None,
-    
+
     auto_alt_ref: int | None = None,
-    
+
     cpu_used: int | None = None,
-    
+
     screen_content_mode: int | None = None,
-    
+
     speed: int | None = None,
-    
+
     quality: int | None| Literal["best", "good", "realtime"] = None,
-    
+
     vp8flags: str | None = None,
-    
+
     arnr_max_frames: int | None = None,
-    
+
     rc_lookahead: int | None = None,
-    
+
     sharpness: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libvpx VP8 (codec vp8)
-    
+
     Args:
         lag_in_frames: Number of frames to look ahead for alternate reference frame selection (from -1 to INT_MAX) (default -1)
         arnr_maxframes: altref noise reduction max frame count (from -1 to INT_MAX) (default -1)
@@ -4897,69 +4897,69 @@ def libvpx(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "lag-in-frames": lag_in_frames,
-        
+
         "arnr-maxframes": arnr_maxframes,
-        
+
         "arnr-strength": arnr_strength,
-        
+
         "arnr-type": arnr_type,
-        
+
         "tune": tune,
-        
+
         "deadline": deadline,
-        
+
         "error-resilient": error_resilient,
-        
+
         "max-intra-rate": max_intra_rate,
-        
+
         "crf": crf,
-        
+
         "static-thresh": static_thresh,
-        
+
         "drop-threshold": drop_threshold,
-        
+
         "noise-sensitivity": noise_sensitivity,
-        
+
         "undershoot-pct": undershoot_pct,
-        
+
         "overshoot-pct": overshoot_pct,
-        
+
         "ts-parameters": ts_parameters,
-        
+
         "auto-alt-ref": auto_alt_ref,
-        
+
         "cpu-used": cpu_used,
-        
+
         "screen-content-mode": screen_content_mode,
-        
+
         "speed": speed,
-        
+
         "quality": quality,
-        
+
         "vp8flags": vp8flags,
-        
+
         "arnr_max_frames": arnr_max_frames,
-        
+
         "rc_lookahead": rc_lookahead,
-        
+
         "sharpness": sharpness,
-        
+
     }))
 
 
 
 def vp8_v4l2m2m(
-    
+
     num_output_buffers: int | None = None,
-    
+
     num_capture_buffers: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     V4L2 mem2mem VP8 encoder wrapper (codec vp8)
-    
+
     Args:
         num_output_buffers: Number of buffers in the output context (from 2 to INT_MAX) (default 16)
         num_capture_buffers: Number of buffers in the capture context (from 4 to INT_MAX) (default 4)
@@ -4968,39 +4968,39 @@ def vp8_v4l2m2m(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "num_output_buffers": num_output_buffers,
-        
+
         "num_capture_buffers": num_capture_buffers,
-        
+
     }))
 
 
 
 def vp8_vaapi(
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     low_power: bool | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     rc_mode: int | None| Literal["auto", "CQP", "CBR", "VBR", "ICQ", "QVBR", "AVBR"] = None,
-    
+
     blbrc: bool | None = None,
-    
+
     loop_filter_level: int | None = None,
-    
+
     loop_filter_sharpness: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     VP8 (VAAPI) (codec vp8)
-    
+
     Args:
         idr_interval: Distance (in I-frames) between key frames (from 0 to INT_MAX) (default 0)
         b_depth: Maximum B-frame reference depth (from 1 to INT_MAX) (default 1)
@@ -5016,53 +5016,53 @@ def vp8_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "low_power": low_power,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "rc_mode": rc_mode,
-        
+
         "blbrc": blbrc,
-        
+
         "loop_filter_level": loop_filter_level,
-        
+
         "loop_filter_sharpness": loop_filter_sharpness,
-        
+
     }))
 
 
 
 def vp9_vaapi(
-    
+
     idr_interval: int | None = None,
-    
+
     b_depth: int | None = None,
-    
+
     async_depth: int | None = None,
-    
+
     low_power: bool | None = None,
-    
+
     max_frame_size: int | None = None,
-    
+
     rc_mode: int | None| Literal["auto", "CQP", "CBR", "VBR", "ICQ", "QVBR", "AVBR"] = None,
-    
+
     blbrc: bool | None = None,
-    
+
     loop_filter_level: int | None = None,
-    
+
     loop_filter_sharpness: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     VP9 (VAAPI) (codec vp9)
-    
+
     Args:
         idr_interval: Distance (in I-frames) between key frames (from 0 to INT_MAX) (default 0)
         b_depth: Maximum B-frame reference depth (from 1 to INT_MAX) (default 1)
@@ -5078,61 +5078,61 @@ def vp9_vaapi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "idr_interval": idr_interval,
-        
+
         "b_depth": b_depth,
-        
+
         "async_depth": async_depth,
-        
+
         "low_power": low_power,
-        
+
         "max_frame_size": max_frame_size,
-        
+
         "rc_mode": rc_mode,
-        
+
         "blbrc": blbrc,
-        
+
         "loop_filter_level": loop_filter_level,
-        
+
         "loop_filter_sharpness": loop_filter_sharpness,
-        
+
     }))
 
 
 
 def wbmp(
-    
+
 ) -> FFMpegEncoderOption:
     """
     WBMP (Wireless Application Protocol Bitmap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def libwebp_anim(
-    
+
     lossless: int | None = None,
-    
+
     preset: int | None| Literal["none", "default", "picture", "photo", "drawing", "icon", "text"] = None,
-    
+
     cr_threshold: int | None = None,
-    
+
     cr_size: int | None = None,
-    
+
     quality: float | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libwebp WebP image (codec webp)
-    
+
     Args:
         lossless: Use lossless mode (from 0 to 1) (default 0)
         preset: Configuration preset (from -1 to 5) (default none)
@@ -5144,37 +5144,37 @@ def libwebp_anim(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "lossless": lossless,
-        
+
         "preset": preset,
-        
+
         "cr_threshold": cr_threshold,
-        
+
         "cr_size": cr_size,
-        
+
         "quality": quality,
-        
+
     }))
 
 
 
 def libwebp(
-    
+
     lossless: int | None = None,
-    
+
     preset: int | None| Literal["none", "default", "picture", "photo", "drawing", "icon", "text"] = None,
-    
+
     cr_threshold: int | None = None,
-    
+
     cr_size: int | None = None,
-    
+
     quality: float | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libwebp WebP image (codec webp)
-    
+
     Args:
         lossless: Use lossless mode (from 0 to 1) (default 0)
         preset: Configuration preset (from -1 to 5) (default none)
@@ -5186,77 +5186,77 @@ def libwebp(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "lossless": lossless,
-        
+
         "preset": preset,
-        
+
         "cr_threshold": cr_threshold,
-        
+
         "cr_size": cr_size,
-        
+
         "quality": quality,
-        
+
     }))
 
 
 
 def wmv1(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Windows Media Video 7
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -5288,117 +5288,117 @@ def wmv1(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
         "sc_threshold": sc_threshold,
-        
+
     }))
 
 
 
 def wmv2(
-    
+
     mpv_flags: str | None = None,
-    
+
     luma_elim_threshold: int | None = None,
-    
+
     chroma_elim_threshold: int | None = None,
-    
+
     quantizer_noise_shaping: int | None = None,
-    
+
     error_rate: int | None = None,
-    
+
     qsquish: float | None = None,
-    
+
     rc_qmod_amp: float | None = None,
-    
+
     rc_qmod_freq: int | None = None,
-    
+
     rc_eq: str | None = None,
-    
+
     rc_init_cplx: float | None = None,
-    
+
     rc_buf_aggressivity: float | None = None,
-    
+
     border_mask: float | None = None,
-    
+
     lmin: int | None = None,
-    
+
     lmax: int | None = None,
-    
+
     skip_threshold: int | None = None,
-    
+
     skip_factor: int | None = None,
-    
+
     skip_exp: int | None = None,
-    
+
     skip_cmp: int | None| Literal["sad", "sse", "satd", "dct", "psnr", "bit", "rd", "zero", "vsad", "vsse", "nsse", "dct264", "dctmax", "chroma", "msad"] = None,
-    
+
     noise_reduction: int | None = None,
-    
+
     ps: int | None = None,
-    
+
     motion_est: int | None| Literal["zero", "epzs", "xone"] = None,
-    
+
     mepc: int | None = None,
-    
+
     mepre: int | None = None,
-    
+
     intra_penalty: int | None = None,
-    
+
     sc_threshold: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Windows Media Video 8
-    
+
     Args:
         mpv_flags: Flags common for all mpegvideo-based encoders. (default 0)
         luma_elim_threshold: single coefficient elimination threshold for luminance (negative values also consider dc coefficient) (from INT_MIN to INT_MAX) (default 0)
@@ -5430,207 +5430,207 @@ def wmv2(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mpv_flags": mpv_flags,
-        
+
         "luma_elim_threshold": luma_elim_threshold,
-        
+
         "chroma_elim_threshold": chroma_elim_threshold,
-        
+
         "quantizer_noise_shaping": quantizer_noise_shaping,
-        
+
         "error_rate": error_rate,
-        
+
         "qsquish": qsquish,
-        
+
         "rc_qmod_amp": rc_qmod_amp,
-        
+
         "rc_qmod_freq": rc_qmod_freq,
-        
+
         "rc_eq": rc_eq,
-        
+
         "rc_init_cplx": rc_init_cplx,
-        
+
         "rc_buf_aggressivity": rc_buf_aggressivity,
-        
+
         "border_mask": border_mask,
-        
+
         "lmin": lmin,
-        
+
         "lmax": lmax,
-        
+
         "skip_threshold": skip_threshold,
-        
+
         "skip_factor": skip_factor,
-        
+
         "skip_exp": skip_exp,
-        
+
         "skip_cmp": skip_cmp,
-        
+
         "noise_reduction": noise_reduction,
-        
+
         "ps": ps,
-        
+
         "motion_est": motion_est,
-        
+
         "mepc": mepc,
-        
+
         "mepre": mepre,
-        
+
         "intra_penalty": intra_penalty,
-        
+
         "sc_threshold": sc_threshold,
-        
+
     }))
 
 
 
 def wrapped_avframe(
-    
+
 ) -> FFMpegEncoderOption:
     """
     AVFrame to AVPacket passthrough
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def xbm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     XBM (X BitMap) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def xface(
-    
+
 ) -> FFMpegEncoderOption:
     """
     X-face image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def xwd(
-    
+
 ) -> FFMpegEncoderOption:
     """
     XWD (X Window Dump) image
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def y41p(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed YUV 4:1:1 12-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def yuv4(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Uncompressed packed 4:2:0
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def zlib(
-    
+
 ) -> FFMpegEncoderOption:
     """
     LCL (LossLess Codec Library) ZLIB
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def zmbv(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Zip Motion Blocks Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def aac(
-    
+
     aac_coder: int | None| Literal["twoloop", "fast"] = None,
-    
+
     aac_ms: bool | None = None,
-    
+
     aac_is: bool | None = None,
-    
+
     aac_pns: bool | None = None,
-    
+
     aac_tns: bool | None = None,
-    
+
     aac_pce: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     AAC (Advanced Audio Coding)
-    
+
     Args:
         aac_coder: Coding algorithm (from 0 to 1) (default twoloop)
         aac_ms: Force M/S stereo coding (default auto)
@@ -5643,69 +5643,69 @@ def aac(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "aac_coder": aac_coder,
-        
+
         "aac_ms": aac_ms,
-        
+
         "aac_is": aac_is,
-        
+
         "aac_pns": aac_pns,
-        
+
         "aac_tns": aac_tns,
-        
+
         "aac_pce": aac_pce,
-        
+
     }))
 
 
 
 def ac3(
-    
+
     center_mixlev: float | None = None,
-    
+
     surround_mixlev: float | None = None,
-    
+
     mixing_level: int | None = None,
-    
+
     room_type: int | None| Literal["notindicated", "large", "small"] = None,
-    
+
     per_frame_metadata: bool | None = None,
-    
+
     copyright: int | None = None,
-    
+
     dialnorm: int | None = None,
-    
+
     dsur_mode: int | None| Literal["notindicated", "on", "off"] = None,
-    
+
     original: int | None = None,
-    
+
     dmix_mode: int | None| Literal["notindicated", "ltrt", "loro", "dplii"] = None,
-    
+
     ltrt_cmixlev: float | None = None,
-    
+
     ltrt_surmixlev: float | None = None,
-    
+
     loro_cmixlev: float | None = None,
-    
+
     loro_surmixlev: float | None = None,
-    
+
     dsurex_mode: int | None| Literal["notindicated", "on", "off", "dpliiz"] = None,
-    
+
     dheadphone_mode: int | None| Literal["notindicated", "on", "off"] = None,
-    
+
     ad_conv_type: int | None| Literal["standard", "hdcd"] = None,
-    
+
     stereo_rematrixing: bool | None = None,
-    
+
     channel_coupling: int | None| Literal["auto"] = None,
-    
+
     cpl_start_band: int | None| Literal["auto"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ATSC A/52A (AC-3)
-    
+
     Args:
         center_mixlev: Center Mix Level (from 0 to 1) (default 0.594604)
         surround_mixlev: Surround Mix Level (from 0 to 1) (default 0.5)
@@ -5732,97 +5732,97 @@ def ac3(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "center_mixlev": center_mixlev,
-        
+
         "surround_mixlev": surround_mixlev,
-        
+
         "mixing_level": mixing_level,
-        
+
         "room_type": room_type,
-        
+
         "per_frame_metadata": per_frame_metadata,
-        
+
         "copyright": copyright,
-        
+
         "dialnorm": dialnorm,
-        
+
         "dsur_mode": dsur_mode,
-        
+
         "original": original,
-        
+
         "dmix_mode": dmix_mode,
-        
+
         "ltrt_cmixlev": ltrt_cmixlev,
-        
+
         "ltrt_surmixlev": ltrt_surmixlev,
-        
+
         "loro_cmixlev": loro_cmixlev,
-        
+
         "loro_surmixlev": loro_surmixlev,
-        
+
         "dsurex_mode": dsurex_mode,
-        
+
         "dheadphone_mode": dheadphone_mode,
-        
+
         "ad_conv_type": ad_conv_type,
-        
+
         "stereo_rematrixing": stereo_rematrixing,
-        
+
         "channel_coupling": channel_coupling,
-        
+
         "cpl_start_band": cpl_start_band,
-        
+
     }))
 
 
 
 def ac3_fixed(
-    
+
     center_mixlev: float | None = None,
-    
+
     surround_mixlev: float | None = None,
-    
+
     mixing_level: int | None = None,
-    
+
     room_type: int | None| Literal["notindicated", "large", "small"] = None,
-    
+
     per_frame_metadata: bool | None = None,
-    
+
     copyright: int | None = None,
-    
+
     dialnorm: int | None = None,
-    
+
     dsur_mode: int | None| Literal["notindicated", "on", "off"] = None,
-    
+
     original: int | None = None,
-    
+
     dmix_mode: int | None| Literal["notindicated", "ltrt", "loro", "dplii"] = None,
-    
+
     ltrt_cmixlev: float | None = None,
-    
+
     ltrt_surmixlev: float | None = None,
-    
+
     loro_cmixlev: float | None = None,
-    
+
     loro_surmixlev: float | None = None,
-    
+
     dsurex_mode: int | None| Literal["notindicated", "on", "off", "dpliiz"] = None,
-    
+
     dheadphone_mode: int | None| Literal["notindicated", "on", "off"] = None,
-    
+
     ad_conv_type: int | None| Literal["standard", "hdcd"] = None,
-    
+
     stereo_rematrixing: bool | None = None,
-    
+
     channel_coupling: int | None| Literal["auto"] = None,
-    
+
     cpl_start_band: int | None| Literal["auto"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ATSC A/52A (AC-3) (codec ac3)
-    
+
     Args:
         center_mixlev: Center Mix Level (from 0 to 1) (default 0.594604)
         surround_mixlev: Surround Mix Level (from 0 to 1) (default 0.5)
@@ -5849,75 +5849,75 @@ def ac3_fixed(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "center_mixlev": center_mixlev,
-        
+
         "surround_mixlev": surround_mixlev,
-        
+
         "mixing_level": mixing_level,
-        
+
         "room_type": room_type,
-        
+
         "per_frame_metadata": per_frame_metadata,
-        
+
         "copyright": copyright,
-        
+
         "dialnorm": dialnorm,
-        
+
         "dsur_mode": dsur_mode,
-        
+
         "original": original,
-        
+
         "dmix_mode": dmix_mode,
-        
+
         "ltrt_cmixlev": ltrt_cmixlev,
-        
+
         "ltrt_surmixlev": ltrt_surmixlev,
-        
+
         "loro_cmixlev": loro_cmixlev,
-        
+
         "loro_surmixlev": loro_surmixlev,
-        
+
         "dsurex_mode": dsurex_mode,
-        
+
         "dheadphone_mode": dheadphone_mode,
-        
+
         "ad_conv_type": ad_conv_type,
-        
+
         "stereo_rematrixing": stereo_rematrixing,
-        
+
         "channel_coupling": channel_coupling,
-        
+
         "cpl_start_band": cpl_start_band,
-        
+
     }))
 
 
 
 def adpcm_adx(
-    
+
 ) -> FFMpegEncoderOption:
     """
     SEGA CRI ADX ADPCM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def adpcm_argo(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM Argonaut Games
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -5925,37 +5925,37 @@ def adpcm_argo(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def g722(
-    
+
 ) -> FFMpegEncoderOption:
     """
     G.722 ADPCM (codec adpcm_g722)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def g726(
-    
+
     code_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     G.726 ADPCM (codec adpcm_g726)
-    
+
     Args:
         code_size: Bits per code (from 2 to 5) (default 4)
 
@@ -5963,21 +5963,21 @@ def g726(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "code_size": code_size,
-        
+
     }))
 
 
 
 def g726le(
-    
+
     code_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     G.726 little endian ADPCM ("right-justified") (codec adpcm_g726le)
-    
+
     Args:
         code_size: Bits per code (from 2 to 5) (default 4)
 
@@ -5985,21 +5985,21 @@ def g726le(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "code_size": code_size,
-        
+
     }))
 
 
 
 def adpcm_ima_alp(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA High Voltage Software ALP
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6007,21 +6007,21 @@ def adpcm_ima_alp(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ima_amv(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA AMV
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6029,21 +6029,21 @@ def adpcm_ima_amv(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ima_apm(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA Ubisoft APM
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6051,21 +6051,21 @@ def adpcm_ima_apm(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ima_qt(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA QuickTime
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6073,21 +6073,21 @@ def adpcm_ima_qt(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ima_ssi(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA Simon & Schuster Interactive
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6095,21 +6095,21 @@ def adpcm_ima_ssi(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ima_wav(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA WAV
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6117,21 +6117,21 @@ def adpcm_ima_wav(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ima_ws(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM IMA Westwood
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6139,21 +6139,21 @@ def adpcm_ima_ws(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_ms(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM Microsoft
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6161,21 +6161,21 @@ def adpcm_ms(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_swf(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM Shockwave Flash
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6183,21 +6183,21 @@ def adpcm_swf(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def adpcm_yamaha(
-    
+
     block_size: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ADPCM Yamaha
-    
+
     Args:
         block_size: set the block size (from 32 to 8192) (default 1024)
 
@@ -6205,23 +6205,23 @@ def adpcm_yamaha(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "block_size": block_size,
-        
+
     }))
 
 
 
 def alac(
-    
+
     min_prediction_order: int | None = None,
-    
+
     max_prediction_order: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ALAC (Apple Lossless Audio Codec)
-    
+
     Args:
         min_prediction_order: (from 1 to 30) (default 4)
         max_prediction_order: (from 1 to 30) (default 6)
@@ -6230,23 +6230,23 @@ def alac(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "min_prediction_order": min_prediction_order,
-        
+
         "max_prediction_order": max_prediction_order,
-        
+
     }))
 
 
 
 def libopencore_amrnb(
-    
+
     dtx: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     OpenCORE AMR-NB (Adaptive Multi-Rate Narrow-Band) (codec amr_nb)
-    
+
     Args:
         dtx: Allow DTX (generate comfort noise) (from 0 to 1) (default 0)
 
@@ -6254,101 +6254,101 @@ def libopencore_amrnb(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "dtx": dtx,
-        
+
     }))
 
 
 
 def anull(
-    
+
 ) -> FFMpegEncoderOption:
     """
     null audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def aptx(
-    
+
 ) -> FFMpegEncoderOption:
     """
     aptX (Audio Processing Technology for Bluetooth)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def aptx_hd(
-    
+
 ) -> FFMpegEncoderOption:
     """
     aptX HD (Audio Processing Technology for Bluetooth)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def comfortnoise(
-    
+
 ) -> FFMpegEncoderOption:
     """
     RFC 3389 comfort noise generator
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def dfpwm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     DFPWM1a audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def dca(
-    
+
     dca_adpcm: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     DCA (DTS Coherent Acoustics) (codec dts)
-    
+
     Args:
         dca_adpcm: Use ADPCM encoding (default false)
 
@@ -6356,55 +6356,55 @@ def dca(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "dca_adpcm": dca_adpcm,
-        
+
     }))
 
 
 
 def eac3(
-    
+
     mixing_level: int | None = None,
-    
+
     room_type: int | None| Literal["notindicated", "large", "small"] = None,
-    
+
     per_frame_metadata: bool | None = None,
-    
+
     copyright: int | None = None,
-    
+
     dialnorm: int | None = None,
-    
+
     dsur_mode: int | None| Literal["notindicated", "on", "off"] = None,
-    
+
     original: int | None = None,
-    
+
     dmix_mode: int | None| Literal["notindicated", "ltrt", "loro", "dplii"] = None,
-    
+
     ltrt_cmixlev: float | None = None,
-    
+
     ltrt_surmixlev: float | None = None,
-    
+
     loro_cmixlev: float | None = None,
-    
+
     loro_surmixlev: float | None = None,
-    
+
     dsurex_mode: int | None| Literal["notindicated", "on", "off", "dpliiz"] = None,
-    
+
     dheadphone_mode: int | None| Literal["notindicated", "on", "off"] = None,
-    
+
     ad_conv_type: int | None| Literal["standard", "hdcd"] = None,
-    
+
     stereo_rematrixing: bool | None = None,
-    
+
     channel_coupling: int | None| Literal["auto"] = None,
-    
+
     cpl_start_band: int | None| Literal["auto"] = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     ATSC A/52 E-AC-3
-    
+
     Args:
         mixing_level: Mixing Level (from -1 to 111) (default -1)
         room_type: Room Type (from -1 to 2) (default -1)
@@ -6429,71 +6429,71 @@ def eac3(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "mixing_level": mixing_level,
-        
+
         "room_type": room_type,
-        
+
         "per_frame_metadata": per_frame_metadata,
-        
+
         "copyright": copyright,
-        
+
         "dialnorm": dialnorm,
-        
+
         "dsur_mode": dsur_mode,
-        
+
         "original": original,
-        
+
         "dmix_mode": dmix_mode,
-        
+
         "ltrt_cmixlev": ltrt_cmixlev,
-        
+
         "ltrt_surmixlev": ltrt_surmixlev,
-        
+
         "loro_cmixlev": loro_cmixlev,
-        
+
         "loro_surmixlev": loro_surmixlev,
-        
+
         "dsurex_mode": dsurex_mode,
-        
+
         "dheadphone_mode": dheadphone_mode,
-        
+
         "ad_conv_type": ad_conv_type,
-        
+
         "stereo_rematrixing": stereo_rematrixing,
-        
+
         "channel_coupling": channel_coupling,
-        
+
         "cpl_start_band": cpl_start_band,
-        
+
     }))
 
 
 
 def flac(
-    
+
     lpc_coeff_precision: int | None = None,
-    
+
     lpc_type: int | None| Literal["none", "fixed", "levinson", "cholesky"] = None,
-    
+
     lpc_passes: int | None = None,
-    
+
     min_partition_order: int | None = None,
-    
+
     prediction_order_method: int | None| Literal["estimation", "2level", "4level", "8level", "search", "log"] = None,
-    
+
     ch_mode: int | None| Literal["auto", "indep", "left_side", "right_side", "mid_side"] = None,
-    
+
     exact_rice_parameters: bool | None = None,
-    
+
     multi_dim_quant: bool | None = None,
-    
+
     min_prediction_order: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     FLAC (Free Lossless Audio Codec)
-    
+
     Args:
         lpc_coeff_precision: LPC coefficient precision (from 0 to 15) (default 15)
         lpc_type: LPC algorithm (from -1 to 3) (default -1)
@@ -6509,65 +6509,65 @@ def flac(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "lpc_coeff_precision": lpc_coeff_precision,
-        
+
         "lpc_type": lpc_type,
-        
+
         "lpc_passes": lpc_passes,
-        
+
         "min_partition_order": min_partition_order,
-        
+
         "prediction_order_method": prediction_order_method,
-        
+
         "ch_mode": ch_mode,
-        
+
         "exact_rice_parameters": exact_rice_parameters,
-        
+
         "multi_dim_quant": multi_dim_quant,
-        
+
         "min_prediction_order": min_prediction_order,
-        
+
     }))
 
 
 
 def g723_1(
-    
+
 ) -> FFMpegEncoderOption:
     """
     G.723.1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def mlp(
-    
+
     max_interval: int | None = None,
-    
+
     lpc_coeff_precision: int | None = None,
-    
+
     lpc_type: int | None| Literal["levinson", "cholesky"] = None,
-    
+
     lpc_passes: int | None = None,
-    
+
     codebook_search: int | None = None,
-    
+
     prediction_order: int | None| Literal["estimation", "search"] = None,
-    
+
     rematrix_precision: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     MLP (Meridian Lossless Packing)
-    
+
     Args:
         max_interval: Max number of frames between each new header (from 8 to 128) (default 16)
         lpc_coeff_precision: LPC coefficient precision (from 0 to 15) (default 15)
@@ -6581,73 +6581,73 @@ def mlp(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "max_interval": max_interval,
-        
+
         "lpc_coeff_precision": lpc_coeff_precision,
-        
+
         "lpc_type": lpc_type,
-        
+
         "lpc_passes": lpc_passes,
-        
+
         "codebook_search": codebook_search,
-        
+
         "prediction_order": prediction_order,
-        
+
         "rematrix_precision": rematrix_precision,
-        
+
     }))
 
 
 
 def mp2(
-    
+
 ) -> FFMpegEncoderOption:
     """
     MP2 (MPEG audio layer 2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def mp2fixed(
-    
+
 ) -> FFMpegEncoderOption:
     """
     MP2 fixed point (MPEG audio layer 2) (codec mp2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def libmp3lame(
-    
+
     reservoir: bool | None = None,
-    
+
     joint_stereo: bool | None = None,
-    
+
     abr: bool | None = None,
-    
+
     copyright: bool | None = None,
-    
+
     original: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libmp3lame MP3 (MPEG audio layer 3) (codec mp3)
-    
+
     Args:
         reservoir: use bit reservoir (default true)
         joint_stereo: use joint stereo (default true)
@@ -6659,47 +6659,47 @@ def libmp3lame(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "reservoir": reservoir,
-        
+
         "joint_stereo": joint_stereo,
-        
+
         "abr": abr,
-        
+
         "copyright": copyright,
-        
+
         "original": original,
-        
+
     }))
 
 
 
 def nellymoser(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Nellymoser Asao
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def opus(
-    
+
     opus_delay: float | None = None,
-    
+
     apply_phase_inv: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     Opus
-    
+
     Args:
         opus_delay: Maximum delay in milliseconds (from 2.5 to 360) (default 360)
         apply_phase_inv: Apply intensity stereo phase inversion (default true)
@@ -6708,35 +6708,35 @@ def opus(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "opus_delay": opus_delay,
-        
+
         "apply_phase_inv": apply_phase_inv,
-        
+
     }))
 
 
 
 def libopus(
-    
+
     application: int | None| Literal["voip", "audio", "lowdelay"] = None,
-    
+
     frame_duration: float | None = None,
-    
+
     packet_loss: int | None = None,
-    
+
     fec: bool | None = None,
-    
+
     vbr: int | None| Literal["off", "on", "constrained"] = None,
-    
+
     mapping_family: int | None = None,
-    
+
     apply_phase_inv: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libopus Opus (codec opus)
-    
+
     Args:
         application: Intended application type (from 2048 to 2051) (default audio)
         frame_duration: Duration of a frame in milliseconds (from 2.5 to 120) (default 20)
@@ -6750,579 +6750,579 @@ def libopus(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "application": application,
-        
+
         "frame_duration": frame_duration,
-        
+
         "packet_loss": packet_loss,
-        
+
         "fec": fec,
-        
+
         "vbr": vbr,
-        
+
         "mapping_family": mapping_family,
-        
+
         "apply_phase_inv": apply_phase_inv,
-        
+
     }))
 
 
 
 def pcm_alaw(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM A-law / G.711 A-law
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_bluray(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 16|20|24-bit big-endian for Blu-ray media
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_dvd(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 16|20|24-bit big-endian for DVD media
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f32be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM 32-bit floating point big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f32le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM 32-bit floating point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f64be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM 64-bit floating point big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_f64le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM 64-bit floating point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_mulaw(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM mu-law / G.711 mu-law
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 16-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16be_planar(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 16-bit big-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 16-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s16le_planar(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 16-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 24-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24daud(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM D-Cinema audio signed 24-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 24-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s24le_planar(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 24-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s32be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 32-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s32le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 32-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s32le_planar(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 32-bit little-endian planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s64be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 64-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s64le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 64-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s8(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 8-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_s8_planar(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM signed 8-bit planar
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u16be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 16-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u16le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 16-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u24be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 24-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u24le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 24-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u32be(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 32-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u32le(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 32-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_u8(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM unsigned 8-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def pcm_vidc(
-    
+
 ) -> FFMpegEncoderOption:
     """
     PCM Archimedes VIDC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def real_144(
-    
+
 ) -> FFMpegEncoderOption:
     """
     RealAudio 1.0 (14.4K) (codec ra_144)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def roq_dpcm(
-    
+
 ) -> FFMpegEncoderOption:
     """
     id RoQ DPCM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def s302m(
-    
+
 ) -> FFMpegEncoderOption:
     """
     SMPTE 302M
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def sbc(
-    
+
     sbc_delay: str | None = None,
-    
+
     msbc: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     SBC (low-complexity subband codec)
-    
+
     Args:
         sbc_delay: set maximum algorithmic latency (default 0.013)
         msbc: use mSBC mode (wideband speech mono SBC) (default false)
@@ -7331,35 +7331,35 @@ def sbc(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "sbc_delay": sbc_delay,
-        
+
         "msbc": msbc,
-        
+
     }))
 
 
 
 def truehd(
-    
+
     max_interval: int | None = None,
-    
+
     lpc_coeff_precision: int | None = None,
-    
+
     lpc_type: int | None| Literal["levinson", "cholesky"] = None,
-    
+
     lpc_passes: int | None = None,
-    
+
     codebook_search: int | None = None,
-    
+
     prediction_order: int | None| Literal["estimation", "search"] = None,
-    
+
     rematrix_precision: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     TrueHD
-    
+
     Args:
         max_interval: Max number of frames between each new header (from 8 to 128) (default 16)
         lpc_coeff_precision: LPC coefficient precision (from 0 to 15) (default 15)
@@ -7373,65 +7373,65 @@ def truehd(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "max_interval": max_interval,
-        
+
         "lpc_coeff_precision": lpc_coeff_precision,
-        
+
         "lpc_type": lpc_type,
-        
+
         "lpc_passes": lpc_passes,
-        
+
         "codebook_search": codebook_search,
-        
+
         "prediction_order": prediction_order,
-        
+
         "rematrix_precision": rematrix_precision,
-        
+
     }))
 
 
 
 def tta(
-    
+
 ) -> FFMpegEncoderOption:
     """
     TTA (True Audio)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def vorbis(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Vorbis
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def libvorbis(
-    
+
     iblock: float | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     libvorbis (codec vorbis)
-    
+
     Args:
         iblock: Sets the impulse block bias (from -15 to 0) (default 0)
 
@@ -7439,23 +7439,23 @@ def libvorbis(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "iblock": iblock,
-        
+
     }))
 
 
 
 def wavpack(
-    
+
     joint_stereo: bool | None = None,
-    
+
     optimize_mono: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     WavPack
-    
+
     Args:
         joint_stereo: (default auto)
         optimize_mono: (default false)
@@ -7464,87 +7464,87 @@ def wavpack(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "joint_stereo": joint_stereo,
-        
+
         "optimize_mono": optimize_mono,
-        
+
     }))
 
 
 
 def wmav1(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Windows Media Audio 1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def wmav2(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Windows Media Audio 2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def ssa(
-    
+
 ) -> FFMpegEncoderOption:
     """
     ASS (Advanced SubStation Alpha) subtitle (codec ass)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def ass(
-    
+
 ) -> FFMpegEncoderOption:
     """
     ASS (Advanced SubStation Alpha) subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def dvbsub(
-    
+
     min_bpp: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     DVB subtitles (codec dvb_subtitle)
-    
+
     Args:
         min_bpp: minimum bits-per-pixel for subtitle colors (2, 4 or 8) (from 2 to 8) (default 4)
 
@@ -7552,23 +7552,23 @@ def dvbsub(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "min_bpp": min_bpp,
-        
+
     }))
 
 
 
 def dvdsub(
-    
+
     palette: str | None = None,
-    
+
     even_rows_fix: bool | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     DVD subtitles (codec dvd_subtitle)
-    
+
     Args:
         palette: set the global palette
         even_rows_fix: Make number of rows even (workaround for some players) (default false)
@@ -7577,23 +7577,23 @@ def dvdsub(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "palette": palette,
-        
+
         "even_rows_fix": even_rows_fix,
-        
+
     }))
 
 
 
 def mov_text(
-    
+
     height: int | None = None,
-    
+
 ) -> FFMpegEncoderOption:
     """
     3GPP Timed Text subtitle
-    
+
     Args:
         height: Frame height, usually video height (from 0 to INT_MAX) (default 0)
 
@@ -7601,1136 +7601,103 @@ def mov_text(
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
         "height": height,
-        
+
     }))
 
 
 
 def srt(
-    
+
 ) -> FFMpegEncoderOption:
     """
     SubRip subtitle (codec subrip)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def subrip(
-    
+
 ) -> FFMpegEncoderOption:
     """
     SubRip subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def text(
-    
+
 ) -> FFMpegEncoderOption:
     """
     Raw text subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def ttml(
-    
+
 ) -> FFMpegEncoderOption:
     """
     TTML subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def webvtt(
-    
+
 ) -> FFMpegEncoderOption:
     """
     WebVTT subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
 
 
 
 def xsub(
-    
+
 ) -> FFMpegEncoderOption:
     """
     DivX subtitles (XSUB)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegEncoderOption(merge({
-        
+
     }))
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/packages/v8/src/ffmpeg/dag/global_runnable/global_args.py
+++ b/packages/v8/src/ffmpeg/dag/global_runnable/global_args.py
@@ -97,252 +97,252 @@ class GlobalArgs(ABC):
 
         return self._global_node(**merge(
             {
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "loglevel": loglevel,
-                
+
                 "v": v,
-                
+
                 "report": report,
-                
+
                 "max_alloc": max_alloc,
-                
+
                 "cpuflags": cpuflags,
-                
+
                 "cpucount": cpucount,
-                
+
                 "hide_banner": hide_banner,
-                
-                
-                
-                
+
+
+
+
                 "y": y,
-                
+
                 "n": n,
-                
+
                 "ignore_unknown": ignore_unknown,
-                
+
                 "copy_unknown": copy_unknown,
-                
+
                 "recast_media": recast_media,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "benchmark": benchmark,
-                
+
                 "benchmark_all": benchmark_all,
-                
+
                 "progress": progress,
-                
+
                 "stdin": stdin,
-                
+
                 "timelimit": timelimit,
-                
+
                 "dump": dump,
-                
+
                 "hex": hex,
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 "frame_drop_threshold": frame_drop_threshold,
-                
+
                 "copyts": copyts,
-                
+
                 "start_at_zero": start_at_zero,
-                
+
                 "copytb": copytb,
-                
-                
-                
-                
+
+
+
+
                 "dts_delta_threshold": dts_delta_threshold,
-                
+
                 "dts_error_threshold": dts_error_threshold,
-                
+
                 "xerror": xerror,
-                
+
                 "abort_on": abort_on,
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
                 "filter_threads": filter_threads,
-                
+
                 "filter_buffered_frames": filter_buffered_frames,
-                
-                
-                
-                
+
+
+
+
                 "filter_complex": filter_complex,
-                
+
                 "filter_complex_threads": filter_complex_threads,
-                
+
                 "lavfi": lavfi,
-                
+
                 "filter_complex_script": filter_complex_script,
-                
+
                 "print_graphs": print_graphs,
-                
+
                 "print_graphs_file": print_graphs_file,
-                
+
                 "print_graphs_format": print_graphs_format,
-                
+
                 "auto_conversion_filters": auto_conversion_filters,
-                
+
                 "stats": stats,
-                
+
                 "stats_period": stats_period,
-                
-                
-                
-                
+
+
+
+
                 "debug_ts": debug_ts,
-                
+
                 "max_error_rate": max_error_rate,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "vstats": vstats,
-                
+
                 "vstats_file": vstats_file,
-                
+
                 "vstats_version": vstats_version,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "vaapi_device": vaapi_device,
-                
+
                 "init_hw_device": init_hw_device,
-                
+
                 "filter_hw_device": filter_hw_device,
-                
+
                 "adrift_threshold": adrift_threshold,
-                
-                
+
+
                 "qphist": qphist,
-                
+
                 "vsync": vsync,
-                
-                
+
+
             }, extra_options)
         ).stream()

--- a/packages/v8/src/ffmpeg/dag/io/_input.py
+++ b/packages/v8/src/ffmpeg/dag/io/_input.py
@@ -128,257 +128,257 @@ def input(
     return InputNode(
         filename=str(filename),
         kwargs=merge({
-            
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "f": f,
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 "c": c,
-                
+
                 "codec": codec,
-                
-                
-                
-                
-                
+
+
+
+
+
                 "t": t,
-                
+
                 "to": to,
-                
-                
+
+
                 "ss": ss,
-                
+
                 "sseof": sseof,
-                
+
                 "seek_timestamp": seek_timestamp,
-                
+
                 "accurate_seek": accurate_seek,
-                
+
                 "isync": isync,
-                
+
                 "itsoffset": itsoffset,
-                
+
                 "itsscale": itsscale,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "re": re,
-                
+
                 "readrate": readrate,
-                
+
                 "readrate_initial_burst": readrate_initial_burst,
-                
+
                 "readrate_catchup": readrate_catchup,
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
                 "bitexact": bitexact,
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
                 "tag": tag,
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
                 "reinit_filter": reinit_filter,
-                
+
                 "drop_changed": drop_changed,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
                 "dump_attachment": dump_attachment,
-                
+
                 "stream_loop": stream_loop,
-                
-                
-                
+
+
+
                 "discard": discard,
-                
-                
+
+
                 "thread_queue_size": thread_queue_size,
-                
+
                 "find_stream_info": find_stream_info,
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
                 "r": r,
-                
-                
+
+
                 "s": s,
-                
-                
+
+
                 "pix_fmt": pix_fmt,
-                
+
                 "display_rotation": display_rotation,
-                
+
                 "display_hflip": display_hflip,
-                
+
                 "display_vflip": display_vflip,
-                
+
                 "vn": vn,
-                
-                
+
+
                 "vcodec": vcodec,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
                 "vtag": vtag,
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 "hwaccel": hwaccel,
-                
+
                 "hwaccel_device": hwaccel_device,
-                
+
                 "hwaccel_output_format": hwaccel_output_format,
-                
-                
+
+
                 "autorotate": autorotate,
-                
-                
+
+
                 "apply_cropping": apply_cropping,
-                
-                
-                
-                
+
+
+
+
                 "ar": ar,
-                
+
                 "ac": ac,
-                
+
                 "an": an,
-                
+
                 "acodec": acodec,
-                
-                
-                
-                
+
+
+
+
                 "sample_fmt": sample_fmt,
-                
+
                 "channel_layout": channel_layout,
-                
+
                 "ch_layout": ch_layout,
-                
-                
+
+
                 "guess_layout_max": guess_layout_max,
-                
+
                 "sn": sn,
-                
+
                 "scodec": scodec,
-                
-                
+
+
                 "fix_sub_duration": fix_sub_duration,
-                
+
                 "canvas_size": canvas_size,
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 "bsf": bsf,
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
                 "dcodec": dcodec,
-                
+
                 "dn": dn,
-                
-                
-                
-                
-                
+
+
+
+
+
                 "top": top,
-                
-                
-                
-                
+
+
+
+
         }, decoder_options, demuxer_options, format_options, codec_options, extra_options )
     ).stream()

--- a/packages/v8/src/ffmpeg/dag/io/_output.py
+++ b/packages/v8/src/ffmpeg/dag/io/_output.py
@@ -163,296 +163,296 @@ def output(
         inputs=streams,
         filename=str(filename),
         kwargs=merge({
-            
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "f": f,
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 "c": c,
-                
+
                 "codec": codec,
-                
+
                 "pre": pre,
-                
+
                 "map": map,
-                
+
                 "map_metadata": map_metadata,
-                
+
                 "map_chapters": map_chapters,
-                
+
                 "t": t,
-                
+
                 "to": to,
-                
+
                 "fs": fs,
-                
+
                 "ss": ss,
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
                 "timestamp": timestamp,
-                
+
                 "metadata": metadata,
-                
+
                 "program": program,
-                
+
                 "stream_group": stream_group,
-                
+
                 "dframes": dframes,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
                 "target": target,
-                
-                
-                
-                
-                
+
+
+
+
+
                 "shortest": shortest,
-                
+
                 "shortest_buf_duration": shortest_buf_duration,
-                
+
                 "bitexact": bitexact,
-                
-                
-                
-                
-                
+
+
+
+
+
                 "copyinkf": copyinkf,
-                
+
                 "copypriorss": copypriorss,
-                
+
                 "frames": frames,
-                
+
                 "tag": tag,
-                
+
                 "q": q,
-                
+
                 "qscale": qscale,
-                
+
                 "profile": profile,
-                
+
                 "filter": filter,
-                
-                
-                
+
+
+
                 "filter_script": filter_script,
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
+
+
+
+
+
+
+
                 "attach": attach,
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 "disposition": disposition,
-                
+
                 "thread_queue_size": thread_queue_size,
-                
-                
+
+
                 "bits_per_raw_sample": bits_per_raw_sample,
-                
+
                 "stats_enc_pre": stats_enc_pre,
-                
+
                 "stats_enc_post": stats_enc_post,
-                
+
                 "stats_mux_pre": stats_mux_pre,
-                
+
                 "stats_enc_pre_fmt": stats_enc_pre_fmt,
-                
+
                 "stats_enc_post_fmt": stats_enc_post_fmt,
-                
+
                 "stats_mux_pre_fmt": stats_mux_pre_fmt,
-                
+
                 "vframes": vframes,
-                
+
                 "r": r,
-                
+
                 "fpsmax": fpsmax,
-                
+
                 "s": s,
-                
+
                 "aspect": aspect,
-                
+
                 "pix_fmt": pix_fmt,
-                
-                
-                
-                
+
+
+
+
                 "vn": vn,
-                
+
                 "rc_override": rc_override,
-                
+
                 "vcodec": vcodec,
-                
+
                 "timecode": timecode,
-                
+
                 "pass": _pass,
-                
+
                 "passlogfile": passlogfile,
-                
-                
-                
-                
+
+
+
+
                 "vf": vf,
-                
+
                 "intra_matrix": intra_matrix,
-                
+
                 "inter_matrix": inter_matrix,
-                
+
                 "chroma_intra_matrix": chroma_intra_matrix,
-                
+
                 "vtag": vtag,
-                
+
                 "fps_mode": fps_mode,
-                
+
                 "force_fps": force_fps,
-                
+
                 "streamid": streamid,
-                
+
                 "force_key_frames": force_key_frames,
-                
+
                 "b": b,
-                
-                
-                
-                
-                
-                
+
+
+
+
+
+
                 "autoscale": autoscale,
-                
-                
+
+
                 "fix_sub_duration_heartbeat": fix_sub_duration_heartbeat,
-                
+
                 "aframes": aframes,
-                
+
                 "aq": aq,
-                
+
                 "ar": ar,
-                
+
                 "ac": ac,
-                
+
                 "an": an,
-                
+
                 "acodec": acodec,
-                
+
                 "ab": ab,
-                
+
                 "apad": apad,
-                
+
                 "atag": atag,
-                
+
                 "sample_fmt": sample_fmt,
-                
+
                 "channel_layout": channel_layout,
-                
+
                 "ch_layout": ch_layout,
-                
+
                 "af": af,
-                
-                
+
+
                 "sn": sn,
-                
+
                 "scodec": scodec,
-                
+
                 "stag": stag,
-                
-                
-                
+
+
+
                 "muxdelay": muxdelay,
-                
+
                 "muxpreload": muxpreload,
-                
+
                 "sdp_file": sdp_file,
-                
+
                 "time_base": time_base,
-                
+
                 "enc_time_base": enc_time_base,
-                
+
                 "bsf": bsf,
-                
+
                 "apre": apre,
-                
+
                 "vpre": vpre,
-                
+
                 "spre": spre,
-                
+
                 "fpre": fpre,
-                
+
                 "max_muxing_queue_size": max_muxing_queue_size,
-                
+
                 "muxing_queue_data_threshold": muxing_queue_data_threshold,
-                
+
                 "dcodec": dcodec,
-                
+
                 "dn": dn,
-                
-                
-                
-                
-                
+
+
+
+
+
                 "top": top,
-                
-                
-                
-                
+
+
+
+
         }, encoder_options, muxer_options, format_options, codec_options, extra_options )
     ).stream()

--- a/packages/v8/src/ffmpeg/dag/io/output_args.py
+++ b/packages/v8/src/ffmpeg/dag/io/output_args.py
@@ -173,295 +173,295 @@ class OutputArgs(ABC):
         """
 
         return self._output_node(*streams, filename=filename, **merge({
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
             "f": f,
-                
-            
-            
-            
-            
-            
+
+
+
+
+
+
             "c": c,
-                
+
             "codec": codec,
-                
+
             "pre": pre,
-                
+
             "map": map,
-                
+
             "map_metadata": map_metadata,
-                
+
             "map_chapters": map_chapters,
-                
+
             "t": t,
-                
+
             "to": to,
-                
+
             "fs": fs,
-                
+
             "ss": ss,
-                
-            
-            
-            
-            
-            
-            
+
+
+
+
+
+
+
             "timestamp": timestamp,
-                
+
             "metadata": metadata,
-                
+
             "program": program,
-                
+
             "stream_group": stream_group,
-                
+
             "dframes": dframes,
-                
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
+
+
+
+
+
+
+
+
+
+
+
+
             "target": target,
-                
-            
-            
-            
-            
+
+
+
+
+
             "shortest": shortest,
-                
+
             "shortest_buf_duration": shortest_buf_duration,
-                
+
             "bitexact": bitexact,
-                
-            
-            
-            
-            
+
+
+
+
+
             "copyinkf": copyinkf,
-                
+
             "copypriorss": copypriorss,
-                
+
             "frames": frames,
-                
+
             "tag": tag,
-                
+
             "q": q,
-                
+
             "qscale": qscale,
-                
+
             "profile": profile,
-                
+
             "filter": filter,
-                
-            
-            
+
+
+
             "filter_script": filter_script,
-                
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
-            
+
+
+
+
+
+
+
+
+
+
+
+
+
             "attach": attach,
-                
-            
-            
-            
-            
-            
+
+
+
+
+
+
             "disposition": disposition,
-                
+
             "thread_queue_size": thread_queue_size,
-                
-            
+
+
             "bits_per_raw_sample": bits_per_raw_sample,
-                
+
             "stats_enc_pre": stats_enc_pre,
-                
+
             "stats_enc_post": stats_enc_post,
-                
+
             "stats_mux_pre": stats_mux_pre,
-                
+
             "stats_enc_pre_fmt": stats_enc_pre_fmt,
-                
+
             "stats_enc_post_fmt": stats_enc_post_fmt,
-                
+
             "stats_mux_pre_fmt": stats_mux_pre_fmt,
-                
+
             "vframes": vframes,
-                
+
             "r": r,
-                
+
             "fpsmax": fpsmax,
-                
+
             "s": s,
-                
+
             "aspect": aspect,
-                
+
             "pix_fmt": pix_fmt,
-                
-            
-            
-            
+
+
+
+
             "vn": vn,
-                
+
             "rc_override": rc_override,
-                
+
             "vcodec": vcodec,
-                
+
             "timecode": timecode,
-                
+
             "pass": _pass,
-                
+
             "passlogfile": passlogfile,
-                
-            
-            
-            
+
+
+
+
             "vf": vf,
-                
+
             "intra_matrix": intra_matrix,
-                
+
             "inter_matrix": inter_matrix,
-                
+
             "chroma_intra_matrix": chroma_intra_matrix,
-                
+
             "vtag": vtag,
-                
+
             "fps_mode": fps_mode,
-                
+
             "force_fps": force_fps,
-                
+
             "streamid": streamid,
-                
+
             "force_key_frames": force_key_frames,
-                
+
             "b": b,
-                
-            
-            
-            
-            
-            
+
+
+
+
+
+
             "autoscale": autoscale,
-                
-            
+
+
             "fix_sub_duration_heartbeat": fix_sub_duration_heartbeat,
-                
+
             "aframes": aframes,
-                
+
             "aq": aq,
-                
+
             "ar": ar,
-                
+
             "ac": ac,
-                
+
             "an": an,
-                
+
             "acodec": acodec,
-                
+
             "ab": ab,
-                
+
             "apad": apad,
-                
+
             "atag": atag,
-                
+
             "sample_fmt": sample_fmt,
-                
+
             "channel_layout": channel_layout,
-                
+
             "ch_layout": ch_layout,
-                
+
             "af": af,
-                
-            
+
+
             "sn": sn,
-                
+
             "scodec": scodec,
-                
+
             "stag": stag,
-                
-            
-            
+
+
+
             "muxdelay": muxdelay,
-                
+
             "muxpreload": muxpreload,
-                
+
             "sdp_file": sdp_file,
-                
+
             "time_base": time_base,
-                
+
             "enc_time_base": enc_time_base,
-                
+
             "bsf": bsf,
-                
+
             "apre": apre,
-                
+
             "vpre": vpre,
-                
+
             "spre": spre,
-                
+
             "fpre": fpre,
-                
+
             "max_muxing_queue_size": max_muxing_queue_size,
-                
+
             "muxing_queue_data_threshold": muxing_queue_data_threshold,
-                
+
             "dcodec": dcodec,
-                
+
             "dn": dn,
-                
-            
-            
-            
-            
+
+
+
+
+
             "top": top,
-                
-            
-            
-            
+
+
+
+
         }, encoder_options, muxer_options, format_options, codec_options, extra_options)).stream()

--- a/packages/v8/src/ffmpeg/filters.py
+++ b/packages/v8/src/ffmpeg/filters.py
@@ -45,36 +45,36 @@ import re
 
 
 
-    
 
-    
 
-    
+
+
+
 def aap(
-    
 
-    
-        
+
+
+
         _input: AudioStream,
-        
-    
-        
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('16'),projection: Int = Default('2'),mu: Float = Default('0.0001'),delta: Float = Default('0.001'),out_mode: Int| Literal["i","d","o","n","e"] | Default = Default('o'),precision: Int| Literal["auto","float","double"] | Default = Default('auto'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Apply Affine Projection algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to estimate unknown audio based on multiple input audio samples.
@@ -100,7 +100,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aap)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -108,85 +108,85 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='aap', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _input,
-            
-        
-            
+
+
+
             _desired,
-            
-        
+
+
 
 
         **merge({
-            
+
             "order": order,
-            
+
             "projection": projection,
-            
+
             "mu": mu,
-            
+
             "delta": delta,
-            
+
             "out_mode": out_mode,
-            
+
             "precision": precision,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
 def acrossfade(
-    
 
-    
-        
+
+
+
         _crossfade0: AudioStream,
-        
-    
-        
+
+
+
         _crossfade1: AudioStream,
-        
-    
+
+
 
 
     *,
     nb_samples: Int64 = Default('44100'),duration: Duration = Default('0'),overlap: Boolean = Default('true'),curve1: Int| Literal["nofade","tri","qsin","esin","hsin","log","ipar","qua","cub","squ","cbr","par","exp","iqsin","ihsin","dese","desi","losi","sinc","isinc","quat","quatr","qsin2","hsin2"] | Default = Default('tri'),curve2: Int| Literal["nofade","tri","qsin","esin","hsin","log","ipar","qua","cub","squ","cbr","par","exp","iqsin","ihsin","dese","desi","losi","sinc","isinc","quat","quatr","qsin2","hsin2"] | Default = Default('tri'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Apply cross fade from one input audio stream to another input audio stream.
 The cross fade is applied for specified duration near the end of first stream.
 
@@ -208,132 +208,132 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acrossfade)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='acrossfade', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _crossfade0,
-            
-        
-            
+
+
+
             _crossfade1,
-            
-        
+
+
 
 
         **merge({
-            
+
             "nb_samples": nb_samples,
-            
+
             "duration": duration,
-            
+
             "overlap": overlap,
-            
+
             "curve1": curve1,
-            
+
             "curve2": curve2,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def ainterleave(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     nb_inputs: Int = Auto('len(streams)'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Temporally interleave frames from several inputs.
 
 interleave works with video inputs, ainterleave with audio.
@@ -372,82 +372,82 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#interleave)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='ainterleave', typings_input='[StreamType.audio] * int(nb_inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "nb_inputs": nb_inputs,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
 def alphamerge(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _alpha: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Add or replace the alpha component of the primary input with the
 grayscale value of a second input. This is intended for use with
 alphaextract to allow the transmission or storage of frame
@@ -473,7 +473,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#alphamerge)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -484,55 +484,55 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='alphamerge', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _alpha,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def amerge(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Merge two or more audio streams into a single multi-channel stream.
 
 The filter accepts the following options:
@@ -549,54 +549,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amerge)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='amerge', typings_input='[StreamType.audio] * int(inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def amix(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),dropout_transition: Float = Default('2'),weights: String = Default('1 1'),normalize: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Mixes multiple audio inputs into a single output.
 
 Note that this filter only supports float samples (the amerge
@@ -622,70 +622,70 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amix)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='amix', typings_input='[StreamType.audio] * int(inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "duration": duration,
-            
+
             "dropout_transition": dropout_transition,
-            
+
             "weights": weights,
-            
+
             "normalize": normalize,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def amultiply(
-    
 
-    
-        
+
+
+
         _multiply0: AudioStream,
-        
-    
-        
+
+
+
         _multiply1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Multiply first audio stream with second audio stream and store result
 in output audio stream. Multiplication is done by multiplying each
 sample from first stream with sample at same position from second stream.
@@ -704,69 +704,69 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amultiply)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='amultiply', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _multiply0,
-            
-        
-            
+
+
+
             _multiply1,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def anlmf(
-    
 
-    
-        
+
+
+
         _input: AudioStream,
-        
-    
-        
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('256'),mu: Float = Default('0.75'),eps: Float = Default('1'),leakage: Float = Default('0'),out_mode: Int| Literal["i","d","o","n","e"] | Default = Default('o'),precision: Int| Literal["auto","float","double"] | Default = Default('auto'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Apply Normalized Least-Mean-(Squares|Fourth) algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to mimic a desired filter by finding the filter coefficients that
@@ -793,7 +793,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anlmf)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -801,74 +801,74 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='anlmf', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _input,
-            
-        
-            
+
+
+
             _desired,
-            
-        
+
+
 
 
         **merge({
-            
+
             "order": order,
-            
+
             "mu": mu,
-            
+
             "eps": eps,
-            
+
             "leakage": leakage,
-            
+
             "out_mode": out_mode,
-            
+
             "precision": precision,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
+
+
+
 def anlms(
-    
 
-    
-        
+
+
+
         _input: AudioStream,
-        
-    
-        
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('256'),mu: Float = Default('0.75'),eps: Float = Default('1'),leakage: Float = Default('0'),out_mode: Int| Literal["i","d","o","n","e"] | Default = Default('o'),precision: Int| Literal["auto","float","double"] | Default = Default('auto'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Apply Normalized Least-Mean-(Squares|Fourth) algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to mimic a desired filter by finding the filter coefficients that
@@ -895,7 +895,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anlmf)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -903,92 +903,92 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='anlms', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _input,
-            
-        
-            
+
+
+
             _desired,
-            
-        
+
+
 
 
         **merge({
-            
+
             "order": order,
-            
+
             "mu": mu,
-            
+
             "eps": eps,
-            
+
             "leakage": leakage,
-            
+
             "out_mode": out_mode,
-            
+
             "precision": precision,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
 def apsnr(
-    
 
-    
-        
+
+
+
         _input0: AudioStream,
-        
-    
-        
+
+
+
         _input1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Measure Audio Peak Signal-to-Noise Ratio.
 
 This filter takes two audio streams for input, and outputs first
@@ -1007,7 +1007,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#apsnr)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -1015,72 +1015,72 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='apsnr', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _input0,
-            
-        
-            
+
+
+
             _input1,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
 def arls(
-    
 
-    
-        
+
+
+
         _input: AudioStream,
-        
-    
-        
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('16'),_lambda: Float = Default('1'),delta: Float = Default('2'),out_mode: Int| Literal["i","d","o","n","e"] | Default = Default('o'),precision: Int| Literal["auto","float","double"] | Default = Default('auto'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Apply Recursive Least Squares algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to mimic a desired filter by recursively finding the filter coefficients that
@@ -1106,7 +1106,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#arls)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -1114,74 +1114,74 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='arls', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _input,
-            
-        
-            
+
+
+
             _desired,
-            
-        
+
+
 
 
         **merge({
-            
+
             "order": order,
-            
+
             "lambda": _lambda,
-            
+
             "delta": delta,
-            
+
             "out_mode": out_mode,
-            
+
             "precision": precision,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def asdr(
-    
 
-    
-        
+
+
+
         _input0: AudioStream,
-        
-    
-        
+
+
+
         _input1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Measure Audio Signal-to-Distortion Ratio.
 
 This filter takes two audio streams for input, and outputs first
@@ -1200,7 +1200,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asdr)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -1208,80 +1208,80 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='asdr', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _input0,
-            
-        
-            
+
+
+
             _input1,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
 def asisdr(
-    
 
-    
-        
+
+
+
         _input0: AudioStream,
-        
-    
-        
+
+
+
         _input1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Measure Audio Scaled-Invariant Signal-to-Distortion Ratio.
 
 This filter takes two audio streams for input, and outputs first
@@ -1300,7 +1300,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asisdr)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -1308,63 +1308,63 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='asisdr', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _input0,
-            
-        
-            
+
+
+
             _input1,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
 def astreamselect(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),map: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Select video or audio streams.
 
 The filter accepts the following options:
@@ -1383,87 +1383,87 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#streamselect)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='astreamselect', typings_input='[StreamType.audio] * int(inputs)', typings_output="[StreamType.audio] * len(re.findall(r'\\d+', str(map)))"),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "map": map,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def axcorrelate(
-    
 
-    
-        
+
+
+
         _axcorrelate0: AudioStream,
-        
-    
-        
+
+
+
         _axcorrelate1: AudioStream,
-        
-    
+
+
 
 
     *,
     size: Int = Default('256'),algo: Int| Literal["slow","fast","best"] | Default = Default('best'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Calculate normalized windowed cross-correlation between two input audio streams.
 
 Resulted samples are always between -1 and 1 inclusive.
@@ -1487,98 +1487,98 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#axcorrelate)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='axcorrelate', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _axcorrelate0,
-            
-        
-            
+
+
+
             _axcorrelate1,
-            
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "algo": algo,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def blend(
-    
 
-    
-        
+
+
+
         _top: VideoStream,
-        
-    
-        
+
+
+
         _bottom: VideoStream,
-        
-    
+
+
 
 
     *,
     c0_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c1_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c2_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c3_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),all_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('-1'),c0_expr: String = Default(None),c1_expr: String = Default(None),c2_expr: String = Default(None),c3_expr: String = Default(None),all_expr: String = Default(None),c0_opacity: Double = Default('1'),c1_opacity: Double = Default('1'),c2_opacity: Double = Default('1'),c3_opacity: Double = Default('1'),all_opacity: Double = Default('1'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Blend two video frames into each other.
 
 The blend filter takes two input streams and outputs one
@@ -1619,7 +1619,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blend)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -1630,92 +1630,92 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='blend', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _top,
-            
-        
-            
+
+
+
             _bottom,
-            
-        
+
+
 
 
         **merge({
-            
+
             "c0_mode": c0_mode,
-            
+
             "c1_mode": c1_mode,
-            
+
             "c2_mode": c2_mode,
-            
+
             "c3_mode": c3_mode,
-            
+
             "all_mode": all_mode,
-            
+
             "c0_expr": c0_expr,
-            
+
             "c1_expr": c1_expr,
-            
+
             "c2_expr": c2_expr,
-            
+
             "c3_expr": c3_expr,
-            
+
             "all_expr": all_expr,
-            
+
             "c0_opacity": c0_opacity,
-            
+
             "c1_opacity": c1_opacity,
-            
+
             "c2_opacity": c2_opacity,
-            
+
             "c3_opacity": c3_opacity,
-            
+
             "all_opacity": all_opacity,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def bm3d(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     sigma: Float = Default('1'),block: Int = Default('16'),bstep: Int = Default('4'),group: Int = Default('1'),range: Int = Default('9'),mstep: Int = Default('1'),thmse: Float = Default('0'),hdthr: Float = Default('2.7'),estim: Int| Literal["basic","final"] | Default = Default('basic'),ref: Boolean = Default('false'),planes: Int = Default('7'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Denoise frames using Block-Matching 3D algorithm.
 
 The filter accepts the following options.
@@ -1743,7 +1743,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bm3d)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -1751,140 +1751,140 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='bm3d', typings_input='[StreamType.video] + [StreamType.video] if ref else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "sigma": sigma,
-            
+
             "block": block,
-            
+
             "bstep": bstep,
-            
+
             "group": group,
-            
+
             "range": range,
-            
+
             "mstep": mstep,
-            
+
             "thmse": thmse,
-            
+
             "hdthr": hdthr,
-            
+
             "estim": estim,
-            
+
             "ref": ref,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def colormap(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _target: VideoStream,
-        
-    
+
+
 
 
     *,
     patch_size: Image_size = Default('64x64'),nb_patches: Int = Default('0'),type: Int| Literal["relative","absolute"] | Default = Default('absolute'),kernel: Int| Literal["euclidean","weuclidean"] | Default = Default('euclidean'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply custom color maps to video stream.
 
 This filter needs three input video streams.
@@ -1910,7 +1910,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colormap)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -1918,77 +1918,77 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='colormap', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _target,
-            
-        
+
+
 
 
         **merge({
-            
+
             "patch_size": patch_size,
-            
+
             "nb_patches": nb_patches,
-            
+
             "type": type,
-            
+
             "kernel": kernel,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
 def concat(
-    
 
-    
+
+
     *streams: FilterableStream,
-    
 
 
-    
+
+
     n: Int = Auto('len(streams) // (int(v) + int(a))'),v: Int = Default('1'),a: Int = Default('0'),unsafe: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Concatenate audio and video streams, joining them together one after the
 other.
 
@@ -2014,77 +2014,77 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#concat)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='concat', typings_input='([StreamType.video]*int(v) + [StreamType.audio]*int(a))*int(n)', typings_output='[StreamType.video]*int(v) + [StreamType.audio]*int(a)'),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "n": n,
-            
+
             "v": v,
-            
+
             "a": a,
-            
+
             "unsafe": unsafe,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def convolve(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _impulse: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('7'),impulse: Int| Literal["first","all"] | Default = Default('all'),noise: Float = Default('1e-07'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply 2D convolution of video stream in frequency domain using second stream
 as impulse.
 
@@ -2106,7 +2106,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#convolve)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -2117,77 +2117,77 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='convolve', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _impulse,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "impulse": impulse,
-            
+
             "noise": noise,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def corr(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Obtain the correlation between two input videos.
 
 This filter takes two input videos.
@@ -2223,7 +2223,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#corr)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -2234,81 +2234,81 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='corr', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def decimate(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     cycle: Int = Default('5'),dupthresh: Double = Default('1.1'),scthresh: Double = Default('15'),blockx: Int = Default('32'),blocky: Int = Default('32'),ppsrc: Boolean = Default('false'),chroma: Boolean = Default('true'),mixed: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Drop duplicated frames at regular intervals.
 
 The filter accepts the following options:
@@ -2332,80 +2332,80 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#decimate)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='decimate', typings_input='[StreamType.video] + ([StreamType.video] if ppsrc else [])', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "cycle": cycle,
-            
+
             "dupthresh": dupthresh,
-            
+
             "scthresh": scthresh,
-            
+
             "blockx": blockx,
-            
+
             "blocky": blocky,
-            
+
             "ppsrc": ppsrc,
-            
+
             "chroma": chroma,
-            
+
             "mixed": mixed,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def deconvolve(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _impulse: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('7'),impulse: Int| Literal["first","all"] | Default = Default('all'),noise: Float = Default('1e-07'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply 2D deconvolution of video stream in frequency domain using second stream
 as impulse.
 
@@ -2427,7 +2427,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deconvolve)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -2438,104 +2438,104 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='deconvolve', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _impulse,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "impulse": impulse,
-            
+
             "noise": noise,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def displace(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _xmap: VideoStream,
-        
-    
-        
+
+
+
         _ymap: VideoStream,
-        
-    
+
+
 
 
     *,
     edge: Int| Literal["blank","smear","wrap","mirror"] | Default = Default('smear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Displace pixels as indicated by second and third input stream.
 
 It takes three input streams and outputs one stream, the first input is the
@@ -2564,7 +2564,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#displace)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -2572,124 +2572,124 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='displace', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _xmap,
-            
-        
-            
+
+
+
             _ymap,
-            
-        
+
+
 
 
         **merge({
-            
+
             "edge": edge,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def feedback(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _feedin: VideoStream,
-        
-    
+
+
 
 
     *,
     x: Int = Default('0'),w: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> tuple[
-    
-        
+
+
             VideoStream,
-        
-    
-        
+
+
+
             VideoStream,
-        
-    
+
+
 ]:
     """
-    
+
 Apply feedback video filter.
 
 This filter pass cropped input frames to 2nd output.
@@ -2717,7 +2717,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#feedback)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -2725,76 +2725,76 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='feedback', typings_input=('video', 'video'), typings_output=('video', 'video')),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _feedin,
-            
-        
+
+
 
 
         **merge({
-            
+
             "x": x,
-            
+
             "w": w,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return (
-        
-            
+
+
                 filter_node.video(0),
-            
-        
-            
+
+
+
                 filter_node.video(1),
-            
-        
+
+
     )
 
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def fieldmatch(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     order: Int| Literal["auto","bff","tff"] | Default = Default('auto'),mode: Int| Literal["pc","pc_n","pc_u","pc_n_ub","pcn","pcn_ub"] | Default = Default('pc_n'),ppsrc: Boolean = Default('false'),field: Int| Literal["auto","bottom","top"] | Default = Default('auto'),mchroma: Boolean = Default('true'),y0: Int = Default('0'),scthresh: Double = Default('12'),combmatch: Int| Literal["none","sc","full"] | Default = Default('sc'),combdbg: Int| Literal["none","pcn","pcnub"] | Default = Default('none'),cthresh: Int = Default('9'),chroma: Boolean = Default('false'),blockx: Int = Default('16'),blocky: Int = Default('16'),combpel: Int = Default('80'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Field matching filter for inverse telecine. It is meant to reconstruct the
 progressive frames from a telecined stream. The filter does not drop duplicated
 frames, so to achieve a complete inverse telecine fieldmatch needs to be
@@ -2852,100 +2852,100 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fieldmatch)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='fieldmatch', typings_input='[StreamType.video] + [StreamType.video] if ppsrc else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "order": order,
-            
+
             "mode": mode,
-            
+
             "ppsrc": ppsrc,
-            
+
             "field": field,
-            
+
             "mchroma": mchroma,
-            
+
             "y0": y0,
-            
+
             "scthresh": scthresh,
-            
+
             "combmatch": combmatch,
-            
+
             "combdbg": combdbg,
-            
+
             "cthresh": cthresh,
-            
+
             "chroma": chroma,
-            
+
             "blockx": blockx,
-            
+
             "blocky": blocky,
-            
+
             "combpel": combpel,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
 def framepack(
-    
 
-    
-        
+
+
+
         _left: VideoStream,
-        
-    
-        
+
+
+
         _right: VideoStream,
-        
-    
+
+
 
 
     *,
     format: Int| Literal["sbs","tab","frameseq","lines","columns"] | Default = Default('sbs'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Pack two different video streams into a stereoscopic video, setting proper
 metadata on supported codecs. The two views should have the same size and
 framerate and processing will stop when the shorter video ends. Please note
@@ -2966,70 +2966,70 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#framepack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='framepack', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _left,
-            
-        
-            
+
+
+
             _right,
-            
-        
+
+
 
 
         **merge({
-            
+
             "format": format,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def freezeframes(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _replace: VideoStream,
-        
-    
+
+
 
 
     *,
     first: Int64 = Default('0'),last: Int64 = Default('0'),replace: Int64 = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Freeze video frames.
 
 This filter freezes video frames using frame from 2nd input.
@@ -3050,83 +3050,83 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#freezeframes)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='freezeframes', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _replace,
-            
-        
+
+
 
 
         **merge({
-            
+
             "first": first,
-            
+
             "last": last,
-            
+
             "replace": replace,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
 def guided(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     radius: Int = Default('3'),eps: Float = Default('0.01'),mode: Int| Literal["basic","fast"] | Default = Default('basic'),sub: Int = Default('4'),guidance: Int| Literal["off","on"] | Default = Default('off'),planes: Int = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply guided filter for edge-preserving smoothing, dehazing and so on.
 
 The filter accepts the following options:
@@ -3149,7 +3149,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#guided)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -3157,75 +3157,75 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='guided', typings_input='[StreamType.video] + [StreamType.video] if guidance else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "radius": radius,
-            
+
             "eps": eps,
-            
+
             "mode": mode,
-            
+
             "sub": sub,
-            
+
             "guidance": guidance,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def haldclut(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _clut: VideoStream,
-        
-    
+
+
 
 
     *,
     clut: Int| Literal["first","all"] | Default = Default('all'),interp: Int| Literal["nearest","trilinear","tetrahedral","pyramid","prism"] | Default = Default('tetrahedral'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply a Hald CLUT to a video stream.
 
 First input is the video stream to process, and second one is the Hald CLUT.
@@ -3248,7 +3248,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#haldclut)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -3259,63 +3259,63 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='haldclut', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _clut,
-            
-        
+
+
 
 
         **merge({
-            
+
             "clut": clut,
-            
+
             "interp": interp,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def headphone(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     map: String = Default(None),gain: Float = Default('0'),lfe: Float = Default('0'),type: Int| Literal["time","freq"] | Default = Default('freq'),size: Int = Default('1024'),hrir: Int| Literal["stereo","multich"] | Default = Default('stereo'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Apply head-related transfer functions (HRTFs) to create virtual
 loudspeakers around the user for binaural listening via headphones.
 The HRIRs are provided via additional streams, for each channel
@@ -3340,78 +3340,78 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#headphone)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='headphone', typings_input="[StreamType.audio] + [StreamType.audio] * (len(str(map).split('|')) - 1) if int(hrir) == 1 else []", typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "map": map,
-            
+
             "gain": gain,
-            
+
             "lfe": lfe,
-            
+
             "type": type,
-            
+
             "size": size,
-            
+
             "hrir": hrir,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
 def hstack(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),shortest: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos horizontally.
 
 All streams must be of same pixel format and of same height.
@@ -3434,54 +3434,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hstack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='hstack', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def hstack_vaapi(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Default('2'),shortest: Boolean = Default('false'),height: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos horizontally.
 
 This is the VA-API variant of the hstack filter, each input stream may
@@ -3504,84 +3504,84 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hstack_vaapi)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='hstack_vaapi', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
             "height": height,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
 def hysteresis(
-    
 
-    
-        
+
+
+
         _base: VideoStream,
-        
-    
-        
+
+
+
         _alt: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),threshold: Int = Default('0'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Grow first stream into second stream by connecting components.
 This makes it possible to build more robust edge masks.
 
@@ -3602,7 +3602,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hysteresis)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -3613,73 +3613,73 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='hysteresis', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _base,
-            
-        
-            
+
+
+
             _alt,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "threshold": threshold,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def identity(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Obtain the identity score between two input videos.
 
 This filter takes two input videos.
@@ -3715,7 +3715,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#identity)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -3726,63 +3726,63 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='identity', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def interleave(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     nb_inputs: Int = Auto('len(streams)'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Temporally interleave frames from several inputs.
 
 interleave works with video inputs, ainterleave with audio.
@@ -3821,54 +3821,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#interleave)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='interleave', typings_input='[StreamType.video] * int(nb_inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "nb_inputs": nb_inputs,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def join(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),channel_layout: String = Default('stereo'),map: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Join multiple input streams into one multi-channel stream.
 
 It accepts the following parameters:
@@ -3887,71 +3887,71 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#join)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='join', typings_input='[StreamType.audio] * int(inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "channel_layout": channel_layout,
-            
+
             "map": map,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
 def limitdiff(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     threshold: Float = Default('0.00392157'),elasticity: Float = Default('2'),reference: Boolean = Default('false'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply limited difference filter using second and optionally third video stream.
 
 The filter accepts the following options:
@@ -3972,7 +3972,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#limitdiff)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -3980,85 +3980,85 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='limitdiff', typings_input='[StreamType.video, StreamType.video] + ([StreamType.video] if reference else [])', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "threshold": threshold,
-            
+
             "elasticity": elasticity,
-            
+
             "reference": reference,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
 def lut2(
-    
 
-    
-        
+
+
+
         _srcx: VideoStream,
-        
-    
-        
+
+
+
         _srcy: VideoStream,
-        
-    
+
+
 
 
     *,
     c0: String = Default('x'),c1: String = Default('x'),c2: String = Default('x'),c3: String = Default('x'),d: Int = Default('0'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The lut2 filter takes two input streams and outputs one
 stream.
 
@@ -4085,7 +4085,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut2)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -4096,86 +4096,86 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='lut2', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _srcx,
-            
-        
-            
+
+
+
             _srcy,
-            
-        
+
+
 
 
         **merge({
-            
+
             "c0": c0,
-            
+
             "c1": c1,
-            
+
             "c2": c2,
-            
+
             "c3": c3,
-            
+
             "d": d,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def maskedclamp(
-    
 
-    
-        
+
+
+
         _base: VideoStream,
-        
-    
-        
+
+
+
         _dark: VideoStream,
-        
-    
-        
+
+
+
         _bright: VideoStream,
-        
-    
+
+
 
 
     *,
     undershoot: Int = Default('0'),overshoot: Int = Default('0'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Clamp the first input stream with the second input and third input stream.
 
 Returns the value of first stream to be between second input
@@ -4198,7 +4198,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedclamp)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4206,76 +4206,76 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='maskedclamp', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _base,
-            
-        
-            
+
+
+
             _dark,
-            
-        
-            
+
+
+
             _bright,
-            
-        
+
+
 
 
         **merge({
-            
+
             "undershoot": undershoot,
-            
+
             "overshoot": overshoot,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def maskedmax(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _filter1: VideoStream,
-        
-    
-        
+
+
+
         _filter2: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Merge the second and third input stream into output stream using absolute differences
 between second input stream and first input stream and absolute difference between
 third input stream and first input stream. The picked value will be from second input
@@ -4297,7 +4297,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedmax)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4305,72 +4305,72 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='maskedmax', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _filter1,
-            
-        
-            
+
+
+
             _filter2,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def maskedmerge(
-    
 
-    
-        
+
+
+
         _base: VideoStream,
-        
-    
-        
+
+
+
         _overlay: VideoStream,
-        
-    
-        
+
+
+
         _mask: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Merge the first input stream with the second input stream using per pixel
 weights in the third input stream.
 
@@ -4395,7 +4395,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedmerge)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4403,72 +4403,72 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='maskedmerge', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _base,
-            
-        
-            
+
+
+
             _overlay,
-            
-        
-            
+
+
+
             _mask,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def maskedmin(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _filter1: VideoStream,
-        
-    
-        
+
+
+
         _filter2: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Merge the second and third input stream into output stream using absolute differences
 between second input stream and first input stream and absolute difference between
 third input stream and first input stream. The picked value will be from second input
@@ -4490,7 +4490,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedmin)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4498,68 +4498,68 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='maskedmin', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _filter1,
-            
-        
-            
+
+
+
             _filter2,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def maskedthreshold(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     threshold: Int = Default('1'),planes: Int = Default('15'),mode: Int| Literal["abs","diff"] | Default = Default('abs'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Pick pixels comparing absolute difference of two video streams with fixed
 threshold.
 
@@ -4585,7 +4585,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedthreshold)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4593,67 +4593,67 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='maskedthreshold', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
             "threshold": threshold,
-            
+
             "planes": planes,
-            
+
             "mode": mode,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def mergeplanes(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     mapping: Int = Default('-1'),format: Pix_fmt = Default('yuva444p'),map0s: Int = Default('0'),map0p: Int = Default('0'),map1s: Int = Default('0'),map1p: Int = Default('0'),map2s: Int = Default('0'),map2p: Int = Default('0'),map3s: Int = Default('0'),map3p: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Merge color channel components from several video streams.
 
 The filter accepts up to 4 input streams, and merge selected input
@@ -4682,83 +4682,83 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mergeplanes)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='mergeplanes', typings_input='[StreamType.video] * int(max(hex(int(mapping))[2::2]))', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "mapping": mapping,
-            
+
             "format": format,
-            
+
             "map0s": map0s,
-            
+
             "map0p": map0p,
-            
+
             "map1s": map1s,
-            
+
             "map1p": map1p,
-            
+
             "map2s": map2s,
-            
+
             "map2p": map2p,
-            
+
             "map3s": map3s,
-            
+
             "map3p": map3p,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def midequalizer(
-    
 
-    
-        
+
+
+
         _in0: VideoStream,
-        
-    
-        
+
+
+
         _in1: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply Midway Image Equalization effect using two video streams.
 
 Midway Image Equalization adjusts a pair of images to have the same
@@ -4784,7 +4784,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#midequalizer)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4792,60 +4792,60 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='midequalizer', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _in0,
-            
-        
-            
+
+
+
             _in1,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def mix(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),weights: String = Default('1 1'),scale: Float = Default('0'),planes: Flags = Default('F'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Mix several video input streams into one video stream.
 
 A description of the accepted options follows.
@@ -4867,7 +4867,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mix)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4875,73 +4875,73 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='mix', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "weights": weights,
-            
+
             "scale": scale,
-            
+
             "planes": planes,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def morpho(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _structure: VideoStream,
-        
-    
+
+
 
 
     *,
     mode: Int| Literal["erode","dilate","open","close","gradient","tophat","blackhat"] | Default = Default('erode'),planes: Int = Default('7'),structure: Int| Literal["first","all"] | Default = Default('all'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 This filter allows to apply main morphological grayscale transforms,
 erode and dilate with arbitrary structures set in second input stream.
 
@@ -4967,7 +4967,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#morpho)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -4978,81 +4978,81 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='morpho', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _structure,
-            
-        
+
+
 
 
         **merge({
-            
+
             "mode": mode,
-            
+
             "planes": planes,
-            
+
             "structure": structure,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def msad(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Obtain the MSAD (Mean Sum of Absolute Differences) between two input videos.
 
 This filter takes two input videos.
@@ -5088,7 +5088,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#msad)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -5099,64 +5099,64 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='msad', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def multiply(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _factor: VideoStream,
-        
-    
+
+
 
 
     *,
     scale: Float = Default('1'),offset: Float = Default('0.5'),planes: Flags = Default('F'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Multiply first video stream pixels values with second video stream pixels values.
 
 The filter accepts the following options:
@@ -5176,7 +5176,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#multiply)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -5184,97 +5184,97 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='multiply', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _factor,
-            
-        
+
+
 
 
         **merge({
-            
+
             "scale": scale,
-            
+
             "offset": offset,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def overlay(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _overlay: VideoStream,
-        
-    
+
+
 
 
     *,
     x: String = Default('0'),y: String = Default('0'),eof_action: Int| Literal["repeat","endall","pass"] | Default = Default('repeat'),eval: Int| Literal["init","frame"] | Default = Default('frame'),shortest: Boolean = Default('false'),format: Int| Literal["yuv420","yuv420p10","yuv422","yuv422p10","yuv444","yuv444p10","rgb","gbrp","auto"] | Default = Default('yuv420'),repeatlast: Boolean = Default('true'),alpha: Int| Literal["straight","premultiplied"] | Default = Default('straight'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
-    
-    
-    
-    
-    
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Overlay one video on top of another.
 
 It takes two inputs and has one output. The first input is the "main"
@@ -5305,7 +5305,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -5313,77 +5313,77 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='overlay', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _overlay,
-            
-        
+
+
 
 
         **merge({
-            
+
             "x": x,
-            
+
             "y": y,
-            
+
             "eof_action": eof_action,
-            
+
             "eval": eval,
-            
+
             "shortest": shortest,
-            
+
             "format": format,
-            
+
             "repeatlast": repeatlast,
-            
+
             "alpha": alpha,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def overlay_opencl(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _overlay: VideoStream,
-        
-    
+
+
 
 
     *,
     x: Int = Default('0'),y: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Overlay one video on top of another.
 
 It takes two inputs and has one output. The first input is the "main" video on which the second input is overlaid.
@@ -5404,71 +5404,71 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay_opencl)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='overlay_opencl', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _overlay,
-            
-        
+
+
 
 
         **merge({
-            
+
             "x": x,
-            
+
             "y": y,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def overlay_vaapi(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _overlay: VideoStream,
-        
-    
+
+
 
 
     *,
     x: String = Default('0'),y: String = Default('0'),w: String = Default('overlay_iw'),h: String = Default('overlay_ih*w/overlay_iw'),alpha: Float = Default('1'),eof_action: Int| Literal["repeat","endall","pass"] | Default = Default('repeat'),shortest: Boolean = Default('false'),repeatlast: Boolean = Default('true'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
-    
-    
-    
-    
-    
+
+
+
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Overlay one video on the top of another.
 
 It takes two inputs and has one output. The first input is the "main" video on which the second input is overlaid.
@@ -5495,94 +5495,94 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay_vaapi)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='overlay_vaapi', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _overlay,
-            
-        
+
+
 
 
         **merge({
-            
+
             "x": x,
-            
+
             "y": y,
-            
+
             "w": w,
-            
+
             "h": h,
-            
+
             "alpha": alpha,
-            
+
             "eof_action": eof_action,
-            
+
             "shortest": shortest,
-            
+
             "repeatlast": repeatlast,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
 def paletteuse(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _palette: VideoStream,
-        
-    
+
+
 
 
     *,
     dither: Int| Literal["bayer","heckbert","floyd_steinberg","sierra2","sierra2_4a","sierra3","burkes","atkinson"] | Default = Default('sierra2_4a'),bayer_scale: Int = Default('2'),diff_mode: Int| Literal["rectangle"] | Default = Default('0'),new: Boolean = Default('false'),alpha_threshold: Int = Default('128'),debug_kdtree: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Use a palette to downsample an input video stream.
 
 The filter takes two inputs: one video stream and a palette. The palette must
@@ -5607,91 +5607,91 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#paletteuse)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='paletteuse', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _palette,
-            
-        
+
+
 
 
         **merge({
-            
+
             "dither": dither,
-            
+
             "bayer_scale": bayer_scale,
-            
+
             "diff_mode": diff_mode,
-            
+
             "new": new,
-            
+
             "alpha_threshold": alpha_threshold,
-            
+
             "debug_kdtree": debug_kdtree,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
 def premultiply(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     planes: Int = Default('15'),inplace: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply alpha premultiply effect to input video stream using first plane
 of second stream as alpha.
 
@@ -5713,7 +5713,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#premultiply)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -5721,62 +5721,62 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='premultiply', typings_input='[StreamType.video] + [StreamType.video] if inplace else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "inplace": inplace,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def program_opencl(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     source: String = Default(None),kernel: String = Default(None),inputs: Int = Default('1'),size: Image_size = Default(None),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Filter video using an OpenCL program.
 
 
@@ -5795,7 +5795,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#program_opencl)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -5803,71 +5803,71 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='program_opencl', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "source": source,
-            
+
             "kernel": kernel,
-            
+
             "inputs": inputs,
-            
+
             "size": size,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def psnr(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),stats_version: Int = Default('1'),output_max: Boolean = Default('false'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Obtain the average, maximum and minimum PSNR (Peak Signal to Noise
 Ratio) between two input videos.
 
@@ -5911,7 +5911,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#psnr)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -5922,83 +5922,83 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='psnr', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
             "stats_file": stats_file,
-            
+
             "stats_version": stats_version,
-            
+
             "output_max": output_max,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
 def remap(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _xmap: VideoStream,
-        
-    
-        
+
+
+
         _ymap: VideoStream,
-        
-    
+
+
 
 
     *,
     format: Int| Literal["color","gray"] | Default = Default('color'),fill: Color = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Remap pixels using 2nd: Xmap and 3rd: Ymap input video stream.
 
 Destination pixel at position (X, Y) will be picked from source (x, y) position
@@ -6022,74 +6022,74 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#remap)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='remap', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _xmap,
-            
-        
-            
+
+
+
             _ymap,
-            
-        
+
+
 
 
         **merge({
-            
+
             "format": format,
-            
+
             "fill": fill,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def remap_opencl(
-    
 
-    
-        
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _xmap: VideoStream,
-        
-    
-        
+
+
+
         _ymap: VideoStream,
-        
-    
+
+
 
 
     *,
     interp: Int| Literal["near","linear"] | Default = Default('linear'),fill: Color = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Remap pixels using 2nd: Xmap and 3rd: Ymap input video stream.
 
 Destination pixel at position (X, Y) will be picked from source (x, y) position
@@ -6113,104 +6113,104 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#remap_opencl)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='remap_opencl', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _source,
-            
-        
-            
+
+
+
             _xmap,
-            
-        
-            
+
+
+
             _ymap,
-            
-        
+
+
 
 
         **merge({
-            
+
             "interp": interp,
-            
+
             "fill": fill,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def scale2ref(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _ref: VideoStream,
-        
-    
+
+
 
 
     *,
     w: String = Default(None),h: String = Default(None),flags: String = Default(''),interl: Boolean = Default('false'),size: String = Default(None),in_color_matrix: Int| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default('auto'),out_color_matrix: Int| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default('2'),in_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),out_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),in_chroma_loc: Int| Literal["auto","unknown","left","center","topleft","top","bottomleft","bottom"] | Default = Default('auto'),out_chroma_loc: Int| Literal["auto","unknown","left","center","topleft","top","bottomleft","bottom"] | Default = Default('auto'),in_primaries: Int| Literal["auto","bt709","bt470m","bt470bg","smpte170m","smpte240m","film","bt2020","smpte428","smpte431","smpte432","jedec-p22","ebu3213"] | Default = Default('auto'),out_primaries: Int| Literal["auto","bt709","bt470m","bt470bg","smpte170m","smpte240m","film","bt2020","smpte428","smpte431","smpte432","jedec-p22","ebu3213"] | Default = Default('auto'),in_transfer: Int| Literal["auto","bt709","bt470m","gamma22","bt470bg","gamma28","smpte170m","smpte240m","linear","iec61966-2-1","srgb","iec61966-2-4","xvycc","bt1361e","bt2020-10","bt2020-12","smpte2084","smpte428","arib-std-b67"] | Default = Default('auto'),in_v_chr_pos: Int = Default('-513'),in_h_chr_pos: Int = Default('-513'),out_v_chr_pos: Int = Default('-513'),out_h_chr_pos: Int = Default('-513'),force_original_aspect_ratio: Int| Literal["disable","decrease","increase"] | Default = Default('disable'),force_divisible_by: Int = Default('1'),reset_sar: Boolean = Default('false'),param0: Double = Default('DBL_MAX'),param1: Double = Default('DBL_MAX'),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> tuple[
-    
-        
+
+
             VideoStream,
-        
-    
-        
+
+
+
             VideoStream,
-        
-    
+
+
 ]:
     """
-    
+
 Scale the input video size and/or convert the image format to the given reference.
 
 
@@ -6249,185 +6249,185 @@ References:
     [FFmpeg Documentation](None)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='scale2ref', typings_input=('video', 'video'), typings_output=('video', 'video')),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _ref,
-            
-        
+
+
 
 
         **merge({
-            
+
             "w": w,
-            
+
             "h": h,
-            
+
             "flags": flags,
-            
+
             "interl": interl,
-            
+
             "size": size,
-            
+
             "in_color_matrix": in_color_matrix,
-            
+
             "out_color_matrix": out_color_matrix,
-            
+
             "in_range": in_range,
-            
+
             "out_range": out_range,
-            
+
             "in_chroma_loc": in_chroma_loc,
-            
+
             "out_chroma_loc": out_chroma_loc,
-            
+
             "in_primaries": in_primaries,
-            
+
             "out_primaries": out_primaries,
-            
+
             "in_transfer": in_transfer,
-            
+
             "in_v_chr_pos": in_v_chr_pos,
-            
+
             "in_h_chr_pos": in_h_chr_pos,
-            
+
             "out_v_chr_pos": out_v_chr_pos,
-            
+
             "out_h_chr_pos": out_h_chr_pos,
-            
+
             "force_original_aspect_ratio": force_original_aspect_ratio,
-            
+
             "force_divisible_by": force_divisible_by,
-            
+
             "reset_sar": reset_sar,
-            
+
             "param0": param0,
-            
+
             "param1": param1,
-            
+
             "eval": eval,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return (
-        
-            
+
+
                 filter_node.video(0),
-            
-        
-            
+
+
+
                 filter_node.video(1),
-            
-        
+
+
     )
 
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def sidechaincompress(
-    
 
-    
-        
+
+
+
         _main: AudioStream,
-        
-    
-        
+
+
+
         _sidechain: AudioStream,
-        
-    
+
+
 
 
     *,
     level_in: Double = Default('1'),mode: Int| Literal["downward","upward"] | Default = Default('downward'),threshold: Double = Default('0.125'),ratio: Double = Default('2'),attack: Double = Default('20'),release: Double = Default('250'),makeup: Double = Default('1'),knee: Double = Default('2.82843'),link: Int| Literal["average","maximum"] | Default = Default('average'),detection: Int| Literal["peak","rms"] | Default = Default('rms'),level_sc: Double = Default('1'),mix: Double = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 This filter acts like normal compressor but has the ability to compress
 detected signal using second input signal.
 It needs two input streams and returns one output stream.
@@ -6460,89 +6460,89 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sidechaincompress)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='sidechaincompress', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _sidechain,
-            
-        
+
+
 
 
         **merge({
-            
+
             "level_in": level_in,
-            
+
             "mode": mode,
-            
+
             "threshold": threshold,
-            
+
             "ratio": ratio,
-            
+
             "attack": attack,
-            
+
             "release": release,
-            
+
             "makeup": makeup,
-            
+
             "knee": knee,
-            
+
             "link": link,
-            
+
             "detection": detection,
-            
+
             "level_sc": level_sc,
-            
+
             "mix": mix,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
+
+
+
 def sidechaingate(
-    
 
-    
-        
+
+
+
         _main: AudioStream,
-        
-    
-        
+
+
+
         _sidechain: AudioStream,
-        
-    
+
+
 
 
     *,
     level_in: Double = Default('1'),mode: Int| Literal["downward","upward"] | Default = Default('downward'),range: Double = Default('0.06125'),threshold: Double = Default('0.125'),ratio: Double = Default('2'),attack: Double = Default('20'),release: Double = Default('250'),makeup: Double = Default('1'),knee: Double = Default('2.82843'),detection: Int| Literal["peak","rms"] | Default = Default('rms'),link: Int| Literal["average","maximum"] | Default = Default('average'),level_sc: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 A sidechain gate acts like a normal (wideband) gate but has the ability to
 filter the detected signal before sending it to the gain reduction stage.
 Normally a gate uses the full range signal to detect a level above the
@@ -6581,7 +6581,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sidechaingate)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -6589,83 +6589,83 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='sidechaingate', typings_input=('audio', 'audio'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _sidechain,
-            
-        
+
+
 
 
         **merge({
-            
+
             "level_in": level_in,
-            
+
             "mode": mode,
-            
+
             "range": range,
-            
+
             "threshold": threshold,
-            
+
             "ratio": ratio,
-            
+
             "attack": attack,
-            
+
             "release": release,
-            
+
             "makeup": makeup,
-            
+
             "knee": knee,
-            
+
             "detection": detection,
-            
+
             "link": link,
-            
+
             "level_sc": level_sc,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def signature(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     detectmode: Int| Literal["off","full","fast"] | Default = Default('off'),nb_inputs: Int = Auto('len(streams)'),filename: String = Default(''),format: Int| Literal["binary","xml"] | Default = Default('binary'),th_d: Int = Default('9000'),th_dc: Int = Default('60000'),th_xh: Int = Default('116'),th_di: Int = Default('0'),th_it: Double = Default('0.5'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Calculates the MPEG-7 Video Signature. The filter can handle more than one
 input. In this case the matching between the inputs can be calculated additionally.
 The filter always passes through the first input. The signature of each stream can
@@ -6693,94 +6693,94 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#signature)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='signature', typings_input='[StreamType.video] * int(nb_inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "detectmode": detectmode,
-            
+
             "nb_inputs": nb_inputs,
-            
+
             "filename": filename,
-            
+
             "format": format,
-            
+
             "th_d": th_d,
-            
+
             "th_dc": th_dc,
-            
+
             "th_xh": th_xh,
-            
+
             "th_di": th_di,
-            
+
             "th_it": th_it,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
 def spectrumsynth(
-    
 
-    
-        
+
+
+
         _magnitude: VideoStream,
-        
-    
-        
+
+
+
         _phase: VideoStream,
-        
-    
+
+
 
 
     *,
     sample_rate: Int = Default('44100'),channels: Int = Default('1'),scale: Int| Literal["lin","log"] | Default = Default('log'),slide: Int| Literal["replace","scroll","fullframe","rscroll"] | Default = Default('fullframe'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('rect'),overlap: Float = Default('1'),orientation: Int| Literal["vertical","horizontal"] | Default = Default('vertical'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Synthesize audio from 2 input video spectrums, first input stream represents
 magnitude across time and second represents phase across time.
 The filter will transform from frequency domain as displayed in videos back
@@ -6817,90 +6817,90 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#spectrumsynth)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='spectrumsynth', typings_input=('video', 'video'), typings_output=('audio',)),
-        
 
-        
-            
+
+
+
             _magnitude,
-            
-        
-            
+
+
+
             _phase,
-            
-        
+
+
 
 
         **merge({
-            
+
             "sample_rate": sample_rate,
-            
+
             "channels": channels,
-            
+
             "scale": scale,
-            
+
             "slide": slide,
-            
+
             "win_func": win_func,
-            
+
             "overlap": overlap,
-            
+
             "orientation": orientation,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def ssim(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Obtain the SSIM (Structural SImilarity Metric) between two input videos.
 
 This filter takes in input two input videos, the first input is
@@ -6930,7 +6930,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ssim)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -6941,68 +6941,68 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='ssim', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
             "stats_file": stats_file,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def ssim360(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),compute_chroma: Int = Default('1'),frame_skip_ratio: Int = Default('0'),ref_projection: Int| Literal["e","equirect","c3x2","c2x3","barrel","barrelsplit"] | Default = Default('e'),main_projection: Int| Literal["e","equirect","c3x2","c2x3","barrel","barrelsplit"] | Default = Default('5'),ref_stereo: Int| Literal["mono","tb","lr"] | Default = Default('mono'),main_stereo: Int| Literal["mono","tb","lr"] | Default = Default('3'),ref_pad: Float = Default('0'),main_pad: Float = Default('0'),use_tape: Int = Default('0'),heatmap_str: String = Default(None),default_heatmap_width: Int = Default('32'),default_heatmap_height: Int = Default('16'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Calculate the SSIM between two 360 video streams.
 
 
@@ -7030,7 +7030,7 @@ References:
     [FFmpeg Documentation](None)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -7038,85 +7038,85 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='ssim360', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
             "stats_file": stats_file,
-            
+
             "compute_chroma": compute_chroma,
-            
+
             "frame_skip_ratio": frame_skip_ratio,
-            
+
             "ref_projection": ref_projection,
-            
+
             "main_projection": main_projection,
-            
+
             "ref_stereo": ref_stereo,
-            
+
             "main_stereo": main_stereo,
-            
+
             "ref_pad": ref_pad,
-            
+
             "main_pad": main_pad,
-            
+
             "use_tape": use_tape,
-            
+
             "heatmap_str": heatmap_str,
-            
+
             "default_heatmap_width": default_heatmap_width,
-            
+
             "default_heatmap_height": default_heatmap_height,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def streamselect(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),map: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Select video or audio streams.
 
 The filter accepts the following options:
@@ -7135,94 +7135,94 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#streamselect)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='streamselect', typings_input='[StreamType.video] * int(inputs)', typings_output="[StreamType.video] * len(re.findall(r'\\d+', str(map)))"),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "map": map,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def threshold(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _threshold: VideoStream,
-        
-    
-        
+
+
+
         _min: VideoStream,
-        
-    
-        
+
+
+
         _max: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply threshold effect to video stream.
 
 This filter needs four video streams to perform thresholding.
@@ -7245,7 +7245,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#threshold)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -7253,104 +7253,104 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='threshold', typings_input=('video', 'video', 'video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _threshold,
-            
-        
-            
+
+
+
             _min,
-            
-        
-            
+
+
+
             _max,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def unpremultiply(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     planes: Int = Default('15'),inplace: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply alpha unpremultiply effect to input video stream using first plane
 of second stream as alpha.
 
@@ -7372,7 +7372,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#unpremultiply)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -7380,77 +7380,77 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='unpremultiply', typings_input='[StreamType.video] + ([StreamType.video] if inplace else [])', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "inplace": inplace,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
 def varblur(
-    
 
-    
-        
+
+
+
         _default: VideoStream,
-        
-    
-        
+
+
+
         _radius: VideoStream,
-        
-    
+
+
 
 
     *,
     min_r: Int = Default('0'),max_r: Int = Default('8'),planes: Int = Default('15'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply variable blur filter by using 2nd video stream to set blur radius.
 The 2nd stream must have the same dimensions.
 
@@ -7472,7 +7472,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#varblur)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -7483,89 +7483,89 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='varblur', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _default,
-            
-        
-            
+
+
+
             _radius,
-            
-        
+
+
 
 
         **merge({
-            
+
             "min_r": min_r,
-            
+
             "max_r": max_r,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
 def vif(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Obtain the average VIF (Visual Information Fidelity) between two input videos.
 
 This filter takes two input videos.
@@ -7602,7 +7602,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vif)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -7613,65 +7613,65 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='vif', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
 def vstack(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),shortest: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos vertically.
 
 All streams must be of same pixel format and of same width.
@@ -7694,54 +7694,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vstack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='vstack', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def vstack_vaapi(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Default('2'),shortest: Boolean = Default('false'),width: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos vertically.
 
 This is the VA-API variant of the vstack filter, each input stream may
@@ -7764,78 +7764,78 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vstack_vaapi)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='vstack_vaapi', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
             "width": width,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def xcorrelate(
-    
 
-    
-        
+
+
+
         _primary: VideoStream,
-        
-    
-        
+
+
+
         _secondary: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('7'),secondary: Int| Literal["first","all"] | Default = Default('all'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply normalized cross-correlation between first and second input video stream.
 
 Second input video stream dimensions must be lower than first input video stream.
@@ -7857,7 +7857,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xcorrelate)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -7868,65 +7868,65 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xcorrelate', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _primary,
-            
-        
-            
+
+
+
             _secondary,
-            
-        
+
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "secondary": secondary,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xfade(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _xfade: VideoStream,
-        
-    
+
+
 
 
     *,
     transition: Int| Literal["custom","fade","wipeleft","wiperight","wipeup","wipedown","slideleft","slideright","slideup","slidedown","circlecrop","rectcrop","distance","fadeblack","fadewhite","radial","smoothleft","smoothright","smoothup","smoothdown","circleopen","circleclose","vertopen","vertclose","horzopen","horzclose","dissolve","pixelize","diagtl","diagtr","diagbl","diagbr","hlslice","hrslice","vuslice","vdslice","hblur","fadegrays","wipetl","wipetr","wipebl","wipebr","squeezeh","squeezev","zoomin","fadefast","fadeslow","hlwind","hrwind","vuwind","vdwind","coverleft","coverright","coverup","coverdown","revealleft","revealright","revealup","revealdown"] | Default = Default('fade'),duration: Duration = Default('1'),offset: Duration = Default('0'),expr: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply cross fade from one input video stream to another input video stream.
 The cross fade is applied for specified duration.
 
@@ -7950,70 +7950,70 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xfade)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xfade', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _xfade,
-            
-        
+
+
 
 
         **merge({
-            
+
             "transition": transition,
-            
+
             "duration": duration,
-            
+
             "offset": offset,
-            
+
             "expr": expr,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xfade_opencl(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _xfade: VideoStream,
-        
-    
+
+
 
 
     *,
     transition: Int| Literal["custom","fade","wipeleft","wiperight","wipeup","wipedown","slideleft","slideright","slideup","slidedown"] | Default = Default('fade'),source: String = Default(None),kernel: String = Default(None),duration: Duration = Default('1'),offset: Duration = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Cross fade two videos with custom transition effect by using OpenCL.
 
 It accepts the following options:
@@ -8034,74 +8034,74 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xfade_opencl)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xfade_opencl', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _xfade,
-            
-        
+
+
 
 
         **merge({
-            
+
             "transition": transition,
-            
+
             "source": source,
-            
+
             "kernel": kernel,
-            
+
             "duration": duration,
-            
+
             "offset": offset,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xmedian(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),planes: Int = Default('15'),percentile: Float = Default('0.5'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Pick median pixels from several input videos.
 
 The filter accepts the following options:
@@ -8122,7 +8122,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xmedian)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -8133,69 +8133,69 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xmedian', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "planes": planes,
-            
+
             "percentile": percentile,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xpsnr(
-    
 
-    
-        
+
+
+
         _main: VideoStream,
-        
-    
-        
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Obtain the average (across all input frames) and minimum (across all color plane averages)
 eXtended Perceptually weighted peak Signal-to-Noise Ratio (XPSNR) between two input videos.
 
@@ -8221,7 +8221,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xpsnr)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -8232,57 +8232,57 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xpsnr', typings_input=('video', 'video'), typings_output=('video',)),
-        
 
-        
-            
+
+
+
             _main,
-            
-        
-            
+
+
+
             _reference,
-            
-        
+
+
 
 
         **merge({
-            
+
             "stats_file": stats_file,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xstack(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),layout: String = Default(None),grid: Image_size = Default(None),shortest: Boolean = Default('false'),fill: String = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack video inputs into custom layout.
 
 All streams must be of same pixel format.
@@ -8305,60 +8305,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xstack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xstack', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "layout": layout,
-            
+
             "grid": grid,
-            
+
             "shortest": shortest,
-            
+
             "fill": fill,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xstack_vaapi(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Default('2'),shortest: Boolean = Default('false'),layout: String = Default(None),grid: Image_size = Default(None),grid_tile_size: Image_size = Default(None),fill: String = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack video inputs into custom layout.
 
 This is the VA-API variant of the xstack filter,  each input stream may
@@ -8384,53 +8384,36 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xstack_vaapi)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xstack_vaapi', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
             "layout": layout,
-            
+
             "grid": grid,
-            
+
             "grid_tile_size": grid_tile_size,
-            
+
             "fill": fill,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
-
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    
-
-    

--- a/packages/v8/src/ffmpeg/formats/demuxers.py
+++ b/packages/v8/src/ffmpeg/formats/demuxers.py
@@ -412,45 +412,45 @@ from ..streams.audio import AudioStream
 
 
 def _3dostr(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     3DO STR
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def _4xm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     4X Technologies
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def aa(
-    
+
     aa_fixed_key: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Audible AA format files
-    
+
     Args:
         aa_fixed_key: Fixed key used for handling Audible AA files
 
@@ -458,53 +458,53 @@ def aa(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "aa_fixed_key": aa_fixed_key,
-        
+
     }))
 
 
 
 def aac(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw ADTS AAC (Advanced Audio Coding)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def aax(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CRI AAX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ac3(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw AC-3
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -512,53 +512,53 @@ def ac3(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def ac4(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw AC-4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ace(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     tri-Ace Audio Container
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def acm(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Interplay ACM
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -566,41 +566,41 @@ def acm(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def act(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     ACT Voice file format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def adf(
-    
+
     linespeed: int | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Artworx Data Format
-    
+
     Args:
         linespeed: set simulated line speed (bytes per second) (from 1 to INT_MAX) (default 6000)
         video_size: set video size, such as 640x480 or hd720.
@@ -610,139 +610,139 @@ def adf(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "linespeed": linespeed,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def adp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     ADP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ads(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony PS2 ADS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def adx(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CRI ADX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def aea(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MD STUDIO audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def afc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AFC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def aiff(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Audio IFF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def aix(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CRI AIX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def alaw(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM A-law
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -751,39 +751,39 @@ def alaw(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def alias_pix(
-    
+
     pattern_type: int | None| Literal["glob_sequence", "glob", "sequence", "none"] = None,
-    
+
     start_number: int | None = None,
-    
+
     start_number_range: int | None = None,
-    
+
     ts_from_file: int | None| Literal["none", "sec", "ns"] = None,
-    
+
     export_path_metadata: bool | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Alias/Wavefront PIX image
-    
+
     Args:
         pattern_type: set pattern type (from 0 to INT_MAX) (default 4)
         start_number: set first number in the sequence (from INT_MIN to INT_MAX) (default 0)
@@ -799,53 +799,53 @@ def alias_pix(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "pattern_type": pattern_type,
-        
+
         "start_number": start_number,
-        
+
         "start_number_range": start_number_range,
-        
+
         "ts_from_file": ts_from_file,
-        
+
         "export_path_metadata": export_path_metadata,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def alp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     LEGO Racers ALP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def amr(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     3GPP AMR
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -853,21 +853,21 @@ def amr(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def amrnb(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw AMR-NB
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -875,21 +875,21 @@ def amrnb(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def amrwb(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw AMR-WB
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -897,37 +897,37 @@ def amrwb(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def anm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Deluxe Paint Animation
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def apac(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw APAC
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -935,73 +935,73 @@ def apac(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def apc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CRYO APC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ape(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Monkey's Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def apm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Ubisoft Rayman 2 APM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def apng(
-    
+
     ignore_loop: bool | None = None,
-    
+
     max_fps: int | None = None,
-    
+
     default_fps: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Animated Portable Network Graphics
-    
+
     Args:
         ignore_loop: ignore loop setting (default true)
         max_fps: maximum framerate (0 is no limit) (from 0 to INT_MAX) (default 0)
@@ -1011,25 +1011,25 @@ def apng(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "ignore_loop": ignore_loop,
-        
+
         "max_fps": max_fps,
-        
+
         "default_fps": default_fps,
-        
+
     }))
 
 
 
 def aptx(
-    
+
     sample_rate: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw aptX
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 48000)
 
@@ -1037,21 +1037,21 @@ def aptx(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
     }))
 
 
 
 def aptx_hd(
-    
+
     sample_rate: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw aptX HD
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 48000)
 
@@ -1059,21 +1059,21 @@ def aptx_hd(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
     }))
 
 
 
 def apv(
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     APV raw bitstream
-    
+
     Args:
         framerate: set frame rate (default "30")
 
@@ -1081,21 +1081,21 @@ def apv(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def aqtitle(
-    
+
     subfps: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AQTitle subtitles
-    
+
     Args:
         subfps: set the movie frame rate (from 0 to INT_MAX) (default 25/1)
 
@@ -1103,71 +1103,71 @@ def aqtitle(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "subfps": subfps,
-        
+
     }))
 
 
 
 def argo_asf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Argonaut Games ASF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def argo_brp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Argonaut Games BRP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def argo_cvg(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Argonaut Games CVG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def asf(
-    
+
     no_resync_search: bool | None = None,
-    
+
     export_xmp: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     ASF (Advanced / Active Streaming Format)
-    
+
     Args:
         no_resync_search: Don't try to resynchronize by looking for a certain optional start code (default false)
         export_xmp: Export full XMP metadata (default false)
@@ -1176,87 +1176,87 @@ def asf(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "no_resync_search": no_resync_search,
-        
+
         "export_xmp": export_xmp,
-        
+
     }))
 
 
 
 def asf_o(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     ASF (Advanced / Active Streaming Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ass(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SSA (SubStation Alpha) subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ast(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AST (Audio Stream)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def au(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sun AU
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def av1(
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AV1 Annex B
-    
+
     Args:
         framerate: (default "25")
 
@@ -1264,21 +1264,21 @@ def av1(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def avi(
-    
+
     use_odml: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AVI (Audio Video Interleaved)
-    
+
     Args:
         use_odml: use odml index (default true)
 
@@ -1286,55 +1286,55 @@ def avi(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "use_odml": use_odml,
-        
+
     }))
 
 
 
 def avr(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AVR (Audio Visual Research)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def avs(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Argonaut Games Creature Shock
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def avs2(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw AVS2-P2/IEEE1857.4
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -1343,25 +1343,25 @@ def avs2(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def avs3(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw AVS3-P2/IEEE1857.10
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -1370,75 +1370,75 @@ def avs3(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def bethsoftvid(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Bethesda Softworks VID
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def bfi(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Brute Force & Ignorance
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def bfstm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     BFSTM (Binary Cafe Stream)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def bin(
-    
+
     linespeed: int | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Binary text
-    
+
     Args:
         linespeed: set simulated line speed (bytes per second) (from 1 to INT_MAX) (default 6000)
         video_size: set video size, such as 640x480 or hd720.
@@ -1448,77 +1448,77 @@ def bin(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "linespeed": linespeed,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def bink(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Bink
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def binka(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Bink Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def bit(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     G.729 BIT file format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def bitpacked(
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Bitpacked
-    
+
     Args:
         pixel_format: set pixel format (default "yuv420p")
         video_size: set frame size
@@ -1528,33 +1528,33 @@ def bitpacked(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def bmp_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped bmp sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -1566,61 +1566,61 @@ def bmp_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def bmv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Discworld II BMV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def boa(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Black Ops Audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def bonk(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw Bonk
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -1628,37 +1628,37 @@ def bonk(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def brender_pix(
-    
+
     pattern_type: int | None| Literal["glob_sequence", "glob", "sequence", "none"] = None,
-    
+
     start_number: int | None = None,
-    
+
     start_number_range: int | None = None,
-    
+
     ts_from_file: int | None| Literal["none", "sec", "ns"] = None,
-    
+
     export_path_metadata: bool | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     BRender PIX image
-    
+
     Args:
         pattern_type: set pattern type (from 0 to INT_MAX) (default 4)
         start_number: set first number in the sequence (from INT_MIN to INT_MAX) (default 0)
@@ -1674,87 +1674,87 @@ def brender_pix(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "pattern_type": pattern_type,
-        
+
         "start_number": start_number,
-        
+
         "start_number_range": start_number_range,
-        
+
         "ts_from_file": ts_from_file,
-        
+
         "export_path_metadata": export_path_metadata,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def brstm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     BRSTM (Binary Revolution Stream)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def c93(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Interplay C93
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def caf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Apple CAF (Core Audio Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def cavsvideo(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw Chinese AVS (Audio Video Standard)
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -1763,41 +1763,41 @@ def cavsvideo(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def cdg(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CD Graphics
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def cdxl(
-    
+
     sample_rate: int | None = None,
-    
+
     frame_rate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Commodore CDXL video
-    
+
     Args:
         sample_rate: (from 8000 to INT_MAX) (default 11025)
         frame_rate: (default "15")
@@ -1806,39 +1806,39 @@ def cdxl(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "frame_rate": frame_rate,
-        
+
     }))
 
 
 
 def cine(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Phantom Cine
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def codec2(
-    
+
     frames_per_packet: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     codec2 .c2 demuxer
-    
+
     Args:
         frames_per_packet: Number of frames to read at a time. Higher = faster decoding, lower granularity (from 1 to INT_MAX) (default 1)
 
@@ -1846,23 +1846,23 @@ def codec2(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frames_per_packet": frames_per_packet,
-        
+
     }))
 
 
 
 def codec2raw(
-    
+
     mode: int | None| Literal["3200", "2400", "1600", "1400", "1300", "1200", "700", "700B", "700C"] = None,
-    
+
     frames_per_packet: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw codec2 demuxer
-    
+
     Args:
         mode: codec2 mode [mandatory] (from -1 to 8) (default -1)
         frames_per_packet: Number of frames to read at a time. Higher = faster decoding, lower granularity (from 1 to INT_MAX) (default 1)
@@ -1871,27 +1871,27 @@ def codec2raw(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "mode": mode,
-        
+
         "frames_per_packet": frames_per_packet,
-        
+
     }))
 
 
 
 def concat(
-    
+
     safe: bool | None = None,
-    
+
     auto_convert: bool | None = None,
-    
+
     segment_time_metadata: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Virtual concatenation script
-    
+
     Args:
         safe: enable safe mode (default true)
         auto_convert: automatically convert bitstream format (default true)
@@ -1901,33 +1901,33 @@ def concat(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "safe": safe,
-        
+
         "auto_convert": auto_convert,
-        
+
         "segment_time_metadata": segment_time_metadata,
-        
+
     }))
 
 
 
 def cri_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped cri sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -1939,29 +1939,29 @@ def cri_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def data(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw data
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -1969,61 +1969,61 @@ def data(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def daud(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     D-Cinema audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dcstr(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sega DC STR
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dds_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped dds sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -2035,63 +2035,63 @@ def dds_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def derf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Xilam DERF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dfa(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Chronomaster DFA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dfpwm(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw DFPWM1a
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 48000)
         ch_layout: (default "mono")
@@ -2100,41 +2100,41 @@ def dfpwm(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def dhav(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Video DAV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dirac(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw Dirac
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -2143,25 +2143,25 @@ def dirac(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def dnxhd(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw DNxHD (SMPTE VC-3)
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -2170,31 +2170,31 @@ def dnxhd(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def dpx_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped dpx sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -2206,77 +2206,77 @@ def dpx_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def dsf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     DSD Stream File (DSF)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dsicin(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Delphine Software International CIN
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dss(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Digital Speech Standard (DSS)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dts(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw DTS
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -2284,53 +2284,53 @@ def dts(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def dtshd(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw DTS-HD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     DV (Digital Video)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def dvbsub(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw dvbsub
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -2338,21 +2338,21 @@ def dvbsub(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def dvbtxt(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     dvbtxt
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -2360,37 +2360,37 @@ def dvbtxt(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def dxa(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     DXA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ea(
-    
+
     merge_alpha: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Electronic Arts Multimedia
-    
+
     Args:
         merge_alpha: return VP6 alpha in the main video stream (default false)
 
@@ -2398,37 +2398,37 @@ def ea(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "merge_alpha": merge_alpha,
-        
+
     }))
 
 
 
 def ea_cdata(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Electronic Arts cdata
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def eac3(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw E-AC-3
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -2436,37 +2436,37 @@ def eac3(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def epaf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Ensoniq Paris Audio File
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def evc(
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     EVC Annex B
-    
+
     Args:
         framerate: (default "25")
 
@@ -2474,29 +2474,29 @@ def evc(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def exr_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped exr sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -2508,31 +2508,31 @@ def exr_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def f32be(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM 32-bit floating-point big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -2541,25 +2541,25 @@ def f32be(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def f32le(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM 32-bit floating-point little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -2568,25 +2568,25 @@ def f32le(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def f64be(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM 64-bit floating-point big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -2595,25 +2595,25 @@ def f64be(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def f64le(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM 64-bit floating-point little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -2622,87 +2622,87 @@ def f64le(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def d(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     fbdev           Linux framebuffer
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ffmetadata(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     FFmpeg metadata in text
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def film_cpk(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sega FILM / CPK
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def filmstrip(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Adobe Filmstrip
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def fits(
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Flexible Image Transport System
-    
+
     Args:
         framerate: set the framerate (default "1")
 
@@ -2710,21 +2710,21 @@ def fits(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def flac(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw FLAC
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -2732,41 +2732,41 @@ def flac(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def flic(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     FLI/FLC/FLX animation
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def flv(
-    
+
     flv_metadata: bool | None = None,
-    
+
     flv_full_metadata: bool | None = None,
-    
+
     flv_ignore_prevtag: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     FLV (Flash Video)
-    
+
     Args:
         flv_metadata: Allocate streams according to the onMetaData array (default false)
         flv_full_metadata: Dump full metadata of the onMetadata (default false)
@@ -2776,73 +2776,73 @@ def flv(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "flv_metadata": flv_metadata,
-        
+
         "flv_full_metadata": flv_full_metadata,
-        
+
         "flv_ignore_prevtag": flv_ignore_prevtag,
-        
+
     }))
 
 
 
 def frm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Megalux Frame
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def fsb(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     FMOD Sample Bank
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def fwse(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Capcom's MT Framework sound
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def g722(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw G.722
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -2850,39 +2850,39 @@ def g722(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def g723_1(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     G.723.1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def g726(
-    
+
     code_size: int | None = None,
-    
+
     sample_rate: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw big-endian G.726 ("left aligned")
-    
+
     Args:
         code_size: Bits per G.726 code (from 2 to 5) (default 4)
         sample_rate: (from 0 to INT_MAX) (default 8000)
@@ -2891,25 +2891,25 @@ def g726(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "code_size": code_size,
-        
+
         "sample_rate": sample_rate,
-        
+
     }))
 
 
 
 def g726le(
-    
+
     code_size: int | None = None,
-    
+
     sample_rate: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw little-endian G.726 ("right aligned")
-    
+
     Args:
         code_size: Bits per G.726 code (from 2 to 5) (default 4)
         sample_rate: (from 0 to INT_MAX) (default 8000)
@@ -2918,39 +2918,39 @@ def g726le(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "code_size": code_size,
-        
+
         "sample_rate": sample_rate,
-        
+
     }))
 
 
 
 def g728(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw G.728
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def g729(
-    
+
     bit_rate: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     G.729 raw format demuxer
-    
+
     Args:
         bit_rate: (from 0 to INT_MAX) (default 8000)
 
@@ -2958,45 +2958,45 @@ def g729(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "bit_rate": bit_rate,
-        
+
     }))
 
 
 
 def gdv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Gremlin Digital Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def gem_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped gem sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3008,51 +3008,51 @@ def gem_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def genh(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     GENeric Header
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def gif(
-    
+
     min_delay: int | None = None,
-    
+
     max_gif_delay: int | None = None,
-    
+
     default_delay: int | None = None,
-    
+
     ignore_loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CompuServe Graphics Interchange Format (GIF)
-    
+
     Args:
         min_delay: minimum valid delay between frames (in hundredths of second) (from 0 to 6000) (default 2)
         max_gif_delay: maximum valid delay between frames (in hundredths of seconds) (from 0 to 65535) (default 65535)
@@ -3063,35 +3063,35 @@ def gif(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "min_delay": min_delay,
-        
+
         "max_gif_delay": max_gif_delay,
-        
+
         "default_delay": default_delay,
-        
+
         "ignore_loop": ignore_loop,
-        
+
     }))
 
 
 
 def gif_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped gif sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3103,29 +3103,29 @@ def gif_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def gsm(
-    
+
     sample_rate: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw GSM
-    
+
     Args:
         sample_rate: (from 1 to 6.50753e+07) (default 8000)
 
@@ -3133,39 +3133,39 @@ def gsm(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
     }))
 
 
 
 def gxf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     GXF (General eXchange Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def h261(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw H.261
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -3174,25 +3174,25 @@ def h261(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def h263(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw H.263
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -3201,25 +3201,25 @@ def h263(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def h264(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw H.264 video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -3228,27 +3228,27 @@ def h264(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def hca(
-    
+
     hca_lowkey: int | None = None,
-    
+
     hca_highkey: int | None = None,
-    
+
     hca_subkey: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CRI HCA
-    
+
     Args:
         hca_lowkey: Low key used for handling CRI HCA files (from 0 to UINT32_MAX) (default 0)
         hca_highkey: High key used for handling CRI HCA files (from 0 to UINT32_MAX) (default 0)
@@ -3258,49 +3258,49 @@ def hca(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "hca_lowkey": hca_lowkey,
-        
+
         "hca_highkey": hca_highkey,
-        
+
         "hca_subkey": hca_subkey,
-        
+
     }))
 
 
 
 def hcom(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Macintosh HCOM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def hdr_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped hdr sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3312,31 +3312,31 @@ def hdr_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def hevc(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw HEVC video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -3345,45 +3345,45 @@ def hevc(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def hls(
-    
+
     live_start_index: int | None = None,
-    
+
     prefer_x_start: bool | None = None,
-    
+
     allowed_extensions: str | None = None,
-    
+
     allowed_segment_extensions: str | None = None,
-    
+
     extension_picky: bool | None = None,
-    
+
     max_reload: int | None = None,
-    
+
     m3u8_hold_counters: int | None = None,
-    
+
     http_persistent: bool | None = None,
-    
+
     http_multiple: bool | None = None,
-    
+
     http_seekable: bool | None = None,
-    
+
     seg_format_options: str | None = None,
-    
+
     seg_max_retry: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Apple HTTP Live Streaming
-    
+
     Args:
         live_start_index: segment index to start live streams at (negative values are from the end) (from INT_MIN to INT_MAX) (default -3)
         prefer_x_start: prefer to use #EXT-X-START if it's in playlist instead of live_start_index (default false)
@@ -3402,111 +3402,111 @@ def hls(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "live_start_index": live_start_index,
-        
+
         "prefer_x_start": prefer_x_start,
-        
+
         "allowed_extensions": allowed_extensions,
-        
+
         "allowed_segment_extensions": allowed_segment_extensions,
-        
+
         "extension_picky": extension_picky,
-        
+
         "max_reload": max_reload,
-        
+
         "m3u8_hold_counters": m3u8_hold_counters,
-        
+
         "http_persistent": http_persistent,
-        
+
         "http_multiple": http_multiple,
-        
+
         "http_seekable": http_seekable,
-        
+
         "seg_format_options": seg_format_options,
-        
+
         "seg_max_retry": seg_max_retry,
-        
+
     }))
 
 
 
 def hnm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Cryo HNM v4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def iamf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Raw Immersive Audio Model and Formats
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ico(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Microsoft Windows ICO
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def idcin(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     id Cinematic
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def idf(
-    
+
     linespeed: int | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     iCE Draw File
-    
+
     Args:
         linespeed: set simulated line speed (bytes per second) (from 1 to INT_MAX) (default 6000)
         video_size: set video size, such as 640x480 or hd720.
@@ -3516,89 +3516,89 @@ def idf(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "linespeed": linespeed,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def iff(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     IFF (Interchange File Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ifv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     IFV CCTV DVR
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ilbc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     iLBC storage
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def image2(
-    
+
     pattern_type: int | None| Literal["glob_sequence", "glob", "sequence", "none"] = None,
-    
+
     start_number: int | None = None,
-    
+
     start_number_range: int | None = None,
-    
+
     ts_from_file: int | None| Literal["none", "sec", "ns"] = None,
-    
+
     export_path_metadata: bool | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     image2 sequence
-    
+
     Args:
         pattern_type: set pattern type (from 0 to INT_MAX) (default 4)
         start_number: set first number in the sequence (from INT_MIN to INT_MAX) (default 0)
@@ -3614,45 +3614,45 @@ def image2(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "pattern_type": pattern_type,
-        
+
         "start_number": start_number,
-        
+
         "start_number_range": start_number_range,
-        
+
         "ts_from_file": ts_from_file,
-        
+
         "export_path_metadata": export_path_metadata,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def image2pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped image2 sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3664,31 +3664,31 @@ def image2pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def ingenient(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw Ingenient MJPEG
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -3697,39 +3697,39 @@ def ingenient(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def ipmovie(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Interplay MVE
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ipu(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw IPU Video
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -3737,109 +3737,109 @@ def ipu(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def ircam(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Berkeley/IRCAM/CARL Sound Format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def iss(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Funcom ISS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def iv8(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     IndigoVision 8000 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ivf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     On2 IVF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ivr(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     IVR (Internet Video Recording)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def j2k_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped j2k sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3851,53 +3851,53 @@ def j2k_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def jacosub(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     JACOsub subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def jpeg_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped jpeg sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3909,37 +3909,37 @@ def jpeg_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def jpegls_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped jpegls sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -3951,53 +3951,53 @@ def jpegls_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def jpegxl_anim(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Animated JPEG XL
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def jpegxl_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped jpegxl sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -4009,65 +4009,65 @@ def jpegxl_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def jv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Bitmap Brothers JV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def d(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     kmsgrab         KMS screen capture
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def kux(
-    
+
     flv_metadata: bool | None = None,
-    
+
     flv_full_metadata: bool | None = None,
-    
+
     flv_ignore_prevtag: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     KUX (YouKu)
-    
+
     Args:
         flv_metadata: Allocate streams according to the onMetaData array (default false)
         flv_full_metadata: Dump full metadata of the onMetadata (default false)
@@ -4077,93 +4077,93 @@ def kux(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "flv_metadata": flv_metadata,
-        
+
         "flv_full_metadata": flv_full_metadata,
-        
+
         "flv_ignore_prevtag": flv_ignore_prevtag,
-        
+
     }))
 
 
 
 def kvag(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Simon & Schuster Interactive VAG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def laf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     LAF (Limitless Audio Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def d(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     lavfi           Libavfilter virtual input device
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def lc3(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     LC3 (Low Complexity Communication Codec)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def live_flv(
-    
+
     flv_metadata: bool | None = None,
-    
+
     flv_full_metadata: bool | None = None,
-    
+
     flv_ignore_prevtag: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     live RTMP FLV (Flash Video)
-    
+
     Args:
         flv_metadata: Allocate streams according to the onMetaData array (default false)
         flv_full_metadata: Dump full metadata of the onMetadata (default false)
@@ -4173,41 +4173,41 @@ def live_flv(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "flv_metadata": flv_metadata,
-        
+
         "flv_full_metadata": flv_full_metadata,
-        
+
         "flv_ignore_prevtag": flv_ignore_prevtag,
-        
+
     }))
 
 
 
 def lmlm4(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw lmlm4
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def loas(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     LOAS AudioSyncStream
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -4215,87 +4215,87 @@ def loas(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def lrc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     LRC lyrics
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def luodat(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Video CCTV DAT
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def lvf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     LVF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def lxf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     VR native stream (LXF)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def m4v(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw MPEG-4 video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -4304,39 +4304,39 @@ def m4v(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def mca(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MCA Audio Format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mcc(
-    
+
     eia608_extract: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MacCaption
-    
+
     Args:
         eia608_extract: extract EIA-608/708 captions from VANC packets (default true)
 
@@ -4344,37 +4344,37 @@ def mcc(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "eia608_extract": eia608_extract,
-        
+
     }))
 
 
 
 def mgsts(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Metal Gear Solid: The Twin Snakes
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def microdvd(
-    
+
     subfps: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MicroDVD subtitle format
-    
+
     Args:
         subfps: set the movie frame rate fallback (from 0 to INT_MAX) (default 0/1)
 
@@ -4382,23 +4382,23 @@ def microdvd(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "subfps": subfps,
-        
+
     }))
 
 
 
 def mjpeg(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw MJPEG video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -4407,25 +4407,25 @@ def mjpeg(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def mjpeg_2000(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw MJPEG 2000 video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -4434,23 +4434,23 @@ def mjpeg_2000(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def mlp(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw MLP
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -4458,101 +4458,101 @@ def mlp(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def mlv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Magic Lantern Video (MLV)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     American Laser Games MM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mmf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Yamaha SMAF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mods(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MobiClip MODS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def moflex(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MobiClip MOFLEX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mp3(
-    
+
     usetoc: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MP2/3 (MPEG audio layer 2/3)
-    
+
     Args:
         usetoc: use table of contents (default false)
 
@@ -4560,79 +4560,79 @@ def mp3(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "usetoc": usetoc,
-        
+
     }))
 
 
 
 def mpc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Musepack
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mpc8(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Musepack SV8
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mpeg(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MPEG-PS (MPEG-2 Program Stream)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mpegts(
-    
+
     resync_size: int | None = None,
-    
+
     fix_teletext_pts: bool | None = None,
-    
+
     scan_all_pmts: bool | None = None,
-    
+
     skip_unknown_pmt: bool | None = None,
-    
+
     merge_pmt_versions: bool | None = None,
-    
+
     max_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MPEG-TS (MPEG-2 Transport Stream)
-    
+
     Args:
         resync_size: set size limit for looking up a new synchronization (from 0 to INT_MAX) (default 65536)
         fix_teletext_pts: try to fix pts values of dvb teletext streams (default true)
@@ -4645,33 +4645,33 @@ def mpegts(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "resync_size": resync_size,
-        
+
         "fix_teletext_pts": fix_teletext_pts,
-        
+
         "scan_all_pmts": scan_all_pmts,
-        
+
         "skip_unknown_pmt": skip_unknown_pmt,
-        
+
         "merge_pmt_versions": merge_pmt_versions,
-        
+
         "max_packet_size": max_packet_size,
-        
+
     }))
 
 
 
 def mpegtsraw(
-    
+
     resync_size: int | None = None,
-    
+
     compute_pcr: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw MPEG-TS (MPEG-2 Transport Stream)
-    
+
     Args:
         resync_size: set size limit for looking up a new synchronization (from 0 to INT_MAX) (default 65536)
         compute_pcr: compute exact PCR for each transport stream packet (default false)
@@ -4680,25 +4680,25 @@ def mpegtsraw(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "resync_size": resync_size,
-        
+
         "compute_pcr": compute_pcr,
-        
+
     }))
 
 
 
 def mpegvideo(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw MPEG video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -4707,23 +4707,23 @@ def mpegvideo(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def mpjpeg(
-    
+
     strict_mime_boundary: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MIME multipart JPEG
-    
+
     Args:
         strict_mime_boundary: require MIME boundaries match (default false)
 
@@ -4731,135 +4731,135 @@ def mpjpeg(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "strict_mime_boundary": strict_mime_boundary,
-        
+
     }))
 
 
 
 def mpl2(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MPL2 subtitles
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mpsub(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MPlayer subtitles
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def msf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony PS3 MSF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def msnwctcp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MSN TCP Webcam stream
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def msp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Microsoft Paint (MSP))
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mtaf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Konami PS2 MTAF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mtv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MTV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mulaw(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM mu-law
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -4868,71 +4868,71 @@ def mulaw(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def musx(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Eurocom MUSX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Silicon Graphics Movie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mvi(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Motion Pixels MVI
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def mxf(
-    
+
     eia608_extract: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MXF (Material eXchange Format)
-    
+
     Args:
         eia608_extract: extract eia 608 captions from s436m track (default false)
 
@@ -4940,133 +4940,133 @@ def mxf(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "eia608_extract": eia608_extract,
-        
+
     }))
 
 
 
 def mxg(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MxPEG clip
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def nc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     NC camera feed
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def nistsphere(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     NIST SPeech HEader REsources
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def nsp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Computerized Speech Lab NSP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def nsv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Nullsoft Streaming Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def nut(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     NUT
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def nuv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     NuppelVideo
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def obu(
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     AV1 low overhead OBU
-    
+
     Args:
         framerate: (default "25")
 
@@ -5074,53 +5074,53 @@ def obu(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def ogg(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Ogg
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def oma(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony OpenMG audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def osq(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw OSQ
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -5128,61 +5128,61 @@ def osq(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def d(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     oss             OSS (Open Sound System) capture
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def paf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Amazing Studio Packed Animation File
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def pam_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pam sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5194,37 +5194,37 @@ def pam_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pbm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pbm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5236,37 +5236,37 @@ def pbm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pcx_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pcx sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5278,53 +5278,53 @@ def pcx_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pdv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PlayDate Video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def pfm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pfm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5336,37 +5336,37 @@ def pfm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pgm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pgm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5378,37 +5378,37 @@ def pgm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pgmyuv_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pgmyuv sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5420,37 +5420,37 @@ def pgmyuv_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pgx_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pgx sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5462,37 +5462,37 @@ def pgx_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def phm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped phm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5504,37 +5504,37 @@ def phm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def photocd_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped photocd sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5546,37 +5546,37 @@ def photocd_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pictor_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped pictor sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5588,69 +5588,69 @@ def pictor_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pjs(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PJS (Phoenix Japanimation Society) subtitles
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def pmp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Playstation Portable PMP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def png_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped png sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5662,53 +5662,53 @@ def png_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def pp_bnk(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Pro Pinball Series Soundbank
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ppm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped ppm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5720,37 +5720,37 @@ def ppm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def psd_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped psd sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5762,101 +5762,101 @@ def psd_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def psxstr(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony Playstation STR
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def pva(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     TechnoTrend PVA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def pvf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PVF (Portable Voice Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def qcp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     QCP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def qdraw_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped qdraw sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5868,53 +5868,53 @@ def qdraw_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def qoa(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     QOA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def qoi_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped qoi sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -5926,49 +5926,49 @@ def qoi_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def r3d(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     REDCODE R3D
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rawvideo(
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw video
-    
+
     Args:
         pixel_format: set pixel format (default "yuv420p")
         video_size: set frame size
@@ -5978,195 +5978,195 @@ def rawvideo(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def rcwt(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RCWT (Raw Captions With Time)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def realtext(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RealText subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def redspark(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RedSpark
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rka(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RKA (RK Audio)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rl2(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RL2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RealMedia
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def roq(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     id RoQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rpl(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RPL / ARMovie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rsd(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     GameCube RSD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rso(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Lego Mindstorms RSO
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def rtp(
-    
+
     rtp_flags: str | None = None,
-    
+
     listen_timeout: str | None = None,
-    
+
     localaddr: str | None = None,
-    
+
     allowed_media_types: str | None = None,
-    
+
     reorder_queue_size: int | None = None,
-    
+
     buffer_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RTP input
-    
+
     Args:
         rtp_flags: set RTP flags (default 0)
         listen_timeout: set maximum timeout (in seconds) to wait for incoming connections (default 10)
@@ -6179,61 +6179,61 @@ def rtp(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "rtp_flags": rtp_flags,
-        
+
         "listen_timeout": listen_timeout,
-        
+
         "localaddr": localaddr,
-        
+
         "allowed_media_types": allowed_media_types,
-        
+
         "reorder_queue_size": reorder_queue_size,
-        
+
         "buffer_size": buffer_size,
-        
+
     }))
 
 
 
 def rtsp(
-    
+
     initial_pause: bool | None = None,
-    
+
     rtsp_transport: str | None = None,
-    
+
     rtsp_flags: str | None = None,
-    
+
     allowed_media_types: str | None = None,
-    
+
     min_port: int | None = None,
-    
+
     max_port: int | None = None,
-    
+
     listen_timeout: int | None = None,
-    
+
     timeout: int | None = None,
-    
+
     reorder_queue_size: int | None = None,
-    
+
     buffer_size: int | None = None,
-    
+
     user_agent: str | None = None,
-    
+
     ca_file: str | None = None,
-    
+
     tls_verify: int | None = None,
-    
+
     cert_file: str | None = None,
-    
+
     key_file: str | None = None,
-    
+
     verifyhost: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     RTSP input
-    
+
     Args:
         initial_pause: do not start playing the stream immediately (default false)
         rtsp_transport: set RTSP transport protocols (default 0)
@@ -6256,53 +6256,53 @@ def rtsp(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "initial_pause": initial_pause,
-        
+
         "rtsp_transport": rtsp_transport,
-        
+
         "rtsp_flags": rtsp_flags,
-        
+
         "allowed_media_types": allowed_media_types,
-        
+
         "min_port": min_port,
-        
+
         "max_port": max_port,
-        
+
         "listen_timeout": listen_timeout,
-        
+
         "timeout": timeout,
-        
+
         "reorder_queue_size": reorder_queue_size,
-        
+
         "buffer_size": buffer_size,
-        
+
         "user_agent": user_agent,
-        
+
         "ca_file": ca_file,
-        
+
         "tls_verify": tls_verify,
-        
+
         "cert_file": cert_file,
-        
+
         "key_file": key_file,
-        
+
         "verifyhost": verifyhost,
-        
+
     }))
 
 
 
 def s16be(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 16-bit big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -6311,25 +6311,25 @@ def s16be(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def s16le(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 16-bit little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -6338,25 +6338,25 @@ def s16le(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def s24be(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 24-bit big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -6365,25 +6365,25 @@ def s24be(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def s24le(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 24-bit little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -6392,25 +6392,25 @@ def s24le(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def s32be(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 32-bit big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -6419,25 +6419,25 @@ def s32be(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def s32le(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 32-bit little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -6446,41 +6446,41 @@ def s32le(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def s337m(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SMPTE 337M
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def s8(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM signed 8-bit
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -6489,55 +6489,55 @@ def s8(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def sami(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SAMI subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sap(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SAP input
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sbc(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw SBC (low-complexity subband codec)
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -6545,23 +6545,23 @@ def sbc(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def sbg(
-    
+
     sample_rate: int | None = None,
-    
+
     max_file_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SBaGen binaural beats script
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 0)
         max_file_size: (from 0 to INT_MAX) (default 5000000)
@@ -6570,81 +6570,81 @@ def sbg(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "max_file_size": max_file_size,
-        
+
     }))
 
 
 
 def scc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Scenarist Closed Captions
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def scd(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Square Enix SCD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sdns(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Xbox SDNS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sdp(
-    
+
     sdp_flags: str | None = None,
-    
+
     listen_timeout: str | None = None,
-    
+
     localaddr: str | None = None,
-    
+
     allowed_media_types: str | None = None,
-    
+
     reorder_queue_size: int | None = None,
-    
+
     buffer_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SDP
-    
+
     Args:
         sdp_flags: SDP flags (default 0)
         listen_timeout: set maximum timeout (in seconds) to wait for incoming connections (default 10)
@@ -6657,79 +6657,79 @@ def sdp(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sdp_flags": sdp_flags,
-        
+
         "listen_timeout": listen_timeout,
-        
+
         "localaddr": localaddr,
-        
+
         "allowed_media_types": allowed_media_types,
-        
+
         "reorder_queue_size": reorder_queue_size,
-        
+
         "buffer_size": buffer_size,
-        
+
     }))
 
 
 
 def sdr2(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SDR2
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sds(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     MIDI Sample Dump Standard
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sdx(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sample Dump eXchange
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ser(
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SER (Simple uncompressed video format for astronomical capturing)
-    
+
     Args:
         framerate: set frame rate (default "25")
 
@@ -6737,45 +6737,45 @@ def ser(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def sga(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Digital Pictures SGA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sgi_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped sgi sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -6787,29 +6787,29 @@ def sgi_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def shn(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw Shorten
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -6817,55 +6817,55 @@ def shn(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def siff(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Beam Software SIFF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def simbiosis_imx(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Simbiosis Interactive IMX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sln(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Asterisk raw pcm
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 8000)
         ch_layout: (default "mono")
@@ -6874,191 +6874,191 @@ def sln(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def smjpeg(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Loki SDL MJPEG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def smk(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Smacker
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def smush(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     LucasArts Smush
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sol(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sierra SOL
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sox(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SoX (Sound eXchange) native
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def spdif(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     IEC 61937 (compressed data in S/PDIF)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def srt(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SubRip subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def stl(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Spruce subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def subviewer(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SubViewer subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def subviewer1(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SubViewer v1 subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def sunrast_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped sunrast sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -7070,69 +7070,69 @@ def sunrast_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def sup(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw HDMV Presentation Graphic Stream subtitles
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def svag(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Konami PS2 SVAG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def svg_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped svg sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -7144,61 +7144,61 @@ def svg_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def svs(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Square SVS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def swf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     SWF (ShockWave Flash)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def tak(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw TAK
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -7206,21 +7206,21 @@ def tak(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def tedcaptions(
-    
+
     start_time: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     TED Talks captions
-    
+
     Args:
         start_time: set the start time (offset) of the subtitles, in ms (from I64_MIN to I64_MAX) (default 15000)
 
@@ -7228,61 +7228,61 @@ def tedcaptions(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "start_time": start_time,
-        
+
     }))
 
 
 
 def thp(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     THP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def tiertexseq(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Tiertex Limited SEQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def tiff_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped tiff sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -7294,45 +7294,45 @@ def tiff_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def tmv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     8088flex TMV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def truehd(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw TrueHD
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -7340,41 +7340,41 @@ def truehd(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def tta(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     TTA (True Audio)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def tty(
-    
+
     chars_per_frame: int | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Tele-typewriter
-    
+
     Args:
         chars_per_frame: (from 1 to INT_MAX) (default 6000)
         video_size: A string describing frame size, such as 640x480 or hd720.
@@ -7384,59 +7384,59 @@ def tty(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "chars_per_frame": chars_per_frame,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def txd(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Renderware TeXture Dictionary
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def ty(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     TiVo TY Stream
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def u16be(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 16-bit big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -7445,25 +7445,25 @@ def u16be(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def u16le(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 16-bit little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -7472,25 +7472,25 @@ def u16le(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def u24be(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 24-bit big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -7499,25 +7499,25 @@ def u24be(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def u24le(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 24-bit little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -7526,25 +7526,25 @@ def u24le(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def u32be(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 32-bit big-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -7553,25 +7553,25 @@ def u32be(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def u32le(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 32-bit little-endian
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -7580,25 +7580,25 @@ def u32le(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def u8(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM unsigned 8-bit
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -7607,41 +7607,41 @@ def u8(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def usm(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     CRI USM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def v210(
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Uncompressed 4:2:2 10-bit
-    
+
     Args:
         video_size: set frame size
         framerate: set frame rate (default "25")
@@ -7650,25 +7650,25 @@ def v210(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def v210x(
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Uncompressed 4:2:2 10-bit
-    
+
     Args:
         video_size: set frame size
         framerate: set frame rate (default "25")
@@ -7677,47 +7677,47 @@ def v210x(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def vag(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony PS2 VAG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vbn_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped vbn sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -7729,31 +7729,31 @@ def vbn_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def vc1(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw VC-1
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -7762,41 +7762,41 @@ def vc1(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def vc1test(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     VC-1 test bitstream
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vidc(
-    
+
     sample_rate: int | None = None,
-    
+
     ch_layout: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     PCM Archimedes VIDC
-    
+
     Args:
         sample_rate: (from 0 to INT_MAX) (default 44100)
         ch_layout: (default "mono")
@@ -7805,87 +7805,87 @@ def vidc(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sample_rate": sample_rate,
-        
+
         "ch_layout": ch_layout,
-        
+
     }))
 
 
 
 def d(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     video4linux2,v4l2 Video4Linux2 device grab
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vividas(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Vividas VIV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vivo(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Vivo
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vmd(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sierra VMD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vobsub(
-    
+
     sub_name: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     VobSub subtitle format
-    
+
     Args:
         sub_name: URI for .sub file
 
@@ -7893,87 +7893,87 @@ def vobsub(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "sub_name": sub_name,
-        
+
     }))
 
 
 
 def voc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Creative Voice
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vpk(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony PS2 VPK
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vplayer(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     VPlayer subtitles
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vqf(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Nippon Telegraph and Telephone Corporation (NTT) TwinVQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def vvc(
-    
+
     framerate: str | None = None,
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     raw H.266/VVC video
-    
+
     Args:
         framerate: (default "25")
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
@@ -7982,23 +7982,23 @@ def vvc(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "framerate": framerate,
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def w64(
-    
+
     max_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony Wave64
-    
+
     Args:
         max_size: max size of single packet (from 0 to 4.1943e+06) (default 0)
 
@@ -8006,39 +8006,39 @@ def w64(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "max_size": max_size,
-        
+
     }))
 
 
 
 def wady(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Marble WADY
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def wav(
-    
+
     ignore_length: bool | None = None,
-    
+
     max_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     WAV / WAVE (Waveform Audio)
-    
+
     Args:
         ignore_length: Ignore length (default false)
         max_size: max size of single packet (from 0 to 4.1943e+06) (default 0)
@@ -8047,57 +8047,57 @@ def wav(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "ignore_length": ignore_length,
-        
+
         "max_size": max_size,
-        
+
     }))
 
 
 
 def wavarc(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Waveform Archiver
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def wc3movie(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Wing Commander III movie
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def webm_dash_manifest(
-    
+
     live: bool | None = None,
-    
+
     bandwidth: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     WebM DASH Manifest
-    
+
     Args:
         live: flag indicating that the input is a live file that only has the headers. (default false)
         bandwidth: bandwidth of this stream to be specified in the DASH manifest. (from 0 to INT_MAX) (default 0)
@@ -8106,31 +8106,31 @@ def webm_dash_manifest(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "live": live,
-        
+
         "bandwidth": bandwidth,
-        
+
     }))
 
 
 
 def webp_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped webp sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -8142,29 +8142,29 @@ def webp_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def webvtt(
-    
+
     kind: int | None| Literal["subtitles", "captions", "descriptions", "metadata"] = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     WebVTT subtitle
-    
+
     Args:
         kind: Set kind of WebVTT track (from 0 to INT_MAX) (default subtitles)
 
@@ -8172,37 +8172,37 @@ def webvtt(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "kind": kind,
-        
+
     }))
 
 
 
 def wsaud(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Westwood Studios audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def wsd(
-    
+
     raw_packet_size: int | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Wideband Single-bit Data (WSD)
-    
+
     Args:
         raw_packet_size: (from 1 to INT_MAX) (default 1024)
 
@@ -8210,121 +8210,121 @@ def wsd(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "raw_packet_size": raw_packet_size,
-        
+
     }))
 
 
 
 def wsvqa(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Westwood Studios VQA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def wtv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Windows Television (WTV)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def wv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     WavPack
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def wve(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Psion 3 audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def d(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     x11grab         X11 screen capture, using XCB
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def xa(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Maxis XA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def xbin(
-    
+
     linespeed: int | None = None,
-    
+
     video_size: str | None = None,
-    
+
     framerate: str | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     eXtended BINary text (XBIN)
-    
+
     Args:
         linespeed: set simulated line speed (bytes per second) (from 1 to INT_MAX) (default 6000)
         video_size: set video size, such as 640x480 or hd720.
@@ -8334,33 +8334,33 @@ def xbin(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "linespeed": linespeed,
-        
+
         "video_size": video_size,
-        
+
         "framerate": framerate,
-        
+
     }))
 
 
 
 def xbm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped xbm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -8372,69 +8372,69 @@ def xbm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def xmd(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Konami XMD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def xmv(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Microsoft XMV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def xpm_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped xpm sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -8446,53 +8446,53 @@ def xpm_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def xvag(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Sony PS3 XVAG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def xwd_pipe(
-    
+
     frame_size: int | None = None,
-    
+
     framerate: str | None = None,
-    
+
     pixel_format: str | None = None,
-    
+
     video_size: str | None = None,
-    
+
     loop: bool | None = None,
-    
+
 ) -> FFMpegDemuxerOption:
     """
     piped xwd sequence
-    
+
     Args:
         frame_size: force frame size in bytes (from 0 to INT_MAX) (default 0)
         framerate: set the video framerate (default "25")
@@ -8504,64 +8504,63 @@ def xwd_pipe(
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
         "frame_size": frame_size,
-        
+
         "framerate": framerate,
-        
+
         "pixel_format": pixel_format,
-        
+
         "video_size": video_size,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def xwma(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Microsoft xWMA
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def yop(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     Psygnosis YOP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
+
     }))
 
 
 
 def yuv4mpegpipe(
-    
+
 ) -> FFMpegDemuxerOption:
     """
     YUV4MPEG pipe
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegDemuxerOption(merge({
-        
-    }))
 
+    }))

--- a/packages/v8/src/ffmpeg/formats/muxers.py
+++ b/packages/v8/src/ffmpeg/formats/muxers.py
@@ -44,61 +44,61 @@ from ..streams.audio import AudioStream
 
 
 def _3g2(
-    
+
     brand: str | None = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_prft: int | None| Literal["pts", "wallclock"] = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     3GP2 (3GPP2 file format)
-    
+
     Args:
         brand: Override major brand
         empty_hdlr_name: write zero-length name string in hdlr atoms within mdia and minf atoms (default false)
@@ -130,117 +130,117 @@ def _3g2(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "brand": brand,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "frag_duration": frag_duration,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "frag_size": frag_size,
-        
+
         "fragment_index": fragment_index,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "movie_timescale": movie_timescale,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "use_editlist": use_editlist,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_prft": write_prft,
-        
+
         "write_tmcd": write_tmcd,
-        
+
     }))
 
 
 
 def _3gp(
-    
+
     brand: str | None = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_prft: int | None| Literal["pts", "wallclock"] = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     3GP (3GPP file format)
-    
+
     Args:
         brand: Override major brand
         empty_hdlr_name: write zero-length name string in hdlr atoms within mdia and minf atoms (default false)
@@ -272,101 +272,101 @@ def _3gp(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "brand": brand,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "frag_duration": frag_duration,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "frag_size": frag_size,
-        
+
         "fragment_index": fragment_index,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "movie_timescale": movie_timescale,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "use_editlist": use_editlist,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_prft": write_prft,
-        
+
         "write_tmcd": write_tmcd,
-        
+
     }))
 
 
 
 def a64(
-    
+
 ) -> FFMpegMuxerOption:
     """
     a64 - video for Commodore 64
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ac3(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw AC-3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ac4(
-    
+
     write_crc: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw AC-4
-    
+
     Args:
         write_crc: enable checksum (default false)
 
@@ -374,25 +374,25 @@ def ac4(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "write_crc": write_crc,
-        
+
     }))
 
 
 
 def adts(
-    
+
     write_id3v2: bool | None = None,
-    
+
     write_apetag: bool | None = None,
-    
+
     write_mpeg2: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     ADTS AAC (Advanced Audio Coding)
-    
+
     Args:
         write_id3v2: Enable ID3v2 tag writing (default false)
         write_apetag: Enable APE tag writing (default false)
@@ -402,59 +402,59 @@ def adts(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "write_id3v2": write_id3v2,
-        
+
         "write_apetag": write_apetag,
-        
+
         "write_mpeg2": write_mpeg2,
-        
+
     }))
 
 
 
 def adx(
-    
+
 ) -> FFMpegMuxerOption:
     """
     CRI ADX
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def aea(
-    
+
 ) -> FFMpegMuxerOption:
     """
     MD STUDIO audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def aiff(
-    
+
     write_id3v2: bool | None = None,
-    
+
     id3v2_version: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Audio IFF
-    
+
     Args:
         write_id3v2: Enable ID3 tags writing. (default false)
         id3v2_version: Select ID3v2 version to write. Currently 3 and 4 are supported. (from 3 to 4) (default 4)
@@ -463,39 +463,39 @@ def aiff(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "write_id3v2": write_id3v2,
-        
+
         "id3v2_version": id3v2_version,
-        
+
     }))
 
 
 
 def alaw(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM A-law
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def alp(
-    
+
     type: int | None| Literal["auto", "tun", "pcm"] = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     LEGO Racers ALP
-    
+
     Args:
         type: set file type (from 0 to 2) (default auto)
 
@@ -503,71 +503,71 @@ def alp(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "type": type,
-        
+
     }))
 
 
 
 def amr(
-    
+
 ) -> FFMpegMuxerOption:
     """
     3GPP AMR
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def amv(
-    
+
 ) -> FFMpegMuxerOption:
     """
     AMV
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def apm(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Ubisoft Rayman 2 APM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def apng(
-    
+
     plays: int | None = None,
-    
+
     final_delay: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Animated Portable Network Graphics
-    
+
     Args:
         plays: Number of times to play the output: 0 - infinite loop, 1 - no loop (from 0 to 65535) (default 1)
         final_delay: Force delay after the last frame (from 0 to 65535) (default 0/1)
@@ -576,75 +576,75 @@ def apng(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "plays": plays,
-        
+
         "final_delay": final_delay,
-        
+
     }))
 
 
 
 def aptx(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw aptX (Audio Processing Technology for Bluetooth)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def aptx_hd(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw aptX HD (Audio Processing Technology for Bluetooth)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def apv(
-    
+
 ) -> FFMpegMuxerOption:
     """
     APV raw bitstream
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def argo_asf(
-    
+
     version_major: int | None = None,
-    
+
     version_minor: int | None = None,
-    
+
     name: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Argonaut Games ASF
-    
+
     Args:
         version_major: override file major version (from 0 to 65535) (default 2)
         version_minor: override file minor version (from 0 to 65535) (default 1)
@@ -654,29 +654,29 @@ def argo_asf(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "version_major": version_major,
-        
+
         "version_minor": version_minor,
-        
+
         "name": name,
-        
+
     }))
 
 
 
 def argo_cvg(
-    
+
     skip_rate_check: bool | None = None,
-    
+
     loop: bool | None = None,
-    
+
     reverb: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Argonaut Games CVG
-    
+
     Args:
         skip_rate_check: skip sample rate check (default false)
         loop: set loop flag (default false)
@@ -686,25 +686,25 @@ def argo_cvg(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "skip_rate_check": skip_rate_check,
-        
+
         "loop": loop,
-        
+
         "reverb": reverb,
-        
+
     }))
 
 
 
 def asf(
-    
+
     packet_size: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     ASF (Advanced / Active Streaming Format)
-    
+
     Args:
         packet_size: Packet size (from 100 to 65536) (default 3200)
 
@@ -712,21 +712,21 @@ def asf(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "packet_size": packet_size,
-        
+
     }))
 
 
 
 def asf_stream(
-    
+
     packet_size: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     ASF (Advanced / Active Streaming Format)
-    
+
     Args:
         packet_size: Packet size (from 100 to 65536) (default 3200)
 
@@ -734,21 +734,21 @@ def asf_stream(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "packet_size": packet_size,
-        
+
     }))
 
 
 
 def ass(
-    
+
     ignore_readorder: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     SSA (SubStation Alpha) subtitle
-    
+
     Args:
         ignore_readorder: write events immediately, even if they're out-of-order (default false)
 
@@ -756,23 +756,23 @@ def ass(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "ignore_readorder": ignore_readorder,
-        
+
     }))
 
 
 
 def ast(
-    
+
     loopstart: int | None = None,
-    
+
     loopend: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     AST (Audio Stream)
-    
+
     Args:
         loopstart: Loopstart position in milliseconds. (from -1 to INT_MAX) (default -1)
         loopend: Loopend position in milliseconds. (from 0 to INT_MAX) (default 0)
@@ -781,43 +781,43 @@ def ast(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "loopstart": loopstart,
-        
+
         "loopend": loopend,
-        
+
     }))
 
 
 
 def au(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Sun AU
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def avi(
-    
+
     reserve_index_space: int | None = None,
-    
+
     write_channel_mask: bool | None = None,
-    
+
     flipped_raw_rgb: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     AVI (Audio Video Interleaved)
-    
+
     Args:
         reserve_index_space: reserve space (in bytes) at the beginning of the file for each stream index (from 0 to INT_MAX) (default 0)
         write_channel_mask: write channel mask into wave format header (default true)
@@ -827,27 +827,27 @@ def avi(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "reserve_index_space": reserve_index_space,
-        
+
         "write_channel_mask": write_channel_mask,
-        
+
         "flipped_raw_rgb": flipped_raw_rgb,
-        
+
     }))
 
 
 
 def avif(
-    
+
     movie_timescale: int | None = None,
-    
+
     loop: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     AVIF
-    
+
     Args:
         movie_timescale: set movie timescale (from 1 to INT_MAX) (default 1000)
         loop: Number of times to loop animated AVIF: 0 - infinite loop (from 0 to INT_MAX) (default 0)
@@ -856,237 +856,237 @@ def avif(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "movie_timescale": movie_timescale,
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def avm2(
-    
+
 ) -> FFMpegMuxerOption:
     """
     SWF (ShockWave Flash) (AVM2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def avs2(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw AVS2-P2/IEEE1857.4 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def avs3(
-    
+
 ) -> FFMpegMuxerOption:
     """
     AVS3-P2/IEEE1857.10
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def bit(
-    
+
 ) -> FFMpegMuxerOption:
     """
     G.729 BIT file format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def caf(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Apple CAF (Core Audio Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def cavsvideo(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw Chinese AVS (Audio Video Standard) video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def codec2(
-    
+
 ) -> FFMpegMuxerOption:
     """
     codec2 .c2 muxer
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def codec2raw(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw codec2 muxer
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def crc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     CRC testing
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dash(
-    
+
     adaptation_sets: str | None = None,
-    
+
     dash_segment_type: int | None| Literal["auto", "mp4", "webm"] = None,
-    
+
     extra_window_size: int | None = None,
-    
+
     format_options: str | None = None,
-    
+
     frag_duration: str | None = None,
-    
+
     frag_type: int | None| Literal["none", "every_frame", "duration", "pframes"] = None,
-    
+
     global_sidx: bool | None = None,
-    
+
     hls_master_name: str | None = None,
-    
+
     hls_playlist: bool | None = None,
-    
+
     http_opts: str | None = None,
-    
+
     http_persistent: bool | None = None,
-    
+
     http_user_agent: str | None = None,
-    
+
     ignore_io_errors: bool | None = None,
-    
+
     index_correction: bool | None = None,
-    
+
     init_seg_name: str | None = None,
-    
+
     ldash: bool | None = None,
-    
+
     lhls: bool | None = None,
-    
+
     master_m3u8_publish_rate: int | None = None,
-    
+
     max_playback_rate: str | None = None,
-    
+
     media_seg_name: str | None = None,
-    
+
     method: str | None = None,
-    
+
     min_playback_rate: str | None = None,
-    
+
     mpd_profile: str | None = None,
-    
+
     remove_at_exit: bool | None = None,
-    
+
     seg_duration: str | None = None,
-    
+
     single_file: bool | None = None,
-    
+
     single_file_name: str | None = None,
-    
+
     streaming: bool | None = None,
-    
+
     target_latency: str | None = None,
-    
+
     timeout: str | None = None,
-    
+
     update_period: int | None = None,
-    
+
     use_template: bool | None = None,
-    
+
     use_timeline: bool | None = None,
-    
+
     utc_timing_url: str | None = None,
-    
+
     window_size: int | None = None,
-    
+
     write_prft: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     DASH Muxer
-    
+
     Args:
         adaptation_sets: Adaptation sets. Syntax: id=0,streams=0,1,2 id=1,streams=3,4 and so on
         dash_segment_type: set dash segment files type (from 0 to 2) (default auto)
@@ -1129,205 +1129,205 @@ def dash(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "adaptation_sets": adaptation_sets,
-        
+
         "dash_segment_type": dash_segment_type,
-        
+
         "extra_window_size": extra_window_size,
-        
+
         "format_options": format_options,
-        
+
         "frag_duration": frag_duration,
-        
+
         "frag_type": frag_type,
-        
+
         "global_sidx": global_sidx,
-        
+
         "hls_master_name": hls_master_name,
-        
+
         "hls_playlist": hls_playlist,
-        
+
         "http_opts": http_opts,
-        
+
         "http_persistent": http_persistent,
-        
+
         "http_user_agent": http_user_agent,
-        
+
         "ignore_io_errors": ignore_io_errors,
-        
+
         "index_correction": index_correction,
-        
+
         "init_seg_name": init_seg_name,
-        
+
         "ldash": ldash,
-        
+
         "lhls": lhls,
-        
+
         "master_m3u8_publish_rate": master_m3u8_publish_rate,
-        
+
         "max_playback_rate": max_playback_rate,
-        
+
         "media_seg_name": media_seg_name,
-        
+
         "method": method,
-        
+
         "min_playback_rate": min_playback_rate,
-        
+
         "mpd_profile": mpd_profile,
-        
+
         "remove_at_exit": remove_at_exit,
-        
+
         "seg_duration": seg_duration,
-        
+
         "single_file": single_file,
-        
+
         "single_file_name": single_file_name,
-        
+
         "streaming": streaming,
-        
+
         "target_latency": target_latency,
-        
+
         "timeout": timeout,
-        
+
         "update_period": update_period,
-        
+
         "use_template": use_template,
-        
+
         "use_timeline": use_timeline,
-        
+
         "utc_timing_url": utc_timing_url,
-        
+
         "window_size": window_size,
-        
+
         "write_prft": write_prft,
-        
+
     }))
 
 
 
 def data(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw data
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def daud(
-    
+
 ) -> FFMpegMuxerOption:
     """
     D-Cinema audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dfpwm(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw DFPWM1a
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dirac(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw Dirac
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dnxhd(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw DNxHD (SMPTE VC-3)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dts(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw DTS
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dv(
-    
+
 ) -> FFMpegMuxerOption:
     """
     DV (Digital Video)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def dvd(
-    
+
     muxrate: int | None = None,
-    
+
     preload: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MPEG-2 PS (DVD VOB)
-    
+
     Args:
         muxrate: mux rate as bits/s (from 0 to 1.67772e+09) (default 0)
         preload: initial demux-decode delay in microseconds (from 0 to INT_MAX) (default 500000)
@@ -1336,135 +1336,135 @@ def dvd(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "muxrate": muxrate,
-        
+
         "preload": preload,
-        
+
     }))
 
 
 
 def eac3(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw E-AC-3
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def evc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw EVC video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def f32be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM 32-bit floating-point big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def f32le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM 32-bit floating-point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def f4v(
-    
+
     brand: str | None = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_prft: int | None| Literal["pts", "wallclock"] = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     F4V Adobe Flash Video
-    
+
     Args:
         brand: Override major brand
         empty_hdlr_name: write zero-length name string in hdlr atoms within mdia and minf atoms (default false)
@@ -1496,153 +1496,153 @@ def f4v(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "brand": brand,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "frag_duration": frag_duration,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "frag_size": frag_size,
-        
+
         "fragment_index": fragment_index,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "movie_timescale": movie_timescale,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "use_editlist": use_editlist,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_prft": write_prft,
-        
+
         "write_tmcd": write_tmcd,
-        
+
     }))
 
 
 
 def f64be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM 64-bit floating-point big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def f64le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM 64-bit floating-point little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def d(
-    
+
 ) -> FFMpegMuxerOption:
     """
     fbdev           Linux framebuffer
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ffmetadata(
-    
+
 ) -> FFMpegMuxerOption:
     """
     FFmpeg metadata in text
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def fifo(
-    
+
     attempt_recovery: bool | None = None,
-    
+
     drop_pkts_on_overflow: bool | None = None,
-    
+
     fifo_format: str | None = None,
-    
+
     format_opts: str | None = None,
-    
+
     max_recovery_attempts: int | None = None,
-    
+
     queue_size: int | None = None,
-    
+
     recovery_wait_streamtime: bool | None = None,
-    
+
     recovery_wait_time: str | None = None,
-    
+
     recover_any_error: bool | None = None,
-    
+
     restart_with_keyframe: bool | None = None,
-    
+
     timeshift: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     FIFO queue pseudo-muxer
-    
+
     Args:
         attempt_recovery: Attempt recovery in case of failure (default false)
         drop_pkts_on_overflow: Drop packets on fifo queue overflow not to block encoder (default false)
@@ -1660,89 +1660,89 @@ def fifo(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "attempt_recovery": attempt_recovery,
-        
+
         "drop_pkts_on_overflow": drop_pkts_on_overflow,
-        
+
         "fifo_format": fifo_format,
-        
+
         "format_opts": format_opts,
-        
+
         "max_recovery_attempts": max_recovery_attempts,
-        
+
         "queue_size": queue_size,
-        
+
         "recovery_wait_streamtime": recovery_wait_streamtime,
-        
+
         "recovery_wait_time": recovery_wait_time,
-        
+
         "recover_any_error": recover_any_error,
-        
+
         "restart_with_keyframe": restart_with_keyframe,
-        
+
         "timeshift": timeshift,
-        
+
     }))
 
 
 
 def film_cpk(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Sega FILM / CPK
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def filmstrip(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Adobe Filmstrip
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def fits(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Flexible Image Transport System
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def flac(
-    
+
     write_header: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw FLAC
-    
+
     Args:
         write_header: Write the file header (default true)
 
@@ -1750,21 +1750,21 @@ def flac(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "write_header": write_header,
-        
+
     }))
 
 
 
 def flv(
-    
+
     flvflags: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     FLV (Flash Video)
-    
+
     Args:
         flvflags: FLV muxer flags (default 0)
 
@@ -1772,39 +1772,39 @@ def flv(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "flvflags": flvflags,
-        
+
     }))
 
 
 
 def framecrc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     framecrc testing
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def framehash(
-    
+
     hash: str | None = None,
-    
+
     format_version: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Per-frame hash testing
-    
+
     Args:
         hash: set hash to use (default "sha256")
         format_version: file format version (from 1 to 2) (default 2)
@@ -1813,25 +1813,25 @@ def framehash(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "hash": hash,
-        
+
         "format_version": format_version,
-        
+
     }))
 
 
 
 def framemd5(
-    
+
     hash: str | None = None,
-    
+
     format_version: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Per-frame MD5 testing
-    
+
     Args:
         hash: set hash to use (default "md5")
         format_version: file format version (from 1 to 2) (default 2)
@@ -1840,89 +1840,89 @@ def framemd5(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "hash": hash,
-        
+
         "format_version": format_version,
-        
+
     }))
 
 
 
 def g722(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw G.722
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def g723_1(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw G.723.1
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def g726(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw big-endian G.726 ("left-justified")
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def g726le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw little-endian G.726 ("right-justified")
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def gif(
-    
+
     loop: int | None = None,
-    
+
     final_delay: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     CompuServe Graphics Interchange Format (GIF)
-    
+
     Args:
         loop: Number of times to loop the output: -1 - no loop, 0 - infinite loop (from -1 to 65535) (default 0)
         final_delay: Force delay (in centiseconds) after the last frame (from -1 to 65535) (default -1)
@@ -1931,103 +1931,103 @@ def gif(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "loop": loop,
-        
+
         "final_delay": final_delay,
-        
+
     }))
 
 
 
 def gsm(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw GSM
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def gxf(
-    
+
 ) -> FFMpegMuxerOption:
     """
     GXF (General eXchange Format)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def h261(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw H.261
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def h263(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw H.263
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def h264(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw H.264 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def hash(
-    
+
     hash: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Hash testing
-    
+
     Args:
         hash: set hash to use (default "sha256")
 
@@ -2035,27 +2035,27 @@ def hash(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "hash": hash,
-        
+
     }))
 
 
 
 def hds(
-    
+
     window_size: int | None = None,
-    
+
     extra_window_size: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     remove_at_exit: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     HDS Muxer
-    
+
     Args:
         window_size: number of fragments kept in the manifest (from 0 to INT_MAX) (default 0)
         extra_window_size: number of fragments kept outside of the manifest before removing from disk (from 0 to INT_MAX) (default 5)
@@ -2066,111 +2066,111 @@ def hds(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "window_size": window_size,
-        
+
         "extra_window_size": extra_window_size,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "remove_at_exit": remove_at_exit,
-        
+
     }))
 
 
 
 def hevc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw HEVC video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def hls(
-    
+
     start_number: int | None = None,
-    
+
     hls_time: str | None = None,
-    
+
     hls_init_time: str | None = None,
-    
+
     hls_list_size: int | None = None,
-    
+
     hls_delete_threshold: int | None = None,
-    
+
     hls_vtt_options: str | None = None,
-    
+
     hls_allow_cache: int | None = None,
-    
+
     hls_base_url: str | None = None,
-    
+
     hls_segment_filename: str | None = None,
-    
+
     hls_segment_options: str | None = None,
-    
+
     hls_segment_size: int | None = None,
-    
+
     hls_key_info_file: str | None = None,
-    
+
     hls_enc: bool | None = None,
-    
+
     hls_enc_key: str | None = None,
-    
+
     hls_enc_key_url: str | None = None,
-    
+
     hls_enc_iv: str | None = None,
-    
+
     hls_subtitle_path: str | None = None,
-    
+
     hls_segment_type: int | None| Literal["mpegts", "fmp4"] = None,
-    
+
     hls_fmp4_init_filename: str | None = None,
-    
+
     hls_fmp4_init_resend: bool | None = None,
-    
+
     hls_flags: str | None = None,
-    
+
     strftime: bool | None = None,
-    
+
     strftime_mkdir: bool | None = None,
-    
+
     hls_playlist_type: int | None| Literal["event", "vod"] = None,
-    
+
     method: str | None = None,
-    
+
     hls_start_number_source: int | None| Literal["generic", "epoch", "epoch_us", "datetime"] = None,
-    
+
     http_user_agent: str | None = None,
-    
+
     var_stream_map: str | None = None,
-    
+
     cc_stream_map: str | None = None,
-    
+
     master_pl_name: str | None = None,
-    
+
     master_pl_publish_rate: int | None = None,
-    
+
     http_persistent: bool | None = None,
-    
+
     timeout: str | None = None,
-    
+
     ignore_io_errors: bool | None = None,
-    
+
     headers: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Apple HTTP Live Streaming
-    
+
     Args:
         start_number: set first number in the sequence (from 0 to I64_MAX) (default 0)
         hls_time: set segment length (default 2)
@@ -2212,147 +2212,147 @@ def hls(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "start_number": start_number,
-        
+
         "hls_time": hls_time,
-        
+
         "hls_init_time": hls_init_time,
-        
+
         "hls_list_size": hls_list_size,
-        
+
         "hls_delete_threshold": hls_delete_threshold,
-        
+
         "hls_vtt_options": hls_vtt_options,
-        
+
         "hls_allow_cache": hls_allow_cache,
-        
+
         "hls_base_url": hls_base_url,
-        
+
         "hls_segment_filename": hls_segment_filename,
-        
+
         "hls_segment_options": hls_segment_options,
-        
+
         "hls_segment_size": hls_segment_size,
-        
+
         "hls_key_info_file": hls_key_info_file,
-        
+
         "hls_enc": hls_enc,
-        
+
         "hls_enc_key": hls_enc_key,
-        
+
         "hls_enc_key_url": hls_enc_key_url,
-        
+
         "hls_enc_iv": hls_enc_iv,
-        
+
         "hls_subtitle_path": hls_subtitle_path,
-        
+
         "hls_segment_type": hls_segment_type,
-        
+
         "hls_fmp4_init_filename": hls_fmp4_init_filename,
-        
+
         "hls_fmp4_init_resend": hls_fmp4_init_resend,
-        
+
         "hls_flags": hls_flags,
-        
+
         "strftime": strftime,
-        
+
         "strftime_mkdir": strftime_mkdir,
-        
+
         "hls_playlist_type": hls_playlist_type,
-        
+
         "method": method,
-        
+
         "hls_start_number_source": hls_start_number_source,
-        
+
         "http_user_agent": http_user_agent,
-        
+
         "var_stream_map": var_stream_map,
-        
+
         "cc_stream_map": cc_stream_map,
-        
+
         "master_pl_name": master_pl_name,
-        
+
         "master_pl_publish_rate": master_pl_publish_rate,
-        
+
         "http_persistent": http_persistent,
-        
+
         "timeout": timeout,
-        
+
         "ignore_io_errors": ignore_io_errors,
-        
+
         "headers": headers,
-        
+
     }))
 
 
 
 def iamf(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Raw Immersive Audio Model and Formats
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ico(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Microsoft Windows ICO
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ilbc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     iLBC storage
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def image2(
-    
+
     update: bool | None = None,
-    
+
     start_number: int | None = None,
-    
+
     strftime: bool | None = None,
-    
+
     frame_pts: bool | None = None,
-    
+
     atomic_writing: bool | None = None,
-    
+
     protocol_opts: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     image2 sequence
-    
+
     Args:
         update: continuously overwrite one file (default false)
         start_number: set first number in the sequence (from 0 to INT_MAX) (default 1)
@@ -2365,95 +2365,95 @@ def image2(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "update": update,
-        
+
         "start_number": start_number,
-        
+
         "strftime": strftime,
-        
+
         "frame_pts": frame_pts,
-        
+
         "atomic_writing": atomic_writing,
-        
+
         "protocol_opts": protocol_opts,
-        
+
     }))
 
 
 
 def image2pipe(
-    
+
 ) -> FFMpegMuxerOption:
     """
     piped image2 sequence
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ipod(
-    
+
     brand: str | None = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_prft: int | None| Literal["pts", "wallclock"] = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     iPod H.264 MP4 (MPEG-4 Part 14)
-    
+
     Args:
         brand: Override major brand
         empty_hdlr_name: write zero-length name string in hdlr atoms within mdia and minf atoms (default false)
@@ -2485,133 +2485,133 @@ def ipod(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "brand": brand,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "frag_duration": frag_duration,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "frag_size": frag_size,
-        
+
         "fragment_index": fragment_index,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "movie_timescale": movie_timescale,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "use_editlist": use_editlist,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_prft": write_prft,
-        
+
         "write_tmcd": write_tmcd,
-        
+
     }))
 
 
 
 def ircam(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Berkeley/IRCAM/CARL Sound Format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ismv(
-    
+
     brand: str | None = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_prft: int | None| Literal["pts", "wallclock"] = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     ISMV/ISMA (Smooth Streaming)
-    
+
     Args:
         brand: Override major brand
         empty_hdlr_name: write zero-length name string in hdlr atoms within mdia and minf atoms (default false)
@@ -2643,117 +2643,117 @@ def ismv(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "brand": brand,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "frag_duration": frag_duration,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "frag_size": frag_size,
-        
+
         "fragment_index": fragment_index,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "movie_timescale": movie_timescale,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "use_editlist": use_editlist,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_prft": write_prft,
-        
+
         "write_tmcd": write_tmcd,
-        
+
     }))
 
 
 
 def ivf(
-    
+
 ) -> FFMpegMuxerOption:
     """
     On2 IVF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def jacosub(
-    
+
 ) -> FFMpegMuxerOption:
     """
     JACOsub subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def kvag(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Simon & Schuster Interactive VAG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def latm(
-    
+
     smc_interval: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     LOAS/LATM
-    
+
     Args:
         smc_interval: StreamMuxConfig interval. (from 1 to 65535) (default 20)
 
@@ -2761,37 +2761,37 @@ def latm(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "smc-interval": smc_interval,
-        
+
     }))
 
 
 
 def lc3(
-    
+
 ) -> FFMpegMuxerOption:
     """
     LC3 (Low Complexity Communication Codec)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def lrc(
-    
+
     precision: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     LRC lyrics
-    
+
     Args:
         precision: precision of the fractional part of the timestamp, 2 for centiseconds (from 1 to 6) (default 2)
 
@@ -2799,57 +2799,57 @@ def lrc(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "precision": precision,
-        
+
     }))
 
 
 
 def m4v(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw MPEG-4 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def matroska(
-    
+
     reserve_index_space: int | None = None,
-    
+
     cues_to_front: bool | None = None,
-    
+
     cluster_size_limit: int | None = None,
-    
+
     cluster_time_limit: int | None = None,
-    
+
     dash: bool | None = None,
-    
+
     dash_track_number: int | None = None,
-    
+
     live: bool | None = None,
-    
+
     allow_raw_vfw: bool | None = None,
-    
+
     flipped_raw_rgb: bool | None = None,
-    
+
     write_crc32: bool | None = None,
-    
+
     default_mode: int | None| Literal["infer", "infer_no_subs", "passthrough"] = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Matroska
-    
+
     Args:
         reserve_index_space: reserve a given amount of space (in bytes) at the beginning of the file for the index (cues) (from 0 to INT_MAX) (default 0)
         cues_to_front: move Cues (the index) to the front by shifting data if necessary (default false)
@@ -2867,49 +2867,49 @@ def matroska(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "reserve_index_space": reserve_index_space,
-        
+
         "cues_to_front": cues_to_front,
-        
+
         "cluster_size_limit": cluster_size_limit,
-        
+
         "cluster_time_limit": cluster_time_limit,
-        
+
         "dash": dash,
-        
+
         "dash_track_number": dash_track_number,
-        
+
         "live": live,
-        
+
         "allow_raw_vfw": allow_raw_vfw,
-        
+
         "flipped_raw_rgb": flipped_raw_rgb,
-        
+
         "write_crc32": write_crc32,
-        
+
         "default_mode": default_mode,
-        
+
     }))
 
 
 
 def mcc(
-    
+
     override_time_code_rate: str | None = None,
-    
+
     use_u_alias: bool | None = None,
-    
+
     mcc_version: int | None = None,
-    
+
     creation_program: str | None = None,
-    
+
     creation_time: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MacCaption
-    
+
     Args:
         override_time_code_rate: override the `Time Code Rate` value in the output
         use_u_alias: use the U alias for E1h 00h 00h 00h, disabled by default because some .mcc files disagree on whether it has 2 or 3 zero bytes (default false)
@@ -2921,29 +2921,29 @@ def mcc(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "override_time_code_rate": override_time_code_rate,
-        
+
         "use_u_alias": use_u_alias,
-        
+
         "mcc_version": mcc_version,
-        
+
         "creation_program": creation_program,
-        
+
         "creation_time": creation_time,
-        
+
     }))
 
 
 
 def md5(
-    
+
     hash: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MD5 testing
-    
+
     Args:
         hash: set hash to use (default "md5")
 
@@ -2951,149 +2951,149 @@ def md5(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "hash": hash,
-        
+
     }))
 
 
 
 def microdvd(
-    
+
 ) -> FFMpegMuxerOption:
     """
     MicroDVD subtitle format
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mjpeg(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw MJPEG video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mkvtimestamp_v2(
-    
+
 ) -> FFMpegMuxerOption:
     """
     extract pts as timecode v2 format, as defined by mkvtoolnix
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mlp(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw MLP
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mmf(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Yamaha SMAF
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mov(
-    
+
     brand: str | None = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_prft: int | None| Literal["pts", "wallclock"] = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     QuickTime / MOV
-    
+
     Args:
         brand: Override major brand
         empty_hdlr_name: write zero-length name string in hdlr atoms within mdia and minf atoms (default false)
@@ -3125,89 +3125,89 @@ def mov(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "brand": brand,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "frag_duration": frag_duration,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "frag_size": frag_size,
-        
+
         "fragment_index": fragment_index,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "movie_timescale": movie_timescale,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "use_editlist": use_editlist,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_prft": write_prft,
-        
+
         "write_tmcd": write_tmcd,
-        
+
     }))
 
 
 
 def mp2(
-    
+
 ) -> FFMpegMuxerOption:
     """
     MP2 (MPEG audio layer 2)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mp3(
-    
+
     id3v2_version: int | None = None,
-    
+
     write_id3v1: bool | None = None,
-    
+
     write_xing: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MP3 (MPEG audio layer 3)
-    
+
     Args:
         id3v2_version: Select ID3v2 version to write. Currently 3 and 4 are supported. (from 0 to 4) (default 4)
         write_id3v1: Enable ID3v1 writing. ID3v1 tags are written in UTF-8 which may not be supported by most software. (default false)
@@ -3217,73 +3217,73 @@ def mp3(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "id3v2_version": id3v2_version,
-        
+
         "write_id3v1": write_id3v1,
-        
+
         "write_xing": write_xing,
-        
+
     }))
 
 
 
 def mp4(
-    
+
     brand: str | None = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_prft: int | None| Literal["pts", "wallclock"] = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MP4 (MPEG-4 Part 14)
-    
+
     Args:
         brand: Override major brand
         empty_hdlr_name: write zero-length name string in hdlr atoms within mdia and minf atoms (default false)
@@ -3315,71 +3315,71 @@ def mp4(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "brand": brand,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "frag_duration": frag_duration,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "frag_size": frag_size,
-        
+
         "fragment_index": fragment_index,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "movie_timescale": movie_timescale,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "use_editlist": use_editlist,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_prft": write_prft,
-        
+
         "write_tmcd": write_tmcd,
-        
+
     }))
 
 
 
 def mpeg(
-    
+
     muxrate: int | None = None,
-    
+
     preload: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MPEG-1 Systems / MPEG program stream
-    
+
     Args:
         muxrate: mux rate as bits/s (from 0 to 1.67772e+09) (default 0)
         preload: initial demux-decode delay in microseconds (from 0 to INT_MAX) (default 500000)
@@ -3388,87 +3388,87 @@ def mpeg(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "muxrate": muxrate,
-        
+
         "preload": preload,
-        
+
     }))
 
 
 
 def mpeg1video(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw MPEG-1 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mpeg2video(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw MPEG-2 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mpegts(
-    
+
     mpegts_transport_stream_id: int | None = None,
-    
+
     mpegts_original_network_id: int | None = None,
-    
+
     mpegts_service_id: int | None = None,
-    
+
     mpegts_service_type: int | None| Literal["digital_tv", "digital_radio", "teletext", "advanced_codec_digital_radio", "mpeg2_digital_hdtv", "advanced_codec_digital_sdtv", "advanced_codec_digital_hdtv", "hevc_digital_hdtv"] = None,
-    
+
     mpegts_pmt_start_pid: int | None = None,
-    
+
     mpegts_start_pid: int | None = None,
-    
+
     mpegts_m2ts_mode: bool | None = None,
-    
+
     muxrate: int | None = None,
-    
+
     pes_payload_size: int | None = None,
-    
+
     mpegts_flags: str | None = None,
-    
+
     mpegts_copyts: bool | None = None,
-    
+
     tables_version: int | None = None,
-    
+
     omit_video_pes_length: bool | None = None,
-    
+
     pcr_period: int | None = None,
-    
+
     pat_period: str | None = None,
-    
+
     sdt_period: str | None = None,
-    
+
     nit_period: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MPEG-TS (MPEG-2 Transport Stream)
-    
+
     Args:
         mpegts_transport_stream_id: Set transport_stream_id field. (from 1 to 65535) (default 1)
         mpegts_original_network_id: Set original_network_id field. (from 1 to 65535) (default 65281)
@@ -3492,53 +3492,53 @@ def mpegts(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "mpegts_transport_stream_id": mpegts_transport_stream_id,
-        
+
         "mpegts_original_network_id": mpegts_original_network_id,
-        
+
         "mpegts_service_id": mpegts_service_id,
-        
+
         "mpegts_service_type": mpegts_service_type,
-        
+
         "mpegts_pmt_start_pid": mpegts_pmt_start_pid,
-        
+
         "mpegts_start_pid": mpegts_start_pid,
-        
+
         "mpegts_m2ts_mode": mpegts_m2ts_mode,
-        
+
         "muxrate": muxrate,
-        
+
         "pes_payload_size": pes_payload_size,
-        
+
         "mpegts_flags": mpegts_flags,
-        
+
         "mpegts_copyts": mpegts_copyts,
-        
+
         "tables_version": tables_version,
-        
+
         "omit_video_pes_length": omit_video_pes_length,
-        
+
         "pcr_period": pcr_period,
-        
+
         "pat_period": pat_period,
-        
+
         "sdt_period": sdt_period,
-        
+
         "nit_period": nit_period,
-        
+
     }))
 
 
 
 def mpjpeg(
-    
+
     boundary_tag: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MIME multipart JPEG
-    
+
     Args:
         boundary_tag: Boundary tag (default "ffmpeg")
 
@@ -3546,39 +3546,39 @@ def mpjpeg(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "boundary_tag": boundary_tag,
-        
+
     }))
 
 
 
 def mulaw(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM mu-law
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def mxf(
-    
+
     signal_standard: int | None| Literal["bt601", "bt1358", "smpte347m", "smpte274m", "smpte296m", "smpte349m", "smpte428"] = None,
-    
+
     store_user_comments: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MXF (Material eXchange Format)
-    
+
     Args:
         signal_standard: Force/set Signal Standard (from -1 to 7) (default -1)
         store_user_comments: (default true)
@@ -3587,27 +3587,27 @@ def mxf(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "signal_standard": signal_standard,
-        
+
         "store_user_comments": store_user_comments,
-        
+
     }))
 
 
 
 def mxf_d10(
-    
+
     d10_channelcount: int | None = None,
-    
+
     signal_standard: int | None| Literal["bt601", "bt1358", "smpte347m", "smpte274m", "smpte296m", "smpte349m", "smpte428"] = None,
-    
+
     store_user_comments: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MXF (Material eXchange Format) D-10 Mapping
-    
+
     Args:
         d10_channelcount: Force/set channelcount in generic sound essence descriptor (from -1 to 8) (default -1)
         signal_standard: Force/set Signal Standard (from -1 to 7) (default -1)
@@ -3617,29 +3617,29 @@ def mxf_d10(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "d10_channelcount": d10_channelcount,
-        
+
         "signal_standard": signal_standard,
-        
+
         "store_user_comments": store_user_comments,
-        
+
     }))
 
 
 
 def mxf_opatom(
-    
+
     mxf_audio_edit_rate: str | None = None,
-    
+
     signal_standard: int | None| Literal["bt601", "bt1358", "smpte347m", "smpte274m", "smpte296m", "smpte349m", "smpte428"] = None,
-    
+
     store_user_comments: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MXF (Material eXchange Format) Operational Pattern Atom
-    
+
     Args:
         mxf_audio_edit_rate: Audio edit rate for timecode (from 0 to INT_MAX) (default 25/1)
         signal_standard: Force/set Signal Standard (from -1 to 7) (default -1)
@@ -3649,43 +3649,43 @@ def mxf_opatom(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "mxf_audio_edit_rate": mxf_audio_edit_rate,
-        
+
         "signal_standard": signal_standard,
-        
+
         "store_user_comments": store_user_comments,
-        
+
     }))
 
 
 
 def null(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw null video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def nut(
-    
+
     syncpoints: str | None = None,
-    
+
     write_index: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     NUT
-    
+
     Args:
         syncpoints: NUT syncpoint behaviour (default 0)
         write_index: Write index (default true)
@@ -3694,45 +3694,45 @@ def nut(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "syncpoints": syncpoints,
-        
+
         "write_index": write_index,
-        
+
     }))
 
 
 
 def obu(
-    
+
 ) -> FFMpegMuxerOption:
     """
     AV1 low overhead OBU
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def oga(
-    
+
     serial_offset: int | None = None,
-    
+
     oggpagesize: int | None = None,
-    
+
     pagesize: int | None = None,
-    
+
     page_duration: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Ogg Audio
-    
+
     Args:
         serial_offset: serial number offset (from 0 to INT_MAX) (default 0)
         oggpagesize: Set preferred Ogg page size. (from 0 to 65025) (default 0)
@@ -3743,33 +3743,33 @@ def oga(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "serial_offset": serial_offset,
-        
+
         "oggpagesize": oggpagesize,
-        
+
         "pagesize": pagesize,
-        
+
         "page_duration": page_duration,
-        
+
     }))
 
 
 
 def ogg(
-    
+
     serial_offset: int | None = None,
-    
+
     oggpagesize: int | None = None,
-    
+
     pagesize: int | None = None,
-    
+
     page_duration: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Ogg
-    
+
     Args:
         serial_offset: serial number offset (from 0 to INT_MAX) (default 0)
         oggpagesize: Set preferred Ogg page size. (from 0 to 65025) (default 0)
@@ -3780,33 +3780,33 @@ def ogg(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "serial_offset": serial_offset,
-        
+
         "oggpagesize": oggpagesize,
-        
+
         "pagesize": pagesize,
-        
+
         "page_duration": page_duration,
-        
+
     }))
 
 
 
 def ogv(
-    
+
     serial_offset: int | None = None,
-    
+
     oggpagesize: int | None = None,
-    
+
     pagesize: int | None = None,
-    
+
     page_duration: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Ogg Video
-    
+
     Args:
         serial_offset: serial number offset (from 0 to INT_MAX) (default 0)
         oggpagesize: Set preferred Ogg page size. (from 0 to 65025) (default 0)
@@ -3817,49 +3817,49 @@ def ogv(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "serial_offset": serial_offset,
-        
+
         "oggpagesize": oggpagesize,
-        
+
         "pagesize": pagesize,
-        
+
         "page_duration": page_duration,
-        
+
     }))
 
 
 
 def oma(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Sony OpenMG audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def opus(
-    
+
     serial_offset: int | None = None,
-    
+
     oggpagesize: int | None = None,
-    
+
     pagesize: int | None = None,
-    
+
     page_duration: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Ogg Opus
-    
+
     Args:
         serial_offset: serial number offset (from 0 to INT_MAX) (default 0)
         oggpagesize: Set preferred Ogg page size. (from 0 to 65025) (default 0)
@@ -3870,91 +3870,91 @@ def opus(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "serial_offset": serial_offset,
-        
+
         "oggpagesize": oggpagesize,
-        
+
         "pagesize": pagesize,
-        
+
         "page_duration": page_duration,
-        
+
     }))
 
 
 
 def d(
-    
+
 ) -> FFMpegMuxerOption:
     """
     oss             OSS (Open Sound System) playback
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def psp(
-    
+
     brand: str | None = None,
-    
+
     empty_hdlr_name: bool | None = None,
-    
+
     encryption_key: str | None = None,
-    
+
     encryption_kid: str | None = None,
-    
+
     encryption_scheme: str | None = None,
-    
+
     frag_duration: int | None = None,
-    
+
     frag_interleave: int | None = None,
-    
+
     frag_size: int | None = None,
-    
+
     fragment_index: int | None = None,
-    
+
     iods_audio_profile: int | None = None,
-    
+
     iods_video_profile: int | None = None,
-    
+
     ism_lookahead: int | None = None,
-    
+
     movflags: str | None = None,
-    
+
     moov_size: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     mov_gamma: float | None = None,
-    
+
     movie_timescale: int | None = None,
-    
+
     rtpflags: str | None = None,
-    
+
     skip_iods: bool | None = None,
-    
+
     use_editlist: bool | None = None,
-    
+
     use_stream_ids_as_track_ids: bool | None = None,
-    
+
     video_track_timescale: int | None = None,
-    
+
     write_btrt: bool | None = None,
-    
+
     write_prft: int | None| Literal["pts", "wallclock"] = None,
-    
+
     write_tmcd: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     PSP MP4 (MPEG-4 Part 14)
-    
+
     Args:
         brand: Override major brand
         empty_hdlr_name: write zero-length name string in hdlr atoms within mdia and minf atoms (default false)
@@ -3986,157 +3986,157 @@ def psp(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "brand": brand,
-        
+
         "empty_hdlr_name": empty_hdlr_name,
-        
+
         "encryption_key": encryption_key,
-        
+
         "encryption_kid": encryption_kid,
-        
+
         "encryption_scheme": encryption_scheme,
-        
+
         "frag_duration": frag_duration,
-        
+
         "frag_interleave": frag_interleave,
-        
+
         "frag_size": frag_size,
-        
+
         "fragment_index": fragment_index,
-        
+
         "iods_audio_profile": iods_audio_profile,
-        
+
         "iods_video_profile": iods_video_profile,
-        
+
         "ism_lookahead": ism_lookahead,
-        
+
         "movflags": movflags,
-        
+
         "moov_size": moov_size,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "mov_gamma": mov_gamma,
-        
+
         "movie_timescale": movie_timescale,
-        
+
         "rtpflags": rtpflags,
-        
+
         "skip_iods": skip_iods,
-        
+
         "use_editlist": use_editlist,
-        
+
         "use_stream_ids_as_track_ids": use_stream_ids_as_track_ids,
-        
+
         "video_track_timescale": video_track_timescale,
-        
+
         "write_btrt": write_btrt,
-        
+
         "write_prft": write_prft,
-        
+
         "write_tmcd": write_tmcd,
-        
+
     }))
 
 
 
 def rawvideo(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def rcwt(
-    
+
 ) -> FFMpegMuxerOption:
     """
     RCWT (Raw Captions With Time)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def rm(
-    
+
 ) -> FFMpegMuxerOption:
     """
     RealMedia
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def roq(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw id RoQ
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def rso(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Lego Mindstorms RSO
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def rtp(
-    
+
     rtpflags: str | None = None,
-    
+
     payload_type: int | None = None,
-    
+
     ssrc: int | None = None,
-    
+
     cname: str | None = None,
-    
+
     seq: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     RTP output
-    
+
     Args:
         rtpflags: RTP muxer flags (default 0)
         payload_type: Specify RTP payload type (from -1 to 127) (default -1)
@@ -4148,31 +4148,31 @@ def rtp(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "rtpflags": rtpflags,
-        
+
         "payload_type": payload_type,
-        
+
         "ssrc": ssrc,
-        
+
         "cname": cname,
-        
+
         "seq": seq,
-        
+
     }))
 
 
 
 def rtp_mpegts(
-    
+
     mpegts_muxer_options: str | None = None,
-    
+
     rtp_muxer_options: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     RTP/mpegts output format
-    
+
     Args:
         mpegts_muxer_options: set list of options for the MPEG-TS muxer
         rtp_muxer_options: set list of options for the RTP muxer
@@ -4181,43 +4181,43 @@ def rtp_mpegts(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "mpegts_muxer_options": mpegts_muxer_options,
-        
+
         "rtp_muxer_options": rtp_muxer_options,
-        
+
     }))
 
 
 
 def rtsp(
-    
+
     rtpflags: str | None = None,
-    
+
     rtsp_transport: str | None = None,
-    
+
     min_port: int | None = None,
-    
+
     max_port: int | None = None,
-    
+
     buffer_size: int | None = None,
-    
+
     pkt_size: int | None = None,
-    
+
     ca_file: str | None = None,
-    
+
     tls_verify: int | None = None,
-    
+
     cert_file: str | None = None,
-    
+
     key_file: str | None = None,
-    
+
     verifyhost: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     RTSP output
-    
+
     Args:
         rtpflags: RTP muxer flags (default 0)
         rtsp_transport: set RTSP transport protocols (default 0)
@@ -4235,255 +4235,255 @@ def rtsp(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "rtpflags": rtpflags,
-        
+
         "rtsp_transport": rtsp_transport,
-        
+
         "min_port": min_port,
-        
+
         "max_port": max_port,
-        
+
         "buffer_size": buffer_size,
-        
+
         "pkt_size": pkt_size,
-        
+
         "ca_file": ca_file,
-        
+
         "tls_verify": tls_verify,
-        
+
         "cert_file": cert_file,
-        
+
         "key_file": key_file,
-        
+
         "verifyhost": verifyhost,
-        
+
     }))
 
 
 
 def s16be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 16-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def s16le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 16-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def s24be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 24-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def s24le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 24-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def s32be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 32-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def s32le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 32-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def s8(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM signed 8-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def sap(
-    
+
 ) -> FFMpegMuxerOption:
     """
     SAP output
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def sbc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw SBC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def scc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Scenarist Closed Captions
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def segment(
-    
+
     reference_stream: str | None = None,
-    
+
     segment_format: str | None = None,
-    
+
     segment_format_options: str | None = None,
-    
+
     segment_list: str | None = None,
-    
+
     segment_header_filename: str | None = None,
-    
+
     segment_list_flags: str | None = None,
-    
+
     segment_list_size: int | None = None,
-    
+
     segment_list_type: int | None| Literal["flat", "csv", "ext", "ffconcat", "m3u8", "hls"] = None,
-    
+
     segment_atclocktime: bool | None = None,
-    
+
     segment_clocktime_offset: str | None = None,
-    
+
     segment_clocktime_wrap_duration: str | None = None,
-    
+
     segment_time: str | None = None,
-    
+
     segment_time_delta: str | None = None,
-    
+
     min_seg_duration: str | None = None,
-    
+
     segment_times: str | None = None,
-    
+
     segment_frames: str | None = None,
-    
+
     segment_wrap: int | None = None,
-    
+
     segment_list_entry_prefix: str | None = None,
-    
+
     segment_start_number: int | None = None,
-    
+
     segment_wrap_number: int | None = None,
-    
+
     strftime: bool | None = None,
-    
+
     increment_tc: bool | None = None,
-    
+
     break_non_keyframes: bool | None = None,
-    
+
     individual_header_trailer: bool | None = None,
-    
+
     write_header_trailer: bool | None = None,
-    
+
     reset_timestamps: bool | None = None,
-    
+
     initial_offset: str | None = None,
-    
+
     write_empty_segments: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     segment
-    
+
     Args:
         reference_stream: set reference stream (default "auto")
         segment_format: set container format used for the segments
@@ -4518,99 +4518,99 @@ def segment(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "reference_stream": reference_stream,
-        
+
         "segment_format": segment_format,
-        
+
         "segment_format_options": segment_format_options,
-        
+
         "segment_list": segment_list,
-        
+
         "segment_header_filename": segment_header_filename,
-        
+
         "segment_list_flags": segment_list_flags,
-        
+
         "segment_list_size": segment_list_size,
-        
+
         "segment_list_type": segment_list_type,
-        
+
         "segment_atclocktime": segment_atclocktime,
-        
+
         "segment_clocktime_offset": segment_clocktime_offset,
-        
+
         "segment_clocktime_wrap_duration": segment_clocktime_wrap_duration,
-        
+
         "segment_time": segment_time,
-        
+
         "segment_time_delta": segment_time_delta,
-        
+
         "min_seg_duration": min_seg_duration,
-        
+
         "segment_times": segment_times,
-        
+
         "segment_frames": segment_frames,
-        
+
         "segment_wrap": segment_wrap,
-        
+
         "segment_list_entry_prefix": segment_list_entry_prefix,
-        
+
         "segment_start_number": segment_start_number,
-        
+
         "segment_wrap_number": segment_wrap_number,
-        
+
         "strftime": strftime,
-        
+
         "increment_tc": increment_tc,
-        
+
         "break_non_keyframes": break_non_keyframes,
-        
+
         "individual_header_trailer": individual_header_trailer,
-        
+
         "write_header_trailer": write_header_trailer,
-        
+
         "reset_timestamps": reset_timestamps,
-        
+
         "initial_offset": initial_offset,
-        
+
         "write_empty_segments": write_empty_segments,
-        
+
     }))
 
 
 
 def smjpeg(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Loki SDL MJPEG
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def smoothstreaming(
-    
+
     window_size: int | None = None,
-    
+
     extra_window_size: int | None = None,
-    
+
     lookahead_count: int | None = None,
-    
+
     min_frag_duration: int | None = None,
-    
+
     remove_at_exit: bool | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Smooth Streaming Muxer
-    
+
     Args:
         window_size: number of fragments kept in the manifest (from 0 to INT_MAX) (default 0)
         extra_window_size: number of fragments kept outside of the manifest before removing from disk (from 0 to INT_MAX) (default 5)
@@ -4622,49 +4622,49 @@ def smoothstreaming(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "window_size": window_size,
-        
+
         "extra_window_size": extra_window_size,
-        
+
         "lookahead_count": lookahead_count,
-        
+
         "min_frag_duration": min_frag_duration,
-        
+
         "remove_at_exit": remove_at_exit,
-        
+
     }))
 
 
 
 def sox(
-    
+
 ) -> FFMpegMuxerOption:
     """
     SoX (Sound eXchange) native
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def spdif(
-    
+
     spdif_flags: str | None = None,
-    
+
     dtshd_rate: int | None = None,
-    
+
     dtshd_fallback_time: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     IEC 61937 (used on S/PDIF - IEC958)
-    
+
     Args:
         spdif_flags: IEC 61937 encapsulation flags (default 0)
         dtshd_rate: mux complete DTS frames in HD mode at the specified IEC958 rate (in Hz, default 0=disabled) (from 0 to 768000) (default 0)
@@ -4674,31 +4674,31 @@ def spdif(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "spdif_flags": spdif_flags,
-        
+
         "dtshd_rate": dtshd_rate,
-        
+
         "dtshd_fallback_time": dtshd_fallback_time,
-        
+
     }))
 
 
 
 def spx(
-    
+
     serial_offset: int | None = None,
-    
+
     oggpagesize: int | None = None,
-    
+
     pagesize: int | None = None,
-    
+
     page_duration: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Ogg Speex
-    
+
     Args:
         serial_offset: serial number offset (from 0 to INT_MAX) (default 0)
         oggpagesize: Set preferred Ogg page size. (from 0 to 65025) (default 0)
@@ -4709,43 +4709,43 @@ def spx(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "serial_offset": serial_offset,
-        
+
         "oggpagesize": oggpagesize,
-        
+
         "pagesize": pagesize,
-        
+
         "page_duration": page_duration,
-        
+
     }))
 
 
 
 def srt(
-    
+
 ) -> FFMpegMuxerOption:
     """
     SubRip subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def streamhash(
-    
+
     hash: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Per-stream hash testing
-    
+
     Args:
         hash: set hash to use (default "sha256")
 
@@ -4753,39 +4753,39 @@ def streamhash(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "hash": hash,
-        
+
     }))
 
 
 
 def sup(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw HDMV Presentation Graphic Stream subtitles
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def svcd(
-    
+
     muxrate: int | None = None,
-    
+
     preload: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MPEG-2 PS (SVCD)
-    
+
     Args:
         muxrate: mux rate as bits/s (from 0 to 1.67772e+09) (default 0)
         preload: initial demux-decode delay in microseconds (from 0 to INT_MAX) (default 500000)
@@ -4794,41 +4794,41 @@ def svcd(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "muxrate": muxrate,
-        
+
         "preload": preload,
-        
+
     }))
 
 
 
 def swf(
-    
+
 ) -> FFMpegMuxerOption:
     """
     SWF (ShockWave Flash)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def tee(
-    
+
     use_fifo: bool | None = None,
-    
+
     fifo_options: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     Multiple muxer tee
-    
+
     Args:
         use_fifo: Use fifo pseudo-muxer to separate actual muxers from encoder (default false)
         fifo_options: fifo pseudo-muxer options
@@ -4837,233 +4837,233 @@ def tee(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "use_fifo": use_fifo,
-        
+
         "fifo_options": fifo_options,
-        
+
     }))
 
 
 
 def truehd(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw TrueHD
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def tta(
-    
+
 ) -> FFMpegMuxerOption:
     """
     TTA (True Audio)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def ttml(
-    
+
 ) -> FFMpegMuxerOption:
     """
     TTML subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u16be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 16-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u16le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 16-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u24be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 24-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u24le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 24-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u32be(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 32-bit big-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u32le(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 32-bit little-endian
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def u8(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM unsigned 8-bit
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def uncodedframecrc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     uncoded framecrc testing
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def vc1(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw VC-1 video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def vc1test(
-    
+
 ) -> FFMpegMuxerOption:
     """
     VC-1 test bitstream
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def vcd(
-    
+
     muxrate: int | None = None,
-    
+
     preload: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MPEG-1 Systems / MPEG program stream (VCD)
-    
+
     Args:
         muxrate: mux rate as bits/s (from 0 to 1.67772e+09) (default 0)
         preload: initial demux-decode delay in microseconds (from 0 to INT_MAX) (default 500000)
@@ -5072,57 +5072,57 @@ def vcd(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "muxrate": muxrate,
-        
+
         "preload": preload,
-        
+
     }))
 
 
 
 def vidc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     PCM Archimedes VIDC
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def d(
-    
+
 ) -> FFMpegMuxerOption:
     """
     video4linux2,v4l2 Video4Linux2 output device
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def vob(
-    
+
     muxrate: int | None = None,
-    
+
     preload: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     MPEG-2 PS (VOB)
-    
+
     Args:
         muxrate: mux rate as bits/s (from 0 to 1.67772e+09) (default 0)
         preload: initial demux-decode delay in microseconds (from 0 to INT_MAX) (default 500000)
@@ -5131,81 +5131,81 @@ def vob(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "muxrate": muxrate,
-        
+
         "preload": preload,
-        
+
     }))
 
 
 
 def voc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Creative Voice
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def vvc(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw H.266/VVC video
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def w64(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Sony Wave64
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def wav(
-    
+
     write_bext: bool | None = None,
-    
+
     write_peak: int | None| Literal["off", "on", "only"] = None,
-    
+
     rf64: int | None| Literal["auto", "always", "never"] = None,
-    
+
     peak_block_size: int | None = None,
-    
+
     peak_format: int | None = None,
-    
+
     peak_ppv: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     WAV / WAVE (Waveform Audio)
-    
+
     Args:
         write_bext: Write BEXT chunk. (default false)
         write_peak: Write Peak Envelope chunk. (from 0 to 2) (default off)
@@ -5218,51 +5218,51 @@ def wav(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "write_bext": write_bext,
-        
+
         "write_peak": write_peak,
-        
+
         "rf64": rf64,
-        
+
         "peak_block_size": peak_block_size,
-        
+
         "peak_format": peak_format,
-        
+
         "peak_ppv": peak_ppv,
-        
+
     }))
 
 
 
 def webm(
-    
+
     reserve_index_space: int | None = None,
-    
+
     cues_to_front: bool | None = None,
-    
+
     cluster_size_limit: int | None = None,
-    
+
     cluster_time_limit: int | None = None,
-    
+
     dash: bool | None = None,
-    
+
     dash_track_number: int | None = None,
-    
+
     live: bool | None = None,
-    
+
     allow_raw_vfw: bool | None = None,
-    
+
     flipped_raw_rgb: bool | None = None,
-    
+
     write_crc32: bool | None = None,
-    
+
     default_mode: int | None| Literal["infer", "infer_no_subs", "passthrough"] = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     WebM
-    
+
     Args:
         reserve_index_space: reserve a given amount of space (in bytes) at the beginning of the file for the index (cues) (from 0 to INT_MAX) (default 0)
         cues_to_front: move Cues (the index) to the front by shifting data if necessary (default false)
@@ -5280,47 +5280,47 @@ def webm(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "reserve_index_space": reserve_index_space,
-        
+
         "cues_to_front": cues_to_front,
-        
+
         "cluster_size_limit": cluster_size_limit,
-        
+
         "cluster_time_limit": cluster_time_limit,
-        
+
         "dash": dash,
-        
+
         "dash_track_number": dash_track_number,
-        
+
         "live": live,
-        
+
         "allow_raw_vfw": allow_raw_vfw,
-        
+
         "flipped_raw_rgb": flipped_raw_rgb,
-        
+
         "write_crc32": write_crc32,
-        
+
         "default_mode": default_mode,
-        
+
     }))
 
 
 
 def webm_chunk(
-    
+
     chunk_start_index: int | None = None,
-    
+
     header: str | None = None,
-    
+
     audio_chunk_duration: int | None = None,
-    
+
     method: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     WebM Chunk Muxer
-    
+
     Args:
         chunk_start_index: start index of the chunk (from 0 to INT_MAX) (default 0)
         header: filename of the header where the initialization data will be written
@@ -5331,39 +5331,39 @@ def webm_chunk(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "chunk_start_index": chunk_start_index,
-        
+
         "header": header,
-        
+
         "audio_chunk_duration": audio_chunk_duration,
-        
+
         "method": method,
-        
+
     }))
 
 
 
 def webm_dash_manifest(
-    
+
     adaptation_sets: str | None = None,
-    
+
     live: bool | None = None,
-    
+
     chunk_start_index: int | None = None,
-    
+
     chunk_duration_ms: int | None = None,
-    
+
     utc_timing_url: str | None = None,
-    
+
     time_shift_buffer_depth: float | None = None,
-    
+
     minimum_update_period: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     WebM DASH Manifest
-    
+
     Args:
         adaptation_sets: Adaptation sets. Syntax: id=0,streams=0,1,2 id=1,streams=3,4 and so on
         live: create a live stream manifest (default false)
@@ -5377,33 +5377,33 @@ def webm_dash_manifest(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "adaptation_sets": adaptation_sets,
-        
+
         "live": live,
-        
+
         "chunk_start_index": chunk_start_index,
-        
+
         "chunk_duration_ms": chunk_duration_ms,
-        
+
         "utc_timing_url": utc_timing_url,
-        
+
         "time_shift_buffer_depth": time_shift_buffer_depth,
-        
+
         "minimum_update_period": minimum_update_period,
-        
+
     }))
 
 
 
 def webp(
-    
+
     loop: int | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     WebP
-    
+
     Args:
         loop: Number of times to loop the output: 0 - infinite loop (from 0 to 65535) (default 1)
 
@@ -5411,45 +5411,45 @@ def webp(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "loop": loop,
-        
+
     }))
 
 
 
 def webvtt(
-    
+
 ) -> FFMpegMuxerOption:
     """
     WebVTT subtitle
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def whip(
-    
+
     handshake_timeout: int | None = None,
-    
+
     pkt_size: int | None = None,
-    
+
     authorization: str | None = None,
-    
+
     cert_file: str | None = None,
-    
+
     key_file: str | None = None,
-    
+
 ) -> FFMpegMuxerOption:
     """
     WHIP(WebRTC-HTTP ingestion protocol) muxer
-    
+
     Args:
         handshake_timeout: Timeout in milliseconds for ICE and DTLS handshake. (from -1 to INT_MAX) (default 5000)
         pkt_size: The maximum size, in bytes, of RTP packets that send out (from -1 to INT_MAX) (default 1200)
@@ -5461,800 +5461,79 @@ def whip(
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
         "handshake_timeout": handshake_timeout,
-        
+
         "pkt_size": pkt_size,
-        
+
         "authorization": authorization,
-        
+
         "cert_file": cert_file,
-        
+
         "key_file": key_file,
-        
+
     }))
 
 
 
 def wsaud(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Westwood Studios audio
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def wtv(
-    
+
 ) -> FFMpegMuxerOption:
     """
     Windows Television (WTV)
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def wv(
-    
+
 ) -> FFMpegMuxerOption:
     """
     raw WavPack
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
 
 
 
 def yuv4mpegpipe(
-    
+
 ) -> FFMpegMuxerOption:
     """
     YUV4MPEG pipe
-    
+
 
     Returns:
         the set codec options
     """
     return FFMpegMuxerOption(merge({
-        
+
     }))
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/packages/v8/src/ffmpeg/sources.py
+++ b/packages/v8/src/ffmpeg/sources.py
@@ -43,31 +43,31 @@ from .streams.audio import AudioStream
 import re
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def abuffer(
-    
 
-    
+
+
 
 
     *,
     time_base: Rational = Default('0/1'),sample_rate: Int = Default('0'),sample_fmt: Sample_fmt = Default('none'),channel_layout: String = Default(None),channels: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Buffer audio frames, and make them available to the filter chain.
 
 This source is mainly intended for a programmatic use, in particular
@@ -91,100 +91,100 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#abuffer)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='abuffer', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "time_base": time_base,
-            
+
             "sample_rate": sample_rate,
-            
+
             "sample_fmt": sample_fmt,
-            
+
             "channel_layout": channel_layout,
-            
+
             "channels": channels,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def aevalsrc(
-    
 
-    
+
+
 
 
     *,
     exprs: String = Default(None),nb_samples: Int = Default('1024'),sample_rate: String = Default('44100'),duration: Duration = Default('-0.000001'),channel_layout: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate an audio signal specified by an expression.
 
 This source accepts in input one or more expressions (one for each
@@ -209,60 +209,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aevalsrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='aevalsrc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "exprs": exprs,
-            
+
             "nb_samples": nb_samples,
-            
+
             "sample_rate": sample_rate,
-            
+
             "duration": duration,
-            
+
             "channel_layout": channel_layout,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def afdelaysrc(
-    
 
-    
+
+
 
 
     *,
     delay: Double = Default('0'),sample_rate: Int = Default('44100'),nb_samples: Int = Default('1024'),taps: Int = Default('0'),channel_layout: String = Default('stereo'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate a fractional delay FIR coefficients.
 
 The resulting stream can be used with afir filter for filtering the audio signal.
@@ -285,60 +285,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afdelaysrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='afdelaysrc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "delay": delay,
-            
+
             "sample_rate": sample_rate,
-            
+
             "nb_samples": nb_samples,
-            
+
             "taps": taps,
-            
+
             "channel_layout": channel_layout,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def afireqsrc(
-    
 
-    
+
+
 
 
     *,
     preset: Int| Literal["custom","flat","acoustic","bass","beats","classic","clear","deep bass","dubstep","electronic","hardstyle","hip-hop","jazz","metal","movie","pop","r&b","rock","vocal booster"] | Default = Default('flat'),gains: String = Default('0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0'),bands: String = Default('25 40 63 100 160 250 400 630 1000 1600 2500 4000 6300 10000 16000 24000'),taps: Int = Default('4096'),sample_rate: Int = Default('44100'),nb_samples: Int = Default('1024'),interp: Int| Literal["linear","cubic"] | Default = Default('linear'),phase: Int| Literal["linear","min"] | Default = Default('min'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate a FIR equalizer coefficients.
 
 The resulting stream can be used with afir filter for filtering the audio signal.
@@ -364,62 +364,62 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afireqsrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='afireqsrc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "preset": preset,
-            
+
             "gains": gains,
-            
+
             "bands": bands,
-            
+
             "taps": taps,
-            
+
             "sample_rate": sample_rate,
-            
+
             "nb_samples": nb_samples,
-            
+
             "interp": interp,
-            
+
             "phase": phase,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
+
+
+
 def afirsrc(
-    
 
-    
+
+
 
 
     *,
     taps: Int = Default('1025'),frequency: String = Default('0 1'),magnitude: String = Default('1 1'),phase: String = Default('0 0'),sample_rate: Int = Default('44100'),nb_samples: Int = Default('1024'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('blackman'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate a FIR coefficients using frequency sampling method.
 
 The resulting stream can be used with afir filter for filtering the audio signal.
@@ -444,78 +444,78 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afirsrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='afirsrc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "taps": taps,
-            
+
             "frequency": frequency,
-            
+
             "magnitude": magnitude,
-            
+
             "phase": phase,
-            
+
             "sample_rate": sample_rate,
-            
+
             "nb_samples": nb_samples,
-            
+
             "win_func": win_func,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
 def ainterleave(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     nb_inputs: Int = Auto('len(streams)'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Temporally interleave frames from several inputs.
 
 interleave works with video inputs, ainterleave with audio.
@@ -554,58 +554,58 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#interleave)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='ainterleave', typings_input='[StreamType.audio] * int(nb_inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "nb_inputs": nb_inputs,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def allrgb(
-    
 
-    
+
+
 
 
     *,
     rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -666,52 +666,52 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='allrgb', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def allyuv(
-    
 
-    
+
+
 
 
     *,
     rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -772,60 +772,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='allyuv', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def amerge(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Merge two or more audio streams into a single multi-channel stream.
 
 The filter accepts the following options:
@@ -842,54 +842,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amerge)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='amerge', typings_input='[StreamType.audio] * int(inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def amix(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),dropout_transition: Float = Default('2'),weights: String = Default('1 1'),normalize: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Mixes multiple audio inputs into a single output.
 
 Note that this filter only supports float samples (the amerge
@@ -915,64 +915,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amix)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='amix', typings_input='[StreamType.audio] * int(inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "duration": duration,
-            
+
             "dropout_transition": dropout_transition,
-            
+
             "weights": weights,
-            
+
             "normalize": normalize,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
+
+
+
 def amovie(
-    
 
-    
+
+
 
 
     *,
     filename: String = Default(None),format_name: String = Default(None),stream_index: Int = Default('-1'),seek_point: Double = Default('0'),streams: String = Default(None),loop: Int = Default('1'),discontinuity: Duration = Default('0'),dec_threads: Int = Default('0'),format_opts: Dictionary = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 This is the same as movie source, except it selects an audio
 stream by default.
 
 
 Args:
-    filename: 
+    filename:
     format_name: set format name
     stream_index: set stream index (from -1 to INT_MAX) (default -1)
     seek_point: set seekpoint (seconds) (from 0 to 9.22337e+12) (default 0)
@@ -991,77 +991,77 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amovie)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='amovie', typings_input="[StreamType.audio] * len(streams.split('+'))", typings_output="[StreamType.audio] * len(streams.split('+'))"),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "filename": filename,
-            
+
             "format_name": format_name,
-            
+
             "stream_index": stream_index,
-            
+
             "seek_point": seek_point,
-            
+
             "streams": streams,
-            
+
             "loop": loop,
-            
+
             "discontinuity": discontinuity,
-            
+
             "dec_threads": dec_threads,
-            
+
             "format_opts": format_opts,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
 def anoisesrc(
-    
 
-    
+
+
 
 
     *,
     sample_rate: Int = Default('48000'),amplitude: Double = Default('1'),duration: Duration = Default('0'),color: Int| Literal["white","pink","brown","blue","violet","velvet"] | Default = Default('white'),seed: Int64 = Default('-1'),nb_samples: Int = Default('1024'),density: Double = Default('0.05'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate a noise audio signal.
 
 The filter accepts the following options:
@@ -1084,64 +1084,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anoisesrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='anoisesrc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "sample_rate": sample_rate,
-            
+
             "amplitude": amplitude,
-            
+
             "duration": duration,
-            
+
             "color": color,
-            
+
             "seed": seed,
-            
+
             "nb_samples": nb_samples,
-            
+
             "density": density,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def anullsrc(
-    
 
-    
+
+
 
 
     *,
     channel_layout: String = Default('stereo'),sample_rate: Int = Default('44100'),nb_samples: Int = Default('1024'),duration: Duration = Default('-0.000001'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 The null audio source, return unprocessed audio frames. It is mainly useful
 as a template and to be employed in analysis / debugging tools, or as
 the source for filters which ignore the input data (for example the sox
@@ -1164,114 +1164,114 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anullsrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='anullsrc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "channel_layout": channel_layout,
-            
+
             "sample_rate": sample_rate,
-            
+
             "nb_samples": nb_samples,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def astreamselect(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),map: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Select video or audio streams.
 
 The filter accepts the following options:
@@ -1290,87 +1290,87 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#streamselect)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='astreamselect', typings_input='[StreamType.audio] * int(inputs)', typings_output="[StreamType.audio] * len(re.findall(r'\\d+', str(map)))"),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "map": map,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def avsynctest(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('hd720'),framerate: Video_rate = Default('30'),samplerate: Int = Default('44100'),amplitude: Float = Default('0.7'),period: Int = Default('3'),delay: Int = Default('0'),cycle: Boolean = Default('false'),duration: Duration = Default('0'),fg: Color = Default('white'),bg: Color = Default('black'),ag: Color = Default('gray'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> tuple[
-    
-        
+
+
             AudioStream,
-        
-    
-        
+
+
+
             VideoStream,
-        
-    
+
+
 ]:
     """
-    
+
 Generate an Audio/Video Sync Test.
 
 Generated stream periodically shows flash video frame and emits beep in audio.
@@ -1401,116 +1401,116 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#avsynctest)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='avsynctest', typings_input=(), typings_output=('audio', 'video')),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "framerate": framerate,
-            
+
             "samplerate": samplerate,
-            
+
             "amplitude": amplitude,
-            
+
             "period": period,
-            
+
             "delay": delay,
-            
+
             "cycle": cycle,
-            
+
             "duration": duration,
-            
+
             "fg": fg,
-            
+
             "bg": bg,
-            
+
             "ag": ag,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return (
-        
-            
+
+
                 filter_node.audio(0),
-            
-        
-            
+
+
+
                 filter_node.video(0),
-            
-        
+
+
     )
 
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def bm3d(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     sigma: Float = Default('1'),block: Int = Default('16'),bstep: Int = Default('4'),group: Int = Default('1'),range: Int = Default('9'),mstep: Int = Default('1'),thmse: Float = Default('0'),hdthr: Float = Default('2.7'),estim: Int| Literal["basic","final"] | Default = Default('basic'),ref: Boolean = Default('false'),planes: Int = Default('7'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Denoise frames using Block-Matching 3D algorithm.
 
 The filter accepts the following options.
@@ -1538,7 +1538,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bm3d)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -1546,71 +1546,71 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='bm3d', typings_input='[StreamType.video] + [StreamType.video] if ref else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "sigma": sigma,
-            
+
             "block": block,
-            
+
             "bstep": bstep,
-            
+
             "group": group,
-            
+
             "range": range,
-            
+
             "mstep": mstep,
-            
+
             "thmse": thmse,
-            
+
             "hdthr": hdthr,
-            
+
             "estim": estim,
-            
+
             "ref": ref,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def buffer(
-    
 
-    
+
+
 
 
     *,
     width: Int = Default('0'),video_size: Image_size = Default(None),height: Int = Default('0'),pix_fmt: Pix_fmt = Default('none'),sar: Rational = Default('0/1'),time_base: Rational = Default('0/1'),colorspace: Int| Literal["gbr","bt709","unknown","fcc","bt470bg","smpte170m","smpte240m","ycgco","ycgco-re","ycgco-ro","bt2020nc","bt2020c","smpte2085","chroma-derived-nc","chroma-derived-c","ictcp","ipt-c2"] | Default = Default('unknown'),range: Int| Literal["unspecified","unknown","limited","tv","mpeg","full","pc","jpeg"] | Default = Default('unspecified'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Buffer video frames, and make them available to the filter chain.
 
 This source is mainly intended for a programmatic use, in particular
@@ -1637,70 +1637,70 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#buffer)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='buffer', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "width": width,
-            
+
             "video_size": video_size,
-            
+
             "height": height,
-            
+
             "pix_fmt": pix_fmt,
-            
+
             "sar": sar,
-            
+
             "time_base": time_base,
-            
+
             "colorspace": colorspace,
-            
+
             "range": range,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def cellauto(
-    
 
-    
+
+
 
 
     *,
     filename: String = Default(None),pattern: String = Default(None),rate: Video_rate = Default('25'),size: Image_size = Default(None),rule: Int = Default('110'),random_fill_ratio: Double = Default('0.618034'),random_seed: Int64 = Default('-1'),scroll: Boolean = Default('true'),start_full: Boolean = Default('false'),full: Boolean = Default('true'),stitch: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Create a pattern generated by an elementary cellular automaton.
 
 The initial state of the cellular automaton can be defined through the
@@ -1735,86 +1735,86 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#cellauto)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='cellauto', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "filename": filename,
-            
+
             "pattern": pattern,
-            
+
             "rate": rate,
-            
+
             "size": size,
-            
+
             "rule": rule,
-            
+
             "random_fill_ratio": random_fill_ratio,
-            
+
             "random_seed": random_seed,
-            
+
             "scroll": scroll,
-            
+
             "start_full": start_full,
-            
+
             "full": full,
-            
+
             "stitch": stitch,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
 def color(
-    
 
-    
+
+
 
 
     *,
     color: Color = Default('black'),size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -1877,60 +1877,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='color', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "color": color,
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def colorchart(
-    
 
-    
+
+
 
 
     *,
     rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),patch_size: Image_size = Default('64x64'),preset: Int| Literal["reference","skintones"] | Default = Default('reference'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -1993,78 +1993,78 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='colorchart', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
             "patch_size": patch_size,
-            
+
             "preset": preset,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def colorspectrum(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),type: Int| Literal["black","white","all"] | Default = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -2127,64 +2127,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='colorspectrum', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
             "type": type,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def concat(
-    
 
-    
+
+
     *streams: FilterableStream,
-    
 
 
-    
+
+
     n: Int = Auto('len(streams) // (int(v) + int(a))'),v: Int = Default('1'),a: Int = Default('0'),unsafe: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Concatenate audio and video streams, joining them together one after the
 other.
 
@@ -2210,95 +2210,95 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#concat)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='concat', typings_input='([StreamType.video]*int(v) + [StreamType.audio]*int(a))*int(n)', typings_output='[StreamType.video]*int(v) + [StreamType.audio]*int(a)'),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "n": n,
-            
+
             "v": v,
-            
+
             "a": a,
-            
+
             "unsafe": unsafe,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def decimate(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     cycle: Int = Default('5'),dupthresh: Double = Default('1.1'),scthresh: Double = Default('15'),blockx: Int = Default('32'),blocky: Int = Default('32'),ppsrc: Boolean = Default('false'),chroma: Boolean = Default('true'),mixed: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Drop duplicated frames at regular intervals.
 
 The filter accepts the following options:
@@ -2322,156 +2322,156 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#decimate)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='decimate', typings_input='[StreamType.video] + ([StreamType.video] if ppsrc else [])', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "cycle": cycle,
-            
+
             "dupthresh": dupthresh,
-            
+
             "scthresh": scthresh,
-            
+
             "blockx": blockx,
-            
+
             "blocky": blocky,
-            
+
             "ppsrc": ppsrc,
-            
+
             "chroma": chroma,
-            
+
             "mixed": mixed,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def fieldmatch(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     order: Int| Literal["auto","bff","tff"] | Default = Default('auto'),mode: Int| Literal["pc","pc_n","pc_u","pc_n_ub","pcn","pcn_ub"] | Default = Default('pc_n'),ppsrc: Boolean = Default('false'),field: Int| Literal["auto","bottom","top"] | Default = Default('auto'),mchroma: Boolean = Default('true'),y0: Int = Default('0'),scthresh: Double = Default('12'),combmatch: Int| Literal["none","sc","full"] | Default = Default('sc'),combdbg: Int| Literal["none","pcn","pcnub"] | Default = Default('none'),cthresh: Int = Default('9'),chroma: Boolean = Default('false'),blockx: Int = Default('16'),blocky: Int = Default('16'),combpel: Int = Default('80'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Field matching filter for inverse telecine. It is meant to reconstruct the
 progressive frames from a telecined stream. The filter does not drop duplicated
 frames, so to achieve a complete inverse telecine fieldmatch needs to be
@@ -2529,112 +2529,112 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fieldmatch)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='fieldmatch', typings_input='[StreamType.video] + [StreamType.video] if ppsrc else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "order": order,
-            
+
             "mode": mode,
-            
+
             "ppsrc": ppsrc,
-            
+
             "field": field,
-            
+
             "mchroma": mchroma,
-            
+
             "y0": y0,
-            
+
             "scthresh": scthresh,
-            
+
             "combmatch": combmatch,
-            
+
             "combdbg": combdbg,
-            
+
             "cthresh": cthresh,
-            
+
             "chroma": chroma,
-            
+
             "blockx": blockx,
-            
+
             "blocky": blocky,
-            
+
             "combpel": combpel,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def gradients(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('640x480'),rate: Video_rate = Default('25'),c0: Color = Default('random'),c1: Color = Default('random'),c2: Color = Default('random'),c3: Color = Default('random'),c4: Color = Default('random'),c5: Color = Default('random'),c6: Color = Default('random'),c7: Color = Default('random'),x0: Int = Default('-1'),y0: Int = Default('-1'),x1: Int = Default('-1'),y1: Int = Default('-1'),nb_colors: Int = Default('2'),seed: Int64 = Default('-1'),duration: Duration = Default('-0.000001'),speed: Float = Default('0.01'),type: Int| Literal["linear","radial","circular","spiral","square"] | Default = Default('linear'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate several gradients.
 
 
@@ -2667,95 +2667,95 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#gradients)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='gradients', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "c0": c0,
-            
+
             "c1": c1,
-            
+
             "c2": c2,
-            
+
             "c3": c3,
-            
+
             "c4": c4,
-            
+
             "c5": c5,
-            
+
             "c6": c6,
-            
+
             "c7": c7,
-            
+
             "x0": x0,
-            
+
             "y0": y0,
-            
+
             "x1": x1,
-            
+
             "y1": y1,
-            
+
             "nb_colors": nb_colors,
-            
+
             "seed": seed,
-            
+
             "duration": duration,
-            
+
             "speed": speed,
-            
+
             "type": type,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def guided(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     radius: Int = Default('3'),eps: Float = Default('0.01'),mode: Int| Literal["basic","fast"] | Default = Default('basic'),sub: Int = Default('4'),guidance: Int| Literal["off","on"] | Default = Default('off'),planes: Int = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply guided filter for edge-preserving smoothing, dehazing and so on.
 
 The filter accepts the following options:
@@ -2778,7 +2778,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#guided)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -2786,61 +2786,61 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='guided', typings_input='[StreamType.video] + [StreamType.video] if guidance else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "radius": radius,
-            
+
             "eps": eps,
-            
+
             "mode": mode,
-            
+
             "sub": sub,
-            
+
             "guidance": guidance,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def haldclutsrc(
-    
 
-    
+
+
 
 
     *,
     level: Int = Default('6'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -2902,58 +2902,58 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='haldclutsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "level": level,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def headphone(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     map: String = Default(None),gain: Float = Default('0'),lfe: Float = Default('0'),type: Int| Literal["time","freq"] | Default = Default('freq'),size: Int = Default('1024'),hrir: Int| Literal["stereo","multich"] | Default = Default('stereo'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Apply head-related transfer functions (HRTFs) to create virtual
 loudspeakers around the user for binaural listening via headphones.
 The HRIRs are provided via additional streams, for each channel
@@ -2978,66 +2978,66 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#headphone)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='headphone', typings_input="[StreamType.audio] + [StreamType.audio] * (len(str(map).split('|')) - 1) if int(hrir) == 1 else []", typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "map": map,
-            
+
             "gain": gain,
-            
+
             "lfe": lfe,
-            
+
             "type": type,
-            
+
             "size": size,
-            
+
             "hrir": hrir,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def hilbert(
-    
 
-    
+
+
 
 
     *,
     sample_rate: Int = Default('44100'),taps: Int = Default('22051'),nb_samples: Int = Default('1024'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('blackman'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate odd-tap Hilbert transform FIR coefficients.
 
 The resulting stream can be used with afir filter for phase-shifting
@@ -3063,64 +3063,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hilbert)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='hilbert', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "sample_rate": sample_rate,
-            
+
             "taps": taps,
-            
+
             "nb_samples": nb_samples,
-            
+
             "win_func": win_func,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def hstack(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),shortest: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos horizontally.
 
 All streams must be of same pixel format and of same height.
@@ -3143,54 +3143,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hstack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='hstack', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def hstack_vaapi(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Default('2'),shortest: Boolean = Default('false'),height: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos horizontally.
 
 This is the VA-API variant of the hstack filter, each input stream may
@@ -3213,82 +3213,82 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hstack_vaapi)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='hstack_vaapi', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
             "height": height,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def interleave(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     nb_inputs: Int = Auto('len(streams)'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Temporally interleave frames from several inputs.
 
 interleave works with video inputs, ainterleave with audio.
@@ -3327,54 +3327,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#interleave)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='interleave', typings_input='[StreamType.video] * int(nb_inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "nb_inputs": nb_inputs,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def join(
-    
 
-    
+
+
     *streams: AudioStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),channel_layout: String = Default('stereo'),map: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Join multiple input streams into one multi-channel stream.
 
 It accepts the following parameters:
@@ -3393,64 +3393,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#join)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='join', typings_input='[StreamType.audio] * int(inputs)', typings_output=('audio',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "channel_layout": channel_layout,
-            
+
             "map": map,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
 def life(
-    
 
-    
+
+
 
 
     *,
     filename: String = Default(None),size: Image_size = Default(None),rate: Video_rate = Default('25'),rule: String = Default('B3/S23'),random_fill_ratio: Double = Default('0.618034'),random_seed: Int64 = Default('-1'),stitch: Boolean = Default('true'),mold: Int = Default('0'),life_color: Color = Default('white'),death_color: Color = Default('black'),mold_color: Color = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate a life pattern.
 
 This source is based on a generalization of John Conway's life game.
@@ -3489,73 +3489,73 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#life)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='life', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "filename": filename,
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "rule": rule,
-            
+
             "random_fill_ratio": random_fill_ratio,
-            
+
             "random_seed": random_seed,
-            
+
             "stitch": stitch,
-            
+
             "mold": mold,
-            
+
             "life_color": life_color,
-            
+
             "death_color": death_color,
-            
+
             "mold_color": mold_color,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def limitdiff(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     threshold: Float = Default('0.00392157'),elasticity: Float = Default('2'),reference: Boolean = Default('false'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply limited difference filter using second and optionally third video stream.
 
 The filter accepts the following options:
@@ -3576,7 +3576,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#limitdiff)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -3584,77 +3584,77 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='limitdiff', typings_input='[StreamType.video, StreamType.video] + ([StreamType.video] if reference else [])', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "threshold": threshold,
-            
+
             "elasticity": elasticity,
-            
+
             "reference": reference,
-            
+
             "planes": planes,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def mandelbrot(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('640x480'),rate: Video_rate = Default('25'),maxiter: Int = Default('7189'),start_x: Double = Default('-0.743644'),start_y: Double = Default('-0.131826'),start_scale: Double = Default('3'),end_scale: Double = Default('0.3'),end_pts: Double = Default('400'),bailout: Double = Default('10'),morphxf: Double = Default('0.01'),morphyf: Double = Default('0.0123'),morphamp: Double = Default('0'),outer: Int| Literal["iteration_count","normalized_iteration_count","white","outz"] | Default = Default('normalized_iteration_count'),inner: Int| Literal["black","period","convergence","mincol"] | Default = Default('mincol'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate a Mandelbrot set fractal, and progressively zoom towards the
 point specified with start_x and start_y.
 
@@ -3685,94 +3685,94 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mandelbrot)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='mandelbrot', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "maxiter": maxiter,
-            
+
             "start_x": start_x,
-            
+
             "start_y": start_y,
-            
+
             "start_scale": start_scale,
-            
+
             "end_scale": end_scale,
-            
+
             "end_pts": end_pts,
-            
+
             "bailout": bailout,
-            
+
             "morphxf": morphxf,
-            
+
             "morphyf": morphyf,
-            
+
             "morphamp": morphamp,
-            
+
             "outer": outer,
-            
+
             "inner": inner,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
 def mergeplanes(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     mapping: Int = Default('-1'),format: Pix_fmt = Default('yuva444p'),map0s: Int = Default('0'),map0p: Int = Default('0'),map1s: Int = Default('0'),map1p: Int = Default('0'),map2s: Int = Default('0'),map2p: Int = Default('0'),map3s: Int = Default('0'),map3p: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Merge color channel components from several video streams.
 
 The filter accepts up to 4 input streams, and merge selected input
@@ -3801,81 +3801,81 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mergeplanes)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='mergeplanes', typings_input='[StreamType.video] * int(max(hex(int(mapping))[2::2]))', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "mapping": mapping,
-            
+
             "format": format,
-            
+
             "map0s": map0s,
-            
+
             "map0p": map0p,
-            
+
             "map1s": map1s,
-            
+
             "map1p": map1p,
-            
+
             "map2s": map2s,
-            
+
             "map2p": map2p,
-            
+
             "map3s": map3s,
-            
+
             "map3p": map3p,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def mix(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),weights: String = Default('1 1'),scale: Float = Default('0'),planes: Flags = Default('F'),duration: Int| Literal["longest","shortest","first"] | Default = Default('longest'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Mix several video input streams into one video stream.
 
 A description of the accepted options follows.
@@ -3897,7 +3897,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mix)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -3905,59 +3905,59 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='mix', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "weights": weights,
-            
+
             "scale": scale,
-            
+
             "planes": planes,
-            
+
             "duration": duration,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def movie(
-    
 
-    
+
+
 
 
     *,
     filename: String = Default(None),format_name: String = Default(None),stream_index: Int = Default('-1'),seek_point: Double = Default('0'),streams: String = Default(None),loop: Int = Default('1'),discontinuity: Duration = Default('0'),dec_threads: Int = Default('0'),format_opts: Dictionary = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Read audio and/or video stream(s) from a movie container.
 
 It accepts the following parameters:
@@ -3983,67 +3983,67 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#movie)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='movie', typings_input="[StreamType.video] * len(streams.split('+'))", typings_output="[StreamType.video] * len(streams.split('+'))"),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "filename": filename,
-            
+
             "format_name": format_name,
-            
+
             "stream_index": stream_index,
-            
+
             "seek_point": seek_point,
-            
+
             "streams": streams,
-            
+
             "loop": loop,
-            
+
             "discontinuity": discontinuity,
-            
+
             "dec_threads": dec_threads,
-            
+
             "format_opts": format_opts,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def mptestsrc(
-    
 
-    
+
+
 
 
     *,
     rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),test: Int| Literal["dc_luma","dc_chroma","freq_luma","freq_chroma","amp_luma","amp_chroma","cbp","mv","ring1","ring2","all"] | Default = Default('all'),max_frames: Int64 = Default('30'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate various test patterns, as generated by the MPlayer test filter.
 
 The size of the generated video is fixed, and is 512x512.
@@ -4066,76 +4066,76 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mptestsrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='mptestsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "test": test,
-            
+
             "max_frames": max_frames,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def nullsrc(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -4197,54 +4197,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='nullsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def openclsrc(
-    
 
-    
+
+
 
 
     *,
     source: String = Default(None),kernel: String = Default(None),size: Image_size = Default(None),format: Pix_fmt = Default('none'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate video using an OpenCL program.
 
 
@@ -4263,72 +4263,72 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#openclsrc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='openclsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "source": source,
-            
+
             "kernel": kernel,
-            
+
             "size": size,
-            
+
             "format": format,
-            
+
             "rate": rate,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
 def pal100bars(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -4390,54 +4390,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='pal100bars', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def pal75bars(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -4499,60 +4499,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='pal75bars', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def perlin(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),octaves: Int = Default('1'),persistence: Double = Default('1'),xscale: Double = Default('1'),yscale: Double = Default('1'),tscale: Double = Default('1'),random_mode: Int| Literal["random","ken","seed"] | Default = Default('random'),random_seed: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate Perlin noise.
 
 Perlin noise is a kind of noise with local continuity in space. This
@@ -4587,85 +4587,85 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#perlin)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='perlin', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "octaves": octaves,
-            
+
             "persistence": persistence,
-            
+
             "xscale": xscale,
-            
+
             "yscale": yscale,
-            
+
             "tscale": tscale,
-            
+
             "random_mode": random_mode,
-            
+
             "random_seed": random_seed,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
 def premultiply(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     planes: Int = Default('15'),inplace: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply alpha premultiply effect to input video stream using first plane
 of second stream as alpha.
 
@@ -4687,7 +4687,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#premultiply)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -4695,62 +4695,62 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='premultiply', typings_input='[StreamType.video] + [StreamType.video] if inplace else []', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "inplace": inplace,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
 def program_opencl(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     source: String = Default(None),kernel: String = Default(None),inputs: Int = Default('1'),size: Image_size = Default(None),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Filter video using an OpenCL program.
 
 
@@ -4769,7 +4769,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#program_opencl)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -4777,85 +4777,85 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='program_opencl', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "source": source,
-            
+
             "kernel": kernel,
-            
+
             "inputs": inputs,
-            
+
             "size": size,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def rgbtestsrc(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),complement: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -4918,69 +4918,69 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='rgbtestsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
             "complement": complement,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
 def scale(
-    
 
-    
+
+
 
 
     *,
     w: String = Default(None),h: String = Default(None),flags: String = Default(''),interl: Boolean = Default('false'),size: String = Default(None),in_color_matrix: Int| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default('auto'),out_color_matrix: Int| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default('2'),in_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),out_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),in_chroma_loc: Int| Literal["auto","unknown","left","center","topleft","top","bottomleft","bottom"] | Default = Default('auto'),out_chroma_loc: Int| Literal["auto","unknown","left","center","topleft","top","bottomleft","bottom"] | Default = Default('auto'),in_primaries: Int| Literal["auto","bt709","bt470m","bt470bg","smpte170m","smpte240m","film","bt2020","smpte428","smpte431","smpte432","jedec-p22","ebu3213"] | Default = Default('auto'),out_primaries: Int| Literal["auto","bt709","bt470m","bt470bg","smpte170m","smpte240m","film","bt2020","smpte428","smpte431","smpte432","jedec-p22","ebu3213"] | Default = Default('auto'),in_transfer: Int| Literal["auto","bt709","bt470m","gamma22","bt470bg","gamma28","smpte170m","smpte240m","linear","iec61966-2-1","srgb","iec61966-2-4","xvycc","bt1361e","bt2020-10","bt2020-12","smpte2084","smpte428","arib-std-b67"] | Default = Default('auto'),in_v_chr_pos: Int = Default('-513'),in_h_chr_pos: Int = Default('-513'),out_v_chr_pos: Int = Default('-513'),out_h_chr_pos: Int = Default('-513'),force_original_aspect_ratio: Int| Literal["disable","decrease","increase"] | Default = Default('disable'),force_divisible_by: Int = Default('1'),reset_sar: Boolean = Default('false'),param0: Double = Default('DBL_MAX'),param1: Double = Default('DBL_MAX'),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Scale (resize) the input video, using the libswscale library.
 
 The scale filter forces the output display aspect ratio to be the same
@@ -5026,7 +5026,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#scale)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -5034,163 +5034,163 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='scale', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "w": w,
-            
+
             "h": h,
-            
+
             "flags": flags,
-            
+
             "interl": interl,
-            
+
             "size": size,
-            
+
             "in_color_matrix": in_color_matrix,
-            
+
             "out_color_matrix": out_color_matrix,
-            
+
             "in_range": in_range,
-            
+
             "out_range": out_range,
-            
+
             "in_chroma_loc": in_chroma_loc,
-            
+
             "out_chroma_loc": out_chroma_loc,
-            
+
             "in_primaries": in_primaries,
-            
+
             "out_primaries": out_primaries,
-            
+
             "in_transfer": in_transfer,
-            
+
             "in_v_chr_pos": in_v_chr_pos,
-            
+
             "in_h_chr_pos": in_h_chr_pos,
-            
+
             "out_v_chr_pos": out_v_chr_pos,
-            
+
             "out_h_chr_pos": out_h_chr_pos,
-            
+
             "force_original_aspect_ratio": force_original_aspect_ratio,
-            
+
             "force_divisible_by": force_divisible_by,
-            
+
             "reset_sar": reset_sar,
-            
+
             "param0": param0,
-            
+
             "param1": param1,
-            
+
             "eval": eval,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def sierpinski(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('640x480'),rate: Video_rate = Default('25'),seed: Int64 = Default('-1'),jump: Int = Default('100'),type: Int| Literal["carpet","triangle"] | Default = Default('carpet'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate a Sierpinski carpet/triangle fractal, and randomly pan around.
 
 This source accepts the following options:
@@ -5211,60 +5211,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sierpinski)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='sierpinski', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "seed": seed,
-            
+
             "jump": jump,
-            
+
             "type": type,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def signature(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     detectmode: Int| Literal["off","full","fast"] | Default = Default('off'),nb_inputs: Int = Auto('len(streams)'),filename: String = Default(''),format: Int| Literal["binary","xml"] | Default = Default('binary'),th_d: Int = Default('9000'),th_dc: Int = Default('60000'),th_xh: Int = Default('116'),th_di: Int = Default('0'),th_it: Double = Default('0.5'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Calculates the MPEG-7 Video Signature. The filter can handle more than one
 input. In this case the matching between the inputs can be calculated additionally.
 The filter always passes through the first input. The signature of each stream can
@@ -5292,70 +5292,70 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#signature)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='signature', typings_input='[StreamType.video] * int(nb_inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "detectmode": detectmode,
-            
+
             "nb_inputs": nb_inputs,
-            
+
             "filename": filename,
-            
+
             "format": format,
-            
+
             "th_d": th_d,
-            
+
             "th_dc": th_dc,
-            
+
             "th_xh": th_xh,
-            
+
             "th_di": th_di,
-            
+
             "th_it": th_it,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def sinc(
-    
 
-    
+
+
 
 
     *,
     sample_rate: Int = Default('44100'),nb_samples: Int = Default('1024'),hp: Float = Default('0'),lp: Float = Default('0'),phase: Float = Default('50'),beta: Float = Default('-1'),att: Float = Default('120'),round: Boolean = Default('false'),hptaps: Int = Default('0'),lptaps: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate a sinc kaiser-windowed low-pass, high-pass, band-pass, or band-reject FIR coefficients.
 
 The resulting stream can be used with afir filter for filtering the audio signal.
@@ -5383,66 +5383,66 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sinc)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='sinc', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "sample_rate": sample_rate,
-            
+
             "nb_samples": nb_samples,
-            
+
             "hp": hp,
-            
+
             "lp": lp,
-            
+
             "phase": phase,
-            
+
             "beta": beta,
-            
+
             "att": att,
-            
+
             "round": round,
-            
+
             "hptaps": hptaps,
-            
+
             "lptaps": lptaps,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
+
+
+
 def sine(
-    
 
-    
+
+
 
 
     *,
     frequency: Double = Default('440'),beep_factor: Double = Default('0'),sample_rate: Int = Default('44100'),duration: Duration = Default('0'),samples_per_frame: String = Default('1024'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> AudioStream:
     """
-    
+
 Generate an audio signal made of a sine wave with amplitude 1/8.
 
 The audio signal is bit-exact.
@@ -5465,60 +5465,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sine)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='sine', typings_input=(), typings_output=('audio',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "frequency": frequency,
-            
+
             "beep_factor": beep_factor,
-            
+
             "sample_rate": sample_rate,
-            
+
             "duration": duration,
-            
+
             "samples_per_frame": samples_per_frame,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.audio(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def smptebars(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -5580,54 +5580,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='smptebars', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def smptehdbars(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -5689,78 +5689,78 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='smptehdbars', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def streamselect(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),map: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> FilterNode:
     """
-    
+
 Select video or audio streams.
 
 The filter accepts the following options:
@@ -5779,69 +5779,69 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#streamselect)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='streamselect', typings_input='[StreamType.video] * int(inputs)', typings_output="[StreamType.video] * len(re.findall(r'\\d+', str(map)))"),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "map": map,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
 
     return filter_node
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
 def testsrc(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),decimals: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -5904,56 +5904,56 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='testsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
             "decimals": decimals,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def testsrc2(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),alpha: Int = Default('255'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -6016,103 +6016,103 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='testsrc2', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
             "alpha": alpha,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def unpremultiply(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     planes: Int = Default('15'),inplace: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Apply alpha unpremultiply effect to input video stream using first plane
 of second stream as alpha.
 
@@ -6134,7 +6134,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#unpremultiply)
 
     """
-    
+
 
 
     if timeline_options is None and enable is not None:
@@ -6142,91 +6142,91 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='unpremultiply', typings_input='[StreamType.video] + ([StreamType.video] if inplace else [])', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "planes": planes,
-            
+
             "inplace": inplace,
-            
+
         },
         extra_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def vstack(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),shortest: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos vertically.
 
 All streams must be of same pixel format and of same width.
@@ -6249,54 +6249,54 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vstack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='vstack', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def vstack_vaapi(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Default('2'),shortest: Boolean = Default('false'),width: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack input videos vertically.
 
 This is the VA-API variant of the vstack filter, each input stream may
@@ -6319,78 +6319,78 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vstack_vaapi)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='vstack_vaapi', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
             "width": width,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
+
+
+
+
+
 def xmedian(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),planes: Int = Default('15'),percentile: Float = Default('0.5'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Pick median pixels from several input videos.
 
 The filter accepts the following options:
@@ -6411,7 +6411,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xmedian)
 
     """
-    
+
 
     if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
         framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -6422,57 +6422,57 @@ References:
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xmedian', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "planes": planes,
-            
+
             "percentile": percentile,
-            
+
         },
         extra_options,
-        
+
         framesync_options,
-        
-        
+
+
         timeline_options,
-        
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def xstack(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Auto('len(streams)'),layout: String = Default(None),grid: Image_size = Default(None),shortest: Boolean = Default('false'),fill: String = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack video inputs into custom layout.
 
 All streams must be of same pixel format.
@@ -6495,60 +6495,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xstack)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xstack', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "layout": layout,
-            
+
             "grid": grid,
-            
+
             "shortest": shortest,
-            
+
             "fill": fill,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
+
+
+
 def xstack_vaapi(
-    
 
-    
+
+
     *streams: VideoStream,
-    
 
 
-    
+
+
     inputs: Int = Default('2'),shortest: Boolean = Default('false'),layout: String = Default(None),grid: Image_size = Default(None),grid_tile_size: Image_size = Default(None),fill: String = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Stack video inputs into custom layout.
 
 This is the VA-API variant of the xstack filter,  each input stream may
@@ -6574,64 +6574,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xstack_vaapi)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='xstack_vaapi', typings_input='[StreamType.video] * int(inputs)', typings_output=('video',)),
-        
 
-        
+
+
         *streams,
-        
+
 
 
         **merge({
-            
+
             "inputs": inputs,
-            
+
             "shortest": shortest,
-            
+
             "layout": layout,
-            
+
             "grid": grid,
-            
+
             "grid_tile_size": grid_tile_size,
-            
+
             "fill": fill,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
 
-    
+
+
+
+
+
 def yuvtestsrc(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 The allrgb source returns frames of size 4096x4096 of all rgb colors.
 
 The allyuv source returns frames of size 4096x4096 of all yuv colors.
@@ -6693,56 +6693,56 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allrgb)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='yuvtestsrc', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
 
 
-    
 
-    
 
-    
 
-    
+
+
+
+
 def zoneplate(
-    
 
-    
+
+
 
 
     *,
     size: Image_size = Default('320x240'),rate: Video_rate = Default('25'),duration: Duration = Default('-0.000001'),sar: Rational = Default('1/1'),precision: Int = Default('10'),xo: Int = Default('0'),yo: Int = Default('0'),to: Int = Default('0'),k0: Int = Default('0'),kx: Int = Default('0'),ky: Int = Default('0'),kt: Int = Default('0'),kxt: Int = Default('0'),kyt: Int = Default('0'),kxy: Int = Default('0'),kx2: Int = Default('0'),ky2: Int = Default('0'),kt2: Int = Default('0'),ku: Int = Default('0'),kv: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
 )-> VideoStream:
     """
-    
+
 Generate a zoneplate test video pattern.
 
 This source accepts the following options:
@@ -6778,69 +6778,62 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#zoneplate)
 
     """
-    
+
 
 
     filter_node = filter_node_factory(
         FFMpegFilterDef(name='zoneplate', typings_input=(), typings_output=('video',)),
-        
 
-        
+
+
 
 
         **merge({
-            
+
             "size": size,
-            
+
             "rate": rate,
-            
+
             "duration": duration,
-            
+
             "sar": sar,
-            
+
             "precision": precision,
-            
+
             "xo": xo,
-            
+
             "yo": yo,
-            
+
             "to": to,
-            
+
             "k0": k0,
-            
+
             "kx": kx,
-            
+
             "ky": ky,
-            
+
             "kt": kt,
-            
+
             "kxt": kxt,
-            
+
             "kyt": kyt,
-            
+
             "kxy": kxy,
-            
+
             "kx2": kx2,
-            
+
             "ky2": ky2,
-            
+
             "kt2": kt2,
-            
+
             "ku": ku,
-            
+
             "kv": kv,
-            
+
         },
         extra_options,
-        
-        
+
+
         )
     )
     return filter_node.video(0)
-
-
-    
-
-    
-
-    

--- a/packages/v8/src/ffmpeg/streams/audio.py
+++ b/packages/v8/src/ffmpeg/streams/audio.py
@@ -48,12 +48,12 @@ class AudioStream(FilterableStream):
     Audio stream.
     """
 
-    
-        
-    
-    
+
+
+
+
     def a3dscope(
-    
+
     self,
 
 
@@ -61,12 +61,12 @@ class AudioStream(FilterableStream):
 
     *,
     rate: Video_rate = Default('25'),size: Image_size = Default('hd720'),fov: Float = Default('90'),roll: Float = Default('0'),pitch: Float = Default('0'),yaw: Float = Default('0'),xzoom: Float = Default('1'),xpos: Float = Default('0'),length: Int = Default('15'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to 3d scope video output.
 
 The filter accepts the following options:
@@ -91,77 +91,77 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#a3dscope)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='a3dscope', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rate": rate,
-                
+
                 "size": size,
-                
+
                 "fov": fov,
-                
+
                 "roll": roll,
-                
+
                 "pitch": pitch,
-                
+
                 "yaw": yaw,
-                
+
                 "xzoom": xzoom,
-                
+
                 "xpos": xpos,
-                
+
                 "length": length,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aap(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('16'),projection: Int = Default('2'),mu: Float = Default('0.0001'),delta: Float = Default('0.001'),out_mode: Int| Literal["i","d","o","n","e"] | Default = Default('o'),precision: Int| Literal["auto","float","double"] | Default = Default('auto'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply Affine Projection algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to estimate unknown audio based on multiple input audio samples.
@@ -187,7 +187,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aap)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -195,52 +195,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aap', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _desired,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "order": order,
-                
+
                 "projection": projection,
-                
+
                 "mu": mu,
-                
+
                 "delta": delta,
-                
+
                 "out_mode": out_mode,
-                
+
                 "precision": precision,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def abench(
-    
+
     self,
 
 
@@ -248,12 +248,12 @@ References:
 
     *,
     action: Int| Literal["start","stop"] | Default = Default('start'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Benchmark part of a filtergraph.
 
 The filter accepts the following options:
@@ -270,37 +270,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bench)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='abench', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "action": action,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def abitscope(
-    
+
     self,
 
 
@@ -308,12 +308,12 @@ References:
 
     *,
     rate: Video_rate = Default('25'),size: Image_size = Default('1024x256'),colors: String = Default('red|green|blue|yellow|orange|lime|pink|magenta|brown'),mode: Int| Literal["bars","trace"] | Default = Default('bars'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a video output, displaying the audio bit scope.
 
 The filter accepts the following options:
@@ -333,47 +333,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#abitscope)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='abitscope', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rate": rate,
-                
+
                 "size": size,
-                
+
                 "colors": colors,
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def acompressor(
-    
+
     self,
 
 
@@ -381,12 +381,12 @@ References:
 
     *,
     level_in: Double = Default('1'),mode: Int| Literal["downward","upward"] | Default = Default('downward'),threshold: Double = Default('0.125'),ratio: Double = Default('2'),attack: Double = Default('20'),release: Double = Default('250'),makeup: Double = Default('1'),knee: Double = Default('2.82843'),link: Int| Literal["average","maximum"] | Default = Default('average'),detection: Int| Literal["peak","rms"] | Default = Default('rms'),level_sc: Double = Default('1'),mix: Double = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 A compressor is mainly used to reduce the dynamic range of a signal.
 Especially modern music is mostly compressed at a high ratio to
 improve the overall loudness. It's done to get the highest attention
@@ -439,59 +439,59 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acompressor)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acompressor', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "mode": mode,
-                
+
                 "threshold": threshold,
-                
+
                 "ratio": ratio,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "makeup": makeup,
-                
+
                 "knee": knee,
-                
+
                 "link": link,
-                
+
                 "detection": detection,
-                
+
                 "level_sc": level_sc,
-                
+
                 "mix": mix,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def acontrast(
-    
+
     self,
 
 
@@ -499,12 +499,12 @@ References:
 
     *,
     contrast: Float = Default('33'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Simple audio dynamic range compression/expansion filter.
 
 The filter accepts the following options:
@@ -521,50 +521,50 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acontrast)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acontrast', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "contrast": contrast,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def acopy(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Copy the input audio source unchanged to the output. This is mainly useful for
 testing purposes.
 
@@ -579,56 +579,56 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acopy)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acopy', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def acrossfade(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _crossfade1: AudioStream,
-        
-    
+
+
 
 
     *,
     nb_samples: Int64 = Default('44100'),duration: Duration = Default('0'),overlap: Boolean = Default('true'),curve1: Int| Literal["nofade","tri","qsin","esin","hsin","log","ipar","qua","cub","squ","cbr","par","exp","iqsin","ihsin","dese","desi","losi","sinc","isinc","quat","quatr","qsin2","hsin2"] | Default = Default('tri'),curve2: Int| Literal["nofade","tri","qsin","esin","hsin","log","ipar","qua","cub","squ","cbr","par","exp","iqsin","ihsin","dese","desi","losi","sinc","isinc","quat","quatr","qsin2","hsin2"] | Default = Default('tri'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply cross fade from one input audio stream to another input audio stream.
 The cross fade is applied for specified duration near the end of first stream.
 
@@ -650,53 +650,53 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acrossfade)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acrossfade', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _crossfade1,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "nb_samples": nb_samples,
-                
+
                 "duration": duration,
-                
+
                 "overlap": overlap,
-                
+
                 "curve1": curve1,
-                
+
                 "curve2": curve2,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def acrossover(
-    
+
     self,
 
 
@@ -704,12 +704,12 @@ References:
 
     *,
     split: String = Default('500'),order: Int| Literal["2nd","4th","6th","8th","10th","12th","14th","16th","18th","20th"] | Default = Default('4th'),level: Float = Default('1'),gain: String = Default('1.f'),precision: Int| Literal["auto","float","double"] | Default = Default('auto'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Split audio stream into several bands.
 
 This filter splits audio stream into two or more frequency ranges.
@@ -734,46 +734,46 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acrossover)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acrossover', typings_input=('audio',), typings_output="[StreamType.audio] * len(re.split(r'[ |]+', str(split)))"),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "split": split,
-                
+
                 "order": order,
-                
+
                 "level": level,
-                
+
                 "gain": gain,
-                
+
                 "precision": precision,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def acrusher(
-    
+
     self,
 
 
@@ -781,15 +781,15 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),bits: Double = Default('8'),mix: Double = Default('0.5'),mode: Int| Literal["lin","log"] | Default = Default('lin'),dc: Double = Default('1'),aa: Double = Default('0.5'),samples: Double = Default('1'),lfo: Boolean = Default('false'),lforange: Double = Default('20'),lforate: Double = Default('0.3'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Reduce audio bit resolution.
 
 This filter is bit crusher with enhanced functionality. A bit crusher
@@ -834,7 +834,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acrusher)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -842,54 +842,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acrusher', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "bits": bits,
-                
+
                 "mix": mix,
-                
+
                 "mode": mode,
-                
+
                 "dc": dc,
-                
+
                 "aa": aa,
-                
+
                 "samples": samples,
-                
+
                 "lfo": lfo,
-                
+
                 "lforange": lforange,
-                
+
                 "lforate": lforate,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def acue(
-    
+
     self,
 
 
@@ -897,12 +897,12 @@ References:
 
     *,
     cue: Int64 = Default('0'),preroll: Duration = Default('0'),buffer: Duration = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Delay audio filtering until a given wallclock timestamp. See the cue
 filter.
 
@@ -920,43 +920,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#acue)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='acue', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cue": cue,
-                
+
                 "preroll": preroll,
-                
+
                 "buffer": buffer,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def adeclick(
-    
+
     self,
 
 
@@ -964,15 +964,15 @@ References:
 
     *,
     window: Double = Default('55'),overlap: Double = Default('75'),arorder: Double = Default('2'),threshold: Double = Default('2'),burst: Double = Default('2'),method: Int| Literal["add","a","save","s"] | Default = Default('add'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Remove impulsive noise from input audio.
 
 Samples detected as impulsive noise are replaced by interpolated samples using
@@ -996,7 +996,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adeclick)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1004,44 +1004,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adeclick', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "window": window,
-                
+
                 "overlap": overlap,
-                
+
                 "arorder": arorder,
-                
+
                 "threshold": threshold,
-                
+
                 "burst": burst,
-                
+
                 "method": method,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adeclip(
-    
+
     self,
 
 
@@ -1049,15 +1049,15 @@ References:
 
     *,
     window: Double = Default('55'),overlap: Double = Default('75'),arorder: Double = Default('8'),threshold: Double = Default('10'),hsize: Int = Default('1000'),method: Int| Literal["add","a","save","s"] | Default = Default('add'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Remove clipped samples from input audio.
 
 Samples detected as clipped are replaced by interpolated samples using
@@ -1081,7 +1081,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adeclip)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1089,44 +1089,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adeclip', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "window": window,
-                
+
                 "overlap": overlap,
-                
+
                 "arorder": arorder,
-                
+
                 "threshold": threshold,
-                
+
                 "hsize": hsize,
-                
+
                 "method": method,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adecorrelate(
-    
+
     self,
 
 
@@ -1134,15 +1134,15 @@ References:
 
     *,
     stages: Int = Default('6'),seed: Int64 = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply decorrelation to input audio stream.
 
 The filter accepts the following options:
@@ -1161,7 +1161,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adecorrelate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1169,36 +1169,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adecorrelate', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "stages": stages,
-                
+
                 "seed": seed,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adelay(
-    
+
     self,
 
 
@@ -1206,15 +1206,15 @@ References:
 
     *,
     delays: String = Default(None),all: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Delay one or more audio channels.
 
 Samples in delayed channel are filled with silence.
@@ -1235,7 +1235,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adelay)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1243,36 +1243,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adelay', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "delays": delays,
-                
+
                 "all": all,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adenorm(
-    
+
     self,
 
 
@@ -1280,15 +1280,15 @@ References:
 
     *,
     level: Double = Default('-351'),type: Int| Literal["dc","ac","square","pulse"] | Default = Default('dc'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Remedy denormals in audio by adding extremely low-level noise.
 
 This filter shall be placed before any filter that can produce denormals.
@@ -1309,7 +1309,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adenorm)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1317,52 +1317,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adenorm', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level": level,
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aderivative(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Compute derivative/integral of audio stream.
 
 Applying both filters one after another produces original audio.
@@ -1379,7 +1379,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aderivative)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1387,32 +1387,32 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aderivative', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adrawgraph(
-    
+
     self,
 
 
@@ -1420,12 +1420,12 @@ References:
 
     *,
     m1: String = Default(''),fg1: String = Default('0xffff0000'),m2: String = Default(''),fg2: String = Default('0xff00ff00'),m3: String = Default(''),fg3: String = Default('0xffff00ff'),m4: String = Default(''),fg4: String = Default('0xffffff00'),bg: Color = Default('white'),min: Float = Default('-1'),max: Float = Default('1'),mode: Int| Literal["bar","dot","line"] | Default = Default('line'),slide: Int| Literal["frame","replace","scroll","rscroll","picture"] | Default = Default('frame'),size: Image_size = Default('900x256'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw a graph using input audio metadata.
 
 See drawgraph
@@ -1456,65 +1456,65 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adrawgraph)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adrawgraph', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "m1": m1,
-                
+
                 "fg1": fg1,
-                
+
                 "m2": m2,
-                
+
                 "fg2": fg2,
-                
+
                 "m3": m3,
-                
+
                 "fg3": fg3,
-                
+
                 "m4": m4,
-                
+
                 "fg4": fg4,
-                
+
                 "bg": bg,
-                
+
                 "min": min,
-                
+
                 "max": max,
-                
+
                 "mode": mode,
-                
+
                 "slide": slide,
-                
+
                 "size": size,
-                
+
                 "rate": rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adrc(
-    
+
     self,
 
 
@@ -1522,15 +1522,15 @@ References:
 
     *,
     transfer: String = Default('p'),attack: Double = Default('50'),release: Double = Default('100'),channels: String = Default('all'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply spectral dynamic range controller filter to input audio stream.
 
 A description of the accepted options follows.
@@ -1551,7 +1551,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adrc)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1559,40 +1559,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adrc', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "transfer": transfer,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "channels": channels,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adynamicequalizer(
-    
+
     self,
 
 
@@ -1600,15 +1600,15 @@ References:
 
     *,
     threshold: Double = Default('0'),dfrequency: Double = Default('1000'),dqfactor: Double = Default('1'),tfrequency: Double = Default('1000'),tqfactor: Double = Default('1'),attack: Double = Default('20'),release: Double = Default('200'),ratio: Double = Default('1'),makeup: Double = Default('0'),range: Double = Default('50'),mode: Int| Literal["listen","cutbelow","cutabove","boostbelow","boostabove"] | Default = Default('cutbelow'),dftype: Int| Literal["bandpass","lowpass","highpass","peak"] | Default = Default('bandpass'),tftype: Int| Literal["bell","lowshelf","highshelf"] | Default = Default('bell'),auto: Int| Literal["disabled","off","on","adaptive"] | Default = Default('off'),precision: Int| Literal["auto","float","double"] | Default = Default('auto'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply dynamic equalization to input audio stream.
 
 A description of the accepted options follows.
@@ -1640,7 +1640,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adynamicequalizer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1648,62 +1648,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adynamicequalizer', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold": threshold,
-                
+
                 "dfrequency": dfrequency,
-                
+
                 "dqfactor": dqfactor,
-                
+
                 "tfrequency": tfrequency,
-                
+
                 "tqfactor": tqfactor,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "ratio": ratio,
-                
+
                 "makeup": makeup,
-                
+
                 "range": range,
-                
+
                 "mode": mode,
-                
+
                 "dftype": dftype,
-                
+
                 "tftype": tftype,
-                
+
                 "auto": auto,
-                
+
                 "precision": precision,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def adynamicsmooth(
-    
+
     self,
 
 
@@ -1711,15 +1711,15 @@ References:
 
     *,
     sensitivity: Double = Default('2'),basefreq: Double = Default('22050'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply dynamic smoothing to input audio stream.
 
 A description of the accepted options follows.
@@ -1738,7 +1738,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#adynamicsmooth)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1746,36 +1746,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='adynamicsmooth', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sensitivity": sensitivity,
-                
+
                 "basefreq": basefreq,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aecho(
-    
+
     self,
 
 
@@ -1783,12 +1783,12 @@ References:
 
     *,
     in_gain: Float = Default('0.6'),out_gain: Float = Default('0.3'),delays: String = Default('1000'),decays: String = Default('0.5'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply echoing to the input audio.
 
 Echoes are reflected sound and can occur naturally amongst mountains
@@ -1816,43 +1816,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aecho)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aecho', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "in_gain": in_gain,
-                
+
                 "out_gain": out_gain,
-                
+
                 "delays": delays,
-                
+
                 "decays": decays,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aemphasis(
-    
+
     self,
 
 
@@ -1860,15 +1860,15 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),mode: Int| Literal["reproduction","production"] | Default = Default('reproduction'),type: Int| Literal["col","emi","bsi","riaa","cd","50fm","75fm","50kf","75kf"] | Default = Default('cd'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Audio emphasis filter creates or restores material directly taken from LPs or
 emphased CDs with different filter curves. E.g. to store music on vinyl the
 signal has to be altered by a filter first to even out the disadvantages of
@@ -1894,7 +1894,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aemphasis)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1902,40 +1902,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aemphasis', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "mode": mode,
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aeval(
-    
+
     self,
 
 
@@ -1943,15 +1943,15 @@ References:
 
     *,
     exprs: String = Default(None),channel_layout: String = Default(None),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Modify an audio signal according to the specified expressions.
 
 This filter accepts one or more expressions (one for each channel),
@@ -1973,7 +1973,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aeval)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1981,38 +1981,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aeval', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "exprs": exprs,
-                
+
                 "channel_layout": channel_layout,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def aexciter(
-    
+
     self,
 
 
@@ -2020,15 +2020,15 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),amount: Double = Default('1'),drive: Double = Default('8.5'),blend: Double = Default('0'),freq: Double = Default('7500'),ceil: Double = Default('9999'),listen: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 An exciter is used to produce high sound that is not present in the
 original signal. This is done by creating harmonic distortions of the
 signal which are restricted in range and added to the original signal.
@@ -2058,7 +2058,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aexciter)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2066,48 +2066,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aexciter', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "amount": amount,
-                
+
                 "drive": drive,
-                
+
                 "blend": blend,
-                
+
                 "freq": freq,
-                
+
                 "ceil": ceil,
-                
+
                 "listen": listen,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def afade(
-    
+
     self,
 
 
@@ -2115,15 +2115,15 @@ References:
 
     *,
     type: Int| Literal["in","out"] | Default = Default('in'),start_sample: Int64 = Default('0'),nb_samples: Int64 = Default('44100'),start_time: Duration = Default('0'),duration: Duration = Default('0'),curve: Int| Literal["nofade","tri","qsin","esin","hsin","log","ipar","qua","cub","squ","cbr","par","exp","iqsin","ihsin","dese","desi","losi","sinc","isinc","quat","quatr","qsin2","hsin2"] | Default = Default('tri'),silence: Double = Default('0'),unity: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply fade-in/out effect to input audio.
 
 A description of the accepted parameters follows.
@@ -2148,7 +2148,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afade)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2156,50 +2156,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='afade', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "type": type,
-                
+
                 "start_sample": start_sample,
-                
+
                 "nb_samples": nb_samples,
-                
+
                 "start_time": start_time,
-                
+
                 "duration": duration,
-                
+
                 "curve": curve,
-                
+
                 "silence": silence,
-                
+
                 "unity": unity,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def afftdn(
-    
+
     self,
 
 
@@ -2207,15 +2207,15 @@ References:
 
     *,
     noise_reduction: Float = Default('12'),noise_floor: Float = Default('-50'),noise_type: Int| Literal["white","w","vinyl","v","shellac","s","custom","c"] | Default = Default('white'),band_noise: String = Default(None),residual_floor: Float = Default('-38'),track_noise: Boolean = Default('false'),track_residual: Boolean = Default('false'),output_mode: Int| Literal["input","i","output","o","noise","n"] | Default = Default('output'),adaptivity: Float = Default('0.5'),floor_offset: Float = Default('1'),noise_link: Int| Literal["none","min","max","average"] | Default = Default('min'),band_multiplier: Float = Default('1.25'),sample_noise: Int| Literal["none","start","begin","stop","end"] | Default = Default('none'),gain_smooth: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Denoise audio samples with FFT.
 
 A description of the accepted parameters follows.
@@ -2246,7 +2246,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afftdn)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2254,60 +2254,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='afftdn', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "noise_reduction": noise_reduction,
-                
+
                 "noise_floor": noise_floor,
-                
+
                 "noise_type": noise_type,
-                
+
                 "band_noise": band_noise,
-                
+
                 "residual_floor": residual_floor,
-                
+
                 "track_noise": track_noise,
-                
+
                 "track_residual": track_residual,
-                
+
                 "output_mode": output_mode,
-                
+
                 "adaptivity": adaptivity,
-                
+
                 "floor_offset": floor_offset,
-                
+
                 "noise_link": noise_link,
-                
+
                 "band_multiplier": band_multiplier,
-                
+
                 "sample_noise": sample_noise,
-                
+
                 "gain_smooth": gain_smooth,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def afftfilt(
-    
+
     self,
 
 
@@ -2315,15 +2315,15 @@ References:
 
     *,
     real: String = Default('re'),imag: String = Default('im'),win_size: Int = Default('4096'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('hann'),overlap: Float = Default('0.75'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply arbitrary expressions to samples in frequency domain.
 
 
@@ -2343,7 +2343,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afftfilt)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2351,46 +2351,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='afftfilt', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "real": real,
-                
+
                 "imag": imag,
-                
+
                 "win_size": win_size,
-                
+
                 "win_func": win_func,
-                
+
                 "overlap": overlap,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def aformat(
-    
+
     self,
 
 
@@ -2398,12 +2398,12 @@ References:
 
     *,
     sample_fmts: Sample_fmt = Default(None),sample_rates: Int = Default(None),channel_layouts: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Set output format constraints for the input audio. The framework will
 negotiate the most appropriate format to minimize conversions.
 
@@ -2423,41 +2423,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aformat)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aformat', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sample_fmts": sample_fmts,
-                
+
                 "sample_rates": sample_rates,
-                
+
                 "channel_layouts": channel_layouts,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def afreqshift(
-    
+
     self,
 
 
@@ -2465,15 +2465,15 @@ References:
 
     *,
     shift: Double = Default('0'),level: Double = Default('1'),order: Int = Default('8'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply frequency shift to input audio samples.
 
 The filter accepts the following options:
@@ -2493,7 +2493,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afreqshift)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2501,38 +2501,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='afreqshift', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "shift": shift,
-                
+
                 "level": level,
-                
+
                 "order": order,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def afwtdn(
-    
+
     self,
 
 
@@ -2540,15 +2540,15 @@ References:
 
     *,
     sigma: Double = Default('0'),levels: Int = Default('10'),wavet: Int| Literal["sym2","sym4","rbior68","deb10","sym10","coif5","bl3"] | Default = Default('sym10'),percent: Double = Default('85'),profile: Boolean = Default('false'),adaptive: Boolean = Default('false'),samples: Int = Default('8192'),softness: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Reduce broadband noise from input samples using Wavelets.
 
 A description of the accepted options follows.
@@ -2573,7 +2573,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#afwtdn)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2581,48 +2581,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='afwtdn', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sigma": sigma,
-                
+
                 "levels": levels,
-                
+
                 "wavet": wavet,
-                
+
                 "percent": percent,
-                
+
                 "profile": profile,
-                
+
                 "adaptive": adaptive,
-                
+
                 "samples": samples,
-                
+
                 "softness": softness,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def agate(
-    
+
     self,
 
 
@@ -2630,15 +2630,15 @@ References:
 
     *,
     level_in: Double = Default('1'),mode: Int| Literal["downward","upward"] | Default = Default('downward'),range: Double = Default('0.06125'),threshold: Double = Default('0.125'),ratio: Double = Default('2'),attack: Double = Default('20'),release: Double = Default('250'),makeup: Double = Default('1'),knee: Double = Default('2.82843'),detection: Int| Literal["peak","rms"] | Default = Default('rms'),link: Int| Literal["average","maximum"] | Default = Default('average'),level_sc: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 A gate is mainly used to reduce lower parts of a signal. This kind of signal
 processing reduces disturbing noise between useful signals.
 
@@ -2677,7 +2677,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#agate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2685,56 +2685,56 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='agate', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "mode": mode,
-                
+
                 "range": range,
-                
+
                 "threshold": threshold,
-                
+
                 "ratio": ratio,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "makeup": makeup,
-                
+
                 "knee": knee,
-                
+
                 "detection": detection,
-                
+
                 "link": link,
-                
+
                 "level_sc": level_sc,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def agraphmonitor(
-    
+
     self,
 
 
@@ -2742,12 +2742,12 @@ References:
 
     *,
     size: Image_size = Default('hd720'),opacity: Float = Default('0.9'),mode: Flags| Literal["full","compact","nozero","noeof","nodisabled"] | Default = Default('0'),flags: Flags| Literal["none","all","queue","frame_count_in","frame_count_out","frame_count_delta","pts","pts_delta","time","time_delta","timebase","format","size","rate","eof","sample_count_in","sample_count_out","sample_count_delta","disabled"] | Default = Default('all+queue'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 See graphmonitor.
 
 
@@ -2766,45 +2766,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#agraphmonitor)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='agraphmonitor', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "opacity": opacity,
-                
+
                 "mode": mode,
-                
+
                 "flags": flags,
-                
+
                 "rate": rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ahistogram(
-    
+
     self,
 
 
@@ -2812,12 +2812,12 @@ References:
 
     *,
     dmode: Int| Literal["single","separate"] | Default = Default('single'),rate: Video_rate = Default('25'),size: Image_size = Default('hd720'),scale: Int| Literal["log","sqrt","cbrt","lin","rlog"] | Default = Default('log'),ascale: Int| Literal["log","lin"] | Default = Default('log'),acount: Int = Default('1'),rheight: Float = Default('0.1'),slide: Int| Literal["replace","scroll"] | Default = Default('replace'),hmode: Int| Literal["abs","sign"] | Default = Default('abs'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a video output, displaying the volume histogram.
 
 The filter accepts the following options:
@@ -2842,53 +2842,53 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ahistogram)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ahistogram', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dmode": dmode,
-                
+
                 "rate": rate,
-                
+
                 "size": size,
-                
+
                 "scale": scale,
-                
+
                 "ascale": ascale,
-                
+
                 "acount": acount,
-                
+
                 "rheight": rheight,
-                
+
                 "slide": slide,
-                
+
                 "hmode": hmode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aiir(
-    
+
     self,
 
 
@@ -2896,12 +2896,12 @@ References:
 
     *,
     zeros: String = Default('1+0i 1-0i'),poles: String = Default('1+0i 1-0i'),gains: String = Default('1|1'),dry: Double = Default('1'),wet: Double = Default('1'),format: Int| Literal["ll","sf","tf","zp","pr","pd","sp"] | Default = Default('zp'),process: Int| Literal["d","s","p"] | Default = Default('s'),precision: Int| Literal["dbl","flt","i32","i16"] | Default = Default('dbl'),e: Int| Literal["dbl","flt","i32","i16"] | Default = Default('dbl'),normalize: Boolean = Default('true'),mix: Double = Default('1'),response: Boolean = Default('false'),channel: Int = Default('0'),size: Image_size = Default('hd720'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Apply an arbitrary Infinite Impulse Response filter.
 
 It accepts the following parameters:
@@ -2933,82 +2933,82 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aiir)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aiir', typings_input=('audio',), typings_output='[StreamType.audio] + [StreamType.video] if response else []'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "zeros": zeros,
-                
+
                 "poles": poles,
-                
+
                 "gains": gains,
-                
+
                 "dry": dry,
-                
+
                 "wet": wet,
-                
+
                 "format": format,
-                
+
                 "process": process,
-                
+
                 "precision": precision,
-                
+
                 "e": e,
-                
+
                 "normalize": normalize,
-                
+
                 "mix": mix,
-                
+
                 "response": response,
-                
+
                 "channel": channel,
-                
+
                 "size": size,
-                
+
                 "rate": rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aintegral(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Compute derivative/integral of audio stream.
 
 Applying both filters one after another produces original audio.
@@ -3025,7 +3025,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aderivative)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3033,50 +3033,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aintegral', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def alatency(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Measure filtering latency.
 
 Report previous filter filtering latency, delay in number of audio samples for audio filters
@@ -3097,7 +3097,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#latency)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3105,32 +3105,32 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='alatency', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def alimiter(
-    
+
     self,
 
 
@@ -3138,15 +3138,15 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),limit: Double = Default('1'),attack: Double = Default('5'),release: Double = Default('50'),asc: Boolean = Default('false'),asc_level: Double = Default('0.5'),level: Boolean = Default('true'),latency: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 The limiter prevents an input signal from rising over a desired threshold.
 This limiter uses lookahead technology to prevent your signal from distorting.
 It means that there is a small delay after the signal is processed. Keep in mind
@@ -3175,7 +3175,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#alimiter)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3183,50 +3183,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='alimiter', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "limit": limit,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "asc": asc,
-                
+
                 "asc_level": asc_level,
-                
+
                 "level": level,
-                
+
                 "latency": latency,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def allpass(
-    
+
     self,
 
 
@@ -3234,15 +3234,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.707'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),order: Int = Default('2'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a two-pole all-pass filter with central frequency (in Hz)
 frequency, and filter-width width.
 An all-pass filter changes the audio's frequency to phase relationship
@@ -3271,7 +3271,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#allpass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3279,54 +3279,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='allpass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "order": order,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def aloop(
-    
+
     self,
 
 
@@ -3334,12 +3334,12 @@ References:
 
     *,
     loop: Int = Default('0'),size: Int64 = Default('0'),start: Int64 = Default('0'),time: Duration = Default('INT64_MAX'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Loop audio samples.
 
 The filter accepts the following options:
@@ -3359,49 +3359,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aloop)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aloop', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "loop": loop,
-                
+
                 "size": size,
-                
+
                 "start": start,
-                
+
                 "time": time,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def ametadata(
-    
+
     self,
 
 
@@ -3409,15 +3409,15 @@ References:
 
     *,
     mode: Int| Literal["select","add","modify","delete","print"] | Default = Default('select'),key: String = Default(None),value: String = Default(None),function: Int| Literal["same_str","starts_with","less","equal","greater","expr","ends_with"] | Default = Default('same_str'),expr: String = Default(None),file: String = Default(None),direct: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Manipulate frame metadata.
 
 This filter accepts the following options:
@@ -3441,7 +3441,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#metadata)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3449,73 +3449,73 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ametadata', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "key": key,
-                
+
                 "value": value,
-                
+
                 "function": function,
-                
+
                 "expr": expr,
-                
+
                 "file": file,
-                
+
                 "direct": direct,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def amultiply(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _multiply1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Multiply first audio stream with second audio stream and store result
 in output audio stream. Multiplication is done by multiplying each
 sample from first stream with sample at same position from second stream.
@@ -3534,43 +3534,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amultiply)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='amultiply', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _multiply1,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def anequalizer(
-    
+
     self,
 
 
@@ -3578,15 +3578,15 @@ References:
 
     *,
     params: String = Default(''),curves: Boolean = Default('false'),size: Image_size = Default('hd720'),mgain: Double = Default('60'),fscale: Int| Literal["lin","log"] | Default = Default('log'),colors: String = Default('red|green|blue|yellow|orange|lime|pink|magenta|brown'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 High-order parametric multiband equalizer for each channel.
 
 It accepts the following parameters:
@@ -3610,7 +3610,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anequalizer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3618,45 +3618,45 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='anequalizer', typings_input=('audio',), typings_output='[StreamType.audio] + [StreamType.video] if curves else []'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "params": params,
-                
+
                 "curves": curves,
-                
+
                 "size": size,
-                
+
                 "mgain": mgain,
-                
+
                 "fscale": fscale,
-                
+
                 "colors": colors,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def anlmdn(
-    
+
     self,
 
 
@@ -3664,15 +3664,15 @@ References:
 
     *,
     strength: Float = Default('1e-05'),patch: Duration = Default('0.002'),research: Duration = Default('0.006'),output: Int| Literal["i","o","n"] | Default = Default('o'),smooth: Float = Default('11'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Reduce broadband noise in audio samples using Non-Local Means algorithm.
 
 Each sample is adjusted by looking for other samples with similar contexts. This
@@ -3698,7 +3698,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anlmdn)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3706,66 +3706,66 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='anlmdn', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "strength": strength,
-                
+
                 "patch": patch,
-                
+
                 "research": research,
-                
+
                 "output": output,
-                
+
                 "smooth": smooth,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def anlmf(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('256'),mu: Float = Default('0.75'),eps: Float = Default('1'),leakage: Float = Default('0'),out_mode: Int| Literal["i","d","o","n","e"] | Default = Default('o'),precision: Int| Literal["auto","float","double"] | Default = Default('auto'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply Normalized Least-Mean-(Squares|Fourth) algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to mimic a desired filter by finding the filter coefficients that
@@ -3792,7 +3792,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anlmf)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3800,76 +3800,76 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='anlmf', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _desired,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "order": order,
-                
+
                 "mu": mu,
-                
+
                 "eps": eps,
-                
+
                 "leakage": leakage,
-                
+
                 "out_mode": out_mode,
-                
+
                 "precision": precision,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def anlms(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('256'),mu: Float = Default('0.75'),eps: Float = Default('1'),leakage: Float = Default('0'),out_mode: Int| Literal["i","d","o","n","e"] | Default = Default('o'),precision: Int| Literal["auto","float","double"] | Default = Default('auto'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply Normalized Least-Mean-(Squares|Fourth) algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to mimic a desired filter by finding the filter coefficients that
@@ -3896,7 +3896,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anlmf)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3904,67 +3904,67 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='anlms', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _desired,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "order": order,
-                
+
                 "mu": mu,
-                
+
                 "eps": eps,
-                
+
                 "leakage": leakage,
-                
+
                 "out_mode": out_mode,
-                
+
                 "precision": precision,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def anull(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Pass the audio source unchanged to the output.
 
 
@@ -3978,39 +3978,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#anull)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='anull', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def apad(
-    
+
     self,
 
 
@@ -4018,15 +4018,15 @@ References:
 
     *,
     packet_size: Int = Default('4096'),pad_len: Int64 = Default('-1'),whole_len: Int64 = Default('-1'),pad_dur: Duration = Default('-0.000001'),whole_dur: Duration = Default('-0.000001'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Pad the end of an audio stream with silence.
 
 This can be used together with ffmpeg -shortest to
@@ -4051,7 +4051,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#apad)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4059,42 +4059,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='apad', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "packet_size": packet_size,
-                
+
                 "pad_len": pad_len,
-                
+
                 "whole_len": whole_len,
-                
+
                 "pad_dur": pad_dur,
-                
+
                 "whole_dur": whole_dur,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aperms(
-    
+
     self,
 
 
@@ -4102,15 +4102,15 @@ References:
 
     *,
     mode: Int| Literal["none","ro","rw","toggle","random"] | Default = Default('none'),seed: Int64 = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Set read/write permissions for the output frames.
 
 These filters are mainly aimed at developers to test direct path in the
@@ -4132,7 +4132,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#perms)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4140,36 +4140,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aperms', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "seed": seed,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aphasemeter(
-    
+
     self,
 
 
@@ -4177,12 +4177,12 @@ References:
 
     *,
     rate: Video_rate = Default('25'),size: Image_size = Default('800x400'),rc: Int = Default('2'),gc: Int = Default('7'),bc: Int = Default('1'),mpc: String = Default('none'),video: Boolean = Default('true'),phasing: Boolean = Default('false'),tolerance: Float = Default('0'),angle: Float = Default('170'),duration: Duration = Default('2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Measures phase of input audio, which is exported as metadata lavfi.aphasemeter.phase,
 representing mean phase of current audio frame. A video output can also be produced and is
 enabled by default. The audio is passed through as first output.
@@ -4216,58 +4216,58 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aphasemeter)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aphasemeter', typings_input=('audio',), typings_output='[StreamType.audio] + ([StreamType.video] if video else [])'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rate": rate,
-                
+
                 "size": size,
-                
+
                 "rc": rc,
-                
+
                 "gc": gc,
-                
+
                 "bc": bc,
-                
+
                 "mpc": mpc,
-                
+
                 "video": video,
-                
+
                 "phasing": phasing,
-                
+
                 "tolerance": tolerance,
-                
+
                 "angle": angle,
-                
+
                 "duration": duration,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aphaser(
-    
+
     self,
 
 
@@ -4275,12 +4275,12 @@ References:
 
     *,
     in_gain: Double = Default('0.4'),out_gain: Double = Default('0.74'),delay: Double = Default('3'),decay: Double = Default('0.4'),speed: Double = Default('0.5'),type: Int| Literal["triangular","t","sinusoidal","s"] | Default = Default('triangular'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Add a phasing effect to the input audio.
 
 A phaser filter creates series of peaks and troughs in the frequency spectrum.
@@ -4305,47 +4305,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aphaser)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aphaser', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "in_gain": in_gain,
-                
+
                 "out_gain": out_gain,
-                
+
                 "delay": delay,
-                
+
                 "decay": decay,
-                
+
                 "speed": speed,
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aphaseshift(
-    
+
     self,
 
 
@@ -4353,15 +4353,15 @@ References:
 
     *,
     shift: Double = Default('0'),level: Double = Default('1'),order: Int = Default('8'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply phase shift to input audio samples.
 
 The filter accepts the following options:
@@ -4381,7 +4381,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aphaseshift)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4389,62 +4389,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aphaseshift', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "shift": shift,
-                
+
                 "level": level,
-                
+
                 "order": order,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def apsnr(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _input1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Measure Audio Peak Signal-to-Noise Ratio.
 
 This filter takes two audio streams for input, and outputs first
@@ -4463,7 +4463,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#apsnr)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4471,40 +4471,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='apsnr', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _input1,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def apsyclip(
-    
+
     self,
 
 
@@ -4512,15 +4512,15 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),clip: Double = Default('1'),diff: Boolean = Default('false'),adaptive: Double = Default('0.5'),iterations: Int = Default('10'),level: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply Psychoacoustic clipper to input audio stream.
 
 The filter accepts the following options:
@@ -4544,7 +4544,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#apsyclip)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4552,46 +4552,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='apsyclip', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "clip": clip,
-                
+
                 "diff": diff,
-                
+
                 "adaptive": adaptive,
-                
+
                 "iterations": iterations,
-                
+
                 "level": level,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def apulsator(
-    
+
     self,
 
 
@@ -4599,12 +4599,12 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),mode: Int| Literal["sine","triangle","square","sawup","sawdown"] | Default = Default('sine'),amount: Double = Default('1'),offset_l: Double = Default('0'),offset_r: Double = Default('0.5'),width: Double = Default('1'),timing: Int| Literal["bpm","ms","hz"] | Default = Default('hz'),bpm: Double = Default('120'),ms: Int = Default('500'),hz: Double = Default('2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Audio pulsator is something between an autopanner and a tremolo.
 But it can produce funny stereo effects as well. Pulsator changes the volume
 of the left and right channel based on a LFO (low frequency oscillator) with
@@ -4643,57 +4643,57 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#apulsator)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='apulsator', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "mode": mode,
-                
+
                 "amount": amount,
-                
+
                 "offset_l": offset_l,
-                
+
                 "offset_r": offset_r,
-                
+
                 "width": width,
-                
+
                 "timing": timing,
-                
+
                 "bpm": bpm,
-                
+
                 "ms": ms,
-                
+
                 "hz": hz,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def arealtime(
-    
+
     self,
 
 
@@ -4701,12 +4701,12 @@ References:
 
     *,
     limit: Duration = Default('2'),speed: Double = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Slow down filtering to match real time approximately.
 
 These filters will pause the filtering for a variable amount of time to
@@ -4728,39 +4728,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#realtime)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='arealtime', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "limit": limit,
-                
+
                 "speed": speed,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aresample(
-    
+
     self,
 
 
@@ -4768,12 +4768,12 @@ References:
 
     *,
     sample_rate: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Resample the input audio to the specified parameters, using the
 libswresample library. If none are specified then the filter will
 automatically convert between its input and output.
@@ -4802,50 +4802,50 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aresample)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aresample', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sample_rate": sample_rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def areverse(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Reverse an audio clip.
 
 Warning: This filter requires memory to buffer the entire clip, so trimming
@@ -4862,59 +4862,59 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#areverse)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='areverse', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def arls(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _desired: AudioStream,
-        
-    
+
+
 
 
     *,
     order: Int = Default('16'),_lambda: Float = Default('1'),delta: Float = Default('2'),out_mode: Int| Literal["i","d","o","n","e"] | Default = Default('o'),precision: Int| Literal["auto","float","double"] | Default = Default('auto'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply Recursive Least Squares algorithm to the first audio stream using the second audio stream.
 
 This adaptive filter is used to mimic a desired filter by recursively finding the filter coefficients that
@@ -4940,7 +4940,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#arls)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4948,50 +4948,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='arls', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _desired,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "order": order,
-                
+
                 "lambda": _lambda,
-                
+
                 "delta": delta,
-                
+
                 "out_mode": out_mode,
-                
+
                 "precision": precision,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def arnndn(
-    
+
     self,
 
 
@@ -4999,15 +4999,15 @@ References:
 
     *,
     model: String = Default(None),mix: Float = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Reduce noise from speech using Recurrent Neural Networks.
 
 This filter accepts the following options:
@@ -5026,7 +5026,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#arnndn)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5034,60 +5034,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='arnndn', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "model": model,
-                
+
                 "mix": mix,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asdr(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _input1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Measure Audio Signal-to-Distortion Ratio.
 
 This filter takes two audio streams for input, and outputs first
@@ -5106,7 +5106,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asdr)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5114,40 +5114,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asdr', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _input1,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asegment(
-    
+
     self,
 
 
@@ -5155,12 +5155,12 @@ References:
 
     *,
     timestamps: String = Default(None),samples: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Split single input stream into multiple streams.
 
 This filter does opposite of concat filters.
@@ -5183,40 +5183,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#segment)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asegment', typings_input=('audio',), typings_output="[StreamType.audio] * len(str(timestamps or samples).split('|'))"),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "timestamps": timestamps,
-                
+
                 "samples": samples,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aselect(
-    
+
     self,
 
 
@@ -5224,12 +5224,12 @@ References:
 
     *,
     expr: String = Default('1'),outputs: Int = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Select frames to pass in output.
 
 This filter accepts the following options:
@@ -5248,40 +5248,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#select)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aselect', typings_input=('audio',), typings_output='[StreamType.audio] * int(outputs)'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "expr": expr,
-                
+
                 "outputs": outputs,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asendcmd(
-    
+
     self,
 
 
@@ -5289,12 +5289,12 @@ References:
 
     *,
     commands: String = Default(None),filename: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Send commands to filters in the filtergraph.
 
 These filters read commands to be sent to other filters in the
@@ -5323,39 +5323,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sendcmd)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asendcmd', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "commands": commands,
-                
+
                 "filename": filename,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asetnsamples(
-    
+
     self,
 
 
@@ -5363,15 +5363,15 @@ References:
 
     *,
     nb_out_samples: Int = Default('1024'),pad: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Set the number of samples per each output audio frame.
 
 The last output packet may contain a different number of samples, as
@@ -5394,7 +5394,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asetnsamples)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5402,36 +5402,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asetnsamples', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "nb_out_samples": nb_out_samples,
-                
+
                 "pad": pad,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asetpts(
-    
+
     self,
 
 
@@ -5439,12 +5439,12 @@ References:
 
     *,
     expr: String = Default('PTS'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Change the PTS (presentation timestamp) of the input frames.
 
 setpts works on video frames, asetpts on audio frames.
@@ -5463,37 +5463,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setpts)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asetpts', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "expr": expr,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asetrate(
-    
+
     self,
 
 
@@ -5501,12 +5501,12 @@ References:
 
     *,
     sample_rate: Int = Default('44100'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Set the sample rate without altering the PCM data.
 This will result in a change of speed and pitch.
 
@@ -5524,37 +5524,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asetrate)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asetrate', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sample_rate": sample_rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asettb(
-    
+
     self,
 
 
@@ -5562,12 +5562,12 @@ References:
 
     *,
     expr: String = Default('intb'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Set the timebase to use for the output frames timestamps.
 It is mainly useful for testing timebase configuration.
 
@@ -5585,50 +5585,50 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#settb)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asettb', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "expr": expr,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ashowinfo(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Show a line containing various information for each input audio frame.
 The input audio is not modified.
 
@@ -5648,35 +5648,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ashowinfo)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ashowinfo', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asidedata(
-    
+
     self,
 
 
@@ -5684,15 +5684,15 @@ References:
 
     *,
     mode: Int| Literal["select","delete"] | Default = Default('select'),type: Int| Literal["PANSCAN","A53_CC","STEREO3D","MATRIXENCODING","DOWNMIX_INFO","REPLAYGAIN","DISPLAYMATRIX","AFD","MOTION_VECTORS","SKIP_SAMPLES","AUDIO_SERVICE_TYPE","MASTERING_DISPLAY_METADATA","GOP_TIMECODE","SPHERICAL","CONTENT_LIGHT_LEVEL","ICC_PROFILE","S12M_TIMECOD","DYNAMIC_HDR_PLUS","REGIONS_OF_INTEREST","VIDEO_ENC_PARAMS","SEI_UNREGISTERED","FILM_GRAIN_PARAMS","DETECTION_BOUNDING_BOXES","DETECTION_BBOXES","DOVI_RPU_BUFFER","DOVI_METADATA","DYNAMIC_HDR_VIVID","AMBIENT_VIEWING_ENVIRONMENT","VIDEO_HINT"] | Default = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Delete frame side data, or select frames based on it.
 
 This filter accepts the following options:
@@ -5711,7 +5711,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sidedata)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5719,60 +5719,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asidedata', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asisdr(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _input1: AudioStream,
-        
-    
 
 
-    
-    
-    
-    
+
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Measure Audio Scaled-Invariant Signal-to-Distortion Ratio.
 
 This filter takes two audio streams for input, and outputs first
@@ -5791,7 +5791,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asisdr)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5799,40 +5799,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asisdr', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _input1,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asoftclip(
-    
+
     self,
 
 
@@ -5840,15 +5840,15 @@ References:
 
     *,
     type: Int| Literal["hard","tanh","atan","cubic","exp","alg","quintic","sin","erf"] | Default = Default('tanh'),threshold: Double = Default('1'),output: Double = Default('1'),param: Double = Default('1'),oversample: Int = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply audio soft clipping.
 
 Soft clipping is a type of distortion effect where the amplitude of a signal is saturated
@@ -5873,7 +5873,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asoftclip)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5881,42 +5881,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asoftclip', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "type": type,
-                
+
                 "threshold": threshold,
-                
+
                 "output": output,
-                
+
                 "param": param,
-                
+
                 "oversample": oversample,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def aspectralstats(
-    
+
     self,
 
 
@@ -5924,12 +5924,12 @@ References:
 
     *,
     win_size: Int = Default('2048'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('hann'),overlap: Float = Default('0.5'),measure: Flags| Literal["none","all","mean","variance","centroid","spread","skewness","kurtosis","entropy","flatness","crest","flux","slope","decrease","rolloff"] | Default = Default('all+mean+variance+centroid+spread+skewness+kurtosis+entropy+flatness+crest+flux+slope+decrease+rolloff'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Display frequency domain statistical information about the audio channels.
 Statistics are calculated and stored as metadata for each audio channel and for each audio frame.
 
@@ -5950,43 +5950,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#aspectralstats)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='aspectralstats', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "win_size": win_size,
-                
+
                 "win_func": win_func,
-                
+
                 "overlap": overlap,
-                
+
                 "measure": measure,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asplit(
-    
+
     self,
 
 
@@ -5994,12 +5994,12 @@ References:
 
     *,
     outputs: Int = Default('2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Split input into several identical outputs.
 
 asplit works with audio input, split with video.
@@ -6020,40 +6020,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#split)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asplit', typings_input=('audio',), typings_output='[StreamType.audio] * int(outputs)'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "outputs": outputs,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def astats(
-    
+
     self,
 
 
@@ -6061,12 +6061,12 @@ References:
 
     *,
     length: Double = Default('0.05'),metadata: Boolean = Default('false'),reset: Int = Default('0'),measure_perchannel: Flags| Literal["none","all","Bit_depth","Crest_factor","DC_offset","Dynamic_range","Entropy","Flat_factor","Max_difference","Max_level","Mean_difference","Min_difference","Min_level","Noise_floor","Noise_floor_count","Number_of_Infs","Number_of_NaNs","Number_of_denormals","Number_of_samples","Peak_count","Peak_level","RMS_difference","RMS_level","RMS_peak","RMS_trough","Zero_crossings","Zero_crossings_rate","Abs_Peak_count"] | Default = Default('all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate+Abs_Peak_count'),measure_overall: Flags| Literal["none","all","Bit_depth","Crest_factor","DC_offset","Dynamic_range","Entropy","Flat_factor","Max_difference","Max_level","Mean_difference","Min_difference","Min_level","Noise_floor","Noise_floor_count","Number_of_Infs","Number_of_NaNs","Number_of_denormals","Number_of_samples","Peak_count","Peak_level","RMS_difference","RMS_level","RMS_peak","RMS_trough","Zero_crossings","Zero_crossings_rate","Abs_Peak_count"] | Default = Default('all+Bit_depth+Crest_factor+DC_offset+Dynamic_range+Entropy+Flat_factor+Max_difference+Max_level+Mean_difference+Min_difference+Min_level+Noise_floor+Noise_floor_count+Number_of_Infs+Number_of_NaNs+Number_of_denormals+Number_of_samples+Peak_count+Peak_level+RMS_difference+RMS_level+RMS_peak+RMS_trough+Zero_crossings+Zero_crossings_rate+Abs_Peak_count'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Display time domain statistical information about the audio channels.
 Statistics are calculated and displayed for each audio channel and,
 where applicable, an overall figure is also given.
@@ -6089,47 +6089,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#astats)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='astats', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "length": length,
-                
+
                 "metadata": metadata,
-                
+
                 "reset": reset,
-                
+
                 "measure_perchannel": measure_perchannel,
-                
+
                 "measure_overall": measure_overall,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def asubboost(
-    
+
     self,
 
 
@@ -6137,15 +6137,15 @@ References:
 
     *,
     dry: Double = Default('1'),wet: Double = Default('1'),boost: Double = Default('2'),decay: Double = Default('0'),feedback: Double = Default('0.9'),cutoff: Double = Default('100'),slope: Double = Default('0.5'),delay: Double = Default('20'),channels: String = Default('all'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Boost subwoofer frequencies.
 
 The filter accepts the following options:
@@ -6171,7 +6171,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asubboost)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6179,50 +6179,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asubboost', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dry": dry,
-                
+
                 "wet": wet,
-                
+
                 "boost": boost,
-                
+
                 "decay": decay,
-                
+
                 "feedback": feedback,
-                
+
                 "cutoff": cutoff,
-                
+
                 "slope": slope,
-                
+
                 "delay": delay,
-                
+
                 "channels": channels,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asubcut(
-    
+
     self,
 
 
@@ -6230,15 +6230,15 @@ References:
 
     *,
     cutoff: Double = Default('20'),order: Int = Default('10'),level: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Cut subwoofer frequencies.
 
 This filter allows to set custom, steeper
@@ -6262,7 +6262,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asubcut)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6270,38 +6270,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asubcut', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cutoff": cutoff,
-                
+
                 "order": order,
-                
+
                 "level": level,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asupercut(
-    
+
     self,
 
 
@@ -6309,15 +6309,15 @@ References:
 
     *,
     cutoff: Double = Default('20000'),order: Int = Default('10'),level: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Cut super frequencies.
 
 The filter accepts the following options:
@@ -6337,7 +6337,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asupercut)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6345,38 +6345,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asupercut', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cutoff": cutoff,
-                
+
                 "order": order,
-                
+
                 "level": level,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asuperpass(
-    
+
     self,
 
 
@@ -6384,15 +6384,15 @@ References:
 
     *,
     centerf: Double = Default('1000'),order: Int = Default('4'),qfactor: Double = Default('1'),level: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply high order Butterworth band-pass filter.
 
 The filter accepts the following options:
@@ -6413,7 +6413,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asuperpass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6421,40 +6421,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asuperpass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "centerf": centerf,
-                
+
                 "order": order,
-                
+
                 "qfactor": qfactor,
-                
+
                 "level": level,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def asuperstop(
-    
+
     self,
 
 
@@ -6462,15 +6462,15 @@ References:
 
     *,
     centerf: Double = Default('1000'),order: Int = Default('4'),qfactor: Double = Default('1'),level: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply high order Butterworth band-stop filter.
 
 The filter accepts the following options:
@@ -6491,7 +6491,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#asuperstop)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6499,42 +6499,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='asuperstop', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "centerf": centerf,
-                
+
                 "order": order,
-                
+
                 "qfactor": qfactor,
-                
+
                 "level": level,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def atempo(
-    
+
     self,
 
 
@@ -6542,12 +6542,12 @@ References:
 
     *,
     tempo: Double = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Adjust audio tempo.
 
 The filter accepts exactly one parameter, the audio tempo. If not
@@ -6571,37 +6571,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#atempo)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='atempo', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "tempo": tempo,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def atilt(
-    
+
     self,
 
 
@@ -6609,15 +6609,15 @@ References:
 
     *,
     freq: Double = Default('10000'),slope: Double = Default('0'),width: Double = Default('1000'),order: Int = Default('5'),level: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply spectral tilt filter to audio stream.
 
 This filter apply any spectral roll-off slope over any specified frequency band.
@@ -6641,7 +6641,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#atilt)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6649,42 +6649,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='atilt', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "freq": freq,
-                
+
                 "slope": slope,
-                
+
                 "width": width,
-                
+
                 "order": order,
-                
+
                 "level": level,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def atrim(
-    
+
     self,
 
 
@@ -6692,12 +6692,12 @@ References:
 
     *,
     start: Duration = Default('INT64_MAX'),end: Duration = Default('INT64_MAX'),start_pts: Int64 = Default('I64_MIN'),end_pts: Int64 = Default('I64_MIN'),duration: Duration = Default('0'),start_sample: Int64 = Default('-1'),end_sample: Int64 = Default('I64_MAX'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Trim the input so that the output contains one continuous subpart of the input.
 
 It accepts the following parameters:
@@ -6720,49 +6720,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#atrim)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='atrim', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "start": start,
-                
+
                 "end": end,
-                
+
                 "start_pts": start_pts,
-                
+
                 "end_pts": end_pts,
-                
+
                 "duration": duration,
-                
+
                 "start_sample": start_sample,
-                
+
                 "end_sample": end_sample,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def avectorscope(
-    
+
     self,
 
 
@@ -6770,12 +6770,12 @@ References:
 
     *,
     mode: Int| Literal["lissajous","lissajous_xy","polar"] | Default = Default('lissajous'),rate: Video_rate = Default('25'),size: Image_size = Default('400x400'),rc: Int = Default('40'),gc: Int = Default('160'),bc: Int = Default('80'),ac: Int = Default('255'),rf: Int = Default('15'),gf: Int = Default('10'),bf: Int = Default('5'),af: Int = Default('5'),zoom: Double = Default('1'),draw: Int| Literal["dot","line","aaline"] | Default = Default('dot'),scale: Int| Literal["lin","sqrt","cbrt","log"] | Default = Default('lin'),swap: Boolean = Default('true'),mirror: Int| Literal["none","x","y","xy"] | Default = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a video output, representing the audio vector
 scope.
 
@@ -6815,94 +6815,94 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#avectorscope)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='avectorscope', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "rate": rate,
-                
+
                 "size": size,
-                
+
                 "rc": rc,
-                
+
                 "gc": gc,
-                
+
                 "bc": bc,
-                
+
                 "ac": ac,
-                
+
                 "rf": rf,
-                
+
                 "gf": gf,
-                
+
                 "bf": bf,
-                
+
                 "af": af,
-                
+
                 "zoom": zoom,
-                
+
                 "draw": draw,
-                
+
                 "scale": scale,
-                
+
                 "swap": swap,
-                
+
                 "mirror": mirror,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def axcorrelate(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _axcorrelate1: AudioStream,
-        
-    
+
+
 
 
     *,
     size: Int = Default('256'),algo: Int| Literal["slow","fast","best"] | Default = Default('best'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Calculate normalized windowed cross-correlation between two input audio streams.
 
 Resulted samples are always between -1 and 1 inclusive.
@@ -6926,47 +6926,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#axcorrelate)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='axcorrelate', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _axcorrelate1,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "algo": algo,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def azmq(
-    
+
     self,
 
 
@@ -6974,12 +6974,12 @@ References:
 
     *,
     bind_address: String = Default('tcp://*:5555'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Receive commands sent through a libzmq client, and forward them to
 filters in the filtergraph.
 
@@ -7038,39 +7038,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#zmq)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='azmq', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "bind_address": bind_address,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def bandpass(
-    
+
     self,
 
 
@@ -7078,15 +7078,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),csg: Boolean = Default('false'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a two-pole Butterworth band-pass filter with central
 frequency frequency, and (3dB-point) band-width width.
 The csg option selects a constant skirt gain (peak gain = Q)
@@ -7117,7 +7117,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bandpass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7125,52 +7125,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bandpass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "csg": csg,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def bandreject(
-    
+
     self,
 
 
@@ -7178,15 +7178,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a two-pole Butterworth band-reject filter with central
 frequency frequency, and (3dB-point) band-width width.
 The filter roll off at 6dB per octave (20dB per decade).
@@ -7214,7 +7214,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bandreject)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7222,50 +7222,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bandreject', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def bass(
-    
+
     self,
 
 
@@ -7273,15 +7273,15 @@ References:
 
     *,
     frequency: Double = Default('100'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),gain: Double = Default('0'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Boost or cut the bass (lower) frequencies of the audio using a two-pole
 shelving filter with a response similar to that of a standard
 hi-fi's tone-controls. This is also known as shelving equalisation (EQ).
@@ -7311,7 +7311,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7319,60 +7319,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "gain": gain,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def biquad(
-    
+
     self,
 
 
@@ -7380,15 +7380,15 @@ References:
 
     *,
     a0: Double = Default('1'),a1: Double = Default('0'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a biquad IIR filter with the given coefficients.
 Where b0, b1, b2 and a0, a1, a2
 are the numerator and denominator coefficients respectively.
@@ -7415,7 +7415,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#biquad)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7423,78 +7423,78 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='biquad', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "a0": a0,
-                
+
                 "a1": a1,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def channelmap(
-    
+
     self,
 
 
@@ -7502,12 +7502,12 @@ References:
 
     *,
     map: String = Default(None),channel_layout: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Remap input channels to new locations.
 
 It accepts the following parameters:
@@ -7525,39 +7525,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#channelmap)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='channelmap', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "map": map,
-                
+
                 "channel_layout": channel_layout,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def channelsplit(
-    
+
     self,
 
 
@@ -7565,12 +7565,12 @@ References:
 
     *,
     channel_layout: String = Default('stereo'),channels: String = Default('all'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Split each channel from an input audio stream into a separate output stream.
 
 It accepts the following parameters:
@@ -7589,40 +7589,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#channelsplit)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='channelsplit', typings_input=('audio',), typings_output='[StreamType.audio] * CHANNEL_LAYOUT[str(channel_layout)]'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "channel_layout": channel_layout,
-                
+
                 "channels": channels,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def chorus(
-    
+
     self,
 
 
@@ -7630,12 +7630,12 @@ References:
 
     *,
     in_gain: Float = Default('0.4'),out_gain: Float = Default('0.4'),delays: String = Default(None),decays: String = Default(None),speeds: String = Default(None),depths: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Add a chorus effect to the audio.
 
 Can make a single vocal sound like a chorus, but can also be applied to instrumentation.
@@ -7666,93 +7666,93 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#chorus)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='chorus', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "in_gain": in_gain,
-                
+
                 "out_gain": out_gain,
-                
+
                 "delays": delays,
-                
+
                 "decays": decays,
-                
+
                 "speeds": speeds,
-                
+
                 "depths": depths,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def compand(
-    
+
     self,
 
 
@@ -7760,12 +7760,12 @@ References:
 
     *,
     attacks: String = Default('0'),decays: String = Default('0.8'),points: String = Default('-70/-70|-60/-20|1/0'),soft_knee: Double = Default('0.01'),gain: Double = Default('0'),volume: Double = Default('0'),delay: Double = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Compress or expand the audio's dynamic range.
 
 It accepts the following parameters:
@@ -7788,49 +7788,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#compand)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='compand', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "attacks": attacks,
-                
+
                 "decays": decays,
-                
+
                 "points": points,
-                
+
                 "soft-knee": soft_knee,
-                
+
                 "gain": gain,
-                
+
                 "volume": volume,
-                
+
                 "delay": delay,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def compensationdelay(
-    
+
     self,
 
 
@@ -7838,15 +7838,15 @@ References:
 
     *,
     mm: Int = Default('0'),cm: Int = Default('0'),m: Int = Default('0'),dry: Double = Default('0'),wet: Double = Default('1'),temp: Int = Default('20'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Compensation Delay Line is a metric based delay to compensate differing
 positions of microphones or speakers.
 
@@ -7885,7 +7885,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#compensationdelay)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7893,62 +7893,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='compensationdelay', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mm": mm,
-                
+
                 "cm": cm,
-                
+
                 "m": m,
-                
+
                 "dry": dry,
-                
+
                 "wet": wet,
-                
+
                 "temp": temp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def crossfeed(
-    
+
     self,
 
 
@@ -7956,15 +7956,15 @@ References:
 
     *,
     strength: Double = Default('0.2'),range: Double = Default('0.5'),slope: Double = Default('0.5'),level_in: Double = Default('0.9'),level_out: Double = Default('1'),block_size: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply headphone crossfeed filter.
 
 Crossfeed is the process of blending the left and right channels of stereo
@@ -7993,7 +7993,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#crossfeed)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8001,44 +8001,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='crossfeed', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "strength": strength,
-                
+
                 "range": range,
-                
+
                 "slope": slope,
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "block_size": block_size,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def crystalizer(
-    
+
     self,
 
 
@@ -8046,15 +8046,15 @@ References:
 
     *,
     i: Float = Default('2'),c: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Simple algorithm for audio noise sharpening.
 
 This filter linearly increases differences between each audio sample.
@@ -8075,7 +8075,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#crystalizer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8083,44 +8083,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='crystalizer', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "i": i,
-                
+
                 "c": c,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def dcshift(
-    
+
     self,
 
 
@@ -8128,15 +8128,15 @@ References:
 
     *,
     shift: Double = Default('0'),limitergain: Double = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a DC shift to the audio.
 
 This can be useful to remove a DC offset (caused perhaps by a hardware problem
@@ -8158,7 +8158,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dcshift)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8166,48 +8166,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dcshift', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "shift": shift,
-                
+
                 "limitergain": limitergain,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def deesser(
-    
+
     self,
 
 
@@ -8215,15 +8215,15 @@ References:
 
     *,
     i: Double = Default('0'),m: Double = Default('0.5'),f: Double = Default('0.5'),s: Int| Literal["i","o","e"] | Default = Default('o'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply de-essing to the audio samples.
 
 
@@ -8242,7 +8242,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deesser)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8250,60 +8250,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deesser', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "i": i,
-                
+
                 "m": m,
-                
+
                 "f": f,
-                
+
                 "s": s,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def dialoguenhance(
-    
+
     self,
 
 
@@ -8311,15 +8311,15 @@ References:
 
     *,
     original: Double = Default('1'),enhance: Double = Default('1'),voice: Double = Default('2'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Enhance dialogue in stereo audio.
 
 This filter accepts stereo input and produce surround (3.0) channels output.
@@ -8344,7 +8344,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dialoguenhance)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8352,56 +8352,56 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dialoguenhance', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "original": original,
-                
+
                 "enhance": enhance,
-                
+
                 "voice": voice,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def drmeter(
-    
+
     self,
 
 
@@ -8409,12 +8409,12 @@ References:
 
     *,
     length: Double = Default('3'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Measure audio dynamic range.
 
 DR values of 14 and higher is found in very dynamic material. DR of 8 to 13
@@ -8435,37 +8435,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#drmeter)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='drmeter', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "length": length,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dynaudnorm(
-    
+
     self,
 
 
@@ -8473,15 +8473,15 @@ References:
 
     *,
     framelen: Int = Default('500'),gausssize: Int = Default('31'),peak: Double = Default('0.95'),maxgain: Double = Default('10'),targetrms: Double = Default('0'),coupling: Boolean = Default('true'),correctdc: Boolean = Default('false'),altboundary: Boolean = Default('false'),compress: Double = Default('0'),threshold: Double = Default('0'),channels: String = Default('all'),overlap: Double = Default('0'),curve: String = Default(None),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Dynamic Audio Normalizer.
 
 This filter applies a certain amount of gain to the input audio in order
@@ -8521,7 +8521,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dynaudnorm)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8529,71 +8529,71 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dynaudnorm', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "framelen": framelen,
-                
+
                 "gausssize": gausssize,
-                
+
                 "peak": peak,
-                
+
                 "maxgain": maxgain,
-                
+
                 "targetrms": targetrms,
-                
+
                 "coupling": coupling,
-                
+
                 "correctdc": correctdc,
-                
+
                 "altboundary": altboundary,
-                
+
                 "compress": compress,
-                
+
                 "threshold": threshold,
-                
+
                 "channels": channels,
-                
+
                 "overlap": overlap,
-                
+
                 "curve": curve,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def earwax(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Make audio easier to listen to on headphones.
 
 This filter adds `cues' to 44.1kHz stereo (i.e. audio CD format) audio
@@ -8614,35 +8614,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#earwax)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='earwax', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ebur128(
-    
+
     self,
 
 
@@ -8650,12 +8650,12 @@ References:
 
     *,
     video: Boolean = Default('false'),size: Image_size = Default('640x480'),meter: Int = Default('9'),framelog: Int| Literal["quiet","info","verbose"] | Default = Default('-1'),metadata: Boolean = Default('false'),peak: Flags| Literal["none","sample","true"] | Default = Default('0'),dualmono: Boolean = Default('false'),panlaw: Double = Default('-3.0103'),target: Int = Default('-23'),gauge: Int| Literal["momentary","m","shortterm","s"] | Default = Default('momentary'),scale: Int| Literal["absolute","LUFS","relative","LU"] | Default = Default('absolute'),integrated: Double = Default('0'),range: Double = Default('0'),lra_low: Double = Default('0'),lra_high: Double = Default('0'),sample_peak: Double = Default('0'),true_peak: Double = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 EBU R128 scanner filter. This filter takes an audio stream and analyzes its loudness
 level. By default, it logs a message at a frequency of 10Hz with the
 Momentary loudness (identified by M), Short-term loudness (S),
@@ -8711,80 +8711,80 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ebur128)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ebur128', typings_input=('audio',), typings_output='[StreamType.video] if video else [] + [StreamType.audio]'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "video": video,
-                
+
                 "size": size,
-                
+
                 "meter": meter,
-                
+
                 "framelog": framelog,
-                
+
                 "metadata": metadata,
-                
+
                 "peak": peak,
-                
+
                 "dualmono": dualmono,
-                
+
                 "panlaw": panlaw,
-                
+
                 "target": target,
-                
+
                 "gauge": gauge,
-                
+
                 "scale": scale,
-                
+
                 "integrated": integrated,
-                
+
                 "range": range,
-                
+
                 "lra_low": lra_low,
-                
+
                 "lra_high": lra_high,
-                
+
                 "sample_peak": sample_peak,
-                
+
                 "true_peak": true_peak,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def equalizer(
-    
+
     self,
 
 
@@ -8792,15 +8792,15 @@ References:
 
     *,
     frequency: Double = Default('0'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('1'),gain: Double = Default('0'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a two-pole peaking equalisation (EQ) filter. With this
 filter, the signal-level at and around a selected frequency can
 be increased or decreased, whilst (unlike bandpass and bandreject
@@ -8833,7 +8833,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#equalizer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8841,62 +8841,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='equalizer', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "gain": gain,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def extrastereo(
-    
+
     self,
 
 
@@ -8904,15 +8904,15 @@ References:
 
     *,
     m: Float = Default('2.5'),c: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Linearly increases the difference between left and right channels which
 adds some sort of "live" effect to playback.
 
@@ -8932,7 +8932,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#extrastereo)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8940,56 +8940,56 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='extrastereo', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "m": m,
-                
+
                 "c": c,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def firequalizer(
-    
+
     self,
 
 
@@ -8997,12 +8997,12 @@ References:
 
     *,
     gain: String = Default('gain_interpolate(f)'),gain_entry: String = Default(None),delay: Double = Default('0.01'),accuracy: Double = Default('5'),wfunc: Int| Literal["rectangular","hann","hamming","blackman","nuttall3","mnuttall3","nuttall","bnuttall","bharris","tukey"] | Default = Default('hann'),fixed: Boolean = Default('false'),multi: Boolean = Default('false'),zero_phase: Boolean = Default('false'),scale: Int| Literal["linlin","linlog","loglin","loglog"] | Default = Default('linlog'),dumpfile: String = Default(None),dumpscale: Int| Literal["linlin","linlog","loglin","loglog"] | Default = Default('linlog'),fft2: Boolean = Default('false'),min_phase: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply FIR Equalization using arbitrary frequency response.
 
 The filter accepts the following option:
@@ -9031,61 +9031,61 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#firequalizer)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='firequalizer', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "gain": gain,
-                
+
                 "gain_entry": gain_entry,
-                
+
                 "delay": delay,
-                
+
                 "accuracy": accuracy,
-                
+
                 "wfunc": wfunc,
-                
+
                 "fixed": fixed,
-                
+
                 "multi": multi,
-                
+
                 "zero_phase": zero_phase,
-                
+
                 "scale": scale,
-                
+
                 "dumpfile": dumpfile,
-                
+
                 "dumpscale": dumpscale,
-                
+
                 "fft2": fft2,
-                
+
                 "min_phase": min_phase,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def flanger(
-    
+
     self,
 
 
@@ -9093,12 +9093,12 @@ References:
 
     *,
     delay: Double = Default('0'),depth: Double = Default('2'),regen: Double = Default('0'),width: Double = Default('71'),speed: Double = Default('0.5'),shape: Int| Literal["triangular","t","sinusoidal","s"] | Default = Default('sinusoidal'),phase: Double = Default('25'),interp: Int| Literal["linear","quadratic"] | Default = Default('linear'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a flanging effect to the audio.
 
 The filter accepts the following options:
@@ -9122,87 +9122,87 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#flanger)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='flanger', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "delay": delay,
-                
+
                 "depth": depth,
-                
+
                 "regen": regen,
-                
+
                 "width": width,
-                
+
                 "speed": speed,
-                
+
                 "shape": shape,
-                
+
                 "phase": phase,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def haas(
-    
+
     self,
 
 
@@ -9210,12 +9210,12 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),side_gain: Double = Default('1'),middle_source: Int| Literal["left","right","mid","side"] | Default = Default('mid'),middle_phase: Boolean = Default('false'),left_delay: Double = Default('2.05'),left_balance: Double = Default('-1'),left_gain: Double = Default('1'),left_phase: Boolean = Default('false'),right_delay: Double = Default('2.12'),right_balance: Double = Default('1'),right_gain: Double = Default('1'),right_phase: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply Haas effect to audio.
 
 Note that this makes most sense to apply on mono signals.
@@ -9248,65 +9248,65 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#haas)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='haas', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "side_gain": side_gain,
-                
+
                 "middle_source": middle_source,
-                
+
                 "middle_phase": middle_phase,
-                
+
                 "left_delay": left_delay,
-                
+
                 "left_balance": left_balance,
-                
+
                 "left_gain": left_gain,
-                
+
                 "left_phase": left_phase,
-                
+
                 "right_delay": right_delay,
-                
+
                 "right_balance": right_balance,
-                
+
                 "right_gain": right_gain,
-                
+
                 "right_phase": right_phase,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def hdcd(
-    
+
     self,
 
 
@@ -9314,12 +9314,12 @@ References:
 
     *,
     disable_autoconvert: Boolean = Default('true'),process_stereo: Boolean = Default('true'),cdt_ms: Int = Default('2000'),force_pe: Boolean = Default('false'),analyze_mode: Int| Literal["off","lle","pe","cdt","tgm"] | Default = Default('off'),bits_per_sample: Int| Literal["16","20","24"] | Default = Default('16'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Decodes High Definition Compatible Digital (HDCD) data. A 16-bit PCM stream with
 embedded HDCD codes is expanded into a 20-bit PCM stream.
 
@@ -9357,51 +9357,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hdcd)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hdcd', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "disable_autoconvert": disable_autoconvert,
-                
+
                 "process_stereo": process_stereo,
-                
+
                 "cdt_ms": cdt_ms,
-                
+
                 "force_pe": force_pe,
-                
+
                 "analyze_mode": analyze_mode,
-                
+
                 "bits_per_sample": bits_per_sample,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def highpass(
-    
+
     self,
 
 
@@ -9409,15 +9409,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.707'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a high-pass filter with 3dB point frequency.
 The filter can be either single-pole, or double-pole (the default).
 The filter roll off at 6dB per pole per octave (20dB per pole per decade).
@@ -9446,7 +9446,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#highpass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9454,52 +9454,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='highpass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def highshelf(
-    
+
     self,
 
 
@@ -9507,15 +9507,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),gain: Double = Default('0'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Boost or cut treble (upper) frequencies of the audio using a two-pole
 shelving filter with a response similar to that of a standard
 hi-fi's tone-controls. This is also known as shelving equalisation (EQ).
@@ -9545,7 +9545,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#treble)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9553,116 +9553,116 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='highshelf', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "gain": gain,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def loudnorm(
-    
+
     self,
 
 
@@ -9670,12 +9670,12 @@ References:
 
     *,
     I: Double = Default('-24'),LRA: Double = Default('7'),TP: Double = Default('-2'),measured_I: Double = Default('0'),measured_LRA: Double = Default('0'),measured_TP: Double = Default('99'),measured_thresh: Double = Default('-70'),offset: Double = Default('0'),linear: Boolean = Default('true'),dual_mono: Boolean = Default('false'),print_format: Int| Literal["none","json","summary"] | Default = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 EBU R128 loudness normalization. Includes both dynamic and linear normalization modes.
 Support for both single pass (livestreams, files) and double pass (files) modes.
 This algorithm can target IL, LRA, and maximum true peak. In dynamic mode, to accurately
@@ -9706,57 +9706,57 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#loudnorm)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='loudnorm', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "I": I,
-                
+
                 "LRA": LRA,
-                
+
                 "TP": TP,
-                
+
                 "measured_I": measured_I,
-                
+
                 "measured_LRA": measured_LRA,
-                
+
                 "measured_TP": measured_TP,
-                
+
                 "measured_thresh": measured_thresh,
-                
+
                 "offset": offset,
-                
+
                 "linear": linear,
-                
+
                 "dual_mono": dual_mono,
-                
+
                 "print_format": print_format,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lowpass(
-    
+
     self,
 
 
@@ -9764,15 +9764,15 @@ References:
 
     *,
     frequency: Double = Default('500'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.707'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply a low-pass filter with 3dB point frequency.
 The filter can be either single-pole or double-pole (the default).
 The filter roll off at 6dB per pole per octave (20dB per pole per decade).
@@ -9801,7 +9801,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lowpass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9809,52 +9809,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lowpass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lowshelf(
-    
+
     self,
 
 
@@ -9862,15 +9862,15 @@ References:
 
     *,
     frequency: Double = Default('100'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),gain: Double = Default('0'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Boost or cut the bass (lower) frequencies of the audio using a two-pole
 shelving filter with a response similar to that of a standard
 hi-fi's tone-controls. This is also known as shelving equalisation (EQ).
@@ -9900,7 +9900,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9908,84 +9908,84 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lowshelf', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "gain": gain,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def mcompand(
-    
+
     self,
 
 
@@ -9993,12 +9993,12 @@ References:
 
     *,
     args: String = Default('0.005,0.1 6 -47/-40,-34/-34,-17/-33 100 | 0.003,0.05 6 -47/-40,-34/-34,-17/-33 400 | 0.000625,0.0125 6 -47/-40,-34/-34,-15/-33 1600 | 0.0001,0.025 6 -47/-40,-34/-34,-31/-31,-0/-30 6400 | 0,0.025 6 -38/-31,-28/-28,-0/-25 22000'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Multiband Compress or expand the audio's dynamic range.
 
 The input audio is divided into bands using 4th order Linkwitz-Riley IIRs.
@@ -10019,111 +10019,111 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mcompand)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='mcompand', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "args": args,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def pan(
-    
+
     self,
 
 
@@ -10131,12 +10131,12 @@ References:
 
     *,
     args: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Mix channels with specific gain levels. The filter accepts the output
 channel layout followed by a set of channels definitions.
 
@@ -10148,7 +10148,7 @@ The filter accepts parameters of the form:
 
 
 Args:
-    args: 
+    args:
     extra_options: Extra options for the filter
 
 Returns:
@@ -10158,91 +10158,91 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pan)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pan', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "args": args,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def replaygain(
-    
+
     self,
 
 
@@ -10250,12 +10250,12 @@ References:
 
     *,
     track_gain: Float = Default('0'),track_peak: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 ReplayGain scanner filter. This filter takes an audio stream as an input and
 outputs it unchanged.
 At end of filtering it displays track_gain and track_peak.
@@ -10275,93 +10275,93 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#replaygain)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='replaygain', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "track_gain": track_gain,
-                
+
                 "track_peak": track_peak,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def showcqt(
-    
+
     self,
 
 
@@ -10369,12 +10369,12 @@ References:
 
     *,
     size: Image_size = Default('1920x1080'),fps: Video_rate = Default('25'),bar_h: Int = Default('-1'),axis_h: Int = Default('-1'),sono_h: Int = Default('-1'),fullhd: Boolean = Default('true'),sono_v: String = Default('16'),bar_v: String = Default('sono_v'),sono_g: Float = Default('3'),bar_g: Float = Default('1'),bar_t: Float = Default('1'),timeclamp: Double = Default('0.17'),attack: Double = Default('0'),basefreq: Double = Default('20.0152'),endfreq: Double = Default('20495.6'),coeffclamp: Float = Default('1'),tlength: String = Default('384*tc/(384+tc*f)'),count: Int = Default('6'),fcount: Int = Default('0'),fontfile: String = Default(None),font: String = Default(None),fontcolor: String = Default('st(0, (midi(f)-59.5)/12);st(1, if(between(ld(0),0,1), 0.5-0.5*cos(2*PI*ld(0)), 0));r(1-ld(1)) + b(ld(1))'),axisfile: String = Default(None),axis: Boolean = Default('true'),csp: Int| Literal["unspecified","bt709","fcc","bt470bg","smpte170m","smpte240m","bt2020ncl"] | Default = Default('unspecified'),cscheme: String = Default('1|0.5|0|0|0.5|1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a video output representing frequency spectrum
 logarithmically using Brown-Puckette constant Q transform algorithm with
 direct frequency domain coefficient calculation (but the transform itself
@@ -10420,87 +10420,87 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showcqt)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showcqt', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "fps": fps,
-                
+
                 "bar_h": bar_h,
-                
+
                 "axis_h": axis_h,
-                
+
                 "sono_h": sono_h,
-                
+
                 "fullhd": fullhd,
-                
+
                 "sono_v": sono_v,
-                
+
                 "bar_v": bar_v,
-                
+
                 "sono_g": sono_g,
-                
+
                 "bar_g": bar_g,
-                
+
                 "bar_t": bar_t,
-                
+
                 "timeclamp": timeclamp,
-                
+
                 "attack": attack,
-                
+
                 "basefreq": basefreq,
-                
+
                 "endfreq": endfreq,
-                
+
                 "coeffclamp": coeffclamp,
-                
+
                 "tlength": tlength,
-                
+
                 "count": count,
-                
+
                 "fcount": fcount,
-                
+
                 "fontfile": fontfile,
-                
+
                 "font": font,
-                
+
                 "fontcolor": fontcolor,
-                
+
                 "axisfile": axisfile,
-                
+
                 "axis": axis,
-                
+
                 "csp": csp,
-                
+
                 "cscheme": cscheme,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showcwt(
-    
+
     self,
 
 
@@ -10508,12 +10508,12 @@ References:
 
     *,
     size: Image_size = Default('640x512'),rate: String = Default('25'),scale: Int| Literal["linear","log","bark","mel","erbs","sqrt","cbrt","qdrt","fm"] | Default = Default('linear'),iscale: Int| Literal["linear","log","sqrt","cbrt","qdrt"] | Default = Default('log'),min: Float = Default('20'),max: Float = Default('20000'),imin: Float = Default('0'),imax: Float = Default('1'),logb: Float = Default('0.0001'),deviation: Float = Default('1'),pps: Int = Default('64'),mode: Int| Literal["magnitude","phase","magphase","channel","stereo"] | Default = Default('magnitude'),slide: Int| Literal["replace","scroll","frame"] | Default = Default('replace'),direction: Int| Literal["lr","rl","ud","du"] | Default = Default('lr'),bar: Float = Default('0'),rotation: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to video output representing frequency spectrum
 using Continuous Wavelet Transform and Morlet wavelet.
 
@@ -10546,67 +10546,67 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showcwt)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showcwt', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "rate": rate,
-                
+
                 "scale": scale,
-                
+
                 "iscale": iscale,
-                
+
                 "min": min,
-                
+
                 "max": max,
-                
+
                 "imin": imin,
-                
+
                 "imax": imax,
-                
+
                 "logb": logb,
-                
+
                 "deviation": deviation,
-                
+
                 "pps": pps,
-                
+
                 "mode": mode,
-                
+
                 "slide": slide,
-                
+
                 "direction": direction,
-                
+
                 "bar": bar,
-                
+
                 "rotation": rotation,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showfreqs(
-    
+
     self,
 
 
@@ -10614,12 +10614,12 @@ References:
 
     *,
     size: Image_size = Default('1024x512'),rate: Video_rate = Default('25'),mode: Int| Literal["line","bar","dot"] | Default = Default('bar'),ascale: Int| Literal["lin","sqrt","cbrt","log"] | Default = Default('log'),fscale: Int| Literal["lin","log","rlog"] | Default = Default('lin'),win_size: Int = Default('2048'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('hann'),overlap: Float = Default('1'),averaging: Int = Default('1'),colors: String = Default('red|green|blue|yellow|orange|lime|pink|magenta|brown'),cmode: Int| Literal["combined","separate"] | Default = Default('combined'),minamp: Float = Default('1e-06'),data: Int| Literal["magnitude","phase","delay"] | Default = Default('magnitude'),channels: String = Default('all'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to video output representing the audio power spectrum.
 Audio amplitude is on Y-axis while frequency is on X-axis.
 
@@ -10650,67 +10650,67 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showfreqs)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showfreqs', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "rate": rate,
-                
+
                 "mode": mode,
-                
+
                 "ascale": ascale,
-                
+
                 "fscale": fscale,
-                
+
                 "win_size": win_size,
-                
+
                 "win_func": win_func,
-                
+
                 "overlap": overlap,
-                
+
                 "averaging": averaging,
-                
+
                 "colors": colors,
-                
+
                 "cmode": cmode,
-                
+
                 "minamp": minamp,
-                
+
                 "data": data,
-                
+
                 "channels": channels,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def showspatial(
-    
+
     self,
 
 
@@ -10718,12 +10718,12 @@ References:
 
     *,
     size: Image_size = Default('512x512'),win_size: Int = Default('4096'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('hann'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert stereo input audio to a video output, representing the spatial relationship
 between two channels.
 
@@ -10744,43 +10744,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showspatial)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showspatial', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "win_size": win_size,
-                
+
                 "win_func": win_func,
-                
+
                 "rate": rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showspectrum(
-    
+
     self,
 
 
@@ -10788,12 +10788,12 @@ References:
 
     *,
     size: Image_size = Default('640x512'),slide: Int| Literal["replace","scroll","fullframe","rscroll","lreplace"] | Default = Default('replace'),mode: Int| Literal["combined","separate"] | Default = Default('combined'),color: Int| Literal["channel","intensity","rainbow","moreland","nebulae","fire","fiery","fruit","cool","magma","green","viridis","plasma","cividis","terrain"] | Default = Default('channel'),scale: Int| Literal["lin","sqrt","cbrt","log","4thrt","5thrt"] | Default = Default('sqrt'),fscale: Int| Literal["lin","log"] | Default = Default('lin'),saturation: Float = Default('1'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('hann'),orientation: Int| Literal["vertical","horizontal"] | Default = Default('vertical'),overlap: Float = Default('0'),gain: Float = Default('1'),data: Int| Literal["magnitude","phase","uphase"] | Default = Default('magnitude'),rotation: Float = Default('0'),start: Int = Default('0'),stop: Int = Default('0'),fps: String = Default('auto'),legend: Boolean = Default('false'),drange: Float = Default('120'),limit: Float = Default('0'),opacity: Float = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a video output, representing the audio frequency
 spectrum.
 
@@ -10830,75 +10830,75 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showspectrum)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showspectrum', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "slide": slide,
-                
+
                 "mode": mode,
-                
+
                 "color": color,
-                
+
                 "scale": scale,
-                
+
                 "fscale": fscale,
-                
+
                 "saturation": saturation,
-                
+
                 "win_func": win_func,
-                
+
                 "orientation": orientation,
-                
+
                 "overlap": overlap,
-                
+
                 "gain": gain,
-                
+
                 "data": data,
-                
+
                 "rotation": rotation,
-                
+
                 "start": start,
-                
+
                 "stop": stop,
-                
+
                 "fps": fps,
-                
+
                 "legend": legend,
-                
+
                 "drange": drange,
-                
+
                 "limit": limit,
-                
+
                 "opacity": opacity,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showspectrumpic(
-    
+
     self,
 
 
@@ -10906,12 +10906,12 @@ References:
 
     *,
     size: Image_size = Default('4096x2048'),mode: Int| Literal["combined","separate"] | Default = Default('combined'),color: Int| Literal["channel","intensity","rainbow","moreland","nebulae","fire","fiery","fruit","cool","magma","green","viridis","plasma","cividis","terrain"] | Default = Default('intensity'),scale: Int| Literal["lin","sqrt","cbrt","log","4thrt","5thrt"] | Default = Default('log'),fscale: Int| Literal["lin","log"] | Default = Default('lin'),saturation: Float = Default('1'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('hann'),orientation: Int| Literal["vertical","horizontal"] | Default = Default('vertical'),gain: Float = Default('1'),legend: Boolean = Default('true'),rotation: Float = Default('0'),start: Int = Default('0'),stop: Int = Default('0'),drange: Float = Default('120'),limit: Float = Default('0'),opacity: Float = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a single video frame, representing the audio frequency
 spectrum.
 
@@ -10944,67 +10944,67 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showspectrumpic)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showspectrumpic', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "mode": mode,
-                
+
                 "color": color,
-                
+
                 "scale": scale,
-                
+
                 "fscale": fscale,
-                
+
                 "saturation": saturation,
-                
+
                 "win_func": win_func,
-                
+
                 "orientation": orientation,
-                
+
                 "gain": gain,
-                
+
                 "legend": legend,
-                
+
                 "rotation": rotation,
-                
+
                 "start": start,
-                
+
                 "stop": stop,
-                
+
                 "drange": drange,
-                
+
                 "limit": limit,
-                
+
                 "opacity": opacity,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showvolume(
-    
+
     self,
 
 
@@ -11012,12 +11012,12 @@ References:
 
     *,
     rate: Video_rate = Default('25'),b: Int = Default('1'),w: Int = Default('400'),h: Int = Default('20'),f: Double = Default('0.95'),c: String = Default('PEAK*255+floor((1-PEAK)*255)*256+0xff000000'),t: Boolean = Default('true'),v: Boolean = Default('true'),dm: Double = Default('0'),dmc: Color = Default('orange'),o: Int| Literal["h","v"] | Default = Default('h'),s: Int = Default('0'),p: Float = Default('0'),m: Int| Literal["p","r"] | Default = Default('p'),ds: Int| Literal["lin","log"] | Default = Default('lin'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio volume to a video output.
 
 The filter accepts the following options:
@@ -11048,65 +11048,65 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showvolume)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showvolume', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rate": rate,
-                
+
                 "b": b,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "f": f,
-                
+
                 "c": c,
-                
+
                 "t": t,
-                
+
                 "v": v,
-                
+
                 "dm": dm,
-                
+
                 "dmc": dmc,
-                
+
                 "o": o,
-                
+
                 "s": s,
-                
+
                 "p": p,
-                
+
                 "m": m,
-                
+
                 "ds": ds,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showwaves(
-    
+
     self,
 
 
@@ -11114,12 +11114,12 @@ References:
 
     *,
     size: Image_size = Default('600x240'),mode: Int| Literal["point","line","p2p","cline"] | Default = Default('point'),n: Rational = Default('0/1'),rate: Video_rate = Default('25'),split_channels: Boolean = Default('false'),colors: String = Default('red|green|blue|yellow|orange|lime|pink|magenta|brown'),scale: Int| Literal["lin","log","sqrt","cbrt"] | Default = Default('lin'),draw: Int| Literal["scale","full"] | Default = Default('scale'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a video output, representing the samples waves.
 
 The filter accepts the following options:
@@ -11143,51 +11143,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showwaves)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showwaves', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "mode": mode,
-                
+
                 "n": n,
-                
+
                 "rate": rate,
-                
+
                 "split_channels": split_channels,
-                
+
                 "colors": colors,
-                
+
                 "scale": scale,
-                
+
                 "draw": draw,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showwavespic(
-    
+
     self,
 
 
@@ -11195,12 +11195,12 @@ References:
 
     *,
     size: Image_size = Default('600x240'),split_channels: Boolean = Default('false'),colors: String = Default('red|green|blue|yellow|orange|lime|pink|magenta|brown'),scale: Int| Literal["lin","log","sqrt","cbrt"] | Default = Default('lin'),draw: Int| Literal["scale","full"] | Default = Default('scale'),filter: Int| Literal["average","peak"] | Default = Default('average'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert input audio to a single video frame, representing the samples waves.
 
 The filter accepts the following options:
@@ -11222,74 +11222,74 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showwavespic)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showwavespic', typings_input=('audio',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "split_channels": split_channels,
-                
+
                 "colors": colors,
-                
+
                 "scale": scale,
-                
+
                 "draw": draw,
-                
+
                 "filter": filter,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def sidechaincompress(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _sidechain: AudioStream,
-        
-    
+
+
 
 
     *,
     level_in: Double = Default('1'),mode: Int| Literal["downward","upward"] | Default = Default('downward'),threshold: Double = Default('0.125'),ratio: Double = Default('2'),attack: Double = Default('20'),release: Double = Default('250'),makeup: Double = Default('1'),knee: Double = Default('2.82843'),link: Int| Literal["average","maximum"] | Default = Default('average'),detection: Int| Literal["peak","rms"] | Default = Default('rms'),level_sc: Double = Default('1'),mix: Double = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 This filter acts like normal compressor but has the ability to compress
 detected signal using second input signal.
 It needs two input streams and returns one output stream.
@@ -11322,91 +11322,91 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sidechaincompress)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sidechaincompress', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _sidechain,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "mode": mode,
-                
+
                 "threshold": threshold,
-                
+
                 "ratio": ratio,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "makeup": makeup,
-                
+
                 "knee": knee,
-                
+
                 "link": link,
-                
+
                 "detection": detection,
-                
+
                 "level_sc": level_sc,
-                
+
                 "mix": mix,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def sidechaingate(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _sidechain: AudioStream,
-        
-    
+
+
 
 
     *,
     level_in: Double = Default('1'),mode: Int| Literal["downward","upward"] | Default = Default('downward'),range: Double = Default('0.06125'),threshold: Double = Default('0.125'),ratio: Double = Default('2'),attack: Double = Default('20'),release: Double = Default('250'),makeup: Double = Default('1'),knee: Double = Default('2.82843'),detection: Int| Literal["peak","rms"] | Default = Default('rms'),link: Int| Literal["average","maximum"] | Default = Default('average'),level_sc: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 A sidechain gate acts like a normal (wideband) gate but has the ability to
 filter the detected signal before sending it to the gain reduction stage.
 Normally a gate uses the full range signal to detect a level above the
@@ -11445,7 +11445,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sidechaingate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11453,72 +11453,72 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sidechaingate', typings_input=('audio', 'audio'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _sidechain,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "mode": mode,
-                
+
                 "range": range,
-                
+
                 "threshold": threshold,
-                
+
                 "ratio": ratio,
-                
+
                 "attack": attack,
-                
+
                 "release": release,
-                
+
                 "makeup": makeup,
-                
+
                 "knee": knee,
-                
+
                 "detection": detection,
-                
+
                 "link": link,
-                
+
                 "level_sc": level_sc,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def silencedetect(
-    
+
     self,
 
 
@@ -11526,12 +11526,12 @@ References:
 
     *,
     n: Double = Default('0.001'),d: Duration = Default('2'),mono: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Detect silence in an audio stream.
 
 This filter logs a message when it detects that the input audio volume is less
@@ -11565,41 +11565,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#silencedetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='silencedetect', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "n": n,
-                
+
                 "d": d,
-                
+
                 "mono": mono,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def silenceremove(
-    
+
     self,
 
 
@@ -11607,15 +11607,15 @@ References:
 
     *,
     start_periods: Int = Default('0'),start_duration: Duration = Default('0'),start_threshold: Double = Default('0'),start_silence: Duration = Default('0'),start_mode: Int| Literal["any","all"] | Default = Default('any'),stop_periods: Int = Default('0'),stop_duration: Duration = Default('0'),stop_threshold: Double = Default('0'),stop_silence: Duration = Default('0'),stop_mode: Int| Literal["any","all"] | Default = Default('all'),detection: Int| Literal["avg","rms","peak","median","ptp","dev"] | Default = Default('rms'),window: Duration = Default('0.02'),timestamp: Int| Literal["write","copy"] | Default = Default('write'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Remove silence from the beginning, middle or end of the audio.
 
 The filter accepts the following options:
@@ -11645,7 +11645,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#silenceremove)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11653,76 +11653,76 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='silenceremove', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "start_periods": start_periods,
-                
+
                 "start_duration": start_duration,
-                
+
                 "start_threshold": start_threshold,
-                
+
                 "start_silence": start_silence,
-                
+
                 "start_mode": start_mode,
-                
+
                 "stop_periods": stop_periods,
-                
+
                 "stop_duration": stop_duration,
-                
+
                 "stop_threshold": stop_threshold,
-                
+
                 "stop_silence": stop_silence,
-                
+
                 "stop_mode": stop_mode,
-                
+
                 "detection": detection,
-                
+
                 "window": window,
-                
+
                 "timestamp": timestamp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def speechnorm(
-    
+
     self,
 
 
@@ -11730,15 +11730,15 @@ References:
 
     *,
     peak: Double = Default('0.95'),expansion: Double = Default('2'),compression: Double = Default('2'),threshold: Double = Default('0'),_raise: Double = Default('0.001'),fall: Double = Default('0.001'),channels: String = Default('all'),invert: Boolean = Default('false'),link: Boolean = Default('false'),rms: Double = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Speech Normalizer.
 
 This filter expands or compresses each half-cycle of audio samples
@@ -11769,7 +11769,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#speechnorm)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11777,62 +11777,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='speechnorm', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "peak": peak,
-                
+
                 "expansion": expansion,
-                
+
                 "compression": compression,
-                
+
                 "threshold": threshold,
-                
+
                 "raise": _raise,
-                
+
                 "fall": fall,
-                
+
                 "channels": channels,
-                
+
                 "invert": invert,
-                
+
                 "link": link,
-                
+
                 "rms": rms,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def stereotools(
-    
+
     self,
 
 
@@ -11840,15 +11840,15 @@ References:
 
     *,
     level_in: Double = Default('1'),level_out: Double = Default('1'),balance_in: Double = Default('0'),balance_out: Double = Default('0'),softclip: Boolean = Default('false'),mutel: Boolean = Default('false'),muter: Boolean = Default('false'),phasel: Boolean = Default('false'),phaser: Boolean = Default('false'),mode: Int| Literal["lr>lr","lr>ms","ms>lr","lr>ll","lr>rr","lr>l+r","lr>rl","ms>ll","ms>rr","ms>rl","lr>l-r"] | Default = Default('lr>lr'),slev: Double = Default('1'),sbal: Double = Default('0'),mlev: Double = Default('1'),mpan: Double = Default('0'),base: Double = Default('0'),delay: Double = Default('0'),sclevel: Double = Default('1'),phase: Double = Default('0'),bmode_in: Int| Literal["balance","amplitude","power"] | Default = Default('balance'),bmode_out: Int| Literal["balance","amplitude","power"] | Default = Default('balance'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 This filter has some handy utilities to manage stereo signals, for converting
 M/S stereo recordings to L/R signal while having control over the parameters
 or spreading the stereo image of master track.
@@ -11887,7 +11887,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#stereotools)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11895,72 +11895,72 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='stereotools', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "balance_in": balance_in,
-                
+
                 "balance_out": balance_out,
-                
+
                 "softclip": softclip,
-                
+
                 "mutel": mutel,
-                
+
                 "muter": muter,
-                
+
                 "phasel": phasel,
-                
+
                 "phaser": phaser,
-                
+
                 "mode": mode,
-                
+
                 "slev": slev,
-                
+
                 "sbal": sbal,
-                
+
                 "mlev": mlev,
-                
+
                 "mpan": mpan,
-                
+
                 "base": base,
-                
+
                 "delay": delay,
-                
+
                 "sclevel": sclevel,
-                
+
                 "phase": phase,
-                
+
                 "bmode_in": bmode_in,
-                
+
                 "bmode_out": bmode_out,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def stereowiden(
-    
+
     self,
 
 
@@ -11968,15 +11968,15 @@ References:
 
     *,
     delay: Float = Default('20'),feedback: Float = Default('0.3'),crossfeed: Float = Default('0.3'),drymix: Float = Default('0.8'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 This filter enhance the stereo effect by suppressing signal common to both
 channels and by delaying the signal of left into right and vice versa,
 thereby widening the stereo effect.
@@ -11999,7 +11999,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#stereowiden)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12007,46 +12007,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='stereowiden', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "delay": delay,
-                
+
                 "feedback": feedback,
-                
+
                 "crossfeed": crossfeed,
-                
+
                 "drymix": drymix,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def superequalizer(
-    
+
     self,
 
 
@@ -12054,12 +12054,12 @@ References:
 
     *,
     _1b: Float = Default('1'),_2b: Float = Default('1'),_3b: Float = Default('1'),_4b: Float = Default('1'),_5b: Float = Default('1'),_6b: Float = Default('1'),_7b: Float = Default('1'),_8b: Float = Default('1'),_9b: Float = Default('1'),_10b: Float = Default('1'),_11b: Float = Default('1'),_12b: Float = Default('1'),_13b: Float = Default('1'),_14b: Float = Default('1'),_15b: Float = Default('1'),_16b: Float = Default('1'),_17b: Float = Default('1'),_18b: Float = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply 18 band equalizer.
 
 The filter accepts the following options:
@@ -12093,71 +12093,71 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#superequalizer)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='superequalizer', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "1b": _1b,
-                
+
                 "2b": _2b,
-                
+
                 "3b": _3b,
-                
+
                 "4b": _4b,
-                
+
                 "5b": _5b,
-                
+
                 "6b": _6b,
-                
+
                 "7b": _7b,
-                
+
                 "8b": _8b,
-                
+
                 "9b": _9b,
-                
+
                 "10b": _10b,
-                
+
                 "11b": _11b,
-                
+
                 "12b": _12b,
-                
+
                 "13b": _13b,
-                
+
                 "14b": _14b,
-                
+
                 "15b": _15b,
-                
+
                 "16b": _16b,
-                
+
                 "17b": _17b,
-                
+
                 "18b": _18b,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def surround(
-    
+
     self,
 
 
@@ -12165,12 +12165,12 @@ References:
 
     *,
     chl_out: String = Default('5.1'),chl_in: String = Default('stereo'),level_in: Float = Default('1'),level_out: Float = Default('1'),lfe: Boolean = Default('true'),lfe_low: Int = Default('128'),lfe_high: Int = Default('256'),lfe_mode: Int| Literal["add","sub"] | Default = Default('add'),smooth: Float = Default('0'),angle: Float = Default('90'),focus: Float = Default('0'),fc_in: Float = Default('1'),fc_out: Float = Default('1'),fl_in: Float = Default('1'),fl_out: Float = Default('1'),fr_in: Float = Default('1'),fr_out: Float = Default('1'),sl_in: Float = Default('1'),sl_out: Float = Default('1'),sr_in: Float = Default('1'),sr_out: Float = Default('1'),bl_in: Float = Default('1'),bl_out: Float = Default('1'),br_in: Float = Default('1'),br_out: Float = Default('1'),bc_in: Float = Default('1'),bc_out: Float = Default('1'),lfe_in: Float = Default('1'),lfe_out: Float = Default('1'),allx: Float = Default('-1'),ally: Float = Default('-1'),fcx: Float = Default('0.5'),flx: Float = Default('0.5'),frx: Float = Default('0.5'),blx: Float = Default('0.5'),brx: Float = Default('0.5'),slx: Float = Default('0.5'),srx: Float = Default('0.5'),bcx: Float = Default('0.5'),fcy: Float = Default('0.5'),fly: Float = Default('0.5'),fry: Float = Default('0.5'),bly: Float = Default('0.5'),bry: Float = Default('0.5'),sly: Float = Default('0.5'),sry: Float = Default('0.5'),bcy: Float = Default('0.5'),win_size: Int = Default('4096'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('hann'),overlap: Float = Default('0.5'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply audio surround upmix filter.
 
 This filter allows to produce multichannel output from audio stream.
@@ -12238,157 +12238,157 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#surround)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='surround', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "chl_out": chl_out,
-                
+
                 "chl_in": chl_in,
-                
+
                 "level_in": level_in,
-                
+
                 "level_out": level_out,
-                
+
                 "lfe": lfe,
-                
+
                 "lfe_low": lfe_low,
-                
+
                 "lfe_high": lfe_high,
-                
+
                 "lfe_mode": lfe_mode,
-                
+
                 "smooth": smooth,
-                
+
                 "angle": angle,
-                
+
                 "focus": focus,
-                
+
                 "fc_in": fc_in,
-                
+
                 "fc_out": fc_out,
-                
+
                 "fl_in": fl_in,
-                
+
                 "fl_out": fl_out,
-                
+
                 "fr_in": fr_in,
-                
+
                 "fr_out": fr_out,
-                
+
                 "sl_in": sl_in,
-                
+
                 "sl_out": sl_out,
-                
+
                 "sr_in": sr_in,
-                
+
                 "sr_out": sr_out,
-                
+
                 "bl_in": bl_in,
-                
+
                 "bl_out": bl_out,
-                
+
                 "br_in": br_in,
-                
+
                 "br_out": br_out,
-                
+
                 "bc_in": bc_in,
-                
+
                 "bc_out": bc_out,
-                
+
                 "lfe_in": lfe_in,
-                
+
                 "lfe_out": lfe_out,
-                
+
                 "allx": allx,
-                
+
                 "ally": ally,
-                
+
                 "fcx": fcx,
-                
+
                 "flx": flx,
-                
+
                 "frx": frx,
-                
+
                 "blx": blx,
-                
+
                 "brx": brx,
-                
+
                 "slx": slx,
-                
+
                 "srx": srx,
-                
+
                 "bcx": bcx,
-                
+
                 "fcy": fcy,
-                
+
                 "fly": fly,
-                
+
                 "fry": fry,
-                
+
                 "bly": bly,
-                
+
                 "bry": bry,
-                
+
                 "sly": sly,
-                
+
                 "sry": sry,
-                
+
                 "bcy": bcy,
-                
+
                 "win_size": win_size,
-                
+
                 "win_func": win_func,
-                
+
                 "overlap": overlap,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def tiltshelf(
-    
+
     self,
 
 
@@ -12396,15 +12396,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),gain: Double = Default('0'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Boost or cut the lower frequencies and cut or boost higher frequencies
 of the audio using a two-pole shelving filter with a response similar to
 that of a standard hi-fi's tone-controls.
@@ -12435,7 +12435,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tiltshelf)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12443,78 +12443,78 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tiltshelf', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "gain": gain,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def treble(
-    
+
     self,
 
 
@@ -12522,15 +12522,15 @@ References:
 
     *,
     frequency: Double = Default('3000'),width_type: Int| Literal["h","q","o","s","k"] | Default = Default('q'),width: Double = Default('0.5'),gain: Double = Default('0'),poles: Int = Default('2'),mix: Double = Default('1'),channels: String = Default('all'),normalize: Boolean = Default('false'),transform: Int| Literal["di","dii","tdi","tdii","latt","svf","zdf"] | Default = Default('di'),precision: Int| Literal["auto","s16","s32","f32","f64"] | Default = Default('auto'),blocksize: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Boost or cut treble (upper) frequencies of the audio using a two-pole
 shelving filter with a response similar to that of a standard
 hi-fi's tone-controls. This is also known as shelving equalisation (EQ).
@@ -12560,7 +12560,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#treble)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12568,54 +12568,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='treble', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frequency": frequency,
-                
+
                 "width_type": width_type,
-                
+
                 "width": width,
-                
+
                 "gain": gain,
-                
+
                 "poles": poles,
-                
+
                 "mix": mix,
-                
+
                 "channels": channels,
-                
+
                 "normalize": normalize,
-                
+
                 "transform": transform,
-                
+
                 "precision": precision,
-                
+
                 "blocksize": blocksize,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tremolo(
-    
+
     self,
 
 
@@ -12623,15 +12623,15 @@ References:
 
     *,
     f: Double = Default('5'),d: Double = Default('0.5'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Sinusoidal amplitude modulation.
 
 The filter accepts the following options:
@@ -12650,7 +12650,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tremolo)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12658,62 +12658,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tremolo', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "f": f,
-                
+
                 "d": d,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def vibrato(
-    
+
     self,
 
 
@@ -12721,15 +12721,15 @@ References:
 
     *,
     f: Double = Default('5'),d: Double = Default('0.5'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Sinusoidal phase modulation.
 
 The filter accepts the following options:
@@ -12748,7 +12748,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vibrato)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12756,44 +12756,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vibrato', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "f": f,
-                
+
                 "d": d,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def virtualbass(
-    
+
     self,
 
 
@@ -12801,15 +12801,15 @@ References:
 
     *,
     cutoff: Double = Default('250'),strength: Double = Default('3'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Apply audio Virtual Bass filter.
 
 This filter accepts stereo input and produce stereo with LFE (2.1) channels output.
@@ -12832,7 +12832,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#virtualbass)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12840,38 +12840,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='virtualbass', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cutoff": cutoff,
-                
+
                 "strength": strength,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def volume(
-    
+
     self,
 
 
@@ -12879,15 +12879,15 @@ References:
 
     *,
     volume: String = Default('1.0'),precision: Int| Literal["fixed","float","double"] | Default = Default('float'),eval: Int| Literal["once","frame"] | Default = Default('once'),replaygain: Int| Literal["drop","ignore","track","album"] | Default = Default('drop'),replaygain_preamp: Double = Default('0'),replaygain_noclip: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Adjust the input audio volume.
 
 It accepts the following parameters:
@@ -12910,7 +12910,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#volume)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12918,57 +12918,57 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='volume', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "volume": volume,
-                
+
                 "precision": precision,
-                
+
                 "eval": eval,
-                
+
                 "replaygain": replaygain,
-                
+
                 "replaygain_preamp": replaygain_preamp,
-                
+
                 "replaygain_noclip": replaygain_noclip,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def volumedetect(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Detect the volume of the input video.
 
 The filter has no parameters. It supports only 16-bit signed integer samples,
@@ -12993,67 +12993,23 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#volumedetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='volumedetect', typings_input=('audio',), typings_output=('audio',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
-
-
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    

--- a/packages/v8/src/ffmpeg/streams/video.py
+++ b/packages/v8/src/ffmpeg/streams/video.py
@@ -48,38 +48,38 @@ class VideoStream(FilterableStream):
     Video stream.
     """
 
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def addroi(
-    
+
     self,
 
 
@@ -87,12 +87,12 @@ class VideoStream(FilterableStream):
 
     *,
     x: String = Default('0'),y: String = Default('0'),w: String = Default('0'),h: String = Default('0'),qoffset: Rational = Default('-1/10'),clear: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Mark a region of interest in a video frame.
 
 The frame data is passed through unchanged, but metadata is attached
@@ -117,132 +117,132 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#addroi)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='addroi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "qoffset": qoffset,
-                
+
                 "clear": clear,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def alphaextract(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Extract the alpha component from the input as a grayscale video. This
 is especially useful with the alphamerge filter.
 
@@ -257,64 +257,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#alphaextract)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='alphaextract', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def alphamerge(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _alpha: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Add or replace the alpha component of the primary input with the
 grayscale value of a second input. This is intended for use with
 alphaextract to allow the transmission or storage of frame
@@ -340,7 +340,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#alphamerge)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -351,50 +351,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='alphamerge', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _alpha,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def amplify(
-    
+
     self,
 
 
@@ -402,15 +402,15 @@ References:
 
     *,
     radius: Int = Default('2'),factor: Float = Default('2'),threshold: Float = Default('10'),tolerance: Float = Default('0'),low: Float = Default('65535'),high: Float = Default('65535'),planes: Flags = Default('7'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Amplify differences between current pixel and pixels of adjacent frames in
 same pixel location.
 
@@ -435,7 +435,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#amplify)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -443,118 +443,118 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='amplify', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "radius": radius,
-                
+
                 "factor": factor,
-                
+
                 "threshold": threshold,
-                
+
                 "tolerance": tolerance,
-                
+
                 "low": low,
-                
+
                 "high": high,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def ass(
-    
+
     self,
 
 
@@ -562,12 +562,12 @@ References:
 
     *,
     filename: String = Default(None),original_size: Image_size = Default(None),fontsdir: String = Default(None),alpha: Boolean = Default('false'),shaping: Int| Literal["auto","simple","complex"] | Default = Default('auto'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Same as the subtitles filter, except that it doesn't require libavcodec
 and libavformat to work. On the other hand, it is limited to ASS (Advanced
 Substation Alpha) subtitles files.
@@ -591,59 +591,59 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ass)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ass', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "filename": filename,
-                
+
                 "original_size": original_size,
-                
+
                 "fontsdir": fontsdir,
-                
+
                 "alpha": alpha,
-                
+
                 "shaping": shaping,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def atadenoise(
-    
+
     self,
 
 
@@ -651,15 +651,15 @@ References:
 
     *,
     _0a: Float = Default('0.02'),_0b: Float = Default('0.04'),_1a: Float = Default('0.02'),_1b: Float = Default('0.04'),_2a: Float = Default('0.02'),_2b: Float = Default('0.04'),s: Int = Default('9'),p: Flags = Default('7'),a: Int| Literal["p","s"] | Default = Default('p'),_0s: Float = Default('32767'),_1s: Float = Default('32767'),_2s: Float = Default('32767'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply an Adaptive Temporal Averaging Denoiser to the video input.
 
 The filter accepts the following options:
@@ -688,7 +688,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#atadenoise)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -696,64 +696,64 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='atadenoise', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "0a": _0a,
-                
+
                 "0b": _0b,
-                
+
                 "1a": _1a,
-                
+
                 "1b": _1b,
-                
+
                 "2a": _2a,
-                
+
                 "2b": _2b,
-                
+
                 "s": s,
-                
+
                 "p": p,
-                
+
                 "a": a,
-                
+
                 "0s": _0s,
-                
+
                 "1s": _1s,
-                
+
                 "2s": _2s,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def avgblur(
-    
+
     self,
 
 
@@ -761,15 +761,15 @@ References:
 
     *,
     sizeX: Int = Default('1'),planes: Int = Default('15'),sizeY: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply average blur filter.
 
 The filter accepts the following options:
@@ -789,7 +789,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#avgblur)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -797,38 +797,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='avgblur', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sizeX": sizeX,
-                
+
                 "planes": planes,
-                
+
                 "sizeY": sizeY,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def avgblur_opencl(
-    
+
     self,
 
 
@@ -836,12 +836,12 @@ References:
 
     *,
     sizeX: Int = Default('1'),planes: Int = Default('15'),sizeY: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply average blur filter.
 
 The filter accepts the following options:
@@ -860,47 +860,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#avgblur_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='avgblur_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sizeX": sizeX,
-                
+
                 "planes": planes,
-                
+
                 "sizeY": sizeY,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def backgroundkey(
-    
+
     self,
 
 
@@ -908,15 +908,15 @@ References:
 
     *,
     threshold: Float = Default('0.08'),similarity: Float = Default('0.1'),blend: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Turns a static background into transparency.
 
 The filter accepts the following option:
@@ -936,7 +936,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#backgroundkey)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -944,44 +944,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='backgroundkey', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold": threshold,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def bbox(
-    
+
     self,
 
 
@@ -989,15 +989,15 @@ References:
 
     *,
     min_val: Int = Default('16'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Compute the bounding box for the non-black pixels in the input frame
 luma plane.
 
@@ -1021,7 +1021,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bbox)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1029,34 +1029,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bbox', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "min_val": min_val,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def bench(
-    
+
     self,
 
 
@@ -1064,12 +1064,12 @@ References:
 
     *,
     action: Int| Literal["start","stop"] | Default = Default('start'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Benchmark part of a filtergraph.
 
 The filter accepts the following options:
@@ -1086,37 +1086,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bench)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bench', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "action": action,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def bilateral(
-    
+
     self,
 
 
@@ -1124,15 +1124,15 @@ References:
 
     *,
     sigmaS: Float = Default('0.1'),sigmaR: Float = Default('0.1'),planes: Int = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply bilateral filter, spatial smoothing while preserving edges.
 
 The filter accepts the following options:
@@ -1152,7 +1152,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bilateral)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1160,40 +1160,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bilateral', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sigmaS": sigmaS,
-                
+
                 "sigmaR": sigmaR,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def bitplanenoise(
-    
+
     self,
 
 
@@ -1201,15 +1201,15 @@ References:
 
     *,
     bitplane: Int = Default('1'),filter: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Show and measure bit plane noise.
 
 The filter accepts the following options:
@@ -1228,7 +1228,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bitplanenoise)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1236,36 +1236,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bitplanenoise', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "bitplane": bitplane,
-                
+
                 "filter": filter,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def blackdetect(
-    
+
     self,
 
 
@@ -1273,12 +1273,12 @@ References:
 
     *,
     d: Double = Default('2'),picture_black_ratio_th: Double = Default('0.98'),pixel_black_th: Double = Default('0.1'),alpha: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect video intervals that are (almost) completely black. Can be
 useful to detect chapter transitions, commercials, or invalid
 recordings.
@@ -1313,43 +1313,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blackdetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='blackdetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "d": d,
-                
+
                 "picture_black_ratio_th": picture_black_ratio_th,
-                
+
                 "pixel_black_th": pixel_black_th,
-                
+
                 "alpha": alpha,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def blackframe(
-    
+
     self,
 
 
@@ -1357,12 +1357,12 @@ References:
 
     *,
     amount: Int = Default('98'),threshold: Int = Default('32'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect frames that are (almost) completely black. Can be useful to
 detect chapter transitions or commercials. Output lines consist of
 the frame number of the detected frame, the percentage of blackness,
@@ -1390,68 +1390,68 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blackframe)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='blackframe', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "amount": amount,
-                
+
                 "threshold": threshold,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def blend(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _bottom: VideoStream,
-        
-    
+
+
 
 
     *,
     c0_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c1_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c2_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c3_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),all_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('-1'),c0_expr: String = Default(None),c1_expr: String = Default(None),c2_expr: String = Default(None),c3_expr: String = Default(None),all_expr: String = Default(None),c0_opacity: Double = Default('1'),c1_opacity: Double = Default('1'),c2_opacity: Double = Default('1'),c3_opacity: Double = Default('1'),all_opacity: Double = Default('1'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Blend two video frames into each other.
 
 The blend filter takes two input streams and outputs one
@@ -1492,7 +1492,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blend)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -1503,72 +1503,72 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='blend', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _bottom,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "c0_mode": c0_mode,
-                
+
                 "c1_mode": c1_mode,
-                
+
                 "c2_mode": c2_mode,
-                
+
                 "c3_mode": c3_mode,
-                
+
                 "all_mode": all_mode,
-                
+
                 "c0_expr": c0_expr,
-                
+
                 "c1_expr": c1_expr,
-                
+
                 "c2_expr": c2_expr,
-                
+
                 "c3_expr": c3_expr,
-                
+
                 "all_expr": all_expr,
-                
+
                 "c0_opacity": c0_opacity,
-                
+
                 "c1_opacity": c1_opacity,
-                
+
                 "c2_opacity": c2_opacity,
-                
+
                 "c3_opacity": c3_opacity,
-                
+
                 "all_opacity": all_opacity,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def blockdetect(
-    
+
     self,
 
 
@@ -1576,12 +1576,12 @@ References:
 
     *,
     period_min: Int = Default('3'),period_max: Int = Default('24'),planes: Int = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Determines blockiness of frames without altering the input frames.
 
 Based on Remco Muijs and Ihor Kirenko: "A no-reference blocking artifact measure for adaptive video processing." 2005 13th European signal processing conference.
@@ -1602,41 +1602,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blockdetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='blockdetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "period_min": period_min,
-                
+
                 "period_max": period_max,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def blurdetect(
-    
+
     self,
 
 
@@ -1644,12 +1644,12 @@ References:
 
     *,
     high: Float = Default('0.117647'),low: Float = Default('0.0588235'),radius: Int = Default('50'),block_pct: Int = Default('80'),block_width: Int = Default('-1'),planes: Int = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Determines blurriness of frames without altering the input frames.
 
 Based on Marziliano, Pina, et al. "A no-reference perceptual blur metric."
@@ -1674,49 +1674,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#blurdetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='blurdetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "high": high,
-                
+
                 "low": low,
-                
+
                 "radius": radius,
-                
+
                 "block_pct": block_pct,
-                
+
                 "block_width": block_width,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def boxblur(
-    
+
     self,
 
 
@@ -1724,15 +1724,15 @@ References:
 
     *,
     luma_radius: String = Default('2'),luma_power: Int = Default('2'),chroma_radius: String = Default(None),chroma_power: Int = Default('-1'),alpha_radius: String = Default(None),alpha_power: Int = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a boxblur algorithm to the input video.
 
 It accepts the following parameters:
@@ -1755,7 +1755,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#boxblur)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1763,44 +1763,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='boxblur', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_radius": luma_radius,
-                
+
                 "luma_power": luma_power,
-                
+
                 "chroma_radius": chroma_radius,
-                
+
                 "chroma_power": chroma_power,
-                
+
                 "alpha_radius": alpha_radius,
-                
+
                 "alpha_power": alpha_power,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def boxblur_opencl(
-    
+
     self,
 
 
@@ -1808,12 +1808,12 @@ References:
 
     *,
     luma_radius: String = Default('2'),luma_power: Int = Default('2'),chroma_radius: String = Default(None),chroma_power: Int = Default('-1'),alpha_radius: String = Default(None),alpha_power: Int = Default('-1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a boxblur algorithm to the input video.
 
 It accepts the following parameters:
@@ -1835,51 +1835,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#boxblur_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='boxblur_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_radius": luma_radius,
-                
+
                 "luma_power": luma_power,
-                
+
                 "chroma_radius": chroma_radius,
-                
+
                 "chroma_power": chroma_power,
-                
+
                 "alpha_radius": alpha_radius,
-                
+
                 "alpha_power": alpha_power,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def bwdif(
-    
+
     self,
 
 
@@ -1887,15 +1887,15 @@ References:
 
     *,
     mode: Int| Literal["send_frame","send_field"] | Default = Default('send_field'),parity: Int| Literal["tff","bff","auto"] | Default = Default('auto'),deint: Int| Literal["all","interlaced"] | Default = Default('all'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlace the input video ("bwdif" stands for "Bob Weaver
 Deinterlacing Filter").
 
@@ -1918,7 +1918,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#bwdif)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -1926,38 +1926,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='bwdif', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "parity": parity,
-                
+
                 "deint": deint,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def cas(
-    
+
     self,
 
 
@@ -1965,15 +1965,15 @@ References:
 
     *,
     strength: Float = Default('0'),planes: Flags = Default('7'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Contrast Adaptive Sharpen filter to video stream.
 
 The filter accepts the following options:
@@ -1992,7 +1992,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#cas)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2000,49 +2000,49 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='cas', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "strength": strength,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ccrepack(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Repack CEA-708 closed captioning side data
 
 This filter fixes various issues seen with commercial encoders
@@ -2062,43 +2062,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ccrepack)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ccrepack', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def chromahold(
-    
+
     self,
 
 
@@ -2106,15 +2106,15 @@ References:
 
     *,
     color: Color = Default('black'),similarity: Float = Default('0.01'),blend: Float = Default('0'),yuv: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove all color information for all colors except for certain one.
 
 The filter accepts the following options:
@@ -2135,7 +2135,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#chromahold)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2143,40 +2143,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='chromahold', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "color": color,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
                 "yuv": yuv,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def chromakey(
-    
+
     self,
 
 
@@ -2184,15 +2184,15 @@ References:
 
     *,
     color: Color = Default('black'),similarity: Float = Default('0.01'),blend: Float = Default('0'),yuv: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 YUV colorspace color/chroma keying.
 
 The filter accepts the following options:
@@ -2213,7 +2213,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#chromakey)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2221,40 +2221,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='chromakey', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "color": color,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
                 "yuv": yuv,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def chromanr(
-    
+
     self,
 
 
@@ -2262,15 +2262,15 @@ References:
 
     *,
     thres: Float = Default('30'),sizew: Int = Default('5'),sizeh: Int = Default('5'),stepw: Int = Default('1'),steph: Int = Default('1'),threy: Float = Default('200'),threu: Float = Default('200'),threv: Float = Default('200'),distance: Int| Literal["manhattan","euclidean"] | Default = Default('manhattan'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reduce chrominance noise.
 
 The filter accepts the following options:
@@ -2296,7 +2296,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#chromanr)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2304,50 +2304,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='chromanr', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "thres": thres,
-                
+
                 "sizew": sizew,
-                
+
                 "sizeh": sizeh,
-                
+
                 "stepw": stepw,
-                
+
                 "steph": steph,
-                
+
                 "threy": threy,
-                
+
                 "threu": threu,
-                
+
                 "threv": threv,
-                
+
                 "distance": distance,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def chromashift(
-    
+
     self,
 
 
@@ -2355,15 +2355,15 @@ References:
 
     *,
     cbh: Int = Default('0'),cbv: Int = Default('0'),crh: Int = Default('0'),crv: Int = Default('0'),edge: Int| Literal["smear","wrap"] | Default = Default('smear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Shift chroma pixels horizontally and/or vertically.
 
 The filter accepts the following options:
@@ -2385,7 +2385,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#chromashift)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2393,42 +2393,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='chromashift', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cbh": cbh,
-                
+
                 "cbv": cbv,
-                
+
                 "crh": crh,
-                
+
                 "crv": crv,
-                
+
                 "edge": edge,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ciescope(
-    
+
     self,
 
 
@@ -2436,12 +2436,12 @@ References:
 
     *,
     system: Int| Literal["ntsc","470m","ebu","470bg","smpte","240m","apple","widergb","cie1931","hdtv","rec709","uhdtv","rec2020","dcip3"] | Default = Default('hdtv'),cie: Int| Literal["xyy","ucs","luv"] | Default = Default('xyy'),gamuts: Flags| Literal["ntsc","470m","ebu","470bg","smpte","240m","apple","widergb","cie1931","hdtv","rec709","uhdtv","rec2020","dcip3"] | Default = Default('0'),size: Int = Default('512'),intensity: Float = Default('0.001'),contrast: Float = Default('0.75'),corrgamma: Boolean = Default('true'),showwhite: Boolean = Default('false'),gamma: Double = Default('2.6'),fill: Boolean = Default('true'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Display CIE color diagram with pixels overlaid onto it.
 
 The filter accepts the following options:
@@ -2467,55 +2467,55 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ciescope)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ciescope', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "system": system,
-                
+
                 "cie": cie,
-                
+
                 "gamuts": gamuts,
-                
+
                 "size": size,
-                
+
                 "intensity": intensity,
-                
+
                 "contrast": contrast,
-                
+
                 "corrgamma": corrgamma,
-                
+
                 "showwhite": showwhite,
-                
+
                 "gamma": gamma,
-                
+
                 "fill": fill,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def codecview(
-    
+
     self,
 
 
@@ -2523,15 +2523,15 @@ References:
 
     *,
     mv: Flags| Literal["pf","bf","bb"] | Default = Default('0'),qp: Boolean = Default('false'),mv_type: Flags| Literal["fp","bp"] | Default = Default('0'),frame_type: Flags| Literal["if","pf","bf"] | Default = Default('0'),block: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Visualize information exported by some codecs.
 
 Some codecs can export information through frames using side-data or other
@@ -2557,7 +2557,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#codecview)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2565,44 +2565,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='codecview', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mv": mv,
-                
+
                 "qp": qp,
-                
+
                 "mv_type": mv_type,
-                
+
                 "frame_type": frame_type,
-                
+
                 "block": block,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def colorbalance(
-    
+
     self,
 
 
@@ -2610,15 +2610,15 @@ References:
 
     *,
     rs: Float = Default('0'),gs: Float = Default('0'),bs: Float = Default('0'),rm: Float = Default('0'),gm: Float = Default('0'),bm: Float = Default('0'),rh: Float = Default('0'),gh: Float = Default('0'),bh: Float = Default('0'),pl: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Modify intensity of primary colors (red, green and blue) of input frames.
 
 The filter allows an input frame to be adjusted in the shadows, midtones or highlights
@@ -2651,7 +2651,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorbalance)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2659,52 +2659,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorbalance', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rs": rs,
-                
+
                 "gs": gs,
-                
+
                 "bs": bs,
-                
+
                 "rm": rm,
-                
+
                 "gm": gm,
-                
+
                 "bm": bm,
-                
+
                 "rh": rh,
-                
+
                 "gh": gh,
-                
+
                 "bh": bh,
-                
+
                 "pl": pl,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorchannelmixer(
-    
+
     self,
 
 
@@ -2712,15 +2712,15 @@ References:
 
     *,
     rr: Double = Default('1'),rg: Double = Default('0'),rb: Double = Default('0'),ra: Double = Default('0'),gr: Double = Default('0'),gg: Double = Default('1'),gb: Double = Default('0'),ga: Double = Default('0'),br: Double = Default('0'),bg: Double = Default('0'),bb: Double = Default('1'),ba: Double = Default('0'),ar: Double = Default('0'),ag: Double = Default('0'),ab: Double = Default('0'),aa: Double = Default('1'),pc: Int| Literal["none","lum","max","avg","sum","nrm","pwr"] | Default = Default('none'),pa: Double = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust video input frames by re-mixing color channels.
 
 This filter modifies a color channel by adding the values associated to
@@ -2762,7 +2762,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorchannelmixer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2770,70 +2770,70 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorchannelmixer', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rr": rr,
-                
+
                 "rg": rg,
-                
+
                 "rb": rb,
-                
+
                 "ra": ra,
-                
+
                 "gr": gr,
-                
+
                 "gg": gg,
-                
+
                 "gb": gb,
-                
+
                 "ga": ga,
-                
+
                 "br": br,
-                
+
                 "bg": bg,
-                
+
                 "bb": bb,
-                
+
                 "ba": ba,
-                
+
                 "ar": ar,
-                
+
                 "ag": ag,
-                
+
                 "ab": ab,
-                
+
                 "aa": aa,
-                
+
                 "pc": pc,
-                
+
                 "pa": pa,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def colorcontrast(
-    
+
     self,
 
 
@@ -2841,15 +2841,15 @@ References:
 
     *,
     rc: Float = Default('0'),gm: Float = Default('0'),by: Float = Default('0'),rcw: Float = Default('0'),gmw: Float = Default('0'),byw: Float = Default('0'),pl: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust color contrast between RGB components.
 
 The filter accepts the following options:
@@ -2873,7 +2873,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorcontrast)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2881,46 +2881,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorcontrast', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rc": rc,
-                
+
                 "gm": gm,
-                
+
                 "by": by,
-                
+
                 "rcw": rcw,
-                
+
                 "gmw": gmw,
-                
+
                 "byw": byw,
-                
+
                 "pl": pl,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorcorrect(
-    
+
     self,
 
 
@@ -2928,15 +2928,15 @@ References:
 
     *,
     rl: Float = Default('0'),bl: Float = Default('0'),rh: Float = Default('0'),bh: Float = Default('0'),saturation: Float = Default('1'),analyze: Int| Literal["manual","average","minmax","median"] | Default = Default('manual'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust color white balance selectively for blacks and whites.
 This filter operates in YUV colorspace.
 
@@ -2960,7 +2960,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorcorrect)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -2968,44 +2968,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorcorrect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rl": rl,
-                
+
                 "bl": bl,
-                
+
                 "rh": rh,
-                
+
                 "bh": bh,
-                
+
                 "saturation": saturation,
-                
+
                 "analyze": analyze,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colordetect(
-    
+
     self,
 
 
@@ -3013,12 +3013,12 @@ References:
 
     *,
     mode: Flags| Literal["color_range","alpha_mode","all"] | Default = Default('color_range+alpha_mode+all'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Analyze the video frames to determine the effective value range and alpha
 mode.
 
@@ -3036,37 +3036,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colordetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colordetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorhold(
-    
+
     self,
 
 
@@ -3074,15 +3074,15 @@ References:
 
     *,
     color: Color = Default('black'),similarity: Float = Default('0.01'),blend: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove all color information for all RGB colors except for certain one.
 
 The filter accepts the following options:
@@ -3102,7 +3102,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorhold)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3110,38 +3110,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorhold', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "color": color,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorize(
-    
+
     self,
 
 
@@ -3149,15 +3149,15 @@ References:
 
     *,
     hue: Float = Default('0'),saturation: Float = Default('0.5'),lightness: Float = Default('0.5'),mix: Float = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Overlay a solid color on the video stream.
 
 The filter accepts the following options:
@@ -3178,7 +3178,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorize)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3186,40 +3186,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorize', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "hue": hue,
-                
+
                 "saturation": saturation,
-                
+
                 "lightness": lightness,
-                
+
                 "mix": mix,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorkey(
-    
+
     self,
 
 
@@ -3227,15 +3227,15 @@ References:
 
     *,
     color: Color = Default('black'),similarity: Float = Default('0.01'),blend: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 RGB colorspace color keying.
 This filter operates on 8-bit RGB format frames by setting the alpha component of each pixel
 which falls within the similarity radius of the key color to 0. The alpha value for pixels outside
@@ -3258,7 +3258,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorkey)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3266,38 +3266,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorkey', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "color": color,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorkey_opencl(
-    
+
     self,
 
 
@@ -3305,12 +3305,12 @@ References:
 
     *,
     color: Color = Default('black'),similarity: Float = Default('0.01'),blend: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 RGB colorspace color keying.
 
 The filter accepts the following options:
@@ -3329,41 +3329,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorkey_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorkey_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "color": color,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorlevels(
-    
+
     self,
 
 
@@ -3371,15 +3371,15 @@ References:
 
     *,
     rimin: Double = Default('0'),gimin: Double = Default('0'),bimin: Double = Default('0'),aimin: Double = Default('0'),rimax: Double = Default('1'),gimax: Double = Default('1'),bimax: Double = Default('1'),aimax: Double = Default('1'),romin: Double = Default('0'),gomin: Double = Default('0'),bomin: Double = Default('0'),aomin: Double = Default('0'),romax: Double = Default('1'),gomax: Double = Default('1'),bomax: Double = Default('1'),aomax: Double = Default('1'),preserve: Int| Literal["none","lum","max","avg","sum","nrm","pwr"] | Default = Default('none'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust video input frames using levels.
 
 The filter accepts the following options:
@@ -3413,7 +3413,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorlevels)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3421,94 +3421,94 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorlevels', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rimin": rimin,
-                
+
                 "gimin": gimin,
-                
+
                 "bimin": bimin,
-                
+
                 "aimin": aimin,
-                
+
                 "rimax": rimax,
-                
+
                 "gimax": gimax,
-                
+
                 "bimax": bimax,
-                
+
                 "aimax": aimax,
-                
+
                 "romin": romin,
-                
+
                 "gomin": gomin,
-                
+
                 "bomin": bomin,
-                
+
                 "aomin": aomin,
-                
+
                 "romax": romax,
-                
+
                 "gomax": gomax,
-                
+
                 "bomax": bomax,
-                
+
                 "aomax": aomax,
-                
+
                 "preserve": preserve,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colormap(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _source: VideoStream,
-        
-    
-        
+
+
+
         _target: VideoStream,
-        
-    
+
+
 
 
     *,
     patch_size: Image_size = Default('64x64'),nb_patches: Int = Default('0'),type: Int| Literal["relative","absolute"] | Default = Default('absolute'),kernel: Int| Literal["euclidean","weuclidean"] | Default = Default('euclidean'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply custom color maps to video stream.
 
 This filter needs three input video streams.
@@ -3534,7 +3534,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colormap)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3542,52 +3542,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colormap', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _source,
-                
-            
-                
+
+
+
                 _target,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "patch_size": patch_size,
-                
+
                 "nb_patches": nb_patches,
-                
+
                 "type": type,
-                
+
                 "kernel": kernel,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colormatrix(
-    
+
     self,
 
 
@@ -3595,15 +3595,15 @@ References:
 
     *,
     src: Int| Literal["bt709","fcc","bt601","bt470","bt470bg","smpte170m","smpte240m","bt2020"] | Default = Default('-1'),dst: Int| Literal["bt709","fcc","bt601","bt470","bt470bg","smpte170m","smpte240m","bt2020"] | Default = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert color matrix.
 
 The filter accepts the following options:
@@ -3622,7 +3622,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colormatrix)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3630,36 +3630,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colormatrix', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "src": src,
-                
+
                 "dst": dst,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def colorspace(
-    
+
     self,
 
 
@@ -3667,15 +3667,15 @@ References:
 
     *,
     all: Int| Literal["bt470m","bt470bg","bt601-6-525","bt601-6-625","bt709","smpte170m","smpte240m","bt2020"] | Default = Default('0'),space: Int| Literal["bt709","fcc","bt470bg","smpte170m","smpte240m","ycgco","gbr","bt2020nc","bt2020ncl"] | Default = Default('2'),range: Int| Literal["tv","mpeg","pc","jpeg"] | Default = Default('0'),primaries: Int| Literal["bt709","bt470m","bt470bg","smpte170m","smpte240m","smpte428","film","smpte431","smpte432","bt2020","jedec-p22","ebu3213"] | Default = Default('2'),trc: Int| Literal["bt709","bt470m","gamma22","bt470bg","gamma28","smpte170m","smpte240m","linear","srgb","iec61966-2-1","xvycc","iec61966-2-4","bt2020-10","bt2020-12"] | Default = Default('2'),format: Int| Literal["yuv420p","yuv420p10","yuv420p12","yuv422p","yuv422p10","yuv422p12","yuv444p","yuv444p10","yuv444p12"] | Default = Default('-1'),fast: Boolean = Default('false'),dither: Int| Literal["none","fsb"] | Default = Default('none'),wpadapt: Int| Literal["bradford","vonkries","identity"] | Default = Default('bradford'),iall: Int| Literal["bt470m","bt470bg","bt601-6-525","bt601-6-625","bt709","smpte170m","smpte240m","bt2020"] | Default = Default('0'),ispace: Int| Literal["bt709","fcc","bt470bg","smpte170m","smpte240m","ycgco","gbr","bt2020nc","bt2020ncl"] | Default = Default('2'),irange: Int| Literal["tv","mpeg","pc","jpeg"] | Default = Default('0'),iprimaries: Int| Literal["bt709","bt470m","bt470bg","smpte170m","smpte240m","smpte428","film","smpte431","smpte432","bt2020","jedec-p22","ebu3213"] | Default = Default('2'),itrc: Int| Literal["bt709","bt470m","gamma22","bt470bg","gamma28","smpte170m","smpte240m","linear","srgb","iec61966-2-1","xvycc","iec61966-2-4","bt2020-10","bt2020-12"] | Default = Default('2'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert colorspace, transfer characteristics or color primaries.
 Input video needs to have an even size.
 
@@ -3707,7 +3707,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colorspace)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3715,62 +3715,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colorspace', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "all": all,
-                
+
                 "space": space,
-                
+
                 "range": range,
-                
+
                 "primaries": primaries,
-                
+
                 "trc": trc,
-                
+
                 "format": format,
-                
+
                 "fast": fast,
-                
+
                 "dither": dither,
-                
+
                 "wpadapt": wpadapt,
-                
+
                 "iall": iall,
-                
+
                 "ispace": ispace,
-                
+
                 "irange": irange,
-                
+
                 "iprimaries": iprimaries,
-                
+
                 "itrc": itrc,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def colortemperature(
-    
+
     self,
 
 
@@ -3778,15 +3778,15 @@ References:
 
     *,
     temperature: Float = Default('6500'),mix: Float = Default('1'),pl: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust color temperature in video to simulate variations in ambient color temperature.
 
 The filter accepts the following options:
@@ -3806,7 +3806,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#colortemperature)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3814,44 +3814,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='colortemperature', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "temperature": temperature,
-                
+
                 "mix": mix,
-                
+
                 "pl": pl,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def convolution(
-    
+
     self,
 
 
@@ -3859,15 +3859,15 @@ References:
 
     *,
     _0m: String = Default('0 0 0 0 1 0 0 0 0'),_1m: String = Default('0 0 0 0 1 0 0 0 0'),_2m: String = Default('0 0 0 0 1 0 0 0 0'),_3m: String = Default('0 0 0 0 1 0 0 0 0'),_0rdiv: Float = Default('0'),_1rdiv: Float = Default('0'),_2rdiv: Float = Default('0'),_3rdiv: Float = Default('0'),_0bias: Float = Default('0'),_1bias: Float = Default('0'),_2bias: Float = Default('0'),_3bias: Float = Default('0'),_0mode: Int| Literal["square","row","column"] | Default = Default('square'),_1mode: Int| Literal["square","row","column"] | Default = Default('square'),_2mode: Int| Literal["square","row","column"] | Default = Default('square'),_3mode: Int| Literal["square","row","column"] | Default = Default('square'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply convolution of 3x3, 5x5, 7x7 or horizontal/vertical up to 49 elements.
 
 The filter accepts the following options:
@@ -3900,7 +3900,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#convolution)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -3908,64 +3908,64 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='convolution', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "0m": _0m,
-                
+
                 "1m": _1m,
-                
+
                 "2m": _2m,
-                
+
                 "3m": _3m,
-                
+
                 "0rdiv": _0rdiv,
-                
+
                 "1rdiv": _1rdiv,
-                
+
                 "2rdiv": _2rdiv,
-                
+
                 "3rdiv": _3rdiv,
-                
+
                 "0bias": _0bias,
-                
+
                 "1bias": _1bias,
-                
+
                 "2bias": _2bias,
-                
+
                 "3bias": _3bias,
-                
+
                 "0mode": _0mode,
-                
+
                 "1mode": _1mode,
-                
+
                 "2mode": _2mode,
-                
+
                 "3mode": _3mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def convolution_opencl(
-    
+
     self,
 
 
@@ -3973,12 +3973,12 @@ References:
 
     *,
     _0m: String = Default('0 0 0 0 1 0 0 0 0'),_2m: String = Default('0 0 0 0 1 0 0 0 0'),_3m: String = Default('0 0 0 0 1 0 0 0 0'),_0rdiv: Float = Default('1'),_1rdiv: Float = Default('1'),_2rdiv: Float = Default('1'),_3rdiv: Float = Default('1'),_0bias: Float = Default('0'),_1bias: Float = Default('0'),_2bias: Float = Default('0'),_3bias: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply convolution of 3x3, 5x5, 7x7 matrix.
 
 The filter accepts the following options:
@@ -4005,86 +4005,86 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#convolution_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='convolution_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "0m": _0m,
-                
+
                 "2m": _2m,
-                
+
                 "3m": _3m,
-                
+
                 "0rdiv": _0rdiv,
-                
+
                 "1rdiv": _1rdiv,
-                
+
                 "2rdiv": _2rdiv,
-                
+
                 "3rdiv": _3rdiv,
-                
+
                 "0bias": _0bias,
-                
+
                 "1bias": _1bias,
-                
+
                 "2bias": _2bias,
-                
+
                 "3bias": _3bias,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def convolve(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _impulse: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('7'),impulse: Int| Literal["first","all"] | Default = Default('all'),noise: Float = Default('1e-07'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply 2D convolution of video stream in frequency domain using second stream
 as impulse.
 
@@ -4106,7 +4106,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#convolve)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -4117,61 +4117,61 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='convolve', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _impulse,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "impulse": impulse,
-                
+
                 "noise": noise,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def copy(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Copy the input video source unchanged to the output. This is mainly useful for
 testing purposes.
 
@@ -4188,64 +4188,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#copy)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='copy', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def corr(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the correlation between two input videos.
 
 This filter takes two input videos.
@@ -4281,7 +4281,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#corr)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -4292,42 +4292,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='corr', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def cover_rect(
-    
+
     self,
 
 
@@ -4335,12 +4335,12 @@ References:
 
     *,
     cover: String = Default(None),mode: Int| Literal["cover","blur"] | Default = Default('blur'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Cover a rectangular object
 
 It accepts the following options:
@@ -4358,39 +4358,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#cover_rect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='cover_rect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cover": cover,
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def crop(
-    
+
     self,
 
 
@@ -4398,12 +4398,12 @@ References:
 
     *,
     out_w: String = Default('iw'),out_h: String = Default('ih'),x: String = Default('(in_w-out_w)/2'),y: String = Default('(in_h-out_h)/2'),keep_aspect: Boolean = Default('false'),exact: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Crop the input video to given dimensions.
 
 It accepts the following parameters:
@@ -4425,47 +4425,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#crop)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='crop', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "out_w": out_w,
-                
+
                 "out_h": out_h,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "keep_aspect": keep_aspect,
-                
+
                 "exact": exact,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def cropdetect(
-    
+
     self,
 
 
@@ -4473,15 +4473,15 @@ References:
 
     *,
     limit: Float = Default('0.0941176'),round: Int = Default('16'),reset: Int = Default('0'),skip: Int = Default('2'),reset_count: Int = Default('0'),max_outliers: Int = Default('0'),mode: Int| Literal["black","mvedges"] | Default = Default('black'),high: Float = Default('0.0980392'),low: Float = Default('0.0588235'),mv_threshold: Int = Default('8'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Auto-detect the crop size.
 
 It calculates the necessary cropping parameters and prints the
@@ -4512,7 +4512,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#cropdetect)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4520,56 +4520,56 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='cropdetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "limit": limit,
-                
+
                 "round": round,
-                
+
                 "reset": reset,
-                
+
                 "skip": skip,
-                
+
                 "reset_count": reset_count,
-                
+
                 "max_outliers": max_outliers,
-                
+
                 "mode": mode,
-                
+
                 "high": high,
-                
+
                 "low": low,
-                
+
                 "mv_threshold": mv_threshold,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def cue(
-    
+
     self,
 
 
@@ -4577,12 +4577,12 @@ References:
 
     *,
     cue: Int64 = Default('0'),preroll: Duration = Default('0'),buffer: Duration = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Delay video filtering until a given wallclock timestamp. The filter first
 passes on preroll amount of frames, then it buffers at most
 buffer amount of frames and waits for the cue. After reaching the cue
@@ -4611,41 +4611,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#cue)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='cue', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cue": cue,
-                
+
                 "preroll": preroll,
-                
+
                 "buffer": buffer,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def curves(
-    
+
     self,
 
 
@@ -4653,15 +4653,15 @@ References:
 
     *,
     preset: Int| Literal["none","color_negative","cross_process","darker","increase_contrast","lighter","linear_contrast","medium_contrast","negative","strong_contrast","vintage"] | Default = Default('none'),master: String = Default(None),red: String = Default(None),green: String = Default(None),blue: String = Default(None),all: String = Default(None),psfile: String = Default(None),plot: String = Default(None),interp: Int| Literal["natural","pchip"] | Default = Default('natural'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply color adjustments using curves.
 
 This filter is similar to the Adobe Photoshop and GIMP curves tools. Each
@@ -4708,7 +4708,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#curves)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4716,50 +4716,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='curves', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "preset": preset,
-                
+
                 "master": master,
-                
+
                 "red": red,
-                
+
                 "green": green,
-                
+
                 "blue": blue,
-                
+
                 "all": all,
-                
+
                 "psfile": psfile,
-                
+
                 "plot": plot,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def datascope(
-    
+
     self,
 
 
@@ -4767,12 +4767,12 @@ References:
 
     *,
     size: Image_size = Default('hd720'),x: Int = Default('0'),y: Int = Default('0'),mode: Int| Literal["mono","color","color2"] | Default = Default('mono'),axis: Boolean = Default('false'),opacity: Float = Default('0.75'),format: Int| Literal["hex","dec"] | Default = Default('hex'),components: Int = Default('15'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Video data analysis filter.
 
 This filter shows hexadecimal pixel values of part of video.
@@ -4798,51 +4798,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#datascope)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='datascope', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "mode": mode,
-                
+
                 "axis": axis,
-                
+
                 "opacity": opacity,
-                
+
                 "format": format,
-                
+
                 "components": components,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dblur(
-    
+
     self,
 
 
@@ -4850,15 +4850,15 @@ References:
 
     *,
     angle: Float = Default('45'),radius: Float = Default('5'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Directional blur filter.
 
 The filter accepts the following options:
@@ -4878,7 +4878,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dblur)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4886,40 +4886,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dblur', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "angle": angle,
-                
+
                 "radius": radius,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def dctdnoiz(
-    
+
     self,
 
 
@@ -4927,15 +4927,15 @@ References:
 
     *,
     sigma: Float = Default('0'),overlap: Int = Default('-1'),expr: String = Default(None),n: Int = Default('3'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Denoise frames using 2D DCT (frequency domain filtering).
 
 This filter is not designed for real time.
@@ -4958,7 +4958,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dctdnoiz)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -4966,40 +4966,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dctdnoiz', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sigma": sigma,
-                
+
                 "overlap": overlap,
-                
+
                 "expr": expr,
-                
+
                 "n": n,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def deband(
-    
+
     self,
 
 
@@ -5007,15 +5007,15 @@ References:
 
     *,
     _1thr: Float = Default('0.02'),_2thr: Float = Default('0.02'),_3thr: Float = Default('0.02'),_4thr: Float = Default('0.02'),range: Int = Default('16'),direction: Float = Default('6.28319'),blur: Boolean = Default('true'),coupling: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove banding artifacts from input video.
 It works by replacing banded pixels with average value of referenced pixels.
 
@@ -5041,7 +5041,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deband)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5049,48 +5049,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deband', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "1thr": _1thr,
-                
+
                 "2thr": _2thr,
-                
+
                 "3thr": _3thr,
-                
+
                 "4thr": _4thr,
-                
+
                 "range": range,
-                
+
                 "direction": direction,
-                
+
                 "blur": blur,
-                
+
                 "coupling": coupling,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def deblock(
-    
+
     self,
 
 
@@ -5098,15 +5098,15 @@ References:
 
     *,
     filter: Int| Literal["weak","strong"] | Default = Default('strong'),block: Int = Default('8'),alpha: Float = Default('0.098'),beta: Float = Default('0.05'),gamma: Float = Default('0.05'),delta: Float = Default('0.05'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove blocking artifacts from input video.
 
 The filter accepts the following options:
@@ -5130,7 +5130,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deblock)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5138,77 +5138,77 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deblock', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "filter": filter,
-                
+
                 "block": block,
-                
+
                 "alpha": alpha,
-                
+
                 "beta": beta,
-                
+
                 "gamma": gamma,
-                
+
                 "delta": delta,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def deconvolve(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _impulse: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('7'),impulse: Int| Literal["first","all"] | Default = Default('all'),noise: Float = Default('1e-07'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply 2D deconvolution of video stream in frequency domain using second stream
 as impulse.
 
@@ -5230,7 +5230,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deconvolve)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -5241,48 +5241,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deconvolve', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _impulse,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "impulse": impulse,
-                
+
                 "noise": noise,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dedot(
-    
+
     self,
 
 
@@ -5290,15 +5290,15 @@ References:
 
     *,
     m: Flags| Literal["dotcrawl","rainbows"] | Default = Default('dotcrawl+rainbows'),lt: Float = Default('0.079'),tl: Float = Default('0.079'),tc: Float = Default('0.058'),ct: Float = Default('0.019'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reduce cross-luminance (dot-crawl) and cross-color (rainbows) from video.
 
 It accepts the following options:
@@ -5320,7 +5320,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dedot)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5328,44 +5328,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dedot', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "m": m,
-                
+
                 "lt": lt,
-                
+
                 "tl": tl,
-                
+
                 "tc": tc,
-                
+
                 "ct": ct,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def deflate(
-    
+
     self,
 
 
@@ -5373,15 +5373,15 @@ References:
 
     *,
     threshold0: Int = Default('65535'),threshold1: Int = Default('65535'),threshold2: Int = Default('65535'),threshold3: Int = Default('65535'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply deflate effect to the video.
 
 This filter replaces the pixel by the local(3x3) average by taking into account
@@ -5405,7 +5405,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deflate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5413,40 +5413,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deflate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold0": threshold0,
-                
+
                 "threshold1": threshold1,
-                
+
                 "threshold2": threshold2,
-                
+
                 "threshold3": threshold3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def deflicker(
-    
+
     self,
 
 
@@ -5454,12 +5454,12 @@ References:
 
     *,
     size: Int = Default('5'),mode: Int| Literal["am","gm","hm","qm","cm","pm","median"] | Default = Default('am'),bypass: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove temporal frame luminance variations.
 
 It accepts the following options:
@@ -5478,41 +5478,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deflicker)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deflicker', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "mode": mode,
-                
+
                 "bypass": bypass,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def deinterlace_vaapi(
-    
+
     self,
 
 
@@ -5520,12 +5520,12 @@ References:
 
     *,
     mode: Int| Literal["default","bob","weave","motion_adaptive","motion_compensated"] | Default = Default('default'),rate: Int| Literal["frame","field"] | Default = Default('frame'),auto: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlacing of VAAPI surfaces
 
 
@@ -5542,41 +5542,41 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deinterlace_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "rate": rate,
-                
+
                 "auto": auto,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dejudder(
-    
+
     self,
 
 
@@ -5584,12 +5584,12 @@ References:
 
     *,
     cycle: Int = Default('4'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove judder produced by partially interlaced telecined content.
 
 Judder can be introduced, for instance, by pullup filter. If the original
@@ -5612,37 +5612,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dejudder)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dejudder', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cycle": cycle,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def delogo(
-    
+
     self,
 
 
@@ -5650,15 +5650,15 @@ References:
 
     *,
     x: String = Default('-1'),y: String = Default('-1'),w: String = Default('-1'),h: String = Default('-1'),show: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Suppress a TV station logo by a simple interpolation of the surrounding
 pixels. Just set a rectangle covering the logo and watch it disappear
 (and sometimes something even uglier appear - your mileage may vary).
@@ -5682,7 +5682,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#delogo)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -5690,42 +5690,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='delogo', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "show": show,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def denoise_vaapi(
-    
+
     self,
 
 
@@ -5733,12 +5733,12 @@ References:
 
     *,
     denoise: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 VAAPI VPP for de-noise
 
 
@@ -5753,37 +5753,37 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='denoise_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "denoise": denoise,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def deshake(
-    
+
     self,
 
 
@@ -5791,12 +5791,12 @@ References:
 
     *,
     x: Int = Default('-1'),y: Int = Default('-1'),w: Int = Default('-1'),h: Int = Default('-1'),rx: Int = Default('16'),ry: Int = Default('16'),edge: Int| Literal["blank","original","clamp","mirror"] | Default = Default('mirror'),blocksize: Int = Default('8'),contrast: Int = Default('125'),search: Int| Literal["exhaustive","less"] | Default = Default('exhaustive'),filename: String = Default(None),opencl: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Attempt to fix small changes in horizontal and/or vertical shift. This
 filter helps remove camera shake from hand-holding a camera, bumping a
 tripod, moving on a vehicle, etc.
@@ -5826,59 +5826,59 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deshake)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deshake', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "rx": rx,
-                
+
                 "ry": ry,
-                
+
                 "edge": edge,
-                
+
                 "blocksize": blocksize,
-                
+
                 "contrast": contrast,
-                
+
                 "search": search,
-                
+
                 "filename": filename,
-                
+
                 "opencl": opencl,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def deshake_opencl(
-    
+
     self,
 
 
@@ -5886,12 +5886,12 @@ References:
 
     *,
     tripod: Boolean = Default('false'),debug: Boolean = Default('false'),adaptive_crop: Boolean = Default('true'),refine_features: Boolean = Default('true'),smooth_strength: Float = Default('0'),smooth_window_multiplier: Float = Default('2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Feature-point based video stabilization filter.
 
 The filter accepts the following options:
@@ -5913,47 +5913,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#deshake_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='deshake_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "tripod": tripod,
-                
+
                 "debug": debug,
-                
+
                 "adaptive_crop": adaptive_crop,
-                
+
                 "refine_features": refine_features,
-                
+
                 "smooth_strength": smooth_strength,
-                
+
                 "smooth_window_multiplier": smooth_window_multiplier,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def despill(
-    
+
     self,
 
 
@@ -5961,15 +5961,15 @@ References:
 
     *,
     type: Int| Literal["green","blue"] | Default = Default('green'),mix: Float = Default('0.5'),expand: Float = Default('0'),red: Float = Default('0'),green: Float = Default('-1'),blue: Float = Default('0'),brightness: Float = Default('0'),alpha: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remove unwanted contamination of foreground colors, caused by reflected color of
 greenscreen or bluescreen.
 
@@ -5995,7 +5995,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#despill)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6003,48 +6003,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='despill', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "type": type,
-                
+
                 "mix": mix,
-                
+
                 "expand": expand,
-                
+
                 "red": red,
-                
+
                 "green": green,
-                
+
                 "blue": blue,
-                
+
                 "brightness": brightness,
-                
+
                 "alpha": alpha,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def detelecine(
-    
+
     self,
 
 
@@ -6052,12 +6052,12 @@ References:
 
     *,
     first_field: Int| Literal["top","t","bottom","b"] | Default = Default('top'),pattern: String = Default('23'),start_frame: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply an exact inverse of the telecine operation. It requires a predefined
 pattern specified using the pattern option which must be the same as that passed
 to the telecine filter.
@@ -6078,43 +6078,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#detelecine)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='detelecine', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "first_field": first_field,
-                
+
                 "pattern": pattern,
-                
+
                 "start_frame": start_frame,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def dilation(
-    
+
     self,
 
 
@@ -6122,15 +6122,15 @@ References:
 
     *,
     coordinates: Int = Default('255'),threshold0: Int = Default('65535'),threshold1: Int = Default('65535'),threshold2: Int = Default('65535'),threshold3: Int = Default('65535'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply dilation effect to the video.
 
 This filter replaces the pixel by the local(3x3) maximum.
@@ -6154,7 +6154,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dilation)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6162,42 +6162,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dilation', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "coordinates": coordinates,
-                
+
                 "threshold0": threshold0,
-                
+
                 "threshold1": threshold1,
-                
+
                 "threshold2": threshold2,
-                
+
                 "threshold3": threshold3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def dilation_opencl(
-    
+
     self,
 
 
@@ -6205,12 +6205,12 @@ References:
 
     *,
     threshold0: Float = Default('65535'),threshold1: Float = Default('65535'),threshold2: Float = Default('65535'),threshold3: Float = Default('65535'),coordinates: Int = Default('255'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply dilation effect to the video.
 
 This filter replaces the pixel by the local(3x3) maximum.
@@ -6233,73 +6233,73 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#dilation_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='dilation_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold0": threshold0,
-                
+
                 "threshold1": threshold1,
-                
+
                 "threshold2": threshold2,
-                
+
                 "threshold3": threshold3,
-                
+
                 "coordinates": coordinates,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def displace(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _xmap: VideoStream,
-        
-    
-        
+
+
+
         _ymap: VideoStream,
-        
-    
+
+
 
 
     *,
     edge: Int| Literal["blank","smear","wrap","mirror"] | Default = Default('smear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Displace pixels as indicated by second and third input stream.
 
 It takes three input streams and outputs one stream, the first input is the
@@ -6328,7 +6328,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#displace)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6336,46 +6336,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='displace', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _xmap,
-                
-            
-                
+
+
+
                 _ymap,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "edge": edge,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def doubleweave(
-    
+
     self,
 
 
@@ -6383,12 +6383,12 @@ References:
 
     *,
     first_field: Int| Literal["top","t","bottom","b"] | Default = Default('top'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The weave takes a field-based video input and join
 each two sequential fields into single frame, producing a new double
 height clip with half the frame rate and half the frame count.
@@ -6410,37 +6410,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#weave)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='doubleweave', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "first_field": first_field,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def drawbox(
-    
+
     self,
 
 
@@ -6448,15 +6448,15 @@ References:
 
     *,
     x: String = Default('0'),y: String = Default('0'),width: String = Default('0'),height: String = Default('0'),color: String = Default('black'),thickness: String = Default('3'),replace: Boolean = Default('false'),box_source: String = Default(None),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw a colored box on the input image.
 
 It accepts the following parameters:
@@ -6481,7 +6481,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#drawbox)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6489,48 +6489,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='drawbox', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "color": color,
-                
+
                 "thickness": thickness,
-                
+
                 "replace": replace,
-                
+
                 "box_source": box_source,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def drawbox_vaapi(
-    
+
     self,
 
 
@@ -6538,12 +6538,12 @@ References:
 
     *,
     x: String = Default('0'),y: String = Default('0'),width: String = Default('0'),height: String = Default('0'),color: Color = Default('black'),thickness: String = Default('3'),replace: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw a colored box on the input image.
 
 It accepts the following parameters:
@@ -6566,49 +6566,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#drawbox_vaapi)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='drawbox_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "color": color,
-                
+
                 "thickness": thickness,
-                
+
                 "replace": replace,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def drawgraph(
-    
+
     self,
 
 
@@ -6616,12 +6616,12 @@ References:
 
     *,
     m1: String = Default(''),fg1: String = Default('0xffff0000'),m2: String = Default(''),fg2: String = Default('0xff00ff00'),m3: String = Default(''),fg3: String = Default('0xffff00ff'),m4: String = Default(''),fg4: String = Default('0xffffff00'),bg: Color = Default('white'),min: Float = Default('-1'),max: Float = Default('1'),mode: Int| Literal["bar","dot","line"] | Default = Default('line'),slide: Int| Literal["frame","replace","scroll","rscroll","picture"] | Default = Default('frame'),size: Image_size = Default('900x256'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw a graph using input video metadata.
 
 It accepts the following parameters:
@@ -6652,65 +6652,65 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#drawgraph)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='drawgraph', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "m1": m1,
-                
+
                 "fg1": fg1,
-                
+
                 "m2": m2,
-                
+
                 "fg2": fg2,
-                
+
                 "m3": m3,
-                
+
                 "fg3": fg3,
-                
+
                 "m4": m4,
-                
+
                 "fg4": fg4,
-                
+
                 "bg": bg,
-                
+
                 "min": min,
-                
+
                 "max": max,
-                
+
                 "mode": mode,
-                
+
                 "slide": slide,
-                
+
                 "size": size,
-                
+
                 "rate": rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def drawgrid(
-    
+
     self,
 
 
@@ -6718,15 +6718,15 @@ References:
 
     *,
     x: String = Default('0'),y: String = Default('0'),width: String = Default('0'),height: String = Default('0'),color: String = Default('black'),thickness: String = Default('1'),replace: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw a grid on the input image.
 
 It accepts the following parameters:
@@ -6750,7 +6750,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#drawgrid)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6758,46 +6758,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='drawgrid', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "color": color,
-                
+
                 "thickness": thickness,
-                
+
                 "replace": replace,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def drawtext(
-    
+
     self,
 
 
@@ -6805,15 +6805,15 @@ References:
 
     *,
     fontfile: String = Default(None),text: String = Default(None),textfile: String = Default(None),fontcolor: Color = Default('black'),fontcolor_expr: String = Default(''),boxcolor: Color = Default('white'),bordercolor: Color = Default('black'),shadowcolor: Color = Default('black'),box: Boolean = Default('false'),boxborderw: String = Default('0'),line_spacing: Int = Default('0'),fontsize: String = Default(None),text_align: Flags| Literal["left","L","right","R","center","C","top","T","bottom","B","middle","M"] | Default = Default('0'),x: String = Default('0'),y: String = Default('0'),boxw: Int = Default('0'),boxh: Int = Default('0'),shadowx: Int = Default('0'),shadowy: Int = Default('0'),borderw: Int = Default('0'),tabsize: Int = Default('4'),basetime: Int64 = Default('I64_MIN'),font: String = Default('Sans'),expansion: Int| Literal["none","normal","strftime"] | Default = Default('normal'),y_align: Int| Literal["text","baseline","font"] | Default = Default('text'),timecode: String = Default(None),tc24hmax: Boolean = Default('false'),timecode_rate: Rational = Default('0/1'),reload: Int = Default('0'),alpha: String = Default('1'),fix_bounds: Boolean = Default('false'),start_number: Int = Default('0'),text_source: String = Default(None),text_shaping: Boolean = Default('true'),ft_load_flags: Flags| Literal["default","no_scale","no_hinting","render","no_bitmap","vertical_layout","force_autohint","crop_bitmap","pedantic","ignore_global_advance_width","no_recurse","ignore_transform","monochrome","linear_design","no_autohint"] | Default = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw a text string or text from a specified file on top of a video, using the
 libfreetype library.
 
@@ -6871,7 +6871,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#drawtext)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -6879,110 +6879,110 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='drawtext', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "fontfile": fontfile,
-                
+
                 "text": text,
-                
+
                 "textfile": textfile,
-                
+
                 "fontcolor": fontcolor,
-                
+
                 "fontcolor_expr": fontcolor_expr,
-                
+
                 "boxcolor": boxcolor,
-                
+
                 "bordercolor": bordercolor,
-                
+
                 "shadowcolor": shadowcolor,
-                
+
                 "box": box,
-                
+
                 "boxborderw": boxborderw,
-                
+
                 "line_spacing": line_spacing,
-                
+
                 "fontsize": fontsize,
-                
+
                 "text_align": text_align,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "boxw": boxw,
-                
+
                 "boxh": boxh,
-                
+
                 "shadowx": shadowx,
-                
+
                 "shadowy": shadowy,
-                
+
                 "borderw": borderw,
-                
+
                 "tabsize": tabsize,
-                
+
                 "basetime": basetime,
-                
+
                 "font": font,
-                
+
                 "expansion": expansion,
-                
+
                 "y_align": y_align,
-                
+
                 "timecode": timecode,
-                
+
                 "tc24hmax": tc24hmax,
-                
+
                 "timecode_rate": timecode_rate,
-                
+
                 "reload": reload,
-                
+
                 "alpha": alpha,
-                
+
                 "fix_bounds": fix_bounds,
-                
+
                 "start_number": start_number,
-                
+
                 "text_source": text_source,
-                
+
                 "text_shaping": text_shaping,
-                
+
                 "ft_load_flags": ft_load_flags,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def edgedetect(
-    
+
     self,
 
 
@@ -6990,15 +6990,15 @@ References:
 
     *,
     high: Double = Default('0.196078'),low: Double = Default('0.0784314'),mode: Int| Literal["wires","colormix","canny"] | Default = Default('wires'),planes: Flags| Literal["y","u","v","r","g","b"] | Default = Default('y+u+v+r+g+b'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect and draw edges. The filter uses the Canny Edge Detection algorithm.
 
 The filter accepts the following options:
@@ -7019,7 +7019,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#edgedetect)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7027,40 +7027,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='edgedetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "high": high,
-                
+
                 "low": low,
-                
+
                 "mode": mode,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def elbg(
-    
+
     self,
 
 
@@ -7068,12 +7068,12 @@ References:
 
     *,
     codebook_length: Int = Default('256'),nb_steps: Int = Default('1'),seed: Int64 = Default('-1'),pal8: Boolean = Default('false'),use_alpha: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a posterize effect using the ELBG (Enhanced LBG) algorithm.
 
 For each input image, the filter will compute the optimal mapping from
@@ -7098,45 +7098,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#elbg)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='elbg', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "codebook_length": codebook_length,
-                
+
                 "nb_steps": nb_steps,
-                
+
                 "seed": seed,
-                
+
                 "pal8": pal8,
-                
+
                 "use_alpha": use_alpha,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def entropy(
-    
+
     self,
 
 
@@ -7144,15 +7144,15 @@ References:
 
     *,
     mode: Int| Literal["normal","diff"] | Default = Default('normal'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Measure graylevel entropy in histogram of color channels of video frames.
 
 It accepts the following parameters:
@@ -7170,7 +7170,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#entropy)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7178,34 +7178,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='entropy', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def epx(
-    
+
     self,
 
 
@@ -7213,12 +7213,12 @@ References:
 
     *,
     n: Int = Default('3'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply the EPX magnification filter which is designed for pixel art.
 
 It accepts the following option:
@@ -7235,37 +7235,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#epx)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='epx', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "n": n,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def eq(
-    
+
     self,
 
 
@@ -7273,15 +7273,15 @@ References:
 
     *,
     contrast: String = Default('1.0'),brightness: String = Default('0.0'),saturation: String = Default('1.0'),gamma: String = Default('1.0'),gamma_r: String = Default('1.0'),gamma_g: String = Default('1.0'),gamma_b: String = Default('1.0'),gamma_weight: String = Default('1.0'),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Set brightness, contrast, saturation and approximate gamma adjustment.
 
 The filter accepts the following options:
@@ -7307,7 +7307,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#eq)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7315,52 +7315,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='eq', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "contrast": contrast,
-                
+
                 "brightness": brightness,
-                
+
                 "saturation": saturation,
-                
+
                 "gamma": gamma,
-                
+
                 "gamma_r": gamma_r,
-                
+
                 "gamma_g": gamma_g,
-                
+
                 "gamma_b": gamma_b,
-                
+
                 "gamma_weight": gamma_weight,
-                
+
                 "eval": eval,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def erosion(
-    
+
     self,
 
 
@@ -7368,15 +7368,15 @@ References:
 
     *,
     coordinates: Int = Default('255'),threshold0: Int = Default('65535'),threshold1: Int = Default('65535'),threshold2: Int = Default('65535'),threshold3: Int = Default('65535'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply erosion effect to the video.
 
 This filter replaces the pixel by the local(3x3) minimum.
@@ -7400,7 +7400,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#erosion)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7408,42 +7408,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='erosion', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "coordinates": coordinates,
-                
+
                 "threshold0": threshold0,
-                
+
                 "threshold1": threshold1,
-                
+
                 "threshold2": threshold2,
-                
+
                 "threshold3": threshold3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def erosion_opencl(
-    
+
     self,
 
 
@@ -7451,12 +7451,12 @@ References:
 
     *,
     threshold0: Float = Default('65535'),threshold1: Float = Default('65535'),threshold2: Float = Default('65535'),threshold3: Float = Default('65535'),coordinates: Int = Default('255'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply erosion effect to the video.
 
 This filter replaces the pixel by the local(3x3) minimum.
@@ -7479,45 +7479,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#erosion_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='erosion_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold0": threshold0,
-                
+
                 "threshold1": threshold1,
-                
+
                 "threshold2": threshold2,
-                
+
                 "threshold3": threshold3,
-                
+
                 "coordinates": coordinates,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def estdif(
-    
+
     self,
 
 
@@ -7525,15 +7525,15 @@ References:
 
     *,
     mode: Int| Literal["frame","field"] | Default = Default('field'),parity: Int| Literal["tff","bff","auto"] | Default = Default('auto'),deint: Int| Literal["all","interlaced"] | Default = Default('all'),rslope: Int = Default('1'),redge: Int = Default('2'),ecost: Int = Default('2'),mcost: Int = Default('1'),dcost: Int = Default('1'),interp: Int| Literal["2p","4p","6p"] | Default = Default('4p'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlace the input video ("estdif" stands for "Edge Slope
 Tracing Deinterlacing Filter").
 
@@ -7562,7 +7562,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#estdif)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7570,50 +7570,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='estdif', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "parity": parity,
-                
+
                 "deint": deint,
-                
+
                 "rslope": rslope,
-                
+
                 "redge": redge,
-                
+
                 "ecost": ecost,
-                
+
                 "mcost": mcost,
-                
+
                 "dcost": dcost,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def exposure(
-    
+
     self,
 
 
@@ -7621,15 +7621,15 @@ References:
 
     *,
     exposure: Float = Default('0'),black: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust exposure of the video stream.
 
 The filter accepts the following options:
@@ -7648,7 +7648,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#exposure)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7656,36 +7656,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='exposure', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "exposure": exposure,
-                
+
                 "black": black,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def extractplanes(
-    
+
     self,
 
 
@@ -7693,12 +7693,12 @@ References:
 
     *,
     planes: Flags| Literal["y","u","v","r","g","b","a"] | Default = Default('r'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Extract color channel components from input video stream into
 separate grayscale video streams.
 
@@ -7717,40 +7717,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#extractplanes)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='extractplanes', typings_input=('video',), typings_output="[StreamType.video] * len(planes.split('+'))"),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def fade(
-    
+
     self,
 
 
@@ -7758,15 +7758,15 @@ References:
 
     *,
     type: Int| Literal["in","out"] | Default = Default('in'),start_frame: Int = Default('0'),nb_frames: Int = Default('25'),alpha: Boolean = Default('false'),start_time: Duration = Default('0'),duration: Duration = Default('0'),color: Color = Default('black'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a fade-in/out effect to the input video.
 
 It accepts the following parameters:
@@ -7790,7 +7790,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fade)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7798,80 +7798,80 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fade', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "type": type,
-                
+
                 "start_frame": start_frame,
-                
+
                 "nb_frames": nb_frames,
-                
+
                 "alpha": alpha,
-                
+
                 "start_time": start_time,
-                
+
                 "duration": duration,
-                
+
                 "color": color,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def feedback(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _feedin: VideoStream,
-        
-    
+
+
 
 
     *,
     x: Int = Default('0'),w: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> tuple[
-    
-        
+
+
             VideoStream,
-        
-    
-        
+
+
+
             VideoStream,
-        
-    
+
+
 ]:
         """
-        
+
 Apply feedback video filter.
 
 This filter pass cropped input frames to 2nd output.
@@ -7899,7 +7899,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#feedback)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -7907,55 +7907,55 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='feedback', typings_input=('video', 'video'), typings_output=('video', 'video')),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _feedin,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "w": w,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return (
-            
-                
+
+
                     filter_node.video(0),
-                
-            
-                
+
+
+
                     filter_node.video(1),
-                
-            
+
+
         )
 
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fftdnoiz(
-    
+
     self,
 
 
@@ -7963,15 +7963,15 @@ References:
 
     *,
     sigma: Float = Default('1'),amount: Float = Default('1'),block: Int = Default('32'),overlap: Float = Default('0.5'),method: Int| Literal["wiener","hard"] | Default = Default('wiener'),prev: Int = Default('0'),next: Int = Default('0'),planes: Int = Default('7'),window: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('hann'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Denoise frames using 3D FFT (frequency domain filtering).
 
 The filter accepts the following options:
@@ -7997,7 +7997,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fftdnoiz)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8005,50 +8005,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fftdnoiz', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sigma": sigma,
-                
+
                 "amount": amount,
-                
+
                 "block": block,
-                
+
                 "overlap": overlap,
-                
+
                 "method": method,
-                
+
                 "prev": prev,
-                
+
                 "next": next,
-                
+
                 "planes": planes,
-                
+
                 "window": window,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fftfilt(
-    
+
     self,
 
 
@@ -8056,15 +8056,15 @@ References:
 
     *,
     dc_Y: Int = Default('0'),dc_U: Int = Default('0'),dc_V: Int = Default('0'),weight_Y: String = Default('1'),weight_U: String = Default(None),weight_V: String = Default(None),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply arbitrary expressions to samples in frequency domain
 
 
@@ -8086,7 +8086,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fftfilt)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8094,46 +8094,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fftfilt', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dc_Y": dc_Y,
-                
+
                 "dc_U": dc_U,
-                
+
                 "dc_V": dc_V,
-                
+
                 "weight_Y": weight_Y,
-                
+
                 "weight_U": weight_U,
-                
+
                 "weight_V": weight_V,
-                
+
                 "eval": eval,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def field(
-    
+
     self,
 
 
@@ -8141,12 +8141,12 @@ References:
 
     *,
     type: Int| Literal["top","bottom"] | Default = Default('top'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Extract a single field from an interlaced image using stride
 arithmetic to avoid wasting CPU time. The output frames are marked as
 non-interlaced.
@@ -8165,37 +8165,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#field)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='field', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fieldhint(
-    
+
     self,
 
 
@@ -8203,12 +8203,12 @@ References:
 
     *,
     hint: String = Default(None),mode: Int| Literal["absolute","relative","pattern"] | Default = Default('absolute'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Create new frames by copying the top and bottom fields from surrounding frames
 supplied as numbers by the hint file.
 
@@ -8225,41 +8225,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fieldhint)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fieldhint', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "hint": hint,
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def fieldorder(
-    
+
     self,
 
 
@@ -8267,15 +8267,15 @@ References:
 
     *,
     order: Int| Literal["bff","tff"] | Default = Default('tff'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Transform the field order of the input video.
 
 It accepts the following parameters:
@@ -8293,7 +8293,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fieldorder)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8301,34 +8301,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fieldorder', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "order": order,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fillborders(
-    
+
     self,
 
 
@@ -8336,15 +8336,15 @@ References:
 
     *,
     left: Int = Default('0'),right: Int = Default('0'),top: Int = Default('0'),bottom: Int = Default('0'),mode: Int| Literal["smear","mirror","fixed","reflect","wrap","fade","margins"] | Default = Default('smear'),color: Color = Default('black'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Fill borders of the input video, without changing video stream dimensions.
 Sometimes video can have garbage at the four edges and you may not want to
 crop video input to keep size multiple of some number.
@@ -8369,7 +8369,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fillborders)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8377,44 +8377,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fillborders', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "left": left,
-                
+
                 "right": right,
-                
+
                 "top": top,
-                
+
                 "bottom": bottom,
-                
+
                 "mode": mode,
-                
+
                 "color": color,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def find_rect(
-    
+
     self,
 
 
@@ -8422,12 +8422,12 @@ References:
 
     *,
     object: String = Default(None),threshold: Float = Default('0.5'),mipmaps: Int = Default('3'),xmin: Int = Default('0'),discard: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Find a rectangular object in the input video.
 
 The object to search for must be specified as a gray8 image specified with the
@@ -8458,49 +8458,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#find_rect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='find_rect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "object": object,
-                
+
                 "threshold": threshold,
-                
+
                 "mipmaps": mipmaps,
-                
+
                 "xmin": xmin,
-                
+
                 "discard": discard,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def floodfill(
-    
+
     self,
 
 
@@ -8508,15 +8508,15 @@ References:
 
     *,
     x: Int = Default('0'),y: Int = Default('0'),s0: Int = Default('0'),s1: Int = Default('0'),s2: Int = Default('0'),s3: Int = Default('0'),d0: Int = Default('0'),d1: Int = Default('0'),d2: Int = Default('0'),d3: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Flood area with values of same pixel components with another values.
 
 It accepts the following options:
@@ -8543,7 +8543,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#floodfill)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8551,52 +8551,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='floodfill', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "s0": s0,
-                
+
                 "s1": s1,
-                
+
                 "s2": s2,
-                
+
                 "s3": s3,
-                
+
                 "d0": d0,
-                
+
                 "d1": d1,
-                
+
                 "d2": d2,
-                
+
                 "d3": d3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def format(
-    
+
     self,
 
 
@@ -8604,12 +8604,12 @@ References:
 
     *,
     pix_fmts: String = Default(None),color_spaces: String = Default(None),color_ranges: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert the input video to one of the specified pixel formats.
 Libavfilter will try to pick one that is suitable as input to
 the next filter.
@@ -8630,41 +8630,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#format)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='format', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "pix_fmts": pix_fmts,
-                
+
                 "color_spaces": color_spaces,
-                
+
                 "color_ranges": color_ranges,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fps(
-    
+
     self,
 
 
@@ -8672,12 +8672,12 @@ References:
 
     *,
     fps: String = Default('25'),start_time: Double = Default('DBL_MAX'),round: Int| Literal["zero","inf","down","up","near"] | Default = Default('near'),eof_action: Int| Literal["round","pass"] | Default = Default('round'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert the video to specified constant frame rate by duplicating or dropping
 frames as necessary.
 
@@ -8698,64 +8698,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fps)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fps', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "fps": fps,
-                
+
                 "start_time": start_time,
-                
+
                 "round": round,
-                
+
                 "eof_action": eof_action,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def framepack(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _right: VideoStream,
-        
-    
+
+
 
 
     *,
     format: Int| Literal["sbs","tab","frameseq","lines","columns"] | Default = Default('sbs'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pack two different video streams into a stereoscopic video, setting proper
 metadata on supported codecs. The two views should have the same size and
 framerate and processing will stop when the shorter video ends. Please note
@@ -8776,45 +8776,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#framepack)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='framepack', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _right,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "format": format,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def framerate(
-    
+
     self,
 
 
@@ -8822,12 +8822,12 @@ References:
 
     *,
     fps: Video_rate = Default('50'),interp_start: Int = Default('15'),interp_end: Int = Default('240'),scene: Double = Default('8.2'),flags: Flags| Literal["scene_change_detect","scd"] | Default = Default('scene_change_detect+scd'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Change the frame rate by interpolating new video output frames from the source
 frames.
 
@@ -8853,45 +8853,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#framerate)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='framerate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "fps": fps,
-                
+
                 "interp_start": interp_start,
-                
+
                 "interp_end": interp_end,
-                
+
                 "scene": scene,
-                
+
                 "flags": flags,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def framestep(
-    
+
     self,
 
 
@@ -8899,15 +8899,15 @@ References:
 
     *,
     step: Int = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Select one frame every N-th frame.
 
 This filter accepts the following option:
@@ -8925,7 +8925,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#framestep)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -8933,34 +8933,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='framestep', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "step": step,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def freezedetect(
-    
+
     self,
 
 
@@ -8968,12 +8968,12 @@ References:
 
     *,
     n: Double = Default('0.001'),d: Duration = Default('2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect frozen video.
 
 This filter logs a message and sets frame metadata when it detects that the
@@ -9004,60 +9004,60 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#freezedetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='freezedetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "n": n,
-                
+
                 "d": d,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def freezeframes(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _replace: VideoStream,
-        
-    
+
+
 
 
     *,
     first: Int64 = Default('0'),last: Int64 = Default('0'),replace: Int64 = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Freeze video frames.
 
 This filter freezes video frames using frame from 2nd input.
@@ -9078,49 +9078,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#freezeframes)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='freezeframes', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _replace,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "first": first,
-                
+
                 "last": last,
-                
+
                 "replace": replace,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fspp(
-    
+
     self,
 
 
@@ -9128,15 +9128,15 @@ References:
 
     *,
     quality: Int = Default('4'),qp: Int = Default('0'),strength: Int = Default('0'),use_bframe_qp: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply fast and simple postprocessing. It is a faster version of spp.
 
 It splits (I)DCT into horizontal/vertical passes. Unlike the simple post-
@@ -9161,7 +9161,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fspp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9169,40 +9169,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fspp', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "quality": quality,
-                
+
                 "qp": qp,
-                
+
                 "strength": strength,
-                
+
                 "use_bframe_qp": use_bframe_qp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def fsync(
-    
+
     self,
 
 
@@ -9210,12 +9210,12 @@ References:
 
     *,
     file: String = Default(''),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Synchronize video frames with an external mapping from a file.
 
 For each input PTS given in the map file it either drops or creates as many
@@ -9249,37 +9249,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#fsync)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='fsync', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "file": file,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def gblur(
-    
+
     self,
 
 
@@ -9287,15 +9287,15 @@ References:
 
     *,
     sigma: Float = Default('0.5'),steps: Int = Default('1'),planes: Int = Default('15'),sigmaV: Float = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Gaussian blur filter.
 
 The filter accepts the following options:
@@ -9316,7 +9316,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#gblur)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9324,40 +9324,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='gblur', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sigma": sigma,
-                
+
                 "steps": steps,
-                
+
                 "planes": planes,
-                
+
                 "sigmaV": sigmaV,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def geq(
-    
+
     self,
 
 
@@ -9365,15 +9365,15 @@ References:
 
     *,
     lum_expr: String = Default(None),cb_expr: String = Default(None),cr_expr: String = Default(None),alpha_expr: String = Default(None),red_expr: String = Default(None),green_expr: String = Default(None),blue_expr: String = Default(None),interpolation: Int| Literal["nearest","n","bilinear","b"] | Default = Default('bilinear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply generic equation to each pixel.
 
 The filter accepts the following options:
@@ -9398,7 +9398,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#geq)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9406,48 +9406,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='geq', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "lum_expr": lum_expr,
-                
+
                 "cb_expr": cb_expr,
-                
+
                 "cr_expr": cr_expr,
-                
+
                 "alpha_expr": alpha_expr,
-                
+
                 "red_expr": red_expr,
-                
+
                 "green_expr": green_expr,
-                
+
                 "blue_expr": blue_expr,
-                
+
                 "interpolation": interpolation,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def gradfun(
-    
+
     self,
 
 
@@ -9455,15 +9455,15 @@ References:
 
     *,
     strength: Float = Default('1.2'),radius: Int = Default('16'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Fix the banding artifacts that are sometimes introduced into nearly flat
 regions by truncation to 8-bit color depth.
 Interpolate the gradients that should go where the bands are, and
@@ -9489,7 +9489,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#gradfun)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9497,38 +9497,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='gradfun', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "strength": strength,
-                
+
                 "radius": radius,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def graphmonitor(
-    
+
     self,
 
 
@@ -9536,12 +9536,12 @@ References:
 
     *,
     size: Image_size = Default('hd720'),opacity: Float = Default('0.9'),mode: Flags| Literal["full","compact","nozero","noeof","nodisabled"] | Default = Default('0'),flags: Flags| Literal["none","all","queue","frame_count_in","frame_count_out","frame_count_delta","pts","pts_delta","time","time_delta","timebase","format","size","rate","eof","sample_count_in","sample_count_out","sample_count_delta","disabled"] | Default = Default('all+queue'),rate: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Show various filtergraph stats.
 
 With this filter one can debug complete filtergraph.
@@ -9565,61 +9565,61 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#graphmonitor)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='graphmonitor', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "size": size,
-                
+
                 "opacity": opacity,
-                
+
                 "mode": mode,
-                
+
                 "flags": flags,
-                
+
                 "rate": rate,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def grayworld(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 A color constancy filter that applies color correction based on the grayworld assumption
 
 See: https://www.researchgate.net/publication/275213614_A_New_Color_Correction_Method_for_Underwater_Imaging
@@ -9643,7 +9643,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#grayworld)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9651,32 +9651,32 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='grayworld', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def greyedge(
-    
+
     self,
 
 
@@ -9684,15 +9684,15 @@ References:
 
     *,
     difford: Int = Default('1'),minknorm: Int = Default('1'),sigma: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 A color constancy variation filter which estimates scene illumination via grey edge algorithm
 and corrects the scene colors accordingly.
 
@@ -9715,7 +9715,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#greyedge)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9723,71 +9723,71 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='greyedge', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "difford": difford,
-                
+
                 "minknorm": minknorm,
-                
+
                 "sigma": sigma,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def haldclut(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _clut: VideoStream,
-        
-    
+
+
 
 
     *,
     clut: Int| Literal["first","all"] | Default = Default('all'),interp: Int| Literal["nearest","trilinear","tetrahedral","pyramid","prism"] | Default = Default('tetrahedral'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a Hald CLUT to a video stream.
 
 First input is the video stream to process, and second one is the Hald CLUT.
@@ -9810,7 +9810,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#haldclut)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -9821,68 +9821,68 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='haldclut', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _clut,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "clut": clut,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def hflip(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Flip the input video horizontally.
 
 For example, to horizontally flip the input video with ffmpeg:
@@ -9902,7 +9902,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hflip)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9910,38 +9910,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hflip', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def histeq(
-    
+
     self,
 
 
@@ -9949,15 +9949,15 @@ References:
 
     *,
     strength: Float = Default('0.2'),intensity: Float = Default('0.21'),antibanding: Int| Literal["none","weak","strong"] | Default = Default('none'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 This filter applies a global color histogram equalization on a
 per-frame basis.
 
@@ -9985,7 +9985,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#histeq)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -9993,38 +9993,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='histeq', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "strength": strength,
-                
+
                 "intensity": intensity,
-                
+
                 "antibanding": antibanding,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def histogram(
-    
+
     self,
 
 
@@ -10032,12 +10032,12 @@ References:
 
     *,
     level_height: Int = Default('200'),scale_height: Int = Default('12'),display_mode: Int| Literal["overlay","parade","stack"] | Default = Default('stack'),levels_mode: Int| Literal["linear","logarithmic"] | Default = Default('linear'),components: Int = Default('7'),fgopacity: Float = Default('0.7'),bgopacity: Float = Default('0.5'),colors_mode: Int| Literal["whiteonblack","blackonwhite","whiteongray","blackongray","coloronblack","coloronwhite","colorongray","blackoncolor","whiteoncolor","grayoncolor"] | Default = Default('whiteonblack'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Compute and draw a color distribution histogram for the input video.
 
 The computed histogram is a representation of the color component
@@ -10069,51 +10069,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#histogram)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='histogram', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "level_height": level_height,
-                
+
                 "scale_height": scale_height,
-                
+
                 "display_mode": display_mode,
-                
+
                 "levels_mode": levels_mode,
-                
+
                 "components": components,
-                
+
                 "fgopacity": fgopacity,
-                
+
                 "bgopacity": bgopacity,
-                
+
                 "colors_mode": colors_mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hqdn3d(
-    
+
     self,
 
 
@@ -10121,15 +10121,15 @@ References:
 
     *,
     luma_spatial: Double = Default('0'),chroma_spatial: Double = Default('0'),luma_tmp: Double = Default('0'),chroma_tmp: Double = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 This is a high precision/quality 3d denoise filter. It aims to reduce
 image noise, producing smooth images and making still images really
 still. It should enhance compressibility.
@@ -10152,7 +10152,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hqdn3d)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -10160,40 +10160,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hqdn3d', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_spatial": luma_spatial,
-                
+
                 "chroma_spatial": chroma_spatial,
-                
+
                 "luma_tmp": luma_tmp,
-                
+
                 "chroma_tmp": chroma_tmp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hqx(
-    
+
     self,
 
 
@@ -10201,12 +10201,12 @@ References:
 
     *,
     n: Int = Default('3'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a high-quality magnification filter designed for pixel art. This filter
 was originally created by Maxim Stepin.
 
@@ -10224,41 +10224,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hqx)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hqx', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "n": n,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def hsvhold(
-    
+
     self,
 
 
@@ -10266,15 +10266,15 @@ References:
 
     *,
     hue: Float = Default('0'),sat: Float = Default('0'),val: Float = Default('0'),similarity: Float = Default('0.01'),blend: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Turns a certain HSV range into gray values.
 
 This filter measures color difference between set HSV color in options
@@ -10300,7 +10300,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hsvhold)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -10308,42 +10308,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hsvhold', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "hue": hue,
-                
+
                 "sat": sat,
-                
+
                 "val": val,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hsvkey(
-    
+
     self,
 
 
@@ -10351,15 +10351,15 @@ References:
 
     *,
     hue: Float = Default('0'),sat: Float = Default('0'),val: Float = Default('0'),similarity: Float = Default('0.01'),blend: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Turns a certain HSV range into transparency.
 
 This filter measures color difference between set HSV color in options
@@ -10385,7 +10385,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hsvkey)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -10393,42 +10393,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hsvkey', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "hue": hue,
-                
+
                 "sat": sat,
-                
+
                 "val": val,
-                
+
                 "similarity": similarity,
-                
+
                 "blend": blend,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hue(
-    
+
     self,
 
 
@@ -10436,15 +10436,15 @@ References:
 
     *,
     h: String = Default(None),s: String = Default('1'),H: String = Default(None),b: String = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Modify the hue and/or the saturation of the input.
 
 It accepts the following parameters:
@@ -10465,7 +10465,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hue)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -10473,40 +10473,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hue', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "h": h,
-                
+
                 "s": s,
-                
+
                 "H": H,
-                
+
                 "b": b,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def huesaturation(
-    
+
     self,
 
 
@@ -10514,15 +10514,15 @@ References:
 
     *,
     hue: Float = Default('0'),saturation: Float = Default('0'),intensity: Float = Default('0'),colors: Flags| Literal["r","y","g","c","b","m","a"] | Default = Default('r+y+g+c+b+m+a'),strength: Float = Default('1'),rw: Float = Default('0.333'),gw: Float = Default('0.334'),bw: Float = Default('0.333'),lightness: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply hue-saturation-intensity adjustments to input video stream.
 
 This filter operates in RGB colorspace.
@@ -10550,7 +10550,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#huesaturation)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -10558,63 +10558,63 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='huesaturation', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "hue": hue,
-                
+
                 "saturation": saturation,
-                
+
                 "intensity": intensity,
-                
+
                 "colors": colors,
-                
+
                 "strength": strength,
-                
+
                 "rw": rw,
-                
+
                 "gw": gw,
-                
+
                 "bw": bw,
-                
+
                 "lightness": lightness,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hwdownload(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Download hardware frames to system memory.
 
 The input must be in hardware frames, and the output a non-hardware format.
@@ -10633,35 +10633,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hwdownload)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hwdownload', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hwmap(
-    
+
     self,
 
 
@@ -10669,12 +10669,12 @@ References:
 
     *,
     mode: Flags| Literal["read","write","overwrite","direct"] | Default = Default('read+write'),derive_device: String = Default(None),reverse: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Map hardware frames to system memory or to another device.
 
 This filter has several different modes of operation; which one is used depends
@@ -10694,41 +10694,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hwmap)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hwmap', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "derive_device": derive_device,
-                
+
                 "reverse": reverse,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hwupload(
-    
+
     self,
 
 
@@ -10736,12 +10736,12 @@ References:
 
     *,
     derive_device: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Upload system memory frames to hardware surfaces.
 
 The device to upload to must be supplied when the filter is initialised.  If
@@ -10765,66 +10765,66 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hwupload)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hwupload', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "derive_device": derive_device,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def hysteresis(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _alt: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),threshold: Int = Default('0'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Grow first stream into second stream by connecting components.
 This makes it possible to build more robust edge masks.
 
@@ -10845,7 +10845,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#hysteresis)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -10856,75 +10856,75 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='hysteresis', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _alt,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "threshold": threshold,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def identity(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the identity score between two input videos.
 
 This filter takes two input videos.
@@ -10960,7 +10960,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#identity)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -10971,42 +10971,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='identity', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def idet(
-    
+
     self,
 
 
@@ -11014,12 +11014,12 @@ References:
 
     *,
     intl_thres: Float = Default('1.04'),prog_thres: Float = Default('1.5'),rep_thres: Float = Default('3'),half_life: Float = Default('0'),analyze_interlaced_flag: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect video interlacing type.
 
 This filter tries to detect if the input frames are interlaced, progressive,
@@ -11047,45 +11047,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#idet)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='idet', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "intl_thres": intl_thres,
-                
+
                 "prog_thres": prog_thres,
-                
+
                 "rep_thres": rep_thres,
-                
+
                 "half_life": half_life,
-                
+
                 "analyze_interlaced_flag": analyze_interlaced_flag,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def il(
-    
+
     self,
 
 
@@ -11093,15 +11093,15 @@ References:
 
     *,
     luma_mode: Int| Literal["none","interleave","i","deinterleave","d"] | Default = Default('none'),chroma_mode: Int| Literal["none","interleave","i","deinterleave","d"] | Default = Default('none'),alpha_mode: Int| Literal["none","interleave","i","deinterleave","d"] | Default = Default('none'),luma_swap: Boolean = Default('false'),chroma_swap: Boolean = Default('false'),alpha_swap: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterleave or interleave fields.
 
 This filter allows one to process interlaced images fields without
@@ -11130,7 +11130,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#il)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11138,44 +11138,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='il', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_mode": luma_mode,
-                
+
                 "chroma_mode": chroma_mode,
-                
+
                 "alpha_mode": alpha_mode,
-                
+
                 "luma_swap": luma_swap,
-                
+
                 "chroma_swap": chroma_swap,
-                
+
                 "alpha_swap": alpha_swap,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def inflate(
-    
+
     self,
 
 
@@ -11183,15 +11183,15 @@ References:
 
     *,
     threshold0: Int = Default('65535'),threshold1: Int = Default('65535'),threshold2: Int = Default('65535'),threshold3: Int = Default('65535'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply inflate effect to the video.
 
 This filter replaces the pixel by the local(3x3) average by taking into account
@@ -11215,7 +11215,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#inflate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11223,40 +11223,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='inflate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold0": threshold0,
-                
+
                 "threshold1": threshold1,
-                
+
                 "threshold2": threshold2,
-                
+
                 "threshold3": threshold3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def interlace(
-    
+
     self,
 
 
@@ -11264,12 +11264,12 @@ References:
 
     *,
     scan: Int| Literal["tff","bff"] | Default = Default('tff'),lowpass: Int| Literal["off","linear","complex"] | Default = Default('linear'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Simple interlacing filter from progressive contents. This interleaves upper (or
 lower) lines from odd frames with lower (or upper) lines from even frames,
 halving the frame rate and preserving image height.
@@ -11301,43 +11301,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#interlace)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='interlace', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "scan": scan,
-                
+
                 "lowpass": lowpass,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def kerndeint(
-    
+
     self,
 
 
@@ -11345,12 +11345,12 @@ References:
 
     *,
     thresh: Int = Default('10'),map: Boolean = Default('false'),order: Boolean = Default('false'),sharp: Boolean = Default('false'),twoway: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlace input video by applying Donald Graft's adaptive kernel
 deinterling. Work on interlaced parts of a video to produce
 progressive frames.
@@ -11373,45 +11373,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#kerndeint)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='kerndeint', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "thresh": thresh,
-                
+
                 "map": map,
-                
+
                 "order": order,
-                
+
                 "sharp": sharp,
-                
+
                 "twoway": twoway,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def kirsch(
-    
+
     self,
 
 
@@ -11419,15 +11419,15 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply kirsch operator to input video stream.
 
 The filter accepts the following option:
@@ -11447,7 +11447,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#kirsch)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11455,38 +11455,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='kirsch', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lagfun(
-    
+
     self,
 
 
@@ -11494,15 +11494,15 @@ References:
 
     *,
     decay: Float = Default('0.95'),planes: Flags = Default('F'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Slowly update darker pixels.
 
 This filter makes short flashes of light appear longer.
@@ -11522,7 +11522,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lagfun)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11530,52 +11530,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lagfun', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "decay": decay,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def latency(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Measure filtering latency.
 
 Report previous filter filtering latency, delay in number of audio samples for audio filters
@@ -11596,7 +11596,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#latency)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11604,32 +11604,32 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='latency', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lenscorrection(
-    
+
     self,
 
 
@@ -11637,15 +11637,15 @@ References:
 
     *,
     cx: Double = Default('0.5'),cy: Double = Default('0.5'),k1: Double = Default('0'),k2: Double = Default('0'),i: Int| Literal["nearest","bilinear"] | Default = Default('nearest'),fc: Color = Default('black@0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Correct radial lens distortion
 
 This filter can be used to correct for radial distortion as can result from the use
@@ -11681,7 +11681,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lenscorrection)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11689,48 +11689,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lenscorrection', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cx": cx,
-                
+
                 "cy": cy,
-                
+
                 "k1": k1,
-                
+
                 "k2": k2,
-                
+
                 "i": i,
-                
+
                 "fc": fc,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def limiter(
-    
+
     self,
 
 
@@ -11738,15 +11738,15 @@ References:
 
     *,
     min: Int = Default('0'),max: Int = Default('65535'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Limits the pixel components values to the specified range [min, max].
 
 The filter accepts the following options:
@@ -11766,7 +11766,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#limiter)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11774,38 +11774,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='limiter', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "min": min,
-                
+
                 "max": max,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def loop(
-    
+
     self,
 
 
@@ -11813,12 +11813,12 @@ References:
 
     *,
     loop: Int = Default('0'),size: Int64 = Default('0'),start: Int64 = Default('0'),time: Duration = Default('INT64_MAX'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Loop video frames.
 
 The filter accepts the following options:
@@ -11838,49 +11838,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#loop)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='loop', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "loop": loop,
-                
+
                 "size": size,
-                
+
                 "start": start,
-                
+
                 "time": time,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def lumakey(
-    
+
     self,
 
 
@@ -11888,15 +11888,15 @@ References:
 
     *,
     threshold: Double = Default('0'),tolerance: Double = Default('0.01'),softness: Double = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Turn certain luma values into transparency.
 
 The filter accepts the following options:
@@ -11916,7 +11916,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lumakey)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -11924,38 +11924,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lumakey', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold": threshold,
-                
+
                 "tolerance": tolerance,
-                
+
                 "softness": softness,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lut(
-    
+
     self,
 
 
@@ -11963,15 +11963,15 @@ References:
 
     *,
     c0: String = Default('clipval'),c1: String = Default('clipval'),c2: String = Default('clipval'),c3: String = Default('clipval'),y: String = Default('clipval'),u: String = Default('clipval'),v: String = Default('clipval'),r: String = Default('clipval'),g: String = Default('clipval'),b: String = Default('clipval'),a: String = Default('clipval'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Compute a look-up table for binding each pixel component input value
 to an output value, and apply it to the input video.
 
@@ -12003,7 +12003,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12011,54 +12011,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lut', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "c0": c0,
-                
+
                 "c1": c1,
-                
+
                 "c2": c2,
-                
+
                 "c3": c3,
-                
+
                 "y": y,
-                
+
                 "u": u,
-                
+
                 "v": v,
-                
+
                 "r": r,
-                
+
                 "g": g,
-                
+
                 "b": b,
-                
+
                 "a": a,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lut1d(
-    
+
     self,
 
 
@@ -12066,15 +12066,15 @@ References:
 
     *,
     file: String = Default(None),interp: Int| Literal["nearest","linear","cosine","cubic","spline"] | Default = Default('linear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a 1D LUT to an input video.
 
 The filter accepts the following options:
@@ -12093,7 +12093,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut1d)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12101,65 +12101,65 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lut1d', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "file": file,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lut2(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _srcy: VideoStream,
-        
-    
+
+
 
 
     *,
     c0: String = Default('x'),c1: String = Default('x'),c2: String = Default('x'),c3: String = Default('x'),d: Int = Default('0'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The lut2 filter takes two input streams and outputs one
 stream.
 
@@ -12186,7 +12186,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut2)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -12197,52 +12197,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lut2', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _srcy,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "c0": c0,
-                
+
                 "c1": c1,
-                
+
                 "c2": c2,
-                
+
                 "c3": c3,
-                
+
                 "d": d,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lut3d(
-    
+
     self,
 
 
@@ -12250,15 +12250,15 @@ References:
 
     *,
     file: String = Default(None),clut: Int| Literal["first","all"] | Default = Default('all'),interp: Int| Literal["nearest","trilinear","tetrahedral","pyramid","prism"] | Default = Default('tetrahedral'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a 3D LUT to an input video.
 
 The filter accepts the following options:
@@ -12278,7 +12278,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut3d)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12286,38 +12286,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lut3d', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "file": file,
-                
+
                 "clut": clut,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lutrgb(
-    
+
     self,
 
 
@@ -12325,15 +12325,15 @@ References:
 
     *,
     c0: String = Default('clipval'),c1: String = Default('clipval'),c2: String = Default('clipval'),c3: String = Default('clipval'),y: String = Default('clipval'),u: String = Default('clipval'),v: String = Default('clipval'),r: String = Default('clipval'),g: String = Default('clipval'),b: String = Default('clipval'),a: String = Default('clipval'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Compute a look-up table for binding each pixel component input value
 to an output value, and apply it to the input video.
 
@@ -12365,7 +12365,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12373,54 +12373,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lutrgb', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "c0": c0,
-                
+
                 "c1": c1,
-                
+
                 "c2": c2,
-                
+
                 "c3": c3,
-                
+
                 "y": y,
-                
+
                 "u": u,
-                
+
                 "v": v,
-                
+
                 "r": r,
-                
+
                 "g": g,
-                
+
                 "b": b,
-                
+
                 "a": a,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def lutyuv(
-    
+
     self,
 
 
@@ -12428,15 +12428,15 @@ References:
 
     *,
     c0: String = Default('clipval'),c1: String = Default('clipval'),c2: String = Default('clipval'),c3: String = Default('clipval'),y: String = Default('clipval'),u: String = Default('clipval'),v: String = Default('clipval'),r: String = Default('clipval'),g: String = Default('clipval'),b: String = Default('clipval'),a: String = Default('clipval'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Compute a look-up table for binding each pixel component input value
 to an output value, and apply it to the input video.
 
@@ -12468,7 +12468,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12476,84 +12476,84 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='lutyuv', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "c0": c0,
-                
+
                 "c1": c1,
-                
+
                 "c2": c2,
-                
+
                 "c3": c3,
-                
+
                 "y": y,
-                
+
                 "u": u,
-                
+
                 "v": v,
-                
+
                 "r": r,
-                
+
                 "g": g,
-                
+
                 "b": b,
-                
+
                 "a": a,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def maskedclamp(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _dark: VideoStream,
-        
-    
-        
+
+
+
         _bright: VideoStream,
-        
-    
+
+
 
 
     *,
     undershoot: Int = Default('0'),overshoot: Int = Default('0'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Clamp the first input stream with the second input and third input stream.
 
 Returns the value of first stream to be between second input
@@ -12576,7 +12576,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedclamp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12584,78 +12584,78 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='maskedclamp', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _dark,
-                
-            
-                
+
+
+
                 _bright,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "undershoot": undershoot,
-                
+
                 "overshoot": overshoot,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def maskedmax(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _filter1: VideoStream,
-        
-    
-        
+
+
+
         _filter2: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Merge the second and third input stream into output stream using absolute differences
 between second input stream and first input stream and absolute difference between
 third input stream and first input stream. The picked value will be from second input
@@ -12677,7 +12677,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedmax)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12685,74 +12685,74 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='maskedmax', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _filter1,
-                
-            
-                
+
+
+
                 _filter2,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def maskedmerge(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _overlay: VideoStream,
-        
-    
-        
+
+
+
         _mask: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Merge the first input stream with the second input stream using per pixel
 weights in the third input stream.
 
@@ -12777,7 +12777,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedmerge)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12785,74 +12785,74 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='maskedmerge', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _overlay,
-                
-            
-                
+
+
+
                 _mask,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def maskedmin(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _filter1: VideoStream,
-        
-    
-        
+
+
+
         _filter2: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Merge the second and third input stream into output stream using absolute differences
 between second input stream and first input stream and absolute difference between
 third input stream and first input stream. The picked value will be from second input
@@ -12874,7 +12874,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedmin)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12882,70 +12882,70 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='maskedmin', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _filter1,
-                
-            
-                
+
+
+
                 _filter2,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def maskedthreshold(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     threshold: Int = Default('1'),planes: Int = Default('15'),mode: Int| Literal["abs","diff"] | Default = Default('abs'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pick pixels comparing absolute difference of two video streams with fixed
 threshold.
 
@@ -12971,7 +12971,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskedthreshold)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -12979,46 +12979,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='maskedthreshold', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "threshold": threshold,
-                
+
                 "planes": planes,
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def maskfun(
-    
+
     self,
 
 
@@ -13026,15 +13026,15 @@ References:
 
     *,
     low: Int = Default('10'),high: Int = Default('10'),planes: Int = Default('15'),fill: Int = Default('0'),sum: Int = Default('10'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Create mask from input video.
 
 For example it is useful to create motion masks after tblend filter.
@@ -13058,7 +13058,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#maskfun)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -13066,42 +13066,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='maskfun', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "low": low,
-                
+
                 "high": high,
-                
+
                 "planes": planes,
-                
+
                 "fill": fill,
-                
+
                 "sum": sum,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def mcdeint(
-    
+
     self,
 
 
@@ -13109,12 +13109,12 @@ References:
 
     *,
     mode: Int| Literal["fast","medium","slow","extra_slow"] | Default = Default('fast'),parity: Int| Literal["tff","bff"] | Default = Default('bff'),qp: Int = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply motion-compensation deinterlacing.
 
 It needs one field per frame as input and must thus be used together
@@ -13136,43 +13136,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mcdeint)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='mcdeint', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "parity": parity,
-                
+
                 "qp": qp,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def median(
-    
+
     self,
 
 
@@ -13180,15 +13180,15 @@ References:
 
     *,
     radius: Int = Default('1'),planes: Int = Default('15'),radiusV: Int = Default('0'),percentile: Float = Default('0.5'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pick median pixel from certain rectangle defined by radius.
 
 This filter accepts the following options:
@@ -13209,7 +13209,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#median)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -13217,42 +13217,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='median', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "radius": radius,
-                
+
                 "planes": planes,
-                
+
                 "radiusV": radiusV,
-                
+
                 "percentile": percentile,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def mestimate(
-    
+
     self,
 
 
@@ -13260,12 +13260,12 @@ References:
 
     *,
     method: Int| Literal["esa","tss","tdls","ntss","fss","ds","hexbs","epzs","umh"] | Default = Default('esa'),mb_size: Int = Default('16'),search_param: Int = Default('7'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Estimate and export motion vectors using block matching algorithms.
 Motion vectors are stored in frame side data to be used by other filters.
 
@@ -13285,41 +13285,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mestimate)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='mestimate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "method": method,
-                
+
                 "mb_size": mb_size,
-                
+
                 "search_param": search_param,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def metadata(
-    
+
     self,
 
 
@@ -13327,15 +13327,15 @@ References:
 
     *,
     mode: Int| Literal["select","add","modify","delete","print"] | Default = Default('select'),key: String = Default(None),value: String = Default(None),function: Int| Literal["same_str","starts_with","less","equal","greater","expr","ends_with"] | Default = Default('same_str'),expr: String = Default(None),file: String = Default(None),direct: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Manipulate frame metadata.
 
 This filter accepts the following options:
@@ -13359,7 +13359,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#metadata)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -13367,70 +13367,70 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='metadata', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "key": key,
-                
+
                 "value": value,
-                
+
                 "function": function,
-                
+
                 "expr": expr,
-                
+
                 "file": file,
-                
+
                 "direct": direct,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def midequalizer(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _in1: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Midway Image Equalization effect using two video streams.
 
 Midway Image Equalization adjusts a pair of images to have the same
@@ -13456,7 +13456,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#midequalizer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -13464,42 +13464,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='midequalizer', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _in1,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def minterpolate(
-    
+
     self,
 
 
@@ -13507,12 +13507,12 @@ References:
 
     *,
     fps: Video_rate = Default('60'),mi_mode: Int| Literal["dup","blend","mci"] | Default = Default('mci'),mc_mode: Int| Literal["obmc","aobmc"] | Default = Default('obmc'),me_mode: Int| Literal["bidir","bilat"] | Default = Default('bilat'),me: Int| Literal["esa","tss","tdls","ntss","fss","ds","hexbs","epzs","umh"] | Default = Default('epzs'),mb_size: Int = Default('16'),search_param: Int = Default('32'),vsbmc: Int = Default('0'),scd: Int| Literal["none","fdiff"] | Default = Default('fdiff'),scd_threshold: Double = Default('10'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert the video to specified frame rate using motion interpolation.
 
 This filter accepts the following options:
@@ -13538,57 +13538,57 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#minterpolate)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='minterpolate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "fps": fps,
-                
+
                 "mi_mode": mi_mode,
-                
+
                 "mc_mode": mc_mode,
-                
+
                 "me_mode": me_mode,
-                
+
                 "me": me,
-                
+
                 "mb_size": mb_size,
-                
+
                 "search_param": search_param,
-                
+
                 "vsbmc": vsbmc,
-                
+
                 "scd": scd,
-                
+
                 "scd_threshold": scd_threshold,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def monochrome(
-    
+
     self,
 
 
@@ -13596,15 +13596,15 @@ References:
 
     *,
     cb: Float = Default('0'),cr: Float = Default('0'),size: Float = Default('1'),high: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert video to gray using custom color filter.
 
 A description of the accepted options follows.
@@ -13625,7 +13625,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#monochrome)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -13633,69 +13633,69 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='monochrome', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "cb": cb,
-                
+
                 "cr": cr,
-                
+
                 "size": size,
-                
+
                 "high": high,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def morpho(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _structure: VideoStream,
-        
-    
+
+
 
 
     *,
     mode: Int| Literal["erode","dilate","open","close","gradient","tophat","blackhat"] | Default = Default('erode'),planes: Int = Default('7'),structure: Int| Literal["first","all"] | Default = Default('all'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 This filter allows to apply main morphological grayscale transforms,
 erode and dilate with arbitrary structures set in second input stream.
 
@@ -13721,7 +13721,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#morpho)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -13732,50 +13732,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='morpho', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _structure,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "planes": planes,
-                
+
                 "structure": structure,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def mpdecimate(
-    
+
     self,
 
 
@@ -13783,12 +13783,12 @@ References:
 
     *,
     max: Int = Default('0'),keep: Int = Default('0'),hi: Int = Default('768'),lo: Int = Default('320'),frac: Float = Default('0.33'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Drop frames that do not differ greatly from the previous frame in
 order to reduce frame rate.
 
@@ -13814,76 +13814,76 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#mpdecimate)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='mpdecimate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "max": max,
-                
+
                 "keep": keep,
-                
+
                 "hi": hi,
-                
+
                 "lo": lo,
-                
+
                 "frac": frac,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def msad(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the MSAD (Mean Sum of Absolute Differences) between two input videos.
 
 This filter takes two input videos.
@@ -13919,7 +13919,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#msad)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -13930,66 +13930,66 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='msad', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def multiply(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _factor: VideoStream,
-        
-    
+
+
 
 
     *,
     scale: Float = Default('1'),offset: Float = Default('0.5'),planes: Flags = Default('F'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Multiply first video stream pixels values with second video stream pixels values.
 
 The filter accepts the following options:
@@ -14009,7 +14009,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#multiply)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14017,46 +14017,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='multiply', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _factor,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "scale": scale,
-                
+
                 "offset": offset,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def negate(
-    
+
     self,
 
 
@@ -14064,15 +14064,15 @@ References:
 
     *,
     components: Flags| Literal["y","u","v","r","g","b","a"] | Default = Default('y+u+v+r+g+b'),negate_alpha: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Negate (invert) the input video.
 
 It accepts the following option:
@@ -14091,7 +14091,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#negate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14099,36 +14099,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='negate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "components": components,
-                
+
                 "negate_alpha": negate_alpha,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def nlmeans(
-    
+
     self,
 
 
@@ -14136,15 +14136,15 @@ References:
 
     *,
     s: Double = Default('1'),p: Int = Default('7'),pc: Int = Default('0'),r: Int = Default('15'),rc: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Denoise frames using Non-Local Means algorithm.
 
 Each pixel is adjusted by looking for other pixels with similar contexts. This
@@ -14174,7 +14174,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#nlmeans)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14182,42 +14182,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='nlmeans', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "s": s,
-                
+
                 "p": p,
-                
+
                 "pc": pc,
-                
+
                 "r": r,
-                
+
                 "rc": rc,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def nlmeans_opencl(
-    
+
     self,
 
 
@@ -14225,12 +14225,12 @@ References:
 
     *,
     s: Double = Default('1'),p: Int = Default('7'),pc: Int = Default('0'),r: Int = Default('15'),rc: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Non-local Means denoise filter through OpenCL, this filter accepts same options as nlmeans.
 
 
@@ -14249,45 +14249,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#nlmeans_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='nlmeans_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "s": s,
-                
+
                 "p": p,
-                
+
                 "pc": pc,
-                
+
                 "r": r,
-                
+
                 "rc": rc,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def nnedi(
-    
+
     self,
 
 
@@ -14295,15 +14295,15 @@ References:
 
     *,
     weights: String = Default('nnedi3_weights.bin'),deint: Int| Literal["all","interlaced"] | Default = Default('all'),field: Int| Literal["af","a","t","b","tf","bf"] | Default = Default('a'),planes: Int = Default('7'),nsize: Int| Literal["s8x6","s16x6","s32x6","s48x6","s8x4","s16x4","s32x4"] | Default = Default('s32x4'),nns: Int| Literal["n16","n32","n64","n128","n256"] | Default = Default('n32'),qual: Int| Literal["fast","slow"] | Default = Default('fast'),etype: Int| Literal["a","abs","s","mse"] | Default = Default('a'),pscrn: Int| Literal["none","original","new","new2","new3"] | Default = Default('new'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlace video using neural network edge directed interpolation.
 
 This filter accepts the following options:
@@ -14329,7 +14329,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#nnedi)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14337,50 +14337,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='nnedi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "weights": weights,
-                
+
                 "deint": deint,
-                
+
                 "field": field,
-                
+
                 "planes": planes,
-                
+
                 "nsize": nsize,
-                
+
                 "nns": nns,
-                
+
                 "qual": qual,
-                
+
                 "etype": etype,
-                
+
                 "pscrn": pscrn,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def noformat(
-    
+
     self,
 
 
@@ -14388,12 +14388,12 @@ References:
 
     *,
     pix_fmts: String = Default(None),color_spaces: String = Default(None),color_ranges: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Force libavfilter not to use any of the specified pixel formats for the
 input to the next filter.
 
@@ -14413,41 +14413,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#noformat)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='noformat', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "pix_fmts": pix_fmts,
-                
+
                 "color_spaces": color_spaces,
-                
+
                 "color_ranges": color_ranges,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def noise(
-    
+
     self,
 
 
@@ -14455,15 +14455,15 @@ References:
 
     *,
     all_seed: Int = Default('-1'),all_strength: Int = Default('0'),all_flags: Flags| Literal["a","p","t","u"] | Default = Default('0'),c0_seed: Int = Default('-1'),c0_strength: Int = Default('0'),c0_flags: Flags| Literal["a","p","t","u"] | Default = Default('0'),c1_seed: Int = Default('-1'),c1_strength: Int = Default('0'),c1_flags: Flags| Literal["a","p","t","u"] | Default = Default('0'),c2_seed: Int = Default('-1'),c2_strength: Int = Default('0'),c2_flags: Flags| Literal["a","p","t","u"] | Default = Default('0'),c3_seed: Int = Default('-1'),c3_strength: Int = Default('0'),c3_flags: Flags| Literal["a","p","t","u"] | Default = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Add noise on video input frame.
 
 The filter accepts the following options:
@@ -14495,7 +14495,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#noise)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14503,62 +14503,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='noise', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "all_seed": all_seed,
-                
+
                 "all_strength": all_strength,
-                
+
                 "all_flags": all_flags,
-                
+
                 "c0_seed": c0_seed,
-                
+
                 "c0_strength": c0_strength,
-                
+
                 "c0_flags": c0_flags,
-                
+
                 "c1_seed": c1_seed,
-                
+
                 "c1_strength": c1_strength,
-                
+
                 "c1_flags": c1_flags,
-                
+
                 "c2_seed": c2_seed,
-                
+
                 "c2_strength": c2_strength,
-                
+
                 "c2_flags": c2_flags,
-                
+
                 "c3_seed": c3_seed,
-                
+
                 "c3_strength": c3_strength,
-                
+
                 "c3_flags": c3_flags,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def normalize(
-    
+
     self,
 
 
@@ -14566,15 +14566,15 @@ References:
 
     *,
     blackpt: Color = Default('black'),whitept: Color = Default('white'),smoothing: Int = Default('0'),independence: Float = Default('1'),strength: Float = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Normalize RGB video (aka histogram stretching, contrast stretching).
 See: https://en.wikipedia.org/wiki/Normalization_(image_processing)
 
@@ -14613,7 +14613,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#normalize)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14621,55 +14621,55 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='normalize', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "blackpt": blackpt,
-                
+
                 "whitept": whitept,
-                
+
                 "smoothing": smoothing,
-                
+
                 "independence": independence,
-                
+
                 "strength": strength,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def null(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pass the video source unchanged to the output.
 
 
@@ -14683,41 +14683,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#null)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='null', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def oscilloscope(
-    
+
     self,
 
 
@@ -14725,15 +14725,15 @@ References:
 
     *,
     x: Float = Default('0.5'),y: Float = Default('0.5'),s: Float = Default('0.8'),t: Float = Default('0.5'),o: Float = Default('0.8'),tx: Float = Default('0.5'),ty: Float = Default('0.9'),tw: Float = Default('0.8'),th: Float = Default('0.3'),c: Int = Default('7'),g: Boolean = Default('true'),st: Boolean = Default('true'),sc: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 2D Video Oscilloscope.
 
 Useful to measure spatial impulse, step responses, chroma delays, etc.
@@ -14765,7 +14765,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#oscilloscope)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14773,87 +14773,87 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='oscilloscope', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "s": s,
-                
+
                 "t": t,
-                
+
                 "o": o,
-                
+
                 "tx": tx,
-                
+
                 "ty": ty,
-                
+
                 "tw": tw,
-                
+
                 "th": th,
-                
+
                 "c": c,
-                
+
                 "g": g,
-                
+
                 "st": st,
-                
+
                 "sc": sc,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def overlay(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _overlay: VideoStream,
-        
-    
+
+
 
 
     *,
     x: String = Default('0'),y: String = Default('0'),eof_action: Int| Literal["repeat","endall","pass"] | Default = Default('repeat'),eval: Int| Literal["init","frame"] | Default = Default('frame'),shortest: Boolean = Default('false'),format: Int| Literal["yuv420","yuv420p10","yuv422","yuv422p10","yuv444","yuv444p10","rgb","gbrp","auto"] | Default = Default('yuv420'),repeatlast: Boolean = Default('true'),alpha: Int| Literal["straight","premultiplied"] | Default = Default('straight'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
-    
-    
-    
-    
-    
+
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Overlay one video on top of another.
 
 It takes two inputs and has one output. The first input is the "main"
@@ -14884,7 +14884,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -14892,79 +14892,79 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='overlay', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _overlay,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "eof_action": eof_action,
-                
+
                 "eval": eval,
-                
+
                 "shortest": shortest,
-                
+
                 "format": format,
-                
+
                 "repeatlast": repeatlast,
-                
+
                 "alpha": alpha,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def overlay_opencl(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _overlay: VideoStream,
-        
-    
+
+
 
 
     *,
     x: Int = Default('0'),y: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Overlay one video on top of another.
 
 It takes two inputs and has one output. The first input is the "main" video on which the second input is overlaid.
@@ -14985,73 +14985,73 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='overlay_opencl', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _overlay,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def overlay_vaapi(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _overlay: VideoStream,
-        
-    
+
+
 
 
     *,
     x: String = Default('0'),y: String = Default('0'),w: String = Default('overlay_iw'),h: String = Default('overlay_ih*w/overlay_iw'),alpha: Float = Default('1'),eof_action: Int| Literal["repeat","endall","pass"] | Default = Default('repeat'),shortest: Boolean = Default('false'),repeatlast: Boolean = Default('true'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
-    
-    
-    
-    
-    
+
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Overlay one video on the top of another.
 
 It takes two inputs and has one output. The first input is the "main" video on which the second input is overlaid.
@@ -15078,61 +15078,61 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#overlay_vaapi)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='overlay_vaapi', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _overlay,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "alpha": alpha,
-                
+
                 "eof_action": eof_action,
-                
+
                 "shortest": shortest,
-                
+
                 "repeatlast": repeatlast,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def owdenoise(
-    
+
     self,
 
 
@@ -15140,15 +15140,15 @@ References:
 
     *,
     depth: Int = Default('8'),luma_strength: Double = Default('1'),chroma_strength: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Overcomplete Wavelet denoiser.
 
 The filter accepts the following options:
@@ -15168,7 +15168,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#owdenoise)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -15176,38 +15176,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='owdenoise', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "depth": depth,
-                
+
                 "luma_strength": luma_strength,
-                
+
                 "chroma_strength": chroma_strength,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pad(
-    
+
     self,
 
 
@@ -15215,12 +15215,12 @@ References:
 
     *,
     width: String = Default('iw'),height: String = Default('ih'),x: String = Default('0'),y: String = Default('0'),color: Color = Default('black'),eval: Int| Literal["init","frame"] | Default = Default('init'),aspect: Rational = Default('0/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Add paddings to the input image, and place the original input at the
 provided x, y coordinates.
 
@@ -15244,49 +15244,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pad)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pad', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "color": color,
-                
+
                 "eval": eval,
-                
+
                 "aspect": aspect,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pad_opencl(
-    
+
     self,
 
 
@@ -15294,12 +15294,12 @@ References:
 
     *,
     width: String = Default('iw'),height: String = Default('ih'),x: String = Default('0'),y: String = Default('0'),color: Color = Default('black'),aspect: Rational = Default('0/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Add paddings to the input image, and place the original input at the
 provided x, y coordinates.
 
@@ -15322,47 +15322,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pad_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pad_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "color": color,
-                
+
                 "aspect": aspect,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pad_vaapi(
-    
+
     self,
 
 
@@ -15370,12 +15370,12 @@ References:
 
     *,
     width: String = Default('iw'),height: String = Default('ih'),x: String = Default('0'),y: String = Default('0'),color: Color = Default('black'),aspect: Rational = Default('0/1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Add paddings to the input image, and place the original input at the
 provided x, y coordinates.
 
@@ -15398,51 +15398,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pad_vaapi)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pad_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "color": color,
-                
+
                 "aspect": aspect,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def palettegen(
-    
+
     self,
 
 
@@ -15450,12 +15450,12 @@ References:
 
     *,
     max_colors: Int = Default('256'),reserve_transparent: Boolean = Default('true'),transparency_color: Color = Default('lime'),stats_mode: Int| Literal["full","diff","single"] | Default = Default('full'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Generate one palette for a whole video stream.
 
 It accepts the following options:
@@ -15475,64 +15475,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#palettegen)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='palettegen', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "max_colors": max_colors,
-                
+
                 "reserve_transparent": reserve_transparent,
-                
+
                 "transparency_color": transparency_color,
-                
+
                 "stats_mode": stats_mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def paletteuse(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _palette: VideoStream,
-        
-    
+
+
 
 
     *,
     dither: Int| Literal["bayer","heckbert","floyd_steinberg","sierra2","sierra2_4a","sierra3","burkes","atkinson"] | Default = Default('sierra2_4a'),bayer_scale: Int = Default('2'),diff_mode: Int| Literal["rectangle"] | Default = Default('0'),new: Boolean = Default('false'),alpha_threshold: Int = Default('128'),debug_kdtree: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Use a palette to downsample an input video stream.
 
 The filter takes two inputs: one video stream and a palette. The palette must
@@ -15557,59 +15557,59 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#paletteuse)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='paletteuse', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _palette,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "dither": dither,
-                
+
                 "bayer_scale": bayer_scale,
-                
+
                 "diff_mode": diff_mode,
-                
+
                 "new": new,
-                
+
                 "alpha_threshold": alpha_threshold,
-                
+
                 "debug_kdtree": debug_kdtree,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def perms(
-    
+
     self,
 
 
@@ -15617,15 +15617,15 @@ References:
 
     *,
     mode: Int| Literal["none","ro","rw","toggle","random"] | Default = Default('none'),seed: Int64 = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Set read/write permissions for the output frames.
 
 These filters are mainly aimed at developers to test direct path in the
@@ -15647,7 +15647,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#perms)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -15655,36 +15655,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='perms', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "seed": seed,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def perspective(
-    
+
     self,
 
 
@@ -15692,15 +15692,15 @@ References:
 
     *,
     x0: String = Default('0'),y0: String = Default('0'),x1: String = Default('W'),y1: String = Default('0'),x2: String = Default('0'),y2: String = Default('H'),x3: String = Default('W'),y3: String = Default('H'),interpolation: Int| Literal["linear","cubic"] | Default = Default('linear'),sense: Int| Literal["source","destination"] | Default = Default('source'),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Correct perspective of video not recorded perpendicular to the screen.
 
 A description of the accepted parameters follows.
@@ -15728,7 +15728,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#perspective)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -15736,54 +15736,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='perspective', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x0": x0,
-                
+
                 "y0": y0,
-                
+
                 "x1": x1,
-                
+
                 "y1": y1,
-                
+
                 "x2": x2,
-                
+
                 "y2": y2,
-                
+
                 "x3": x3,
-                
+
                 "y3": y3,
-                
+
                 "interpolation": interpolation,
-                
+
                 "sense": sense,
-                
+
                 "eval": eval,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def phase(
-    
+
     self,
 
 
@@ -15791,15 +15791,15 @@ References:
 
     *,
     mode: Int| Literal["p","t","b","T","B","u","U","a","A"] | Default = Default('A'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Delay interlaced video by one field time so that the field order changes.
 
 The intended use is to fix PAL movies that have been captured with the
@@ -15820,7 +15820,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#phase)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -15828,34 +15828,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='phase', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def photosensitivity(
-    
+
     self,
 
 
@@ -15863,12 +15863,12 @@ References:
 
     *,
     frames: Int = Default('30'),threshold: Float = Default('1'),skip: Int = Default('1'),bypass: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reduce various flashes in video, so to help users with epilepsy.
 
 It accepts the following options:
@@ -15888,56 +15888,56 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#photosensitivity)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='photosensitivity', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frames": frames,
-                
+
                 "threshold": threshold,
-                
+
                 "skip": skip,
-                
+
                 "bypass": bypass,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pixdesctest(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pixel format descriptor test filter, mainly useful for internal
 testing. The output video should be equal to the input video.
 
@@ -15959,35 +15959,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pixdesctest)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pixdesctest', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pixelize(
-    
+
     self,
 
 
@@ -15995,15 +15995,15 @@ References:
 
     *,
     width: Int = Default('16'),height: Int = Default('16'),mode: Int| Literal["avg","min","max"] | Default = Default('avg'),planes: Flags = Default('F'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply pixelization to video stream.
 
 The filter accepts the following options:
@@ -16024,7 +16024,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pixelize)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -16032,40 +16032,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pixelize', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "mode": mode,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pixscope(
-    
+
     self,
 
 
@@ -16073,15 +16073,15 @@ References:
 
     *,
     x: Float = Default('0.5'),y: Float = Default('0.5'),w: Int = Default('7'),h: Int = Default('7'),o: Float = Default('0.5'),wx: Float = Default('-1'),wy: Float = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Display sample values of color channels. Mainly useful for checking color
 and levels. Minimum supported resolution is 640x480.
 
@@ -16106,7 +16106,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pixscope)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -16114,46 +16114,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pixscope', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "o": o,
-                
+
                 "wx": wx,
-                
+
                 "wy": wy,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pp7(
-    
+
     self,
 
 
@@ -16161,15 +16161,15 @@ References:
 
     *,
     qp: Int = Default('0'),mode: Int| Literal["hard","soft","medium"] | Default = Default('medium'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Postprocessing filter 7. It is variant of the spp filter,
 similar to spp = 6 with 7 point DCT, where only the center sample is
 used after IDCT.
@@ -16190,7 +16190,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pp7)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -16198,38 +16198,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pp7', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "qp": qp,
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def prewitt(
-    
+
     self,
 
 
@@ -16237,15 +16237,15 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply prewitt operator to input video stream.
 
 The filter accepts the following option:
@@ -16265,7 +16265,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#prewitt)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -16273,38 +16273,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='prewitt', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def prewitt_opencl(
-    
+
     self,
 
 
@@ -16312,12 +16312,12 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply the Prewitt operator (https://en.wikipedia.org/wiki/Prewitt_operator) to input video stream.
 
 The filter accepts the following option:
@@ -16336,41 +16336,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#prewitt_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='prewitt_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def procamp_vaapi(
-    
+
     self,
 
 
@@ -16378,12 +16378,12 @@ References:
 
     *,
     b: Float = Default('0'),s: Float = Default('1'),c: Float = Default('1'),h: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 ProcAmp (color balance) adjustments for hue, saturation, brightness, contrast
 
 
@@ -16401,45 +16401,45 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='procamp_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "b": b,
-                
+
                 "s": s,
-                
+
                 "c": c,
-                
+
                 "h": h,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def pseudocolor(
-    
+
     self,
 
 
@@ -16447,15 +16447,15 @@ References:
 
     *,
     c0: String = Default('val'),c1: String = Default('val'),c2: String = Default('val'),c3: String = Default('val'),index: Int = Default('0'),preset: Int| Literal["none","magma","inferno","plasma","viridis","turbo","cividis","range1","range2","shadows","highlights","solar","nominal","preferred","total","spectral","cool","heat","fiery","blues","green","helix"] | Default = Default('none'),opacity: Float = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Alter frame colors in video with pseudocolors.
 
 This filter accepts the following options:
@@ -16479,7 +16479,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pseudocolor)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -16487,75 +16487,75 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pseudocolor', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "c0": c0,
-                
+
                 "c1": c1,
-                
+
                 "c2": c2,
-                
+
                 "c3": c3,
-                
+
                 "index": index,
-                
+
                 "preset": preset,
-                
+
                 "opacity": opacity,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def psnr(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),stats_version: Int = Default('1'),output_max: Boolean = Default('false'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the average, maximum and minimum PSNR (Peak Signal to Noise
 Ratio) between two input videos.
 
@@ -16599,7 +16599,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#psnr)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -16610,48 +16610,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='psnr', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "stats_file": stats_file,
-                
+
                 "stats_version": stats_version,
-                
+
                 "output_max": output_max,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def pullup(
-    
+
     self,
 
 
@@ -16659,12 +16659,12 @@ References:
 
     *,
     jl: Int = Default('1'),jr: Int = Default('1'),jt: Int = Default('4'),jb: Int = Default('4'),sb: Boolean = Default('false'),mp: Int| Literal["y","u","v"] | Default = Default('y'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pulldown reversal (inverse telecine) filter, capable of handling mixed
 hard-telecine, 24000/1001 fps progressive, and 30000/1001 fps progressive
 content.
@@ -16697,47 +16697,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#pullup)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='pullup', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "jl": jl,
-                
+
                 "jr": jr,
-                
+
                 "jt": jt,
-                
+
                 "jb": jb,
-                
+
                 "sb": sb,
-                
+
                 "mp": mp,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def qp(
-    
+
     self,
 
 
@@ -16745,15 +16745,15 @@ References:
 
     *,
     qp: String = Default(None),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Change video quantization parameters (QP).
 
 The filter accepts the following option:
@@ -16771,7 +16771,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#qp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -16779,34 +16779,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='qp', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "qp": qp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def random(
-    
+
     self,
 
 
@@ -16814,12 +16814,12 @@ References:
 
     *,
     frames: Int = Default('30'),seed: Int64 = Default('-1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Flush video frames from internal cache of frames into a random order.
 No frame is discarded.
 Inspired by frei0r nervous filter.
@@ -16837,39 +16837,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#random)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='random', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frames": frames,
-                
+
                 "seed": seed,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def readeia608(
-    
+
     self,
 
 
@@ -16877,15 +16877,15 @@ References:
 
     *,
     scan_min: Int = Default('0'),scan_max: Int = Default('29'),spw: Float = Default('0.27'),chp: Boolean = Default('false'),lp: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Read closed captioning (EIA-608) information from the top lines of a video frame.
 
 This filter adds frame metadata for lavfi.readeia608.X.cc and
@@ -16909,7 +16909,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#readeia608)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -16917,42 +16917,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='readeia608', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "scan_min": scan_min,
-                
+
                 "scan_max": scan_max,
-                
+
                 "spw": spw,
-                
+
                 "chp": chp,
-                
+
                 "lp": lp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def readvitc(
-    
+
     self,
 
 
@@ -16960,12 +16960,12 @@ References:
 
     *,
     scan_max: Int = Default('45'),thr_b: Double = Default('0.2'),thr_w: Double = Default('0.6'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Read vertical interval timecode (VITC) information from the top lines of a
 video frame.
 
@@ -16990,41 +16990,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#readvitc)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='readvitc', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "scan_max": scan_max,
-                
+
                 "thr_b": thr_b,
-                
+
                 "thr_w": thr_w,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def realtime(
-    
+
     self,
 
 
@@ -17032,12 +17032,12 @@ References:
 
     *,
     limit: Duration = Default('2'),speed: Double = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Slow down filtering to match real time approximately.
 
 These filters will pause the filtering for a variable amount of time to
@@ -17059,64 +17059,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#realtime)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='realtime', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "limit": limit,
-                
+
                 "speed": speed,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def remap(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _xmap: VideoStream,
-        
-    
-        
+
+
+
         _ymap: VideoStream,
-        
-    
+
+
 
 
     *,
     format: Int| Literal["color","gray"] | Default = Default('color'),fill: Color = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remap pixels using 2nd: Xmap and 3rd: Ymap input video stream.
 
 Destination pixel at position (X, Y) will be picked from source (x, y) position
@@ -17140,76 +17140,76 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#remap)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='remap', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _xmap,
-                
-            
-                
+
+
+
                 _ymap,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "format": format,
-                
+
                 "fill": fill,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def remap_opencl(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _xmap: VideoStream,
-        
-    
-        
+
+
+
         _ymap: VideoStream,
-        
-    
+
+
 
 
     *,
     interp: Int| Literal["near","linear"] | Default = Default('linear'),fill: Color = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Remap pixels using 2nd: Xmap and 3rd: Ymap input video stream.
 
 Destination pixel at position (X, Y) will be picked from source (x, y) position
@@ -17233,51 +17233,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#remap_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='remap_opencl', typings_input=('video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _xmap,
-                
-            
-                
+
+
+
                 _ymap,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "interp": interp,
-                
+
                 "fill": fill,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def removegrain(
-    
+
     self,
 
 
@@ -17285,15 +17285,15 @@ References:
 
     *,
     m0: Int = Default('0'),m1: Int = Default('0'),m2: Int = Default('0'),m3: Int = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The removegrain filter is a spatial denoiser for progressive video.
 
 
@@ -17312,7 +17312,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#removegrain)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -17320,40 +17320,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='removegrain', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "m0": m0,
-                
+
                 "m1": m1,
-                
+
                 "m2": m2,
-                
+
                 "m3": m3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def removelogo(
-    
+
     self,
 
 
@@ -17361,15 +17361,15 @@ References:
 
     *,
     filename: String = Default(None),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Suppress a TV station logo, using an image file to determine which
 pixels comprise the logo. It works by filling in the pixels that
 comprise the logo with neighboring pixels.
@@ -17389,7 +17389,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#removelogo)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -17397,47 +17397,47 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='removelogo', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "filename": filename,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def repeatfields(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 This filter uses the repeat_field flag from the Video ES headers and hard repeats
 fields based on its value.
 
@@ -17452,50 +17452,50 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#repeatfields)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='repeatfields', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def reverse(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reverse a video clip.
 
 Warning: This filter requires memory to buffer the entire clip, so trimming
@@ -17512,35 +17512,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#reverse)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='reverse', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def rgbashift(
-    
+
     self,
 
 
@@ -17548,15 +17548,15 @@ References:
 
     *,
     rh: Int = Default('0'),rv: Int = Default('0'),gh: Int = Default('0'),gv: Int = Default('0'),bh: Int = Default('0'),bv: Int = Default('0'),ah: Int = Default('0'),av: Int = Default('0'),edge: Int| Literal["smear","wrap"] | Default = Default('smear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Shift R/G/B/A pixels horizontally and/or vertically.
 
 The filter accepts the following options:
@@ -17582,7 +17582,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#rgbashift)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -17590,52 +17590,52 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='rgbashift', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "rh": rh,
-                
+
                 "rv": rv,
-                
+
                 "gh": gh,
-                
+
                 "gv": gv,
-                
+
                 "bh": bh,
-                
+
                 "bv": bv,
-                
+
                 "ah": ah,
-                
+
                 "av": av,
-                
+
                 "edge": edge,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def roberts(
-    
+
     self,
 
 
@@ -17643,15 +17643,15 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply roberts cross operator to input video stream.
 
 The filter accepts the following option:
@@ -17671,7 +17671,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#roberts)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -17679,38 +17679,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='roberts', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def roberts_opencl(
-    
+
     self,
 
 
@@ -17718,12 +17718,12 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply the Roberts cross operator (https://en.wikipedia.org/wiki/Roberts_cross) to input video stream.
 
 The filter accepts the following option:
@@ -17742,41 +17742,41 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#roberts_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='roberts_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def rotate(
-    
+
     self,
 
 
@@ -17784,15 +17784,15 @@ References:
 
     *,
     angle: String = Default('0'),out_w: String = Default('iw'),out_h: String = Default('ih'),fillcolor: String = Default('black'),bilinear: Boolean = Default('true'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Rotate video by an arbitrary angle expressed in radians.
 
 The filter accepts the following options:
@@ -17816,7 +17816,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#rotate)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -17824,42 +17824,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='rotate', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "angle": angle,
-                
+
                 "out_w": out_w,
-                
+
                 "out_h": out_h,
-                
+
                 "fillcolor": fillcolor,
-                
+
                 "bilinear": bilinear,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def sab(
-    
+
     self,
 
 
@@ -17867,15 +17867,15 @@ References:
 
     *,
     luma_radius: Float = Default('1'),luma_pre_filter_radius: Float = Default('1'),luma_strength: Float = Default('1'),chroma_radius: Float = Default('-0.9'),chroma_pre_filter_radius: Float = Default('-0.9'),chroma_strength: Float = Default('-0.9'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Shape Adaptive Blur.
 
 The filter accepts the following options:
@@ -17898,7 +17898,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sab)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -17906,63 +17906,63 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sab', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_radius": luma_radius,
-                
+
                 "luma_pre_filter_radius": luma_pre_filter_radius,
-                
+
                 "luma_strength": luma_strength,
-                
+
                 "chroma_radius": chroma_radius,
-                
+
                 "chroma_pre_filter_radius": chroma_pre_filter_radius,
-                
+
                 "chroma_strength": chroma_strength,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def scale(
-    
+
     self,
 
 
-    
+
 
 
     *,
     w: String = Default(None),h: String = Default(None),flags: String = Default(''),interl: Boolean = Default('false'),size: String = Default(None),in_color_matrix: Int| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default('auto'),out_color_matrix: Int| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default('2'),in_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),out_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),in_chroma_loc: Int| Literal["auto","unknown","left","center","topleft","top","bottomleft","bottom"] | Default = Default('auto'),out_chroma_loc: Int| Literal["auto","unknown","left","center","topleft","top","bottomleft","bottom"] | Default = Default('auto'),in_primaries: Int| Literal["auto","bt709","bt470m","bt470bg","smpte170m","smpte240m","film","bt2020","smpte428","smpte431","smpte432","jedec-p22","ebu3213"] | Default = Default('auto'),out_primaries: Int| Literal["auto","bt709","bt470m","bt470bg","smpte170m","smpte240m","film","bt2020","smpte428","smpte431","smpte432","jedec-p22","ebu3213"] | Default = Default('auto'),in_transfer: Int| Literal["auto","bt709","bt470m","gamma22","bt470bg","gamma28","smpte170m","smpte240m","linear","iec61966-2-1","srgb","iec61966-2-4","xvycc","bt1361e","bt2020-10","bt2020-12","smpte2084","smpte428","arib-std-b67"] | Default = Default('auto'),in_v_chr_pos: Int = Default('-513'),in_h_chr_pos: Int = Default('-513'),out_v_chr_pos: Int = Default('-513'),out_h_chr_pos: Int = Default('-513'),force_original_aspect_ratio: Int| Literal["disable","decrease","increase"] | Default = Default('disable'),force_divisible_by: Int = Default('1'),reset_sar: Boolean = Default('false'),param0: Double = Default('DBL_MAX'),param1: Double = Default('DBL_MAX'),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Scale (resize) the input video, using the libswscale library.
 
 The scale filter forces the output display aspect ratio to be the same
@@ -18008,7 +18008,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#scale)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -18016,112 +18016,112 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='scale', typings_input=(), typings_output=('video',)),
-            
+
             self,
 
 
-            
+
 
 
             **merge({
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "flags": flags,
-                
+
                 "interl": interl,
-                
+
                 "size": size,
-                
+
                 "in_color_matrix": in_color_matrix,
-                
+
                 "out_color_matrix": out_color_matrix,
-                
+
                 "in_range": in_range,
-                
+
                 "out_range": out_range,
-                
+
                 "in_chroma_loc": in_chroma_loc,
-                
+
                 "out_chroma_loc": out_chroma_loc,
-                
+
                 "in_primaries": in_primaries,
-                
+
                 "out_primaries": out_primaries,
-                
+
                 "in_transfer": in_transfer,
-                
+
                 "in_v_chr_pos": in_v_chr_pos,
-                
+
                 "in_h_chr_pos": in_h_chr_pos,
-                
+
                 "out_v_chr_pos": out_v_chr_pos,
-                
+
                 "out_h_chr_pos": out_h_chr_pos,
-                
+
                 "force_original_aspect_ratio": force_original_aspect_ratio,
-                
+
                 "force_divisible_by": force_divisible_by,
-                
+
                 "reset_sar": reset_sar,
-                
+
                 "param0": param0,
-                
+
                 "param1": param1,
-                
+
                 "eval": eval,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def scale2ref(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _ref: VideoStream,
-        
-    
+
+
 
 
     *,
     w: String = Default(None),h: String = Default(None),flags: String = Default(''),interl: Boolean = Default('false'),size: String = Default(None),in_color_matrix: Int| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default('auto'),out_color_matrix: Int| Literal["auto","bt601","bt470","smpte170m","bt709","fcc","smpte240m","bt2020"] | Default = Default('2'),in_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),out_range: Int| Literal["auto","unknown","full","limited","jpeg","mpeg","tv","pc"] | Default = Default('auto'),in_chroma_loc: Int| Literal["auto","unknown","left","center","topleft","top","bottomleft","bottom"] | Default = Default('auto'),out_chroma_loc: Int| Literal["auto","unknown","left","center","topleft","top","bottomleft","bottom"] | Default = Default('auto'),in_primaries: Int| Literal["auto","bt709","bt470m","bt470bg","smpte170m","smpte240m","film","bt2020","smpte428","smpte431","smpte432","jedec-p22","ebu3213"] | Default = Default('auto'),out_primaries: Int| Literal["auto","bt709","bt470m","bt470bg","smpte170m","smpte240m","film","bt2020","smpte428","smpte431","smpte432","jedec-p22","ebu3213"] | Default = Default('auto'),in_transfer: Int| Literal["auto","bt709","bt470m","gamma22","bt470bg","gamma28","smpte170m","smpte240m","linear","iec61966-2-1","srgb","iec61966-2-4","xvycc","bt1361e","bt2020-10","bt2020-12","smpte2084","smpte428","arib-std-b67"] | Default = Default('auto'),in_v_chr_pos: Int = Default('-513'),in_h_chr_pos: Int = Default('-513'),out_v_chr_pos: Int = Default('-513'),out_h_chr_pos: Int = Default('-513'),force_original_aspect_ratio: Int| Literal["disable","decrease","increase"] | Default = Default('disable'),force_divisible_by: Int = Default('1'),reset_sar: Boolean = Default('false'),param0: Double = Default('DBL_MAX'),param1: Double = Default('DBL_MAX'),eval: Int| Literal["init","frame"] | Default = Default('init'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> tuple[
-    
-        
+
+
             VideoStream,
-        
-    
-        
+
+
+
             VideoStream,
-        
-    
+
+
 ]:
         """
-        
+
 Scale the input video size and/or convert the image format to the given reference.
 
 
@@ -18160,102 +18160,102 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='scale2ref', typings_input=('video', 'video'), typings_output=('video', 'video')),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _ref,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "flags": flags,
-                
+
                 "interl": interl,
-                
+
                 "size": size,
-                
+
                 "in_color_matrix": in_color_matrix,
-                
+
                 "out_color_matrix": out_color_matrix,
-                
+
                 "in_range": in_range,
-                
+
                 "out_range": out_range,
-                
+
                 "in_chroma_loc": in_chroma_loc,
-                
+
                 "out_chroma_loc": out_chroma_loc,
-                
+
                 "in_primaries": in_primaries,
-                
+
                 "out_primaries": out_primaries,
-                
+
                 "in_transfer": in_transfer,
-                
+
                 "in_v_chr_pos": in_v_chr_pos,
-                
+
                 "in_h_chr_pos": in_h_chr_pos,
-                
+
                 "out_v_chr_pos": out_v_chr_pos,
-                
+
                 "out_h_chr_pos": out_h_chr_pos,
-                
+
                 "force_original_aspect_ratio": force_original_aspect_ratio,
-                
+
                 "force_divisible_by": force_divisible_by,
-                
+
                 "reset_sar": reset_sar,
-                
+
                 "param0": param0,
-                
+
                 "param1": param1,
-                
+
                 "eval": eval,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return (
-            
-                
+
+
                     filter_node.video(0),
-                
-            
-                
+
+
+
                     filter_node.video(1),
-                
-            
+
+
         )
 
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def scale_vaapi(
-    
+
     self,
 
 
@@ -18263,12 +18263,12 @@ References:
 
     *,
     w: String = Default('iw'),h: String = Default('ih'),format: String = Default(None),mode: Int| Literal["default","fast","hq","nl_anamorphic"] | Default = Default('hq'),out_color_matrix: String = Default(None),out_range: Int| Literal["full","limited","jpeg","mpeg","tv","pc"] | Default = Default('0'),out_color_primaries: String = Default(None),out_color_transfer: String = Default(None),out_chroma_location: String = Default(None),force_original_aspect_ratio: Int| Literal["disable","decrease","increase"] | Default = Default('disable'),force_divisible_by: Int = Default('1'),reset_sar: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Scale to/from VAAPI surfaces.
 
 
@@ -18294,59 +18294,59 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='scale_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "format": format,
-                
+
                 "mode": mode,
-                
+
                 "out_color_matrix": out_color_matrix,
-                
+
                 "out_range": out_range,
-                
+
                 "out_color_primaries": out_color_primaries,
-                
+
                 "out_color_transfer": out_color_transfer,
-                
+
                 "out_chroma_location": out_chroma_location,
-                
+
                 "force_original_aspect_ratio": force_original_aspect_ratio,
-                
+
                 "force_divisible_by": force_divisible_by,
-                
+
                 "reset_sar": reset_sar,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def scdet(
-    
+
     self,
 
 
@@ -18354,12 +18354,12 @@ References:
 
     *,
     threshold: Double = Default('10'),sc_pass: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect video scene change.
 
 This filter sets frame metadata with mafd between frame, the scene score, and
@@ -18392,39 +18392,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#scdet)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='scdet', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold": threshold,
-                
+
                 "sc_pass": sc_pass,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def scharr(
-    
+
     self,
 
 
@@ -18432,15 +18432,15 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply scharr operator to input video stream.
 
 The filter accepts the following option:
@@ -18460,7 +18460,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#scharr)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -18468,38 +18468,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='scharr', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def scroll(
-    
+
     self,
 
 
@@ -18507,15 +18507,15 @@ References:
 
     *,
     horizontal: Float = Default('0'),vertical: Float = Default('0'),hpos: Float = Default('0'),vpos: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Scroll input video horizontally and/or vertically by constant speed.
 
 The filter accepts the following options:
@@ -18536,7 +18536,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#scroll)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -18544,40 +18544,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='scroll', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "horizontal": horizontal,
-                
+
                 "vertical": vertical,
-                
+
                 "hpos": hpos,
-                
+
                 "vpos": vpos,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def segment(
-    
+
     self,
 
 
@@ -18585,12 +18585,12 @@ References:
 
     *,
     timestamps: String = Default(None),frames: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Split single input stream into multiple streams.
 
 This filter does opposite of concat filters.
@@ -18613,40 +18613,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#segment)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='segment', typings_input=('video',), typings_output="[StreamType.video] * len((str(timestamps or frames)).split('|'))"),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "timestamps": timestamps,
-                
+
                 "frames": frames,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def select(
-    
+
     self,
 
 
@@ -18654,12 +18654,12 @@ References:
 
     *,
     expr: String = Default('1'),outputs: Int = Default('1'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Select frames to pass in output.
 
 This filter accepts the following options:
@@ -18678,40 +18678,40 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#select)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='select', typings_input=('video',), typings_output='[StreamType.video] * int(outputs)'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "expr": expr,
-                
+
                 "outputs": outputs,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def selectivecolor(
-    
+
     self,
 
 
@@ -18719,15 +18719,15 @@ References:
 
     *,
     correction_method: Int| Literal["absolute","relative"] | Default = Default('absolute'),reds: String = Default(None),yellows: String = Default(None),greens: String = Default(None),cyans: String = Default(None),blues: String = Default(None),magentas: String = Default(None),whites: String = Default(None),neutrals: String = Default(None),blacks: String = Default(None),psfile: String = Default(None),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Adjust cyan, magenta, yellow and black (CMYK) to certain ranges of colors (such
 as "reds", "yellows", "greens", "cyans", ...). The adjustment range is defined
 by the "purity" of the color (that is, how saturated it already is).
@@ -18759,7 +18759,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#selectivecolor)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -18767,54 +18767,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='selectivecolor', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "correction_method": correction_method,
-                
+
                 "reds": reds,
-                
+
                 "yellows": yellows,
-                
+
                 "greens": greens,
-                
+
                 "cyans": cyans,
-                
+
                 "blues": blues,
-                
+
                 "magentas": magentas,
-                
+
                 "whites": whites,
-                
+
                 "neutrals": neutrals,
-                
+
                 "blacks": blacks,
-                
+
                 "psfile": psfile,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def sendcmd(
-    
+
     self,
 
 
@@ -18822,12 +18822,12 @@ References:
 
     *,
     commands: String = Default(None),filename: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Send commands to filters in the filtergraph.
 
 These filters read commands to be sent to other filters in the
@@ -18856,52 +18856,52 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sendcmd)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sendcmd', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "commands": commands,
-                
+
                 "filename": filename,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def separatefields(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The separatefields takes a frame-based video input and splits
 each frame into its components fields, producing a new half height clip
 with twice the frame rate and twice the frame count.
@@ -18921,35 +18921,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#separatefields)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='separatefields', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def setdar(
-    
+
     self,
 
 
@@ -18957,12 +18957,12 @@ References:
 
     *,
     dar: String = Default('0'),max: Int = Default('100'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The setdar filter sets the Display Aspect Ratio for the filter
 output video.
 
@@ -19004,39 +19004,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setdar)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='setdar', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dar": dar,
-                
+
                 "max": max,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def setfield(
-    
+
     self,
 
 
@@ -19044,12 +19044,12 @@ References:
 
     *,
     mode: Int| Literal["auto","bff","tff","prog"] | Default = Default('auto'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Force field for the output video frame.
 
 The setfield filter marks the interlace type field for the
@@ -19071,37 +19071,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setfield)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='setfield', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def setparams(
-    
+
     self,
 
 
@@ -19109,12 +19109,12 @@ References:
 
     *,
     field_mode: Int| Literal["auto","bff","tff","prog"] | Default = Default('auto'),range: Int| Literal["auto","unspecified","unknown","limited","tv","mpeg","full","pc","jpeg"] | Default = Default('auto'),color_primaries: Int| Literal["auto","bt709","unknown","bt470m","bt470bg","smpte170m","smpte240m","film","bt2020","smpte428","smpte431","smpte432","jedec-p22","ebu3213"] | Default = Default('auto'),color_trc: Int| Literal["auto","bt709","unknown","bt470m","bt470bg","smpte170m","smpte240m","linear","log100","log316","iec61966-2-4","bt1361e","iec61966-2-1","bt2020-10","bt2020-12","smpte2084","smpte428","arib-std-b67"] | Default = Default('auto'),colorspace: Int| Literal["auto","gbr","bt709","unknown","fcc","bt470bg","smpte170m","smpte240m","ycgco","ycgco-re","ycgco-ro","bt2020nc","bt2020c","smpte2085","chroma-derived-nc","chroma-derived-c","ictcp","ipt-c2"] | Default = Default('auto'),chroma_location: Int| Literal["auto","unspecified","unknown","left","center","topleft","top","bottomleft","bottom"] | Default = Default('auto'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Force frame parameter for the output video frame.
 
 The setparams filter marks interlace and color range for the
@@ -19139,47 +19139,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setparams)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='setparams', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "field_mode": field_mode,
-                
+
                 "range": range,
-                
+
                 "color_primaries": color_primaries,
-                
+
                 "color_trc": color_trc,
-                
+
                 "colorspace": colorspace,
-                
+
                 "chroma_location": chroma_location,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def setpts(
-    
+
     self,
 
 
@@ -19187,12 +19187,12 @@ References:
 
     *,
     expr: String = Default('PTS'),strip_fps: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Change the PTS (presentation timestamp) of the input frames.
 
 setpts works on video frames, asetpts on audio frames.
@@ -19212,39 +19212,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setpts)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='setpts', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "expr": expr,
-                
+
                 "strip_fps": strip_fps,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def setrange(
-    
+
     self,
 
 
@@ -19252,12 +19252,12 @@ References:
 
     *,
     range: Int| Literal["auto","unspecified","unknown","limited","tv","mpeg","full","pc","jpeg"] | Default = Default('auto'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Force color range for the output video frame.
 
 The setrange filter marks the color range property for the
@@ -19279,37 +19279,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setrange)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='setrange', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "range": range,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def setsar(
-    
+
     self,
 
 
@@ -19317,12 +19317,12 @@ References:
 
     *,
     sar: String = Default('0'),max: Int = Default('100'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The setdar filter sets the Display Aspect Ratio for the filter
 output video.
 
@@ -19364,39 +19364,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#setdar)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='setsar', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sar": sar,
-                
+
                 "max": max,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def settb(
-    
+
     self,
 
 
@@ -19404,12 +19404,12 @@ References:
 
     *,
     expr: String = Default('intb'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Set the timebase to use for the output frames timestamps.
 It is mainly useful for testing timebase configuration.
 
@@ -19427,37 +19427,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#settb)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='settb', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "expr": expr,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def sharpness_vaapi(
-    
+
     self,
 
 
@@ -19465,12 +19465,12 @@ References:
 
     *,
     sharpness: Int = Default('44'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 VAAPI VPP for sharpness
 
 
@@ -19485,37 +19485,37 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sharpness_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "sharpness": sharpness,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def shear(
-    
+
     self,
 
 
@@ -19523,15 +19523,15 @@ References:
 
     *,
     shx: Float = Default('0'),shy: Float = Default('0'),fillcolor: String = Default('black'),interp: Int| Literal["nearest","bilinear"] | Default = Default('bilinear'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply shear transform to input video.
 
 This filter supports the following options:
@@ -19552,7 +19552,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#shear)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -19560,46 +19560,46 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='shear', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "shx": shx,
-                
+
                 "shy": shy,
-                
+
                 "fillcolor": fillcolor,
-                
+
                 "interp": interp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def showinfo(
-    
+
     self,
 
 
@@ -19607,12 +19607,12 @@ References:
 
     *,
     checksum: Boolean = Default('true'),udu_sei_as_ascii: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Show a line containing various information for each input video frame.
 The input video is not modified.
 
@@ -19631,39 +19631,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showinfo)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showinfo', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "checksum": checksum,
-                
+
                 "udu_sei_as_ascii": udu_sei_as_ascii,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def showpalette(
-    
+
     self,
 
 
@@ -19671,12 +19671,12 @@ References:
 
     *,
     s: Int = Default('30'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Displays the 256 colors palette of each frame. This filter is only relevant for
 pal8 pixel format frames.
 
@@ -19694,49 +19694,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#showpalette)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='showpalette', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "s": s,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def shuffleframes(
-    
+
     self,
 
 
@@ -19744,15 +19744,15 @@ References:
 
     *,
     mapping: String = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reorder and/or duplicate and/or drop video frames.
 
 It accepts the following parameters:
@@ -19770,7 +19770,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#shuffleframes)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -19778,34 +19778,34 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='shuffleframes', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mapping": mapping,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def shufflepixels(
-    
+
     self,
 
 
@@ -19813,15 +19813,15 @@ References:
 
     *,
     direction: Int| Literal["forward","inverse"] | Default = Default('forward'),mode: Int| Literal["horizontal","vertical","block"] | Default = Default('horizontal'),width: Int = Default('10'),height: Int = Default('10'),seed: Int64 = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reorder pixels in video frames.
 
 This filter accepts the following options:
@@ -19843,7 +19843,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#shufflepixels)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -19851,42 +19851,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='shufflepixels', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "direction": direction,
-                
+
                 "mode": mode,
-                
+
                 "width": width,
-                
+
                 "height": height,
-                
+
                 "seed": seed,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def shuffleplanes(
-    
+
     self,
 
 
@@ -19894,15 +19894,15 @@ References:
 
     *,
     map0: Int = Default('0'),map1: Int = Default('1'),map2: Int = Default('2'),map3: Int = Default('3'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Reorder and/or duplicate video planes.
 
 It accepts the following parameters:
@@ -19923,7 +19923,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#shuffleplanes)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -19931,44 +19931,44 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='shuffleplanes', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "map0": map0,
-                
+
                 "map1": map1,
-                
+
                 "map2": map2,
-                
+
                 "map3": map3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def sidedata(
-    
+
     self,
 
 
@@ -19976,15 +19976,15 @@ References:
 
     *,
     mode: Int| Literal["select","delete"] | Default = Default('select'),type: Int| Literal["PANSCAN","A53_CC","STEREO3D","MATRIXENCODING","DOWNMIX_INFO","REPLAYGAIN","DISPLAYMATRIX","AFD","MOTION_VECTORS","SKIP_SAMPLES","AUDIO_SERVICE_TYPE","MASTERING_DISPLAY_METADATA","GOP_TIMECODE","SPHERICAL","CONTENT_LIGHT_LEVEL","ICC_PROFILE","S12M_TIMECOD","DYNAMIC_HDR_PLUS","REGIONS_OF_INTEREST","VIDEO_ENC_PARAMS","SEI_UNREGISTERED","FILM_GRAIN_PARAMS","DETECTION_BOUNDING_BOXES","DETECTION_BBOXES","DOVI_RPU_BUFFER","DOVI_METADATA","DYNAMIC_HDR_VIVID","AMBIENT_VIEWING_ENVIRONMENT","VIDEO_HINT"] | Default = Default('-1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Delete frame side data, or select frames based on it.
 
 This filter accepts the following options:
@@ -20003,7 +20003,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sidedata)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -20011,38 +20011,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sidedata', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def signalstats(
-    
+
     self,
 
 
@@ -20050,12 +20050,12 @@ References:
 
     *,
     stat: Flags| Literal["tout","vrep","brng"] | Default = Default('0'),out: Int| Literal["tout","vrep","brng"] | Default = Default('-1'),c: Color = Default('yellow'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Evaluate various visual metrics that assist in determining issues associated
 with the digitization of analog video media.
 
@@ -20075,51 +20075,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#signalstats)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='signalstats', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "stat": stat,
-                
+
                 "out": out,
-                
+
                 "c": c,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     def siti(
-    
+
     self,
 
 
@@ -20127,12 +20127,12 @@ References:
 
     *,
     print_summary: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Calculate Spatial Information (SI) and Temporal Information (TI) scores for a video,
 as defined in ITU-T Rec. P.910 (11/21): Subjective video quality assessment methods
 for multimedia applications. Available PDF at https://www.itu.int/rec/T-REC-P.910-202111-S/en.
@@ -20153,37 +20153,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#siti)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='siti', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "print_summary": print_summary,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def smartblur(
-    
+
     self,
 
 
@@ -20191,15 +20191,15 @@ References:
 
     *,
     luma_radius: Float = Default('1'),luma_strength: Float = Default('1'),luma_threshold: Int = Default('0'),chroma_radius: Float = Default('-0.9'),chroma_strength: Float = Default('-2'),chroma_threshold: Int = Default('-31'),alpha_radius: Float = Default('-0.9'),alpha_strength: Float = Default('-2'),alpha_threshold: Int = Default('-31'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Blur the input video without impacting the outlines.
 
 It accepts the following options:
@@ -20225,7 +20225,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#smartblur)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -20233,54 +20233,54 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='smartblur', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_radius": luma_radius,
-                
+
                 "luma_strength": luma_strength,
-                
+
                 "luma_threshold": luma_threshold,
-                
+
                 "chroma_radius": chroma_radius,
-                
+
                 "chroma_strength": chroma_strength,
-                
+
                 "chroma_threshold": chroma_threshold,
-                
+
                 "alpha_radius": alpha_radius,
-                
+
                 "alpha_strength": alpha_strength,
-                
+
                 "alpha_threshold": alpha_threshold,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def sobel(
-    
+
     self,
 
 
@@ -20288,15 +20288,15 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply sobel operator to input video stream.
 
 The filter accepts the following option:
@@ -20316,7 +20316,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sobel)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -20324,38 +20324,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sobel', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def sobel_opencl(
-    
+
     self,
 
 
@@ -20363,12 +20363,12 @@ References:
 
     *,
     planes: Int = Default('15'),scale: Float = Default('1'),delta: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply the Sobel operator (https://en.wikipedia.org/wiki/Sobel_operator) to input video stream.
 
 The filter accepts the following option:
@@ -20387,62 +20387,62 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#sobel_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='sobel_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "scale": scale,
-                
+
                 "delta": delta,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def spectrumsynth(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _phase: VideoStream,
-        
-    
+
+
 
 
     *,
     sample_rate: Int = Default('44100'),channels: Int = Default('1'),scale: Int| Literal["lin","log"] | Default = Default('log'),slide: Int| Literal["replace","scroll","fullframe","rscroll"] | Default = Default('fullframe'),win_func: Int| Literal["rect","bartlett","hann","hanning","hamming","blackman","welch","flattop","bharris","bnuttall","bhann","sine","nuttall","lanczos","gauss","tukey","dolph","cauchy","parzen","poisson","bohman","kaiser"] | Default = Default('rect'),overlap: Float = Default('1'),orientation: Int| Literal["vertical","horizontal"] | Default = Default('vertical'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> AudioStream:
         """
-        
+
 Synthesize audio from 2 input video spectrums, first input stream represents
 magnitude across time and second represents phase across time.
 The filter will transform from frequency domain as displayed in videos back
@@ -20479,59 +20479,59 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#spectrumsynth)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='spectrumsynth', typings_input=('video', 'video'), typings_output=('audio',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _phase,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "sample_rate": sample_rate,
-                
+
                 "channels": channels,
-                
+
                 "scale": scale,
-                
+
                 "slide": slide,
-                
+
                 "win_func": win_func,
-                
+
                 "overlap": overlap,
-                
+
                 "orientation": orientation,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.audio(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def split(
-    
+
     self,
 
 
@@ -20539,12 +20539,12 @@ References:
 
     *,
     outputs: Int = Default('2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> FilterNode:
         """
-        
+
 Split input into several identical outputs.
 
 asplit works with audio input, split with video.
@@ -20565,38 +20565,38 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#split)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='split', typings_input=('video',), typings_output='[StreamType.video] * int(outputs)'),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "outputs": outputs,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
 
         return filter_node
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def spp(
-    
+
     self,
 
 
@@ -20604,15 +20604,15 @@ References:
 
     *,
     quality: Int = Default('3'),qp: Int = Default('0'),mode: Int| Literal["hard","soft"] | Default = Default('hard'),use_bframe_qp: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a simple postprocessing filter that compresses and decompresses the image
 at several (or - in the case of quality level 6 - all) shifts
 and average the results.
@@ -20635,7 +20635,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#spp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -20643,69 +20643,69 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='spp', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "quality": quality,
-                
+
                 "qp": qp,
-                
+
                 "mode": mode,
-                
+
                 "use_bframe_qp": use_bframe_qp,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ssim(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the SSIM (Structural SImilarity Metric) between two input videos.
 
 This filter takes in input two input videos, the first input is
@@ -20735,7 +20735,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#ssim)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -20746,70 +20746,70 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ssim', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "stats_file": stats_file,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def ssim360(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),compute_chroma: Int = Default('1'),frame_skip_ratio: Int = Default('0'),ref_projection: Int| Literal["e","equirect","c3x2","c2x3","barrel","barrelsplit"] | Default = Default('e'),main_projection: Int| Literal["e","equirect","c3x2","c2x3","barrel","barrelsplit"] | Default = Default('5'),ref_stereo: Int| Literal["mono","tb","lr"] | Default = Default('mono'),main_stereo: Int| Literal["mono","tb","lr"] | Default = Default('3'),ref_pad: Float = Default('0'),main_pad: Float = Default('0'),use_tape: Int = Default('0'),heatmap_str: String = Default(None),default_heatmap_width: Int = Default('32'),default_heatmap_height: Int = Default('16'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Calculate the SSIM between two 360 video streams.
 
 
@@ -20837,7 +20837,7 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -20845,66 +20845,66 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='ssim360', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "stats_file": stats_file,
-                
+
                 "compute_chroma": compute_chroma,
-                
+
                 "frame_skip_ratio": frame_skip_ratio,
-                
+
                 "ref_projection": ref_projection,
-                
+
                 "main_projection": main_projection,
-                
+
                 "ref_stereo": ref_stereo,
-                
+
                 "main_stereo": main_stereo,
-                
+
                 "ref_pad": ref_pad,
-                
+
                 "main_pad": main_pad,
-                
+
                 "use_tape": use_tape,
-                
+
                 "heatmap_str": heatmap_str,
-                
+
                 "default_heatmap_width": default_heatmap_width,
-                
+
                 "default_heatmap_height": default_heatmap_height,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def stereo3d(
-    
+
     self,
 
 
@@ -20912,12 +20912,12 @@ References:
 
     *,
     _in: Int| Literal["ab2l","tb2l","ab2r","tb2r","abl","tbl","abr","tbr","al","ar","sbs2l","sbs2r","sbsl","sbsr","irl","irr","icl","icr"] | Default = Default('sbsl'),out: Int| Literal["ab2l","tb2l","ab2r","tb2r","abl","tbl","abr","tbr","agmc","agmd","agmg","agmh","al","ar","arbg","arcc","arcd","arcg","arch","argg","aybc","aybd","aybg","aybh","irl","irr","ml","mr","sbs2l","sbs2r","sbsl","sbsr","chl","chr","icl","icr","hdmi"] | Default = Default('arcd'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert between different stereoscopic image formats.
 
 The filters accept the following options:
@@ -20935,45 +20935,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#stereo3d)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='stereo3d', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "in": _in,
-                
+
                 "out": out,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
     def subtitles(
-    
+
     self,
 
 
@@ -20981,12 +20981,12 @@ References:
 
     *,
     filename: String = Default(None),original_size: Image_size = Default(None),fontsdir: String = Default(None),alpha: Boolean = Default('false'),charenc: String = Default(None),stream_index: Int = Default('-1'),force_style: String = Default(None),wrap_unicode: Boolean = Default('auto'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Draw subtitles on top of input video using the libass library.
 
 To enable compilation of this filter you need to configure FFmpeg with
@@ -21015,64 +21015,64 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#subtitles)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='subtitles', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "filename": filename,
-                
+
                 "original_size": original_size,
-                
+
                 "fontsdir": fontsdir,
-                
+
                 "alpha": alpha,
-                
+
                 "charenc": charenc,
-                
+
                 "stream_index": stream_index,
-                
+
                 "force_style": force_style,
-                
+
                 "wrap_unicode": wrap_unicode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def super2xsai(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Scale the input by 2x and smooth using the Super2xSaI (Scale and
 Interpolate) pixel art scaling algorithm.
 
@@ -21089,39 +21089,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#super2xsai)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='super2xsai', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def swaprect(
-    
+
     self,
 
 
@@ -21129,15 +21129,15 @@ References:
 
     *,
     w: String = Default('w/2'),h: String = Default('h/2'),x1: String = Default('w/2'),y1: String = Default('h/2'),x2: String = Default('0'),y2: String = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Swap two rectangular objects in video.
 
 This filter accepts the following options:
@@ -21160,7 +21160,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#swaprect)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -21168,60 +21168,60 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='swaprect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "x1": x1,
-                
+
                 "y1": y1,
-                
+
                 "x2": x2,
-                
+
                 "y2": y2,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def swapuv(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Swap U & V plane.
 
 
@@ -21236,7 +21236,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#swapuv)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -21244,32 +21244,32 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='swapuv', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tblend(
-    
+
     self,
 
 
@@ -21277,15 +21277,15 @@ References:
 
     *,
     c0_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c1_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c2_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),c3_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('normal'),all_mode: Int| Literal["addition","addition128","grainmerge","and","average","burn","darken","difference","difference128","grainextract","divide","dodge","exclusion","extremity","freeze","glow","hardlight","hardmix","heat","lighten","linearlight","multiply","multiply128","negation","normal","or","overlay","phoenix","pinlight","reflect","screen","softlight","subtract","vividlight","xor","softdifference","geometric","harmonic","bleach","stain","interpolate","hardoverlay"] | Default = Default('-1'),c0_expr: String = Default(None),c1_expr: String = Default(None),c2_expr: String = Default(None),c3_expr: String = Default(None),all_expr: String = Default(None),c0_opacity: Double = Default('1'),c1_opacity: Double = Default('1'),c2_opacity: Double = Default('1'),c3_opacity: Double = Default('1'),all_opacity: Double = Default('1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Blend successive video frames.
 
 See blend
@@ -21317,7 +21317,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tblend)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -21325,62 +21325,62 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tblend', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "c0_mode": c0_mode,
-                
+
                 "c1_mode": c1_mode,
-                
+
                 "c2_mode": c2_mode,
-                
+
                 "c3_mode": c3_mode,
-                
+
                 "all_mode": all_mode,
-                
+
                 "c0_expr": c0_expr,
-                
+
                 "c1_expr": c1_expr,
-                
+
                 "c2_expr": c2_expr,
-                
+
                 "c3_expr": c3_expr,
-                
+
                 "all_expr": all_expr,
-                
+
                 "c0_opacity": c0_opacity,
-                
+
                 "c1_opacity": c1_opacity,
-                
+
                 "c2_opacity": c2_opacity,
-                
+
                 "c3_opacity": c3_opacity,
-                
+
                 "all_opacity": all_opacity,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def telecine(
-    
+
     self,
 
 
@@ -21388,12 +21388,12 @@ References:
 
     *,
     first_field: Int| Literal["top","t","bottom","b"] | Default = Default('top'),pattern: String = Default('23'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply telecine process to the video.
 
 This filter accepts the following options:
@@ -21411,43 +21411,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#telecine)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='telecine', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "first_field": first_field,
-                
+
                 "pattern": pattern,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def thistogram(
-    
+
     self,
 
 
@@ -21455,12 +21455,12 @@ References:
 
     *,
     width: Int = Default('0'),display_mode: Int| Literal["overlay","parade","stack"] | Default = Default('stack'),levels_mode: Int| Literal["linear","logarithmic"] | Default = Default('linear'),components: Int = Default('7'),bgopacity: Float = Default('0.9'),envelope: Boolean = Default('false'),ecolor: Color = Default('gold'),slide: Int| Literal["frame","replace","scroll","rscroll","picture"] | Default = Default('replace'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Compute and draw a color distribution histogram for the input video across time.
 
 Unlike histogram video filter which only shows histogram of single input frame
@@ -21491,83 +21491,83 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#thistogram)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='thistogram', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "width": width,
-                
+
                 "display_mode": display_mode,
-                
+
                 "levels_mode": levels_mode,
-                
+
                 "components": components,
-                
+
                 "bgopacity": bgopacity,
-                
+
                 "envelope": envelope,
-                
+
                 "ecolor": ecolor,
-                
+
                 "slide": slide,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def threshold(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _threshold: VideoStream,
-        
-    
-        
+
+
+
         _min: VideoStream,
-        
-    
-        
+
+
+
         _max: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply threshold effect to video stream.
 
 This filter needs four video streams to perform thresholding.
@@ -21590,7 +21590,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#threshold)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -21598,50 +21598,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='threshold', typings_input=('video', 'video', 'video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _threshold,
-                
-            
-                
+
+
+
                 _min,
-                
-            
-                
+
+
+
                 _max,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def thumbnail(
-    
+
     self,
 
 
@@ -21649,15 +21649,15 @@ References:
 
     *,
     n: Int = Default('100'),log: Int| Literal["quiet","info","verbose"] | Default = Default('info'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Select the most representative frame in a given sequence of consecutive frames.
 
 The filter accepts the following options:
@@ -21676,7 +21676,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#thumbnail)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -21684,36 +21684,36 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='thumbnail', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "n": n,
-                
+
                 "log": log,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tile(
-    
+
     self,
 
 
@@ -21721,12 +21721,12 @@ References:
 
     *,
     layout: Image_size = Default('6x5'),nb_frames: Int = Default('0'),margin: Int = Default('0'),padding: Int = Default('0'),color: Color = Default('black'),overlap: Int = Default('0'),init_padding: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Tile several successive frames together.
 
 The untile filter can do the reverse.
@@ -21751,49 +21751,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tile)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tile', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "layout": layout,
-                
+
                 "nb_frames": nb_frames,
-                
+
                 "margin": margin,
-                
+
                 "padding": padding,
-                
+
                 "color": color,
-                
+
                 "overlap": overlap,
-                
+
                 "init_padding": init_padding,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tiltandshift(
-    
+
     self,
 
 
@@ -21801,12 +21801,12 @@ References:
 
     *,
     tilt: Int = Default('1'),start: Int| Literal["none","frame","black"] | Default = Default('none'),end: Int| Literal["none","frame","black"] | Default = Default('none'),hold: Int = Default('0'),pad: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply tilt-and-shift effect.
 
 What happens when you invert time and space?
@@ -21848,47 +21848,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tiltandshift)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tiltandshift', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "tilt": tilt,
-                
+
                 "start": start,
-                
+
                 "end": end,
-                
+
                 "hold": hold,
-                
+
                 "pad": pad,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def tinterlace(
-    
+
     self,
 
 
@@ -21896,12 +21896,12 @@ References:
 
     *,
     mode: Int| Literal["merge","drop_even","drop_odd","pad","interleave_top","interleave_bottom","interlacex2","mergex2"] | Default = Default('merge'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Perform various types of temporal field interlacing.
 
 Frames are counted starting from 1, so the first input frame is
@@ -21921,37 +21921,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tinterlace)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tinterlace', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tlut2(
-    
+
     self,
 
 
@@ -21959,15 +21959,15 @@ References:
 
     *,
     c0: String = Default('x'),c1: String = Default('x'),c2: String = Default('x'),c3: String = Default('x'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The lut2 filter takes two input streams and outputs one
 stream.
 
@@ -21992,7 +21992,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#lut2)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -22000,40 +22000,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tlut2', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "c0": c0,
-                
+
                 "c1": c1,
-                
+
                 "c2": c2,
-                
+
                 "c3": c3,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tmedian(
-    
+
     self,
 
 
@@ -22041,15 +22041,15 @@ References:
 
     *,
     radius: Int = Default('1'),planes: Int = Default('15'),percentile: Float = Default('0.5'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Pick median pixels from several successive input video frames.
 
 The filter accepts the following options:
@@ -22069,7 +22069,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tmedian)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -22077,38 +22077,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tmedian', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "radius": radius,
-                
+
                 "planes": planes,
-                
+
                 "percentile": percentile,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tmidequalizer(
-    
+
     self,
 
 
@@ -22116,15 +22116,15 @@ References:
 
     *,
     radius: Int = Default('5'),sigma: Float = Default('0.5'),planes: Int = Default('15'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Temporal Midway Video Equalization effect.
 
 Midway Video Equalization adjusts a sequence of video frames to have the same
@@ -22148,7 +22148,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tmidequalizer)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -22156,38 +22156,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tmidequalizer', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "radius": radius,
-                
+
                 "sigma": sigma,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tmix(
-    
+
     self,
 
 
@@ -22195,15 +22195,15 @@ References:
 
     *,
     frames: Int = Default('3'),weights: String = Default('1 1 1'),scale: Float = Default('0'),planes: Flags = Default('F'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Mix successive video frames.
 
 A description of the accepted options follows.
@@ -22224,7 +22224,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tmix)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -22232,40 +22232,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tmix', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "frames": frames,
-                
+
                 "weights": weights,
-                
+
                 "scale": scale,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tonemap(
-    
+
     self,
 
 
@@ -22273,12 +22273,12 @@ References:
 
     *,
     tonemap: Int| Literal["none","linear","gamma","clip","reinhard","hable","mobius"] | Default = Default('none'),param: Double = Default('nan'),desat: Double = Default('2'),peak: Double = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Tone map colors from different dynamic ranges.
 
 This filter expects data in single precision floating point, as it needs to
@@ -22307,43 +22307,43 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tonemap)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tonemap', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "tonemap": tonemap,
-                
+
                 "param": param,
-                
+
                 "desat": desat,
-                
+
                 "peak": peak,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tonemap_opencl(
-    
+
     self,
 
 
@@ -22351,12 +22351,12 @@ References:
 
     *,
     tonemap: Int| Literal["none","linear","gamma","clip","reinhard","hable","mobius"] | Default = Default('none'),transfer: Int| Literal["bt709","bt2020"] | Default = Default('bt709'),matrix: Int| Literal["bt709","bt2020"] | Default = Default('-1'),primaries: Int| Literal["bt709","bt2020"] | Default = Default('-1'),range: Int| Literal["tv","pc","limited","full"] | Default = Default('-1'),format: Pix_fmt = Default('none'),peak: Double = Default('0'),param: Double = Default('nan'),desat: Double = Default('0.5'),threshold: Double = Default('0.2'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Perform HDR(PQ/HLG) to SDR conversion with tone-mapping.
 
 It accepts the following parameters:
@@ -22382,55 +22382,55 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tonemap_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tonemap_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "tonemap": tonemap,
-                
+
                 "transfer": transfer,
-                
+
                 "matrix": matrix,
-                
+
                 "primaries": primaries,
-                
+
                 "range": range,
-                
+
                 "format": format,
-                
+
                 "peak": peak,
-                
+
                 "param": param,
-                
+
                 "desat": desat,
-                
+
                 "threshold": threshold,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tonemap_vaapi(
-    
+
     self,
 
 
@@ -22438,12 +22438,12 @@ References:
 
     *,
     format: String = Default(None),matrix: String = Default(None),primaries: String = Default(None),transfer: String = Default(None),display: String = Default(None),light: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Perform HDR-to-SDR or HDR-to-HDR tone-mapping.
 It currently only accepts HDR10 as input.
 
@@ -22466,47 +22466,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tonemap_vaapi)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tonemap_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "format": format,
-                
+
                 "matrix": matrix,
-                
+
                 "primaries": primaries,
-                
+
                 "transfer": transfer,
-                
+
                 "display": display,
-                
+
                 "light": light,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def tpad(
-    
+
     self,
 
 
@@ -22514,12 +22514,12 @@ References:
 
     *,
     start: Int = Default('0'),stop: Int = Default('0'),start_mode: Int| Literal["add","clone"] | Default = Default('add'),stop_mode: Int| Literal["add","clone"] | Default = Default('add'),start_duration: Duration = Default('0'),stop_duration: Duration = Default('0'),color: Color = Default('black'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Temporarily pad video frames.
 
 The filter accepts the following options:
@@ -22542,49 +22542,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#tpad)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='tpad', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "start": start,
-                
+
                 "stop": stop,
-                
+
                 "start_mode": start_mode,
-                
+
                 "stop_mode": stop_mode,
-                
+
                 "start_duration": start_duration,
-                
+
                 "stop_duration": stop_duration,
-                
+
                 "color": color,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def transpose(
-    
+
     self,
 
 
@@ -22592,12 +22592,12 @@ References:
 
     *,
     dir: Int| Literal["cclock_flip","clock","cclock","clock_flip"] | Default = Default('cclock_flip'),passthrough: Int| Literal["none","portrait","landscape"] | Default = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Transpose rows with columns in the input video and optionally flip it.
 
 It accepts the following parameters:
@@ -22615,39 +22615,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#transpose)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='transpose', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dir": dir,
-                
+
                 "passthrough": passthrough,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def transpose_opencl(
-    
+
     self,
 
 
@@ -22655,12 +22655,12 @@ References:
 
     *,
     dir: Int| Literal["cclock_flip","clock","cclock","clock_flip"] | Default = Default('cclock_flip'),passthrough: Int| Literal["none","portrait","landscape"] | Default = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Transpose input video
 
 
@@ -22676,39 +22676,39 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='transpose_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dir": dir,
-                
+
                 "passthrough": passthrough,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def transpose_vaapi(
-    
+
     self,
 
 
@@ -22716,12 +22716,12 @@ References:
 
     *,
     dir: Int| Literal["cclock_flip","clock","cclock","clock_flip","reversal","hflip","vflip"] | Default = Default('cclock_flip'),passthrough: Int| Literal["none","portrait","landscape"] | Default = Default('none'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 VAAPI VPP for transpose
 
 
@@ -22737,43 +22737,43 @@ References:
     [FFmpeg Documentation](None)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='transpose_vaapi', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "dir": dir,
-                
+
                 "passthrough": passthrough,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def trim(
-    
+
     self,
 
 
@@ -22781,12 +22781,12 @@ References:
 
     *,
     start: Duration = Default('INT64_MAX'),end: Duration = Default('INT64_MAX'),start_pts: Int64 = Default('I64_MIN'),end_pts: Int64 = Default('I64_MIN'),duration: Duration = Default('0'),start_frame: Int64 = Default('-1'),end_frame: Int64 = Default('I64_MAX'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Trim the input so that the output contains one continuous subpart of the input.
 
 It accepts the following parameters:
@@ -22809,51 +22809,51 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#trim)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='trim', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "start": start,
-                
+
                 "end": end,
-                
+
                 "start_pts": start_pts,
-                
+
                 "end_pts": end_pts,
-                
+
                 "duration": duration,
-                
+
                 "start_frame": start_frame,
-                
+
                 "end_frame": end_frame,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def unsharp(
-    
+
     self,
 
 
@@ -22861,15 +22861,15 @@ References:
 
     *,
     luma_msize_x: Int = Default('5'),luma_msize_y: Int = Default('5'),luma_amount: Float = Default('1'),chroma_msize_x: Int = Default('5'),chroma_msize_y: Int = Default('5'),chroma_amount: Float = Default('0'),alpha_msize_x: Int = Default('5'),alpha_msize_y: Int = Default('5'),alpha_amount: Float = Default('0'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Sharpen or blur the input video.
 
 It accepts the following parameters:
@@ -22895,7 +22895,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#unsharp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -22903,50 +22903,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='unsharp', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_msize_x": luma_msize_x,
-                
+
                 "luma_msize_y": luma_msize_y,
-                
+
                 "luma_amount": luma_amount,
-                
+
                 "chroma_msize_x": chroma_msize_x,
-                
+
                 "chroma_msize_y": chroma_msize_y,
-                
+
                 "chroma_amount": chroma_amount,
-                
+
                 "alpha_msize_x": alpha_msize_x,
-                
+
                 "alpha_msize_y": alpha_msize_y,
-                
+
                 "alpha_amount": alpha_amount,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def unsharp_opencl(
-    
+
     self,
 
 
@@ -22954,12 +22954,12 @@ References:
 
     *,
     luma_msize_x: Float = Default('5'),luma_msize_y: Float = Default('5'),luma_amount: Float = Default('1'),chroma_msize_x: Float = Default('5'),chroma_msize_y: Float = Default('5'),chroma_amount: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Sharpen or blur the input video.
 
 It accepts the following parameters:
@@ -22981,47 +22981,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#unsharp_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='unsharp_opencl', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "luma_msize_x": luma_msize_x,
-                
+
                 "luma_msize_y": luma_msize_y,
-                
+
                 "luma_amount": luma_amount,
-                
+
                 "chroma_msize_x": chroma_msize_x,
-                
+
                 "chroma_msize_y": chroma_msize_y,
-                
+
                 "chroma_amount": chroma_amount,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def untile(
-    
+
     self,
 
 
@@ -23029,12 +23029,12 @@ References:
 
     *,
     layout: Image_size = Default('6x5'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Decompose a video made of tiled images into the individual images.
 
 The frame rate of the output video is the frame rate of the input video
@@ -23056,37 +23056,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#untile)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='untile', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "layout": layout,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def uspp(
-    
+
     self,
 
 
@@ -23094,15 +23094,15 @@ References:
 
     *,
     quality: Int = Default('3'),qp: Int = Default('0'),use_bframe_qp: Boolean = Default('false'),codec: String = Default('snow'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply ultra slow/simple postprocessing filter that compresses and decompresses
 the image at several (or - in the case of quality level 8 - all)
 shifts and average the results.
@@ -23131,7 +23131,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#uspp)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -23139,40 +23139,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='uspp', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "quality": quality,
-                
+
                 "qp": qp,
-                
+
                 "use_bframe_qp": use_bframe_qp,
-                
+
                 "codec": codec,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def v360(
-    
+
     self,
 
 
@@ -23180,12 +23180,12 @@ References:
 
     *,
     input: Int| Literal["e","equirect","c3x2","c6x1","eac","dfisheye","flat","rectilinear","gnomonic","barrel","fb","c1x6","sg","mercator","ball","hammer","sinusoidal","fisheye","pannini","cylindrical","tetrahedron","barrelsplit","tsp","hequirect","he","equisolid","og","octahedron","cylindricalea"] | Default = Default('e'),output: Int| Literal["e","equirect","c3x2","c6x1","eac","dfisheye","flat","rectilinear","gnomonic","barrel","fb","c1x6","sg","mercator","ball","hammer","sinusoidal","fisheye","pannini","cylindrical","perspective","tetrahedron","barrelsplit","tsp","hequirect","he","equisolid","og","octahedron","cylindricalea"] | Default = Default('c3x2'),interp: Int| Literal["near","nearest","line","linear","lagrange9","cube","cubic","lanc","lanczos","sp16","spline16","gauss","gaussian","mitchell"] | Default = Default('line'),w: Int = Default('0'),h: Int = Default('0'),in_stereo: Int| Literal["2d","sbs","tb"] | Default = Default('2d'),out_stereo: Int| Literal["2d","sbs","tb"] | Default = Default('2d'),in_forder: String = Default('rludfb'),out_forder: String = Default('rludfb'),in_frot: String = Default('000000'),out_frot: String = Default('000000'),in_pad: Float = Default('0'),out_pad: Float = Default('0'),fin_pad: Int = Default('0'),fout_pad: Int = Default('0'),yaw: Float = Default('0'),pitch: Float = Default('0'),roll: Float = Default('0'),rorder: String = Default('ypr'),h_fov: Float = Default('0'),v_fov: Float = Default('0'),d_fov: Float = Default('0'),h_flip: Boolean = Default('false'),v_flip: Boolean = Default('false'),d_flip: Boolean = Default('false'),ih_flip: Boolean = Default('false'),iv_flip: Boolean = Default('false'),in_trans: Boolean = Default('false'),out_trans: Boolean = Default('false'),ih_fov: Float = Default('0'),iv_fov: Float = Default('0'),id_fov: Float = Default('0'),h_offset: Float = Default('0'),v_offset: Float = Default('0'),alpha_mask: Boolean = Default('false'),reset_rot: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Convert 360 videos between various formats.
 
 The filter accepts the following options:
@@ -23237,107 +23237,107 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#v360)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='v360', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "input": input,
-                
+
                 "output": output,
-                
+
                 "interp": interp,
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "in_stereo": in_stereo,
-                
+
                 "out_stereo": out_stereo,
-                
+
                 "in_forder": in_forder,
-                
+
                 "out_forder": out_forder,
-                
+
                 "in_frot": in_frot,
-                
+
                 "out_frot": out_frot,
-                
+
                 "in_pad": in_pad,
-                
+
                 "out_pad": out_pad,
-                
+
                 "fin_pad": fin_pad,
-                
+
                 "fout_pad": fout_pad,
-                
+
                 "yaw": yaw,
-                
+
                 "pitch": pitch,
-                
+
                 "roll": roll,
-                
+
                 "rorder": rorder,
-                
+
                 "h_fov": h_fov,
-                
+
                 "v_fov": v_fov,
-                
+
                 "d_fov": d_fov,
-                
+
                 "h_flip": h_flip,
-                
+
                 "v_flip": v_flip,
-                
+
                 "d_flip": d_flip,
-                
+
                 "ih_flip": ih_flip,
-                
+
                 "iv_flip": iv_flip,
-                
+
                 "in_trans": in_trans,
-                
+
                 "out_trans": out_trans,
-                
+
                 "ih_fov": ih_fov,
-                
+
                 "iv_fov": iv_fov,
-                
+
                 "id_fov": id_fov,
-                
+
                 "h_offset": h_offset,
-                
+
                 "v_offset": v_offset,
-                
+
                 "alpha_mask": alpha_mask,
-                
+
                 "reset_rot": reset_rot,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vaguedenoiser(
-    
+
     self,
 
 
@@ -23345,15 +23345,15 @@ References:
 
     *,
     threshold: Float = Default('2'),method: Int| Literal["hard","soft","garrote"] | Default = Default('garrote'),nsteps: Int = Default('6'),percent: Float = Default('85'),planes: Int = Default('15'),type: Int| Literal["universal","bayes"] | Default = Default('universal'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply a wavelet based denoiser.
 
 It transforms each frame from the video input into the wavelet domain,
@@ -23382,7 +23382,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vaguedenoiser)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -23390,73 +23390,73 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vaguedenoiser', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "threshold": threshold,
-                
+
                 "method": method,
-                
+
                 "nsteps": nsteps,
-                
+
                 "percent": percent,
-                
+
                 "planes": planes,
-                
+
                 "type": type,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def varblur(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _radius: VideoStream,
-        
-    
+
+
 
 
     *,
     min_r: Int = Default('0'),max_r: Int = Default('8'),planes: Int = Default('15'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply variable blur filter by using 2nd video stream to set blur radius.
 The 2nd stream must have the same dimensions.
 
@@ -23478,7 +23478,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#varblur)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -23489,48 +23489,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='varblur', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _radius,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "min_r": min_r,
-                
+
                 "max_r": max_r,
-                
+
                 "planes": planes,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vectorscope(
-    
+
     self,
 
 
@@ -23538,12 +23538,12 @@ References:
 
     *,
     mode: Int| Literal["gray","tint","color","color2","color3","color4","color5"] | Default = Default('gray'),x: Int = Default('1'),y: Int = Default('2'),intensity: Float = Default('0.004'),envelope: Int| Literal["none","instant","peak","peak+instant"] | Default = Default('none'),graticule: Int| Literal["none","green","color","invert"] | Default = Default('none'),opacity: Float = Default('0.75'),flags: Flags| Literal["white","black","name"] | Default = Default('name'),bgopacity: Float = Default('0.3'),lthreshold: Float = Default('0'),hthreshold: Float = Default('1'),colorspace: Int| Literal["auto","601","709"] | Default = Default('auto'),tint0: Float = Default('0'),tint1: Float = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Display 2 color component values in the two dimensional graph (which is called
 a vectorscope).
 
@@ -23574,79 +23574,79 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vectorscope)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vectorscope', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "intensity": intensity,
-                
+
                 "envelope": envelope,
-                
+
                 "graticule": graticule,
-                
+
                 "opacity": opacity,
-                
+
                 "flags": flags,
-                
+
                 "bgopacity": bgopacity,
-                
+
                 "lthreshold": lthreshold,
-                
+
                 "hthreshold": hthreshold,
-                
+
                 "colorspace": colorspace,
-                
+
                 "tint0": tint0,
-                
+
                 "tint1": tint1,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vflip(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Flip the input video vertically.
 
 For example, to vertically flip a video with ffmpeg:
@@ -23666,7 +23666,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vflip)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -23674,45 +23674,45 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vflip', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vfrdet(
-    
+
     self,
 
 
 
 
-    
-    
-    
-    
+
+
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Detect variable frame rate video.
 
 This filter tries to detect if the input is variable or constant frame rate.
@@ -23733,35 +23733,35 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vfrdet)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vfrdet', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vibrance(
-    
+
     self,
 
 
@@ -23769,15 +23769,15 @@ References:
 
     *,
     intensity: Float = Default('0'),rbal: Float = Default('1'),gbal: Float = Default('1'),bbal: Float = Default('1'),rlum: Float = Default('0.212656'),glum: Float = Default('0.715158'),blum: Float = Default('0.072186'),alternate: Boolean = Default('false'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Boost or alter saturation.
 
 The filter accepts the following options:
@@ -23802,7 +23802,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vibrance)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -23810,50 +23810,50 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vibrance', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "intensity": intensity,
-                
+
                 "rbal": rbal,
-                
+
                 "gbal": gbal,
-                
+
                 "bbal": bbal,
-                
+
                 "rlum": rlum,
-                
+
                 "glum": glum,
-                
+
                 "blum": blum,
-                
+
                 "alternate": alternate,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def vidstabdetect(
-    
+
     self,
 
 
@@ -23861,12 +23861,12 @@ References:
 
     *,
     result: String = Default('transforms.trf'),shakiness: Int = Default('5'),accuracy: Int = Default('15'),stepsize: Int = Default('6'),mincontrast: Double = Default('0.25'),show: Int = Default('0'),tripod: Int = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Analyze video stabilization/deshaking. Perform pass 1 of 2, see
 vidstabtransform for pass 2.
 
@@ -23897,49 +23897,49 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vidstabdetect)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vidstabdetect', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "result": result,
-                
+
                 "shakiness": shakiness,
-                
+
                 "accuracy": accuracy,
-                
+
                 "stepsize": stepsize,
-                
+
                 "mincontrast": mincontrast,
-                
+
                 "show": show,
-                
+
                 "tripod": tripod,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vidstabtransform(
-    
+
     self,
 
 
@@ -23947,12 +23947,12 @@ References:
 
     *,
     input: String = Default('transforms.trf'),smoothing: Int = Default('15'),optalgo: Int| Literal["opt","gauss","avg"] | Default = Default('opt'),maxshift: Int = Default('-1'),maxangle: Double = Default('-1'),crop: Int| Literal["keep","black"] | Default = Default('keep'),invert: Int = Default('0'),relative: Int = Default('1'),zoom: Double = Default('0'),optzoom: Int = Default('1'),zoomspeed: Double = Default('0.25'),interpol: Int| Literal["no","linear","bilinear","bicubic"] | Default = Default('bilinear'),tripod: Boolean = Default('false'),debug: Boolean = Default('false'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Video stabilization/deshaking: pass 2 of 2,
 see vidstabdetect for pass 1.
 
@@ -23990,92 +23990,92 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vidstabtransform)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vidstabtransform', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "input": input,
-                
+
                 "smoothing": smoothing,
-                
+
                 "optalgo": optalgo,
-                
+
                 "maxshift": maxshift,
-                
+
                 "maxangle": maxangle,
-                
+
                 "crop": crop,
-                
+
                 "invert": invert,
-                
+
                 "relative": relative,
-                
+
                 "zoom": zoom,
-                
+
                 "optzoom": optzoom,
-                
+
                 "zoomspeed": zoomspeed,
-                
+
                 "interpol": interpol,
-                
+
                 "tripod": tripod,
-                
+
                 "debug": debug,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vif(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
 
 
-    
-    
-    
+
+
+
+
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the average VIF (Visual Information Fidelity) between two input videos.
 
 This filter takes two input videos.
@@ -24112,7 +24112,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vif)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -24123,42 +24123,42 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vif', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def vignette(
-    
+
     self,
 
 
@@ -24166,15 +24166,15 @@ References:
 
     *,
     angle: String = Default('PI/5'),x0: String = Default('w/2'),y0: String = Default('h/2'),mode: Int| Literal["forward","backward"] | Default = Default('forward'),eval: Int| Literal["init","frame"] | Default = Default('init'),dither: Boolean = Default('true'),aspect: Rational = Default('1/1'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Make or reverse a natural vignetting effect.
 
 The filter accepts the following options:
@@ -24198,7 +24198,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vignette)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -24206,48 +24206,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vignette', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "angle": angle,
-                
+
                 "x0": x0,
-                
+
                 "y0": y0,
-                
+
                 "mode": mode,
-                
+
                 "eval": eval,
-                
+
                 "dither": dither,
-                
+
                 "aspect": aspect,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def vmafmotion(
-    
+
     self,
 
 
@@ -24255,12 +24255,12 @@ References:
 
     *,
     stats_file: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the average VMAF motion score of a video.
 It is one of the component metrics of VMAF.
 
@@ -24280,45 +24280,45 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#vmafmotion)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='vmafmotion', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "stats_file": stats_file,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
+
+
+
+
     def w3fdif(
-    
+
     self,
 
 
@@ -24326,15 +24326,15 @@ References:
 
     *,
     filter: Int| Literal["simple","complex"] | Default = Default('complex'),mode: Int| Literal["frame","field"] | Default = Default('field'),parity: Int| Literal["tff","bff","auto"] | Default = Default('auto'),deint: Int| Literal["all","interlaced"] | Default = Default('all'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlace the input video ("w3fdif" stands for "Weston 3 Field
 Deinterlacing Filter").
 
@@ -24367,7 +24367,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#w3fdif)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -24375,40 +24375,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='w3fdif', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "filter": filter,
-                
+
                 "mode": mode,
-                
+
                 "parity": parity,
-                
+
                 "deint": deint,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def waveform(
-    
+
     self,
 
 
@@ -24416,12 +24416,12 @@ References:
 
     *,
     mode: Int| Literal["row","column"] | Default = Default('column'),intensity: Float = Default('0.04'),mirror: Boolean = Default('true'),display: Int| Literal["overlay","stack","parade"] | Default = Default('stack'),components: Int = Default('1'),envelope: Int| Literal["none","instant","peak","peak+instant"] | Default = Default('none'),filter: Int| Literal["lowpass","flat","aflat","chroma","color","acolor","xflat","yflat"] | Default = Default('lowpass'),graticule: Int| Literal["none","green","orange","invert"] | Default = Default('none'),opacity: Float = Default('0.75'),flags: Flags| Literal["numbers","dots"] | Default = Default('numbers'),scale: Int| Literal["digital","millivolts","ire"] | Default = Default('digital'),bgopacity: Float = Default('0.75'),tint0: Float = Default('0'),tint1: Float = Default('0'),fitmode: Int| Literal["none","size"] | Default = Default('none'),input: Int| Literal["all","first"] | Default = Default('first'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Video waveform monitor.
 
 The waveform monitor plots color component intensity. By default luma
@@ -24457,67 +24457,67 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#waveform)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='waveform', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "intensity": intensity,
-                
+
                 "mirror": mirror,
-                
+
                 "display": display,
-                
+
                 "components": components,
-                
+
                 "envelope": envelope,
-                
+
                 "filter": filter,
-                
+
                 "graticule": graticule,
-                
+
                 "opacity": opacity,
-                
+
                 "flags": flags,
-                
+
                 "scale": scale,
-                
+
                 "bgopacity": bgopacity,
-                
+
                 "tint0": tint0,
-                
+
                 "tint1": tint1,
-                
+
                 "fitmode": fitmode,
-                
+
                 "input": input,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def weave(
-    
+
     self,
 
 
@@ -24525,12 +24525,12 @@ References:
 
     *,
     first_field: Int| Literal["top","t","bottom","b"] | Default = Default('top'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 The weave takes a field-based video input and join
 each two sequential fields into single frame, producing a new double
 height clip with half the frame rate and half the frame count.
@@ -24552,37 +24552,37 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#weave)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='weave', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "first_field": first_field,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def xbr(
-    
+
     self,
 
 
@@ -24590,12 +24590,12 @@ References:
 
     *,
     n: Int = Default('3'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply the xBR high-quality magnification filter which is designed for pixel
 art. It follows a set of edge-detection rules, see
 https://forums.libretro.com/t/xbr-algorithm-tutorial/123.
@@ -24614,66 +24614,66 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xbr)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='xbr', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "n": n,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def xcorrelate(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _secondary: VideoStream,
-        
-    
+
+
 
 
     *,
     planes: Int = Default('7'),secondary: Int| Literal["first","all"] | Default = Default('all'),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply normalized cross-correlation between first and second input video stream.
 
 Second input video stream dimensions must be lower than first input video stream.
@@ -24695,7 +24695,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xcorrelate)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -24706,67 +24706,67 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='xcorrelate', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _secondary,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "planes": planes,
-                
+
                 "secondary": secondary,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def xfade(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _xfade: VideoStream,
-        
-    
+
+
 
 
     *,
     transition: Int| Literal["custom","fade","wipeleft","wiperight","wipeup","wipedown","slideleft","slideright","slideup","slidedown","circlecrop","rectcrop","distance","fadeblack","fadewhite","radial","smoothleft","smoothright","smoothup","smoothdown","circleopen","circleclose","vertopen","vertclose","horzopen","horzclose","dissolve","pixelize","diagtl","diagtr","diagbl","diagbr","hlslice","hrslice","vuslice","vdslice","hblur","fadegrays","wipetl","wipetr","wipebl","wipebr","squeezeh","squeezev","zoomin","fadefast","fadeslow","hlwind","hrwind","vuwind","vdwind","coverleft","coverright","coverup","coverdown","revealleft","revealright","revealup","revealdown"] | Default = Default('fade'),duration: Duration = Default('1'),offset: Duration = Default('0'),expr: String = Default(None),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply cross fade from one input video stream to another input video stream.
 The cross fade is applied for specified duration.
 
@@ -24790,72 +24790,72 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xfade)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='xfade', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _xfade,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "transition": transition,
-                
+
                 "duration": duration,
-                
+
                 "offset": offset,
-                
+
                 "expr": expr,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def xfade_opencl(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _xfade: VideoStream,
-        
-    
+
+
 
 
     *,
     transition: Int| Literal["custom","fade","wipeleft","wiperight","wipeup","wipedown","slideleft","slideright","slideup","slidedown"] | Default = Default('fade'),source: String = Default(None),kernel: String = Default(None),duration: Duration = Default('1'),offset: Duration = Default('0'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Cross fade two videos with custom transition effect by using OpenCL.
 
 It accepts the following options:
@@ -24876,84 +24876,84 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xfade_opencl)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='xfade_opencl', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _xfade,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "transition": transition,
-                
+
                 "source": source,
-                
+
                 "kernel": kernel,
-                
+
                 "duration": duration,
-                
+
                 "offset": offset,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def xpsnr(
-    
+
     self,
 
 
-    
-        
-        
-    
-        
+
+
+
+
+
         _reference: VideoStream,
-        
-    
+
+
 
 
     *,
     stats_file: String = Default(None),
-    
+
     framesync_options: FFMpegFrameSyncOption | None = None,
     eof_action: str | None = None,
     shortest: bool | None = None,
     repeatlast: bool | None = None,
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Obtain the average (across all input frames) and minimum (across all color plane averages)
 eXtended Perceptually weighted peak Signal-to-Noise Ratio (XPSNR) between two input videos.
 
@@ -24979,7 +24979,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#xpsnr)
 
         """
-        
+
 
         if framesync_options is None and any(v is not None for v in (eof_action, shortest, repeatlast)):
             framesync_options = FFMpegFrameSyncOption(merge({"eof_action": eof_action, "shortest": shortest, "repeatlast": repeatlast}))
@@ -24990,48 +24990,48 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='xpsnr', typings_input=('video', 'video'), typings_output=('video',)),
-            
+
             self,
 
 
-            
-                
-                
-            
-                
+
+
+
+
+
                 _reference,
-                
-            
+
+
 
 
             **merge({
-                
+
                 "stats_file": stats_file,
-                
+
             },
             extra_options,
-            
+
             framesync_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
+
+
     def yadif(
-    
+
     self,
 
 
@@ -25039,15 +25039,15 @@ References:
 
     *,
     mode: Int| Literal["send_frame","send_field","send_frame_nospatial","send_field_nospatial"] | Default = Default('send_frame'),parity: Int| Literal["tff","bff","auto"] | Default = Default('auto'),deint: Int| Literal["all","interlaced"] | Default = Default('all'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Deinterlace the input video ("yadif" means "yet another deinterlacing
 filter").
 
@@ -25068,7 +25068,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#yadif)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -25076,38 +25076,38 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='yadif', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "mode": mode,
-                
+
                 "parity": parity,
-                
+
                 "deint": deint,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def yaepblur(
-    
+
     self,
 
 
@@ -25115,15 +25115,15 @@ References:
 
     *,
     radius: Int = Default('3'),planes: Int = Default('1'),sigma: Int = Default('128'),
-    
-    
+
+
     timeline_options: FFMpegTimelineOption | None = None,
     enable: str | None = None,
-    
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply blur filter while preserving edges ("yaepblur" means "yet another edge preserving blur filter").
 The algorithm is described in
 "J. S. Lee, Digital image enhancement and noise filtering by use of local statistics, IEEE Trans. Pattern Anal. Mach. Intell. PAMI-2, 1980."
@@ -25145,7 +25145,7 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#yaepblur)
 
         """
-        
+
 
 
         if timeline_options is None and enable is not None:
@@ -25153,40 +25153,40 @@ References:
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='yaepblur', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "radius": radius,
-                
+
                 "planes": planes,
-                
+
                 "sigma": sigma,
-                
+
             },
             extra_options,
-            
-            
+
+
             timeline_options,
-            
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def zmq(
-    
+
     self,
 
 
@@ -25194,12 +25194,12 @@ References:
 
     *,
     bind_address: String = Default('tcp://*:5555'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Receive commands sent through a libzmq client, and forward them to
 filters in the filtergraph.
 
@@ -25258,39 +25258,39 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#zmq)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='zmq', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "bind_address": bind_address,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-        
-    
-    
+
+
+
+
+
+
+
     def zoompan(
-    
+
     self,
 
 
@@ -25298,12 +25298,12 @@ References:
 
     *,
     zoom: String = Default('1'),x: String = Default('0'),y: String = Default('0'),d: String = Default('90'),s: Image_size = Default('hd720'),fps: Video_rate = Default('25'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Apply Zoom & Pan effect.
 
 This filter accepts the following options:
@@ -25325,47 +25325,47 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#zoompan)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='zoompan', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "zoom": zoom,
-                
+
                 "x": x,
-                
+
                 "y": y,
-                
+
                 "d": d,
-                
+
                 "s": s,
-                
+
                 "fps": fps,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
 
 
-        
-    
-        
-    
-    
+
+
+
+
+
     def zscale(
-    
+
     self,
 
 
@@ -25373,12 +25373,12 @@ References:
 
     *,
     w: String = Default(None),h: String = Default(None),size: String = Default(None),dither: Int| Literal["none","ordered","random","error_diffusion"] | Default = Default('none'),filter: Int| Literal["point","bilinear","bicubic","spline16","spline36","lanczos"] | Default = Default('bilinear'),out_range: Int| Literal["input","limited","full","unknown","tv","pc"] | Default = Default('input'),primaries: Int| Literal["input","709","unspecified","170m","240m","2020","unknown","bt709","bt470m","bt470bg","smpte170m","smpte240m","film","bt2020","smpte428","smpte431","smpte432","jedec-p22","ebu3213"] | Default = Default('input'),transfer: Int| Literal["input","709","unspecified","601","linear","2020_10","2020_12","unknown","bt470m","bt470bg","smpte170m","smpte240m","bt709","log100","log316","bt2020-10","bt2020-12","smpte2084","iec61966-2-4","iec61966-2-1","arib-std-b67"] | Default = Default('input'),matrix: Int| Literal["input","709","unspecified","470bg","170m","2020_ncl","2020_cl","unknown","gbr","bt709","fcc","bt470bg","smpte170m","smpte240m","ycgco","bt2020nc","bt2020c","chroma-derived-nc","chroma-derived-c","ictcp"] | Default = Default('input'),in_range: Int| Literal["input","limited","full","unknown","tv","pc"] | Default = Default('input'),primariesin: Int| Literal["input","709","unspecified","170m","240m","2020","unknown","bt709","bt470m","bt470bg","smpte170m","smpte240m","film","bt2020","smpte428","smpte431","smpte432","jedec-p22","ebu3213"] | Default = Default('input'),transferin: Int| Literal["input","709","unspecified","601","linear","2020_10","2020_12","unknown","bt470m","bt470bg","smpte170m","smpte240m","bt709","log100","log316","bt2020-10","bt2020-12","smpte2084","iec61966-2-4","iec61966-2-1","arib-std-b67"] | Default = Default('input'),matrixin: Int| Literal["input","709","unspecified","470bg","170m","2020_ncl","2020_cl","unknown","gbr","bt709","fcc","bt470bg","smpte170m","smpte240m","ycgco","bt2020nc","bt2020c","chroma-derived-nc","chroma-derived-c","ictcp"] | Default = Default('input'),chromal: Int| Literal["input","left","center","topleft","top","bottomleft","bottom"] | Default = Default('input'),chromalin: Int| Literal["input","left","center","topleft","top","bottomleft","bottom"] | Default = Default('input'),npl: Double = Default('nan'),agamma: Boolean = Default('true'),param_a: Double = Default('nan'),param_b: Double = Default('nan'),
-    
-    
+
+
     extra_options: dict[str, Any] | None = None,
     )-> VideoStream:
         """
-        
+
 Scale (resize) the input video, using the z.lib library:
 https://github.com/sekrit-twc/zimg. To enable compilation of this
 filter, you need to configure FFmpeg with --enable-libzimg.
@@ -25420,65 +25420,61 @@ References:
     [FFmpeg Documentation](https://ffmpeg.org/ffmpeg-filters.html#zscale)
 
         """
-        
+
 
 
         filter_node = filter_node_factory(
             FFMpegFilterDef(name='zscale', typings_input=('video',), typings_output=('video',)),
-            
+
             self,
 
 
 
 
             **merge({
-                
+
                 "w": w,
-                
+
                 "h": h,
-                
+
                 "size": size,
-                
+
                 "dither": dither,
-                
+
                 "filter": filter,
-                
+
                 "out_range": out_range,
-                
+
                 "primaries": primaries,
-                
+
                 "transfer": transfer,
-                
+
                 "matrix": matrix,
-                
+
                 "in_range": in_range,
-                
+
                 "primariesin": primariesin,
-                
+
                 "transferin": transferin,
-                
+
                 "matrixin": matrixin,
-                
+
                 "chromal": chromal,
-                
+
                 "chromalin": chromalin,
-                
+
                 "npl": npl,
-                
+
                 "agamma": agamma,
-                
+
                 "param_a": param_a,
-                
+
                 "param_b": param_b,
-                
+
             },
             extra_options,
-            
-            
+
+
             )
         )
         return filter_node.video(0)
-
-
-        
-    

--- a/pyproject-workspace.toml
+++ b/pyproject-workspace.toml
@@ -26,7 +26,7 @@ readme = "README.md"
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
-    "ruff>=0.9.6",
+    "ruff==0.12.2",
     "mypy>=1.0",
     "prek>=0.1.0",
 ]
@@ -44,7 +44,7 @@ all = [
 dev-dependencies = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
-    "ruff>=0.9.6",
+    "ruff==0.12.2",
     "mypy>=1.0",
     "prek>=0.1.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dev-dependencies = [
     "ty",
     "devtools",
     "black",
-    "ruff>=0.9.6,<0.13.0",
+    "ruff==0.12.2",
     "prek>=0.1.0",
     "typer",
     "jinja2",

--- a/src/scripts/code_gen/cli.py
+++ b/src/scripts/code_gen/cli.py
@@ -137,9 +137,10 @@ def gen_filter_info(
 
 
 def _normalize_option_flags(options: list[FFMpegOption]) -> list[FFMpegOption]:
-    """Translate old-style (pre-7.0) flag values to the current bit layout
-    and fix known flag omissions.
+    """
+    Translate old-style (pre-7.0) flag values to the current bit layout.
 
+    Fix known flag omissions.
     If the options already use the modern layout, only the fixup step runs.
     Detection works by inspecting known OPT_EXIT options (``-L``, ``-h``).
 
@@ -157,10 +158,7 @@ def _normalize_option_flags(options: list[FFMpegOption]) -> list[FFMpegOption]:
         (o for o in options if o.name in ("L", "h", "help", "version")), None
     )
     if exit_option is not None and uses_old_flag_layout(exit_option.flags):
-        options = [
-            replace(o, flags=translate_old_flags(o.flags))
-            for o in options
-        ]
+        options = [replace(o, flags=translate_old_flags(o.flags)) for o in options]
 
     # Options that FFmpeg's source marks as output-only but also work on input.
     _ALSO_INPUT = {"bsf"}

--- a/src/scripts/code_gen/gen.py
+++ b/src/scripts/code_gen/gen.py
@@ -388,6 +388,9 @@ def render(
         opath = outpath / str(template_path).replace(".jinja", "")
         opath.parent.mkdir(parents=True, exist_ok=True)
 
+        # Strip trailing whitespace from each line to satisfy pre-commit hooks
+        code = "\n".join(line.rstrip() for line in code.splitlines())
+
         with opath.open("w") as ofile:
             ofile.write("# NOTE: this file is auto-generated, do not modify\n")
             ofile.write(code)

--- a/uv.lock
+++ b/uv.lock
@@ -510,7 +510,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.6" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.12.2" },
     { name = "syrupy", marker = "extra == 'dev'", specifier = ">=5.0" },
 ]
 provides-extras = ["dev", "graph"]
@@ -2389,7 +2389,7 @@ dev = [
 requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.6" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.12.2" },
     { name = "typed-ffmpeg-v8", editable = "packages/v8" },
 ]
 provides-extras = ["dev"]
@@ -2415,7 +2415,7 @@ requires-dist = [
     { name = "ffmpeg-core", editable = "packages/core" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.6" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.12.2" },
     { name = "syrupy", marker = "extra == 'dev'", specifier = ">=5.0" },
 ]
 provides-extras = ["dev"]
@@ -2441,7 +2441,7 @@ requires-dist = [
     { name = "ffmpeg-core", editable = "packages/core" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.6" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.12.2" },
     { name = "syrupy", marker = "extra == 'dev'", specifier = ">=5.0" },
 ]
 provides-extras = ["dev"]
@@ -2467,7 +2467,7 @@ requires-dist = [
     { name = "ffmpeg-core", editable = "packages/core" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.6" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.12.2" },
     { name = "syrupy", marker = "extra == 'dev'", specifier = ">=5.0" },
 ]
 provides-extras = ["dev"]
@@ -2493,7 +2493,7 @@ requires-dist = [
     { name = "ffmpeg-core", editable = "packages/core" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.6" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.12.2" },
     { name = "syrupy", marker = "extra == 'dev'", specifier = ">=5.0" },
 ]
 provides-extras = ["dev"]
@@ -2576,7 +2576,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=4.1,<7.0" },
     { name = "pytest-datadir", specifier = ">=1.5.0" },
     { name = "pytest-recording", specifier = ">=0.13.1" },
-    { name = "ruff", specifier = ">=0.9.6,<0.13.0" },
+    { name = "ruff", specifier = "==0.12.2" },
     { name = "syrupy", specifier = ">=4.6.0" },
     { name = "ty" },
     { name = "typer" },


### PR DESCRIPTION
## Summary

- Fix docstring formatting (D205) and ruff-format issues in `cli.py`
- Add trailing whitespace stripping to codegen post-processing (`gen.py`) to prevent future regressions
- Fix ruff-format issues in `packages/tests-shared/` files
- Clean up trailing whitespace in all generated package files (v5-v8)

## Test plan

- [x] `uvx prek run --all-files` passes all checks (ruff, ruff-format, trailing-whitespace, ty)
- [ ] CI lint job passes on this branch

https://claude.ai/code/session_0113RbJ6vvqf1T2Qaun8Utqa