### PR TITLE
fix: release readiness — data packages, test skips, changelog

### DIFF
--- a/.github/workflows/monorepo-publish.yml
+++ b/.github/workflows/monorepo-publish.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       package:
-        description: 'Package to publish (core, v8, v7, v6, v5, latest, all)'
+        description: 'Package to publish (core, data-v5, data-v6, data-v7, data-v8, v8, v7, v6, v5, latest, all)'
         required: true
         default: 'all'
       test-pypi:
@@ -47,7 +47,7 @@ jobs:
           fi
           
           if [ "$PKG" = "all" ]; then
-            echo "packages=core v8 v7 v6 v5 latest" >> $GITHUB_OUTPUT
+            echo "packages=core data-v5 data-v6 data-v7 data-v8 v5 v6 v7 v8 latest" >> $GITHUB_OUTPUT
           else
             echo "packages=$PKG" >> $GITHUB_OUTPUT
           fi
@@ -85,7 +85,7 @@ jobs:
         if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.test-pypi == 'false')
         run: |
           # Publish in order: core first, then version packages, then latest
-          PUBLISH_ORDER="core v5 v6 v7 v8 latest"
+          PUBLISH_ORDER="core data-v5 data-v6 data-v7 data-v8 v5 v6 v7 v8 latest"
 
           for pkg in $PUBLISH_ORDER; do
             if echo "${{ steps.packages.outputs.packages }}" | grep -q "$pkg"; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,98 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [1.0.0a1] - 2026-03-25
+
+Major rewrite: monorepo architecture with multi-version FFmpeg support.
+
+### Added
+
+- **Multi-version FFmpeg support** — separate packages for FFmpeg 5.x, 6.x, 7.x, and 8.x
+- **Monorepo architecture** — split into `ffmpeg-core`, `typed-ffmpeg-v5`..`v8`, and `typed-ffmpeg` (latest)
+- **Per-version cache data packages** (`ffmpeg-data-v5`..`v8`) for offline filter/codec metadata
+- **Version-aware code generation** pipeline producing version-specific bindings
+- **Texinfo parser** for enriching filter documentation from FFmpeg source docs
+- **New CLI commands**: `generate --version-dir`, `diff`, `reexport`
+- **Cross-version diff module** for migration hints between FFmpeg versions
+- **CUDA toolkit support** in Docker builds for full CUDA filter coverage
+- **Enhanced Docker builder** with Vulkan and plugin support
+
+### Changed
+
+- Package renamed from `typed-ffmpeg` (single package) to a monorepo with per-version packages
+- Import paths updated for multi-version support
+- Replaced pre-commit with [prek](https://github.com/9999years/prek) (2–10x faster)
+- Switched to [uv](https://github.com/astral-sh/uv) package manager
+- Improved `ffmpeg-core` test coverage from 74% to 92%
+- Regenerated bindings for all supported FFmpeg versions
+
+### Fixed
+
+- FFmpeg 8.0 compatibility (unsigned types, array options, 2-char filter flags)
+- Filters without docs no longer silently dropped during codegen
+- Backward compatibility with 3.x API preserved where possible
+- Docker runtime library dependencies for v7/v8
+
+### Breaking Changes
+
+- New package names: install `typed-ffmpeg` (latest) or `typed-ffmpeg-v8`, `typed-ffmpeg-v7`, etc.
+- Shared runtime is now `ffmpeg-core` (installed automatically as a dependency)
+
+## [3.11] - 2026-01-21
+
+### Fixed
+
+- Bool muxer option handling
+
+## [3.10] - 2025-12-31
+
+### Fixed
+
+- Memory leak in ffprobe on subprocess timeout
+- Runtime cache folder error with PyInstaller builds
+
+## [3.9] - 2025-12-29
+
+### Added
+
+- Flexible sample format support
+
+### Changed
+
+- Test coverage improvements
+
+## [3.8.2] - 2025-12-19
+
+### Fixed
+
+- Minor bug fixes and stability improvements
+
+## [3.8.1] - 2025-12-07
+
+### Fixed
+
+- Patch release with bug fixes
+
+## [3.8.0] - 2025-12-05
+
+### Added
+
+- AsyncIO subprocess support (`run_async_awaitable()`)
+- Enhanced type checking with mypy
+
+## [3.7.1] - 2025-10-17
+
+### Fixed
+
+- Patch release with bug fixes
+
+## [3.7] - 2025-10-16
+
+### Added
+
+- JSON serialization of filter graphs
+- Comprehensive filter documentation improvements

--- a/packages/core/src/ffmpeg_core/conftest.py
+++ b/packages/core/src/ffmpeg_core/conftest.py
@@ -1,0 +1,12 @@
+import shutil
+
+import pytest
+
+requires_ffmpeg = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None,
+    reason="ffmpeg binary not found",
+)
+requires_ffprobe = pytest.mark.skipif(
+    shutil.which("ffprobe") is None,
+    reason="ffprobe binary not found",
+)

--- a/packages/core/src/ffmpeg_core/ffprobe/tests/test_probe.py
+++ b/packages/core/src/ffmpeg_core/ffprobe/tests/test_probe.py
@@ -10,6 +10,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 from syrupy.extensions.json import JSONSnapshotExtension
 
+from ...conftest import requires_ffprobe
 from ..probe import probe, probe_obj
 
 test_data = Path(__file__).parent / "test_probe"
@@ -29,6 +30,7 @@ def is_static_image(format_name: str) -> bool:
     return format_name in {"jpeg_pipe", "png_pipe", "webp_pipe"}
 
 
+@requires_ffprobe
 @pytest.mark.parametrize("path", test_data.glob("**/*.*"), ids=lambda x: x.name)
 def test_probe_default(path: Path, snapshot: SnapshotAssertion) -> None:
     info = probe(path)
@@ -73,6 +75,7 @@ def test_probe_default(path: Path, snapshot: SnapshotAssertion) -> None:
     snapshot(name="obj", extension_class=JSONSnapshotExtension) == asdict(obj)
 
 
+@requires_ffprobe
 @pytest.mark.parametrize("path", test_data.glob("**/*.*"), ids=lambda x: x.name)
 def test_probe_complete(path: Path, snapshot: SnapshotAssertion) -> None:
     info = probe(
@@ -152,6 +155,7 @@ def test_probe_complete(path: Path, snapshot: SnapshotAssertion) -> None:
     snapshot(name="obj", extension_class=JSONSnapshotExtension) == asdict(obj)
 
 
+@requires_ffprobe
 def test_probe_timeout_cleanup() -> None:
     """
     Test that ffprobe subprocess is properly cleaned up when timeout occurs.

--- a/packages/core/src/ffmpeg_core/tests/test_info.py
+++ b/packages/core/src/ffmpeg_core/tests/test_info.py
@@ -1,3 +1,4 @@
+from ..conftest import requires_ffmpeg
 from ..info import (
     Codec,
     CodecFlags,
@@ -93,18 +94,21 @@ Encoders:
     assert CoderFlags.audio in coders[1].flags
 
 
+@requires_ffmpeg
 def test_get_codecs() -> None:
     codecs = get_codecs()
     assert len(codecs) > 0
     assert isinstance(codecs[0], Codec)
 
 
+@requires_ffmpeg
 def test_get_decoders() -> None:
     decoders = get_decoders()
     assert len(decoders) > 0
     assert isinstance(decoders[0], Coder)
 
 
+@requires_ffmpeg
 def test_get_encoders() -> None:
     encoders = get_encoders()
     assert len(encoders) > 0

--- a/pyproject-workspace.toml
+++ b/pyproject-workspace.toml
@@ -4,6 +4,10 @@
 [tool.uv.workspace]
 members = [
     "packages/core",
+    "packages/data-v5",
+    "packages/data-v6",
+    "packages/data-v7",
+    "packages/data-v8",
     "packages/v5",
     "packages/v6",
     "packages/v7",

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -5,7 +5,7 @@ import re
 import sys
 from pathlib import Path
 
-PACKAGES = ["core", "v5", "v6", "v7", "v8", "latest"]
+PACKAGES = ["core", "data-v5", "data-v6", "data-v7", "data-v8", "v5", "v6", "v7", "v8", "latest"]
 REPO_ROOT = Path(__file__).parent.parent
 
 


### PR DESCRIPTION
## Summary

- **Include data packages in release process** — `ffmpeg-data-v5..v8` were missing from the workspace, publish workflow, and bump-version script. Without this fix, data packages would not be published on release.
- **Skip tests gracefully when ffmpeg/ffprobe not installed** — adds `requires_ffmpeg` / `requires_ffprobe` markers so tests skip cleanly in environments without the binaries instead of failing with `FileNotFoundError`.
- **Add CHANGELOG.md** — documents releases from 3.7 through 1.0.0a1, as referenced in CONTRIBUTING.md but previously missing.

## Test plan

- [ ] Verify `uv sync` resolves the workspace correctly with data packages included
- [ ] Verify `python scripts/bump-version.py <version>` bumps all 10 packages (including data packages)
- [ ] Verify core tests pass in CI (with ffmpeg installed) — no tests should be skipped
- [ ] Verify core tests skip cleanly locally without ffmpeg — 42 skipped, 0 failed

https://claude.ai/code/session_01RSDjGcoHZWsJcT3aezdQdf