### PR TITLE
chore: release v4.3 (FFmpeg 7.0 loopback decoders)

### DIFF
--- a/packages/compatible/pyproject.toml
+++ b/packages/compatible/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "typed-ffmpeg-compatible"
-version = "4.1"
+version = "4.3"
 description = "typed-ffmpeg under the typed_ffmpeg module name (no conflict with ffmpeg-python)"
 authors = [
     {name = "lucemia", email = "lucemia@gmail.com"}
@@ -34,7 +34,7 @@ classifiers = [
 # as `typed_ffmpeg` so it doesn't conflict with ffmpeg-python's
 # `ffmpeg` module.
 dependencies = [
-    "typed-ffmpeg-v8>=4.1,<5.0",
+    "typed-ffmpeg-v8>=4.3,<5.0",
 ]
 
 [build-system]

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ffmpeg-core"
-version = "4.1"
+version = "4.3"
 description = "Core runtime for typed-ffmpeg (DAG, compilation, IR layer)"
 authors = [
     {name = "lucemia", email = "lucemia@gmail.com"}

--- a/packages/data-v5/pyproject.toml
+++ b/packages/data-v5/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ffmpeg-data-v5"
-version = "4.1"
+version = "4.3"
 description = "Cache data files for typed-ffmpeg-v5 (FFmpeg 5.x)"
 authors = [
     {name = "lucemia", email = "lucemia@gmail.com"}

--- a/packages/data-v6/pyproject.toml
+++ b/packages/data-v6/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ffmpeg-data-v6"
-version = "4.1"
+version = "4.3"
 description = "Cache data files for typed-ffmpeg-v6 (FFmpeg 6.x)"
 authors = [
     {name = "lucemia", email = "lucemia@gmail.com"}

--- a/packages/data-v7/pyproject.toml
+++ b/packages/data-v7/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ffmpeg-data-v7"
-version = "4.1"
+version = "4.3"
 description = "Cache data files for typed-ffmpeg-v7 (FFmpeg 7.x)"
 authors = [
     {name = "lucemia", email = "lucemia@gmail.com"}

--- a/packages/data-v8/pyproject.toml
+++ b/packages/data-v8/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ffmpeg-data-v8"
-version = "4.1"
+version = "4.3"
 description = "Cache data files for typed-ffmpeg-v8 (FFmpeg 8.x)"
 authors = [
     {name = "lucemia", email = "lucemia@gmail.com"}

--- a/packages/latest/pyproject.toml
+++ b/packages/latest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "typed-ffmpeg"
-version = "4.1"
+version = "4.3"
 description = "Modern Python & TypeScript FFmpeg wrappers with comprehensive typing (latest version)"
 authors = [
     {name = "lucemia", email = "lucemia@gmail.com"}
@@ -33,7 +33,7 @@ classifiers = [
 # Meta-package: no source code, just depends on typed-ffmpeg-v8
 # which provides `import ffmpeg` directly.
 dependencies = [
-    "typed-ffmpeg-v8>=4.1,<5.0",
+    "typed-ffmpeg-v8>=4.3,<5.0",
 ]
 
 [tool.uv.sources]

--- a/packages/v5/pyproject.toml
+++ b/packages/v5/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "typed-ffmpeg-v5"
-version = "4.1"
+version = "4.3"
 description = "Typed FFmpeg bindings for FFmpeg 5.x"
 authors = [
     {name = "lucemia", email = "lucemia@gmail.com"}
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Multimedia :: Video",
 ]
 
-dependencies = ["ffmpeg-core>=4.1,<5.0"]
+dependencies = ["ffmpeg-core>=4.3,<5.0"]
 
 [tool.uv.sources]
 ffmpeg-core = { workspace = true }

--- a/packages/v6/pyproject.toml
+++ b/packages/v6/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "typed-ffmpeg-v6"
-version = "4.1"
+version = "4.3"
 description = "Typed FFmpeg bindings for FFmpeg 6.x"
 authors = [
     {name = "lucemia", email = "lucemia@gmail.com"}
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Multimedia :: Video",
 ]
 
-dependencies = ["ffmpeg-core>=4.1,<5.0"]
+dependencies = ["ffmpeg-core>=4.3,<5.0"]
 
 [tool.uv.sources]
 ffmpeg-core = { workspace = true }

--- a/packages/v7/pyproject.toml
+++ b/packages/v7/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "typed-ffmpeg-v7"
-version = "4.1"
+version = "4.3"
 description = "Typed FFmpeg bindings for FFmpeg 7.x"
 authors = [
     {name = "lucemia", email = "lucemia@gmail.com"}
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Multimedia :: Video",
 ]
 
-dependencies = ["ffmpeg-core>=4.1,<5.0"]
+dependencies = ["ffmpeg-core>=4.3,<5.0"]
 
 [tool.uv.sources]
 ffmpeg-core = { workspace = true }

--- a/packages/v8/pyproject.toml
+++ b/packages/v8/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "typed-ffmpeg-v8"
-version = "4.1"
+version = "4.3"
 description = "Typed FFmpeg bindings for FFmpeg 8.x"
 authors = [
     {name = "lucemia", email = "lucemia@gmail.com"}
@@ -31,7 +31,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "ffmpeg-core>=4.1,<5.0",
+    "ffmpeg-core>=4.3,<5.0",
 ]
 
 [tool.uv.sources]


### PR DESCRIPTION
Version bump to **4.3** across all monorepo packages ahead of the v4.3 release.

Headline: **FFmpeg 7.0 loopback decoder support** (`-dec` / `[dec:N]`) — #966, merged in #967.

- Bumps `core`, `data-v5..v8`, `v5..v8`, `latest`, `compatible` from 4.1 → 4.3 (via `scripts/bump-version.py`, which also syncs inter-package constraints to `>=4.3,<5.0`).
- Skips the phantom `v4.2` tag (which was never published to PyPI); real latest on PyPI is 4.1.

Merging this, then tagging `v4.3` + publishing the GitHub release triggers `monorepo-publish.yml` (which validates every package version == tag before uploading to PyPI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrT2aq5dzBEuWyWiJ6gbGL